### PR TITLE
Fix #122 JDBC Monitoring MBeans

### DIFF
--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/pool/monitor/JdbcConnPoolAppStatsProvider.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/pool/monitor/JdbcConnPoolAppStatsProvider.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2014] [C2B2 Consulting Limited]
 
 package org.glassfish.jdbc.pool.monitor;
 

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/pool/monitor/JdbcConnPoolStatsProvider.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/pool/monitor/JdbcConnPoolStatsProvider.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2014] [C2B2 Consulting Limited]
 
 package org.glassfish.jdbc.pool.monitor;
 


### PR DESCRIPTION
This pull requests fixes #122 and GLASSFISH-21272 certain attributes on the JDBC connection pool monitoring MBean show as UNAVAILABLE
