### PR TITLE
Revert Mojarra

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -65,7 +65,7 @@
         <jsp-impl.version>2.3.3-b02</jsp-impl.version>
         <jstl-impl.version>1.2.4</jstl-impl.version>
         <jstl-api.version>1.2.1</jstl-api.version>
-        <mojarra.version>2.2.9</mojarra.version>
+        <mojarra.version>2.2.7</mojarra.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>4.0.2.10</woodstock.version>
         <javax.ejb-api.version>3.2</javax.ejb-api.version>


### PR DESCRIPTION
Upgrading Mojarra to 2.2.9 builds the Jenkins build but not local builds. Revert until we can figure that out.