### PR TITLE
Pull in latest hk2 

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -147,7 +147,7 @@
         <servlet-api.version>3.1.0</servlet-api.version>
         <grizzly.version>2.3.15-gfa</grizzly.version>
         <saaj-api.version>1.3.4</saaj-api.version>
-        <hk2.version>2.3.0</hk2.version>
+        <hk2.version>2.4.0-b03</hk2.version>
         <hk2.plugin.version>2.3.0</hk2.plugin.version>
         <javax.el.version>3.0.1-b03</javax.el.version>
         <javax.el-api.version>3.0.1-b03</javax.el-api.version>


### PR DESCRIPTION
Fix #13 Cargo Tracker does not deploy by pulling in latest hk2 which includes the fix.
