### PR TITLE
create-managed-executor-service does not propagate longrunningtasks parameter

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
@@ -200,6 +200,7 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         managedExecutorService.setKeepAliveSeconds(keepAliveSeconds);
         managedExecutorService.setThreadLifetimeSeconds(threadLifetimeSeconds);
         managedExecutorService.setEnabled(enabled);
+        managedExecutorService.setLongRunningTasks(longRunningTasks);
         if (properties != null) {
             for ( Map.Entry e : properties.entrySet()) {
                 Property prop = managedExecutorService.createChild(Property.class);


### PR DESCRIPTION
Fix #68 
This ensures the commandline property longrunningtasks is propagated correctly when creating a new ManagedExecutorService
