### PR TITLE
Fix spurious log messages on boot of AMX

### DIFF
--- a/appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/EnableSpdyCommand.java
+++ b/appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/EnableSpdyCommand.java
@@ -176,19 +176,19 @@ public class EnableSpdyCommand implements AdminCommand {
                     if (maxStreams != null) {
                         int maxStreamsLocal = Integer.parseInt(maxStreams);
                         if (maxStreamsLocal > 0) {
-                            spdy.setMaxConcurrentStreams(maxStreamsLocal);
+                            spdy.setMaxConcurrentStreams(Integer.toString(maxStreamsLocal));
                         }
                     }
                     if (initialWindowSize != null) {
                         int initialWindowSizeLocal = Integer.parseInt(initialWindowSize);
                         if (initialWindowSizeLocal > 0) {
-                            spdy.setInitialWindowSizeInBytes(initialWindowSizeLocal);
+                            spdy.setInitialWindowSizeInBytes(Integer.toString(initialWindowSizeLocal));
                         }
                     }
                     if (maxFrameLengthInBytes != null) {
                         int maxFrameLengthInBytesLocal = Integer.parseInt(maxFrameLengthInBytes);
                         if (maxFrameLengthInBytesLocal > 0 && maxFrameLengthInBytesLocal < (1 << 24)) {
-                            spdy.setMaxFrameLengthInBytes(maxFrameLengthInBytesLocal);
+                            spdy.setMaxFrameLengthInBytes(Integer.toString(maxFrameLengthInBytesLocal));
                         }
                     }
                     if (mode != null) {

--- a/appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/SpdyAddOnProvider.java
+++ b/appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/SpdyAddOnProvider.java
@@ -114,9 +114,9 @@ public class SpdyAddOnProvider implements AddOn, ConfigAwareElement<Spdy> {
         
         spdyAddOn = new GlassFishSpdyAddOn(spdyMode, spdyVersions);
         
-        spdyAddOn.setInitialWindowSize(spdy.getInitialWindowSizeInBytes());
-        spdyAddOn.setMaxConcurrentStreams(spdy.getMaxConcurrentStreams());
-        spdyAddOn.setMaxFrameLength(spdy.getMaxFrameLengthInBytes());
+        spdyAddOn.setInitialWindowSize(Integer.getInteger(spdy.getInitialWindowSizeInBytes()));
+        spdyAddOn.setMaxConcurrentStreams(Integer.getInteger(spdy.getMaxConcurrentStreams()));
+        spdyAddOn.setMaxFrameLength(Integer.getInteger(spdy.getMaxFrameLengthInBytes()));
     }
 
     @Override

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -717,7 +717,7 @@ public class GenericGrizzlyListener implements GrizzlyListener {
                                         final Spdy spdyElement,
                                         final FilterChainBuilder builder,
                                         final boolean secure) {
-        if (spdyElement != null && spdyElement.getEnabled()) {
+        if (spdyElement != null && GrizzlyConfig.toBoolean(spdyElement.getEnabled())) {
 
             boolean isNpnMode = spdyElement.getMode() == null ||
                     "npn".equalsIgnoreCase(spdyElement.getMode());

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Spdy.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Spdy.java
@@ -62,9 +62,9 @@ public interface Spdy extends ConfigBeanProxy, PropertyBag {
      * Enables SPDY support.
      */
     @Attribute(defaultValue = "" + ENABLED, dataType = Boolean.class)
-    boolean getEnabled();
+    String getEnabled();
 
-    void setEnabled(boolean enabled);
+    void setEnabled(String enabled);
 
     /**
      * SPDY mode.
@@ -80,25 +80,25 @@ public interface Spdy extends ConfigBeanProxy, PropertyBag {
      * The default is 50.
      */
     @Attribute(defaultValue = "" + MAX_CONCURRENT_STREAMS, dataType = Integer.class)
-    int getMaxConcurrentStreams();
+    String getMaxConcurrentStreams();
 
-    void setMaxConcurrentStreams(int maxConcurrentStreams);
+    void setMaxConcurrentStreams(String maxConcurrentStreams);
 
     /**
      * Configures the initial window size in bytes.  The default is 64K.
      */
     @Attribute(defaultValue = "" + INITIAL_WINDOW_SIZE_IN_BYTES, dataType = Integer.class)
-    int getInitialWindowSizeInBytes();
+    String getInitialWindowSizeInBytes();
 
-    void setInitialWindowSizeInBytes(int initialWindowSizeInBytes);
+    void setInitialWindowSizeInBytes(String initialWindowSizeInBytes);
 
     /**
      * Configures the maximum length of SPDY frame to be accepted.  The default is 2^24.
      */
     @Attribute(defaultValue = "" + MAX_FRAME_LENGTH_IN_BYTES, dataType = Integer.class)
-    int getMaxFrameLengthInBytes();
+    String getMaxFrameLengthInBytes();
 
-    void setMaxFrameLengthInBytes(int maxFrameLengthInBytes);
+    void setMaxFrameLengthInBytes(String maxFrameLengthInBytes);
     
     /**
      * Enables SPDY support.


### PR DESCRIPTION
Modified SPDY configuration to expose Strings as required for AMX. Other code modified to convert to and from Strings
