### PR TITLE
Fix for GLASSFISH-21018

### DIFF
--- a/appserver/payara-admingui/full/src/main/resources/batch/batchConfiguration_1.inc
+++ b/appserver/payara-admingui/full/src/main/resources/batch/batchConfiguration_1.inc
@@ -55,7 +55,7 @@
         setSessionAttribute(key="#{pageSession.tabSetName}" value="batchConfig");
         createMap(result="#{pageSession.attrsMap}")
         mapPut(map="#{pageSession.attrsMap}" key="target" value="#{pageSession.encodedTarget}");
-        gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-batch-runtime-configuration"  method="GET" result="#{requestScope.resp}");
+        gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-batch-runtime-configuration?target=#{pageSession.target}"  method="GET" result="#{requestScope.resp}");
         setPageSessionAttribute(key="valueMap", value="#{requestScope.resp.data.extraProperties.listBatchRuntimeConfiguration}");
         mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.encodedTarget}");
     />


### PR DESCRIPTION
#42 fix for GlassFish-21018. Target was not passed to the list-batch-runtime-configuration REST call so only the DAS batch configuration is shown in the console.
