### PR TITLE
Integrate JBatch 1.0.1-b4

### DIFF
--- a/appserver/batch/glassfish-batch-connector/pom.xml
+++ b/appserver/batch/glassfish-batch-connector/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
 		<groupId>javax.batch</groupId>
 		<artifactId>javax.batch-api</artifactId>
-		<version>1.0</version>
+		<version>${javax.batch-api.version}</version>
 	</dependency>
         <dependency>
             <groupId>com.ibm.jbatch</groupId>

--- a/appserver/batch/glassfish-batch-connector/src/main/java/fish/payara/jbatch/persistence/rdbms/MySqlPersistenceManager.java
+++ b/appserver/batch/glassfish-batch-connector/src/main/java/fish/payara/jbatch/persistence/rdbms/MySqlPersistenceManager.java
@@ -119,16 +119,12 @@ public class MySqlPersistenceManager extends JBatchJDBCPersistenceManager {
 
 		try {
 			conn = getConnectionToDefaultSchema();
-			dbmd = conn.getMetaData();
-			rs = dbmd.getSchemas();
+                        PreparedStatement stmt = conn.prepareStatement("SHOW DATABASES like ?");
+                        stmt.setString(1, schema);
+			rs = stmt.executeQuery();
 
 			while (rs.next()) {
-
-				String schemaname = rs.getString("TABLE_SCHEM");
-				if (schema.equalsIgnoreCase(schemaname)) {
-					logger.exiting(CLASSNAME, "isMySQLSchemaValid", true);
-					return true;
-				}
+                            result = true;
 			}
 		} catch (SQLException e) {
 			logger.severe(e.getLocalizedMessage());

--- a/appserver/batch/glassfish-batch-connector/src/main/java/org/glassfish/batch/spi/impl/BatchRuntimeHelper.java
+++ b/appserver/batch/glassfish-batch-connector/src/main/java/org/glassfish/batch/spi/impl/BatchRuntimeHelper.java
@@ -172,13 +172,11 @@ public class BatchRuntimeHelper
         batchSPIManager.registerExecutorServiceProvider(glassFishBatchExecutorServiceProvider);
         batchSPIManager.registerBatchSecurityHelper(glassFishBatchSecurityHelper);
         // setting this puts JBatch into SE mode which is a JBatch bug.
-       // batchSPIManager.registerPlatformMode(BatchSPIManager.PlatformMode.EE);
+        batchSPIManager.registerPlatformMode(BatchSPIManager.PlatformMode.EE);
 
         Properties overrideProperties = new Properties();
         overrideProperties.put(PAYARA_TABLE_PREFIX_PROPERTY, batchRuntimeConfiguration.getTablePrefix());
         overrideProperties.put(PAYARA_TABLE_SUFFIX_PROPERTY, batchRuntimeConfiguration.getTableSuffix());
-
-        // uncomment when we incorporate the latest JBatch
         overrideProperties.put(ServiceTypes.PERSISTENCE_MANAGEMENT_SERVICE, determinePersistenceManagerClass());
         overrideProperties.put(ServiceTypes.CONTAINER_ARTIFACT_FACTORY_SERVICE,"com.ibm.jbatch.container.services.impl.CDIBatchArtifactFactoryImpl" );
         overrideProperties.put(ServiceTypes.BATCH_THREADPOOL_SERVICE, "com.ibm.jbatch.container.services.impl.SPIDelegatingThreadPoolServiceImpl");

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -126,8 +126,8 @@
         <concurrent-api.version>1.0</concurrent-api.version>
         <concurrent.version>1.0</concurrent.version>
         <javax.batch-api.version>1.0.1-b01</javax.batch-api.version>
-        <com.ibm.jbatch.container.version>1.0.1-b01</com.ibm.jbatch.container.version>
-        <com.ibm.jbatch.spi.version>1.0.1-b01</com.ibm.jbatch.spi.version>
+        <com.ibm.jbatch.container.version>1.0.1-b04</com.ibm.jbatch.container.version>
+        <com.ibm.jbatch.spi.version>1.0.1-b04</com.ibm.jbatch.spi.version>
         <javax.xml.soap-api.version>1.3.7</javax.xml.soap-api.version>
 	<javax.management.j2ee-api.version>1.1.1</javax.management.j2ee-api.version>
         <jboss.logging.version>3.1.3.GA</jboss.logging.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -125,9 +125,9 @@
         <jsonp-jaxrs.version>1.0</jsonp-jaxrs.version>
         <concurrent-api.version>1.0</concurrent-api.version>
         <concurrent.version>1.0</concurrent.version>
-        <javax.batch-api.version>1.0</javax.batch-api.version>
-        <com.ibm.jbatch.container.version>1.0.1-payara-p1</com.ibm.jbatch.container.version>
-        <com.ibm.jbatch.spi.version>1.0.1-payara-p1</com.ibm.jbatch.spi.version>
+        <javax.batch-api.version>1.0.1-b01</javax.batch-api.version>
+        <com.ibm.jbatch.container.version>1.0.1-b01</com.ibm.jbatch.container.version>
+        <com.ibm.jbatch.spi.version>1.0.1-b01</com.ibm.jbatch.spi.version>
         <javax.xml.soap-api.version>1.3.7</javax.xml.soap-api.version>
 	<javax.management.j2ee-api.version>1.1.1</javax.management.j2ee-api.version>
         <jboss.logging.version>3.1.3.GA</jboss.logging.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -172,7 +172,7 @@
         <grizzly.version>2.3.18</grizzly.version>
         <saaj-api.version>1.3.4</saaj-api.version>
         <hk2.version>2.4.0-b08</hk2.version>
-	<hk2.plugin.version>2.4.0-b06</hk2.plugin.version>
+	<hk2.plugin.version>2.4.0-b08</hk2.plugin.version>
         <javax.el.version>3.0.1-b03</javax.el.version>
         <javax.el-api.version>3.0.1-b03</javax.el-api.version>
         <trilead-ssh2.version>build212-hudson-6</trilead-ssh2.version>


### PR DESCRIPTION
Integrate the released JBatch upgrade, now it is on Maven Central and remove dependency on Payara patched JBatch.

Also fixes a bug in the MySQL Persistence where checking the schema exists failed.