### PR TITLE
Fix bug whereby Cache Key could be different for the same parameters

### DIFF
--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraCacheKeyInvocationContext.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraCacheKeyInvocationContext.java
@@ -20,6 +20,7 @@ package fish.payara.cdi.jsr107.impl;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -219,7 +220,7 @@ public class PayaraCacheKeyInvocationContext<A extends Annotation> implements Ca
     @Override
     public CacheInvocationParameter[] getKeyParameters() {
         CacheInvocationParameter allParams[] = getAllParameters();
-        HashSet<CacheInvocationParameter> result = new HashSet<>();
+        LinkedList<CacheInvocationParameter> result = new LinkedList<>();
 
         // add only CacheKey elements
         for (CacheInvocationParameter result1 : allParams) {


### PR DESCRIPTION
Replace use of HashSet with LinkedList as order of parameters used in the key could be different due to lack of order of iteration in a HashSet