### PR TITLE
Incorporate C2B2 Eclipselink fix

### DIFF
--- a/appserver/packager/glassfish-jpa/pom.xml
+++ b/appserver/packager/glassfish-jpa/pom.xml
@@ -118,8 +118,25 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
+            </profile>
+            
+	    <profile>
+	               <id>payara_eclipselinkrepo</id>
+	                   <activation>
+	                          <activeByDefault>true</activeByDefault>
+	                   </activation>
+	                  <repositories>
+	                  		<repository>
+	               			<id>payara_eclipselinkrepo-release</id>
+	               			<releases>
+	               				<enabled>true</enabled>
+	               			</releases>
+	               			<url>https://raw.github.com/Payara/eclipselinkrepo/master/releases</url>
+	                   		</repository>
+	                  </repositories>
+	    </profile>
     </profiles>
+       
 
     <dependencies>
        <dependency>

--- a/appserver/packager/jersey/pom.xml
+++ b/appserver/packager/jersey/pom.xml
@@ -122,6 +122,21 @@
                 </plugins>
             </build>
         </profile>
+       		<profile>
+	               <id>payara_eclipselinkrepo</id>
+	                   <activation>
+	                          <activeByDefault>true</activeByDefault>
+	                   </activation>
+	                  <repositories>
+	                  		<repository>
+	               			<id>payara_eclipselinkrepo-release</id>
+	               			<releases>
+	               				<enabled>true</enabled>
+	               			</releases>
+	               			<url>https://raw.github.com/Payara/eclipselinkrepo/master/releases</url>
+	                   		</repository>
+	                  </repositories>
+	        </profile>
     </profiles>
 
     <dependencies>

--- a/appserver/persistence/eclipselink-wrapper/pom.xml
+++ b/appserver/persistence/eclipselink-wrapper/pom.xml
@@ -72,52 +72,79 @@
             </roles>
         </developer>
     </developers>
+    
+
+    <profiles>
+        <profile>
+           <id>payara_eclipselinkrepo</id>
+               <activation>
+                      <activeByDefault>true</activeByDefault>
+               </activation>
+              <repositories>
+              		<repository>
+           			<id>payara_eclipselinkrepo-release</id>
+           			<releases>
+           				<enabled>true</enabled>
+           			</releases>
+           			<url>https://raw.github.com/Payara/eclipselinkrepo/master/releases</url>
+               		</repository>
+              </repositories>
+           </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.core</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-            <version>${eclipselink.version}</version>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.dbws</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.oracle</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.antlr</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.asm</artifactId>
+             <version>2.5.2.p1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -107,7 +107,7 @@
         <jaxb.version>2.2.10-b140802.1033</jaxb.version>
         <stax2-api.version>3.1.1</stax2-api.version>
         <javax.xml.registry-api.version>1.0.5</javax.xml.registry-api.version>
-        <eclipselink.version>2.5.2-RC1</eclipselink.version>
+        <eclipselink.version>2.5.2.p1</eclipselink.version>
         <javax-persistence-api.version>2.1.0</javax-persistence-api.version> 
         <dbschema.version>3.1.1</dbschema.version>
         <dbschema.osgi.version>6.0</dbschema.osgi.version>

--- a/appserver/verifier/verifier-impl/pom.xml
+++ b/appserver/verifier/verifier-impl/pom.xml
@@ -91,6 +91,24 @@
             </roles>
         </developer>
     </developers>
+    
+    <profiles>
+        <profile>
+           <id>payara_eclipselinkrepo</id>
+               <activation>
+                      <activeByDefault>true</activeByDefault>
+               </activation>
+              <repositories>
+              		<repository>
+           			<id>payara_eclipselinkrepo-release</id>
+           			<releases>
+           				<enabled>true</enabled>
+           			</releases>
+           			<url>https://raw.github.com/Payara/eclipselinkrepo/master/releases</url>
+               		</repository>
+              </repositories>
+           </profile>
+    </profiles>
 
     <dependencies>
         <!-- All the dependencies have been marked provided so that 


### PR DESCRIPTION
Payara pom.xml changes to integrate eclipselink 2.5.2 RC-1 patched jars hosted on Payara/eclipselinkrepo
