### PR TITLE
Update version numbers for poms missed by maven-release-plugin

### DIFF
--- a/appserver/distributions/glassfish/pom.xml
+++ b/appserver/distributions/glassfish/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish</artifactId>
     <name>Glassfish Distribution</name>

--- a/appserver/distributions/minnow/pom.xml
+++ b/appserver/distributions/minnow/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>minnow</artifactId>
     <name>Glassfish Minnow Distribution</name>

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>web</artifactId>
     <name>Glassfish Web Distribution</name>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -46,11 +46,11 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-embedded-all</artifactId>
-    <version>4.1.151-SNAPSHOT</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>Embedded GlassFish All-In-One</name>
 
     <packaging>jar</packaging>

--- a/appserver/extras/embedded/nucleus/pom.xml
+++ b/appserver/extras/embedded/nucleus/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-embedded-nucleus</artifactId>

--- a/appserver/extras/embedded/pom.xml
+++ b/appserver/extras/embedded/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>embedded</artifactId>
     <packaging>pom</packaging>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -47,12 +47,12 @@
   <parent>
     <groupId>org.glassfish.main.extras</groupId>
     <artifactId>extras</artifactId>
-    <version>4.1.151-SNAPSHOT</version>
+    <version>4.1.152-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>glassfish-embedded-web</artifactId>
-  <version>4.1.151-SNAPSHOT</version>
+  <version>4.1.152-SNAPSHOT</version>
   <name>Embedded GlassFish Web</name>
       <packaging>jar</packaging>
 

--- a/appserver/installer/pom.xml
+++ b/appserver/installer/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     
     <groupId>org.glassfish.main.installer</groupId>

--- a/appserver/javaee-api/javax.javaee-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>javaee-api-parent</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javaee-api</artifactId>

--- a/appserver/javaee-api/javax.javaee-endorsed-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-endorsed-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>javaee-api-parent</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javaee-endorsed-api</artifactId>

--- a/appserver/javaee-api/javax.javaee-web-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-web-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>javaee-api-parent</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javaee-web-api</artifactId>

--- a/appserver/javaee-api/pom.xml
+++ b/appserver/javaee-api/pom.xml
@@ -46,11 +46,11 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151-SNAPSHOT</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>javaee-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.151-SNAPSHOT</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>JavaEE API</name>
     <description>Java EE API combined bundles</description>
 


### PR DESCRIPTION
The maven-release plugin missed some poms, I've manually updated them