### PR TITLE
Integrate Jenkins Build ID into the Payara version

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -133,7 +133,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- on Hudson and RE, this gets replaced by real build ID -->
-        <build.id>4.1.144.p0</build.id>
+        <build.id>#badassfish-b${build.number}</build.id>
         <findbugs.skip>false</findbugs.skip>
         <findbugs.threshold>High</findbugs.threshold>
         <findbugs.common>exclude-common.xml</findbugs.common>


### PR DESCRIPTION
Integrates Jenkins build id into the mvn property so that we can relate the Payara version to the specific Jenkins Build
