### PR TITLE
Force early creation of static transaction manager to fix GLASSFISH-21175

### DIFF
--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
@@ -142,6 +142,7 @@ public class JavaEETransactionManagerJTSDelegate
         initTransactionProperties();
 
         setInstance(this);
+        setTransactionManager();
     }
 
     public boolean useLAO() {

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/EventSemaphore.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/EventSemaphore.java
@@ -147,16 +147,16 @@ public class EventSemaphore {
      * @see
      */
     
-    synchronized public void waitTimeoutEvent(int cmtTimeout) 
-    	throws InterruptedException {
-    	
-    	if( !posted){
-    		    long timeout = (System.currentTimeMillis()/1000) + cmtTimeout;
-            	while( timeout - (System.currentTimeMillis()/1000) > 0 ){
-            		wait(timeout - (System.currentTimeMillis()/1000));
-            	}
-        	}
-    	}
+    synchronized public void waitTimeoutEvent(int cmtTimeout)
+            throws InterruptedException {
+
+        if (!posted) {
+            long timeout = (System.currentTimeMillis() / 1000) + cmtTimeout;
+            while (!posted && timeout - (System.currentTimeMillis() / 1000) > 0) {
+                wait(timeout - (System.currentTimeMillis() / 1000));
+            }
+        }
+    }
 
     /**Posts the event semaphore.
      * <p>


### PR DESCRIPTION
Further fix for GLASSFISH-21175. Lazy creation of transaction manager causes race condition in Resynch code of the RecoveryManager.

Forcing early creation of the singleton Transaction Manager ensures recovery starts before the creation of the first transaction.
