### PR TITLE
Fix for GLASSFISH-21017

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2015] [Zenthis Limited]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -117,6 +117,13 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
                     strings.get("new.mp.again"), true);
             if (nmp == null)
                 throw new CommandException(strings.get("no.console"));
+            
+            // if password is less than 6 characters then the domain can become corrupt
+            // FIXES GLASSFISH-21017
+            if (nmp.length() < 6) {
+                throw new CommandException(strings.get("password.too.short"));
+            }
+            
             domainConfig.put(DomainConfig.K_MASTER_PASSWORD, mp);
             domainConfig.put(DomainConfig.K_NEW_MASTER_PASSWORD, nmp);
             domainConfig.put(DomainConfig.K_SAVE_MASTER_PASSWORD, savemp);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2015] [Zenthis Limited]
 
 ## list-domains
 ## domain1 running
@@ -131,6 +132,7 @@ new.mp=Enter the new master password
 new.mp.again=Enter the new master password again
 both.domaindir.nodedir.not.allowed=You cannot specify both domaindir and nodedir together. \
 You can use one or the other.
+password.too.short=Master password length must be 6 characters or greater 
 ################################
 serviceUser_wrong_os=The serviceuser parameter is only supported on Linux.
 create.service.badServiceName=Windows requires that the service name contain only \


### PR DESCRIPTION
Fixes #141 GLASSFISH-21017
Domain keystore becomes corrupt if change-master-password is used with a password shorter than 6 characters