### PR TITLE
Fix UnifiedX509KeyManager GLASSFISH-21249

### DIFF
--- a/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/manager/UnifiedX509KeyManager.java
+++ b/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/manager/UnifiedX509KeyManager.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.security.ssl.manager;
 
@@ -136,7 +137,7 @@ public class UnifiedX509KeyManager implements X509KeyManager /* extends X509Exte
     public String[] getServerAliases(String keyType, Principal[] issuers) {
         ArrayList serverAliases = new ArrayList();
         for (int i = 0; i < mgrs.length; i++) {
-            String[] serAliases = mgrs[i].getClientAliases(keyType, issuers);
+            String[] serAliases = mgrs[i].getServerAliases(keyType, issuers);
             if (serAliases != null && serAliases.length > 0) {
                 for (int j = 0; j < serAliases.length; j++) {
                     serverAliases.add(serAliases[j]);


### PR DESCRIPTION
Fixes #85 GLASSFISH-21249 UnifiedX509KeyManager calls incorrect method on wrapped Key Manager.
getServerAliases calls getClientAliases on the wrapped key manager.