### PR TITLE
Fix Debug not showing correctly in the console 

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/RuntimeInfo.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/RuntimeInfo.java
@@ -102,8 +102,9 @@ public class RuntimeInfo implements AdminCommand {
         report.setActionExitCode(SUCCESS);
         top = report.getTopMessagePart();
         logger = context.getLogger();
-        jpdaEnabled = Boolean.parseBoolean(ctx.getArguments().getProperty("-debug"));
+        boolean javaEnabledOnCmd = Boolean.parseBoolean(ctx.getArguments().getProperty("-debug"));
         javaConfig = config.getJavaConfig();
+        jpdaEnabled = javaEnabledOnCmd || Boolean.parseBoolean(javaConfig.getDebugEnabled());
         int debugPort = parsePort(javaConfig.getDebugOptions());
         top.addProperty("debug", Boolean.toString(jpdaEnabled));
         top.addProperty("debugPort", Integer.toString(debugPort));


### PR DESCRIPTION
Debug was not showing correctly in the console when enabled in the JVM settings but not on the command line with --debug. 
Fixed get-runtime-info service in the kernel to check both the command line and the debug JVM settings
