### PR TITLE
Update Payara version to 4.1.152-SNAPSHOT

### DIFF
--- a/appserver/admin/admin-core/pom.xml
+++ b/appserver/admin/admin-core/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>admin-core</artifactId>

--- a/appserver/admin/backup-l10n/pom.xml
+++ b/appserver/admin/backup-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/admin/backup/pom.xml
+++ b/appserver/admin/backup/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>backup</artifactId>

--- a/appserver/admin/cli-optional-l10n/pom.xml
+++ b/appserver/admin/cli-optional-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cli-optional-l10n</artifactId>

--- a/appserver/admin/cli-optional/pom.xml
+++ b/appserver/admin/cli-optional/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>cli-optional</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admin/cli/pom.xml
+++ b/appserver/admin/cli/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>appserver-cli</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admin/pom.xml
+++ b/appserver/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.admin</groupId>

--- a/appserver/admin/template/pom.xml
+++ b/appserver/admin/template/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>appserver-domain</artifactId>

--- a/appserver/ant-tasks/pom.xml
+++ b/appserver/ant-tasks/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>  
     <artifactId>ant-tasks</artifactId>

--- a/appserver/appclient/client/acc-config/pom.xml
+++ b/appserver/appclient/client/acc-config/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>client</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/appclient/client/acc-l10n/pom.xml
+++ b/appserver/appclient/client/acc-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>client</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/appclient/client/acc-standalone-l10n/pom.xml
+++ b/appserver/appclient/client/acc-standalone-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>client</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/appclient/client/acc-standalone/pom.xml
+++ b/appserver/appclient/client/acc-standalone/pom.xml
@@ -61,7 +61,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>client</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>client</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gf-client-module</artifactId>

--- a/appserver/appclient/client/appclient-scripts/pom.xml
+++ b/appserver/appclient/client/appclient-scripts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>client</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>appclient-scripts</artifactId>

--- a/appserver/appclient/client/pom.xml
+++ b/appserver/appclient/client/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>appclient</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.appclient</groupId>
     <artifactId>client</artifactId>

--- a/appserver/appclient/pom.xml
+++ b/appserver/appclient/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>appclient</artifactId>
     <packaging>pom</packaging>

--- a/appserver/appclient/server/connector/pom.xml
+++ b/appserver/appclient/server/connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>server</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.main.appclient.server</groupId>

--- a/appserver/appclient/server/core-l10n/pom.xml
+++ b/appserver/appclient/server/core-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>server</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/appclient/server/core/pom.xml
+++ b/appserver/appclient/server/core/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.appclient</groupId>
         <artifactId>server</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.main.appclient.server</groupId>

--- a/appserver/appclient/server/pom.xml
+++ b/appserver/appclient/server/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>appclient</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.appclient</groupId>

--- a/appserver/batch/batch-database/pom.xml
+++ b/appserver/batch/batch-database/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>org.glassfish.main.batch</groupId>
         <artifactId>batch</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>batch-databases</artifactId>

--- a/appserver/batch/glassfish-batch-commands/pom.xml
+++ b/appserver/batch/glassfish-batch-commands/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.batch</groupId>
         <artifactId>batch</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/batch/glassfish-batch-connector/pom.xml
+++ b/appserver/batch/glassfish-batch-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.batch</groupId>
         <artifactId>batch</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/batch/hazelcast-jbatch-store/pom.xml
+++ b/appserver/batch/hazelcast-jbatch-store/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.main.batch</groupId>
         <artifactId>batch</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/batch/jbatch-repackaged/pom.xml
+++ b/appserver/batch/jbatch-repackaged/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.main.batch</groupId>
         <artifactId>batch</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/batch/pom.xml
+++ b/appserver/batch/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/common/amx-javaee/pom.xml
+++ b/appserver/common/amx-javaee/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>amx-javaee</artifactId>

--- a/appserver/common/annotation-framework-l10n/pom.xml
+++ b/appserver/common/annotation-framework-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>annotation-framework-l10n</artifactId>

--- a/appserver/common/annotation-framework/pom.xml
+++ b/appserver/common/annotation-framework/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>annotation-framework</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/common/container-common-l10n/pom.xml
+++ b/appserver/common/container-common-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/common/container-common/pom.xml
+++ b/appserver/common/container-common/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/common/glassfish-ee-api/pom.xml
+++ b/appserver/common/glassfish-ee-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>    
     <artifactId>glassfish-ee-api</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/common/glassfish-naming-l10n/pom.xml
+++ b/appserver/common/glassfish-naming-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/common/glassfish-naming/pom.xml
+++ b/appserver/common/glassfish-naming/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish-naming</artifactId>

--- a/appserver/common/mejb-frag/pom.xml
+++ b/appserver/common/mejb-frag/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>mejb-frag</artifactId>

--- a/appserver/common/mejb/pom.xml
+++ b/appserver/common/mejb/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mejb</artifactId>

--- a/appserver/common/pom.xml
+++ b/appserver/common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.common</groupId>

--- a/appserver/common/stats77-l10n/pom.xml
+++ b/appserver/common/stats77-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/common/stats77/pom.xml
+++ b/appserver/common/stats77/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>stats77</artifactId>

--- a/appserver/concurrent/concurrent-connector-l10n/pom.xml
+++ b/appserver/concurrent/concurrent-connector-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.concurrent</groupId>
         <artifactId>concurrent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/concurrent/concurrent-connector/pom.xml
+++ b/appserver/concurrent/concurrent-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.concurrent</groupId>
         <artifactId>concurrent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>    
     <artifactId>concurrent-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/concurrent/concurrent-impl-l10n/pom.xml
+++ b/appserver/concurrent/concurrent-impl-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.concurrent</groupId>
         <artifactId>concurrent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.concurrent</groupId>
         <artifactId>concurrent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>    
     <artifactId>concurrent-impl</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/concurrent/pom.xml
+++ b/appserver/concurrent/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +53,7 @@
     <artifactId>concurrent</artifactId>
     <name>Concurrency Utilities Modules</name>
     <packaging>pom</packaging>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
 
     <developers>
         <developer>

--- a/appserver/connectors/admin-l10n/pom.xml
+++ b/appserver/connectors/admin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>connectors-admin-l10n</artifactId>

--- a/appserver/connectors/admin/pom.xml
+++ b/appserver/connectors/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>    
     <artifactId>connectors-admin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/connectors/connectors-connector/pom.xml
+++ b/appserver/connectors/connectors-connector/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gf-connectors-connector</artifactId>

--- a/appserver/connectors/connectors-inbound-runtime-l10n/pom.xml
+++ b/appserver/connectors/connectors-inbound-runtime-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/connectors/connectors-inbound-runtime/pom.xml
+++ b/appserver/connectors/connectors-inbound-runtime/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/connectors/connectors-internal-api-l10n/pom.xml
+++ b/appserver/connectors/connectors-internal-api-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/connectors/connectors-internal-api/pom.xml
+++ b/appserver/connectors/connectors-internal-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/connectors/connectors-runtime-l10n/pom.xml
+++ b/appserver/connectors/connectors-runtime-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/connectors/connectors-runtime/pom.xml
+++ b/appserver/connectors/connectors-runtime/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/connectors/descriptors/pom.xml
+++ b/appserver/connectors/descriptors/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>descriptors</artifactId>
     <packaging>distribution-fragment</packaging>

--- a/appserver/connectors/pom.xml
+++ b/appserver/connectors/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.connectors</groupId>
     <artifactId>connectors</artifactId>

--- a/appserver/connectors/work-management-l10n/pom.xml
+++ b/appserver/connectors/work-management-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>work-management-l10n</artifactId>

--- a/appserver/connectors/work-management/pom.xml
+++ b/appserver/connectors/work-management/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>work-management</artifactId>

--- a/appserver/core/api-exporter-fragment/pom.xml
+++ b/appserver/core/api-exporter-fragment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>api-exporter-fragment</artifactId>

--- a/appserver/core/javaee-kernel/pom.xml
+++ b/appserver/core/javaee-kernel/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaee-kernel</artifactId>

--- a/appserver/core/pom.xml
+++ b/appserver/core/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>org.glassfish.main.core</groupId>

--- a/appserver/deployment/client-l10n/pom.xml
+++ b/appserver/deployment/client-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>deployment-client-l10n</artifactId>

--- a/appserver/deployment/client/pom.xml
+++ b/appserver/deployment/client/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>deployment-client</artifactId>

--- a/appserver/deployment/dol-l10n/pom.xml
+++ b/appserver/deployment/dol-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dol-l10n</artifactId>

--- a/appserver/deployment/dol/pom.xml
+++ b/appserver/deployment/dol/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dol</artifactId>

--- a/appserver/deployment/dtds/pom.xml
+++ b/appserver/deployment/dtds/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>dtds</artifactId>
     <packaging>distribution-fragment</packaging>

--- a/appserver/deployment/javaee-core-l10n/pom.xml
+++ b/appserver/deployment/javaee-core-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/deployment/javaee-core/pom.xml
+++ b/appserver/deployment/javaee-core/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/deployment/javaee-full-l10n/pom.xml
+++ b/appserver/deployment/javaee-full-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/deployment/javaee-full/pom.xml
+++ b/appserver/deployment/javaee-full/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/deployment/jsr88-jar/pom.xml
+++ b/appserver/deployment/jsr88-jar/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.deployment</groupId>

--- a/appserver/deployment/jsr88-jar/sun-as-jsr88-dm-frag/pom.xml
+++ b/appserver/deployment/jsr88-jar/sun-as-jsr88-dm-frag/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>jsr-88</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>sun-as-jsr88-dm-frag</artifactId>

--- a/appserver/deployment/jsr88-jar/sun-as-jsr88-dm/pom.xml
+++ b/appserver/deployment/jsr88-jar/sun-as-jsr88-dm/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>jsr-88</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>sun-as-jsr88-dm</artifactId>

--- a/appserver/deployment/pom.xml
+++ b/appserver/deployment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.deployment</groupId>

--- a/appserver/deployment/schemas/pom.xml
+++ b/appserver/deployment/schemas/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>schemas</artifactId>
     <packaging>distribution-fragment</packaging>

--- a/appserver/distributions/glassfish/pom.xml
+++ b/appserver/distributions/glassfish/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish</artifactId>
     <name>Glassfish Distribution</name>

--- a/appserver/distributions/minnow/pom.xml
+++ b/appserver/distributions/minnow/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>minnow</artifactId>
     <name>Glassfish Minnow Distribution</name>

--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-ml</artifactId>
     <name>Payara Multi-Language Distribution</name>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-web-ml</artifactId>
     <name>Payara Web Multi-Language Distribution</name>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-web</artifactId>
     <name>Payara Web Distribution</name>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara</artifactId>
     <name>Payara Distribution</name>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>org.glassfish.main.distributions</groupId>

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>web</artifactId>
     <name>Glassfish Web Distribution</name>

--- a/appserver/ejb/ejb-all/pom.xml
+++ b/appserver/ejb/ejb-all/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/ejb/ejb-connector-l10n/pom.xml
+++ b/appserver/ejb/ejb-connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-ejb-connector-l10n</artifactId>

--- a/appserver/ejb/ejb-connector/pom.xml
+++ b/appserver/ejb/ejb-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-ejb-connector</artifactId>

--- a/appserver/ejb/ejb-container-l10n/pom.xml
+++ b/appserver/ejb/ejb-container-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ejb-container-l10n</artifactId>

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/ejb/ejb-full-container/pom.xml
+++ b/appserver/ejb/ejb-full-container/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/ejb/ejb-internal-api/pom.xml
+++ b/appserver/ejb/ejb-internal-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/ejb/ejb-timer-databases/pom.xml
+++ b/appserver/ejb/ejb-timer-databases/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>org.glassfish.main.ejb</groupId>
         <artifactId>ejb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>ejb-timer-databases</artifactId>

--- a/appserver/ejb/ejb-timer-service-app/pom.xml
+++ b/appserver/ejb/ejb-timer-service-app/pom.xml
@@ -45,7 +45,7 @@
    <parent>
        <groupId>org.glassfish.main.ejb</groupId>
        <artifactId>ejb</artifactId>
-       <version>4.1.151</version>
+       <version>4.1.152-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/appserver/ejb/pom.xml
+++ b/appserver/ejb/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.ejb</groupId>
     <artifactId>ejb</artifactId>

--- a/appserver/extras/appserv-rt/dist-frag/pom.xml
+++ b/appserver/extras/appserv-rt/dist-frag/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>appserv-rt-pom</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <name>GlassFish appserv-rt distribution fragment</name>
     <artifactId>appserv-rt-frag</artifactId>

--- a/appserver/extras/appserv-rt/manifest-jar/pom.xml
+++ b/appserver/extras/appserv-rt/manifest-jar/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>appserv-rt-pom</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/extras/appserv-rt/pom.xml
+++ b/appserver/extras/appserv-rt/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -46,11 +46,11 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-embedded-all</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>Embedded GlassFish All-In-One</name>
 
     <packaging>jar</packaging>

--- a/appserver/extras/embedded/nucleus/pom.xml
+++ b/appserver/extras/embedded/nucleus/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-embedded-nucleus</artifactId>

--- a/appserver/extras/embedded/pom.xml
+++ b/appserver/extras/embedded/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>embedded</artifactId>
     <packaging>pom</packaging>

--- a/appserver/extras/embedded/shell/glassfish-embedded-shell-frag/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-shell-frag/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/appserver/extras/embedded/shell/glassfish-embedded-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-shell/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-embedded-shell</artifactId>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell-frag/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell-frag/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -46,12 +46,12 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <artifactId>glassfish-embedded-static-shell</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>Embedded GlassFish Static Shell</name>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/extras/embedded/shell/pom.xml
+++ b/appserver/extras/embedded/shell/pom.xml
@@ -47,12 +47,12 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>glassfish-embedded-shell-jar</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
 
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -47,12 +47,12 @@
   <parent>
     <groupId>org.glassfish.main.extras</groupId>
     <artifactId>extras</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>glassfish-embedded-web</artifactId>
-  <version>4.1.151</version>
+  <version>4.1.152-SNAPSHOT</version>
   <name>Embedded GlassFish Web</name>
       <packaging>jar</packaging>
 

--- a/appserver/extras/javaee/dist-frag/pom.xml
+++ b/appserver/extras/javaee/dist-frag/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>javaee-pom</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <name>GlassFish javaee.jar distribution fragment</name>
     <artifactId>javaee-frag</artifactId>

--- a/appserver/extras/javaee/manifest-jar/pom.xml
+++ b/appserver/extras/javaee/manifest-jar/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>javaee-pom</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <name>GlassFish javaee.jar </name>

--- a/appserver/extras/javaee/pom.xml
+++ b/appserver/extras/javaee/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.extras</groupId>
     <artifactId>extras</artifactId>

--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish</artifactId>
     <name>Glassfish Featureset</name>

--- a/appserver/featuresets/minnow-ml/pom.xml
+++ b/appserver/featuresets/minnow-ml/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>minnow-ml</artifactId>
     <name>Glassfish Minnow Multi-Language Featureset</name>

--- a/appserver/featuresets/minnow/pom.xml
+++ b/appserver/featuresets/minnow/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>minnow</artifactId>
     <name>Glassfish Minnow Featureset</name>

--- a/appserver/featuresets/payara-ml/pom.xml
+++ b/appserver/featuresets/payara-ml/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-ml</artifactId>
     <name>Payara Multi-Language Featureset</name>

--- a/appserver/featuresets/payara-web-ml/pom.xml
+++ b/appserver/featuresets/payara-web-ml/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-web-ml</artifactId>
     <name>Payara Web Multi-Language Featureset</name>

--- a/appserver/featuresets/payara-web/pom.xml
+++ b/appserver/featuresets/payara-web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-web</artifactId>
     <name>Payara Web Featureset</name>

--- a/appserver/featuresets/payara/pom.xml
+++ b/appserver/featuresets/payara/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara</artifactId>
     <name>Payara Featureset</name>

--- a/appserver/featuresets/pom.xml
+++ b/appserver/featuresets/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>org.glassfish.main.featuresets</groupId>

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.featuresets</groupId>
         <artifactId>featuresets</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>web</artifactId>
     <name>Glassfish Web Featureset</name>

--- a/appserver/flashlight/btrace/pom.xml
+++ b/appserver/flashlight/btrace/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../common/pom.xml</relativePath>
     </parent>
 

--- a/appserver/flashlight/client/pom.xml
+++ b/appserver/flashlight/client/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../common/pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.flashlight</groupId>

--- a/appserver/flashlight/pom.xml
+++ b/appserver/flashlight/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.flashlight</groupId>

--- a/appserver/grizzly/glassfish-grizzly-extra-all/pom.xml
+++ b/appserver/grizzly/glassfish-grizzly-extra-all/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.grizzly</groupId>
         <artifactId>glassfish-grizzly</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/grizzly/glassfish-spdy/pom.xml
+++ b/appserver/grizzly/glassfish-spdy/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.grizzly</groupId>
         <artifactId>glassfish-grizzly</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/grizzly/grizzly-container/pom.xml
+++ b/appserver/grizzly/grizzly-container/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.grizzly</groupId>
         <artifactId>glassfish-grizzly</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/grizzly/pom.xml
+++ b/appserver/grizzly/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.grizzly</groupId>

--- a/appserver/ha/ha-file-store/pom.xml
+++ b/appserver/ha/ha-file-store/pom.xml
@@ -44,7 +44,7 @@
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/ha/ha-hazelcast-store/pom.xml
+++ b/appserver/ha/ha-hazelcast-store/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/ha/ha-shoal-cache-bootstrap/pom.xml
+++ b/appserver/ha/ha-shoal-cache-bootstrap/pom.xml
@@ -44,7 +44,7 @@
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/ha/ha-shoal-store/pom.xml
+++ b/appserver/ha/ha-shoal-store/pom.xml
@@ -44,7 +44,7 @@
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/ha/pom.xml
+++ b/appserver/ha/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.ha</groupId>

--- a/appserver/installer/pom.xml
+++ b/appserver/installer/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     
     <groupId>org.glassfish.main.installer</groupId>

--- a/appserver/javaee-api/javax.javaee-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>javaee-api-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javaee-api</artifactId>

--- a/appserver/javaee-api/javax.javaee-endorsed-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-endorsed-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>javaee-api-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javaee-endorsed-api</artifactId>

--- a/appserver/javaee-api/javax.javaee-web-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-web-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>javaee-api-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javaee-web-api</artifactId>

--- a/appserver/javaee-api/pom.xml
+++ b/appserver/javaee-api/pom.xml
@@ -46,11 +46,11 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>javaee-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>JavaEE API</name>
     <description>Java EE API combined bundles</description>
 

--- a/appserver/jdbc/admin-l10n/pom.xml
+++ b/appserver/jdbc/admin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-admin-l10n</artifactId>

--- a/appserver/jdbc/admin/pom.xml
+++ b/appserver/jdbc/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jdbc-admin</artifactId>

--- a/appserver/jdbc/jdbc-config-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-config-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-config-l10n</artifactId>

--- a/appserver/jdbc/jdbc-config/pom.xml
+++ b/appserver/jdbc/jdbc-config/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/jdbc/jdbc-ra/jdbc-core-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc.jdbc-ra</groupId>
         <artifactId>jdbc-ra</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-core-l10n</artifactId>

--- a/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
@@ -45,7 +45,7 @@
   <parent>
     <artifactId>jdbc-ra</artifactId>
     <groupId>org.glassfish.main.jdbc.jdbc-ra</groupId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/appserver/jdbc/jdbc-ra/jdbc-ra-distribution/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-ra-distribution/pom.xml
@@ -45,7 +45,7 @@
   <parent>
     <artifactId>jdbc-ra</artifactId>
     <groupId>org.glassfish.main.jdbc.jdbc-ra</groupId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/appserver/jdbc/jdbc-ra/jdbc30/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc30/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <artifactId>jdbc-ra</artifactId>
         <groupId>org.glassfish.main.jdbc.jdbc-ra</groupId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/jdbc/jdbc-ra/jdbc40/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc40/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <artifactId>jdbc-ra</artifactId>
         <groupId>org.glassfish.main.jdbc.jdbc-ra</groupId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/jdbc/jdbc-ra/pom.xml
+++ b/appserver/jdbc/jdbc-ra/pom.xml
@@ -45,7 +45,7 @@
   <parent>
       <groupId>org.glassfish.main</groupId>
       <artifactId>glassfish-parent</artifactId>
-      <version>4.1.151</version>
+      <version>4.1.152-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -54,7 +54,7 @@
   <artifactId>jdbc-ra</artifactId>
   <name>JDBC Resource Adapter</name>
   <packaging>pom</packaging>
-  <version>4.1.151</version>
+  <version>4.1.152-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/appserver/jdbc/jdbc-runtime-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-runtime-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-runtime-l10n</artifactId>

--- a/appserver/jdbc/jdbc-runtime/pom.xml
+++ b/appserver/jdbc/jdbc-runtime/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jdbc-runtime</artifactId>

--- a/appserver/jdbc/pom.xml
+++ b/appserver/jdbc/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +53,7 @@
     <artifactId>jdbc</artifactId>
     <name>JDBC Module</name>
     <packaging>pom</packaging>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/appserver/jdbc/templates/pom.xml
+++ b/appserver/jdbc/templates/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.jdbc</groupId>
         <artifactId>jdbc</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/jms/admin-l10n/pom.xml
+++ b/appserver/jms/admin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jms-admin-l10n</artifactId>

--- a/appserver/jms/admin/pom.xml
+++ b/appserver/jms/admin/pom.xml
@@ -46,13 +46,13 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jms-admin</artifactId>
     <packaging>glassfish-jar</packaging>
     
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>JMS admin</name>
 
     <developers>

--- a/appserver/jms/gf-jms-connector-l10n/pom.xml
+++ b/appserver/jms/gf-jms-connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-jms-connector-l10n</artifactId>

--- a/appserver/jms/gf-jms-connector/pom.xml
+++ b/appserver/jms/gf-jms-connector/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +53,7 @@
     <packaging>glassfish-jar</packaging>
     <name>JMS Connector Module for Runtime</name>
     
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <developers>
         <developer>
             <id>vijc</id>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>internal-api</artifactId>
-            <version>4.1.151</version>
+            <version>4.1.152-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/appserver/jms/gf-jms-injection-l10n/pom.xml
+++ b/appserver/jms/gf-jms-injection-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-jms-injection-l10n</artifactId>

--- a/appserver/jms/gf-jms-injection/pom.xml
+++ b/appserver/jms/gf-jms-injection/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -53,7 +53,7 @@
     <artifactId>gf-jms-injection</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>JMS Injection Module for Runtime</name>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
 
     <developers>
         <developer>

--- a/appserver/jms/jms-core-l10n/pom.xml
+++ b/appserver/jms/jms-core-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jms-core-l10n</artifactId>

--- a/appserver/jms/jms-core/pom.xml
+++ b/appserver/jms/jms-core/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.jms</groupId>
         <artifactId>jms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/jms/pom.xml
+++ b/appserver/jms/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.jms</groupId>

--- a/appserver/load-balancer/admin-l10n/pom.xml
+++ b/appserver/load-balancer/admin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.loadbalancer</groupId>
         <artifactId>load-balancer</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/load-balancer/admin/pom.xml
+++ b/appserver/load-balancer/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.loadbalancer</groupId>
         <artifactId>load-balancer</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>load-balancer-admin</artifactId>

--- a/appserver/load-balancer/gf-load-balancer-connector-l10n/pom.xml
+++ b/appserver/load-balancer/gf-load-balancer-connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.loadbalancer</groupId>
         <artifactId>load-balancer</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/load-balancer/gf-load-balancer-connector/pom.xml
+++ b/appserver/load-balancer/gf-load-balancer-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.loadbalancer</groupId>
         <artifactId>load-balancer</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-load-balancer-connector</artifactId>

--- a/appserver/load-balancer/pom.xml
+++ b/appserver/load-balancer/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.loadbalancer</groupId>

--- a/appserver/orb/orb-connector-l10n/pom.xml
+++ b/appserver/orb/orb-connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.orb</groupId>
         <artifactId>orb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/orb/orb-connector/pom.xml
+++ b/appserver/orb/orb-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.orb</groupId>
         <artifactId>orb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>orb-connector</artifactId>

--- a/appserver/orb/orb-enabler/pom.xml
+++ b/appserver/orb/orb-enabler/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.orb</groupId>
         <artifactId>orb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>orb-enabler</artifactId>

--- a/appserver/orb/orb-iiop/pom.xml
+++ b/appserver/orb/orb-iiop/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.orb</groupId>
         <artifactId>orb</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>orb-iiop</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/orb/pom.xml
+++ b/appserver/orb/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.orb</groupId>

--- a/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
+++ b/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.main.osgi-platforms</groupId>
         <artifactId>osgi-console-extensions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>felix-webconsole-extension</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/osgi-platforms/payara-osgi-console-plugin-l10n/pom.xml
+++ b/appserver/osgi-platforms/payara-osgi-console-plugin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../payara-admingui/pom.xml</relativePath>
     </parent>
 

--- a/appserver/osgi-platforms/payara-osgi-console-plugin/pom.xml
+++ b/appserver/osgi-platforms/payara-osgi-console-plugin/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
       <relativePath>../../payara-admingui/pom.xml</relativePath>
     </parent>
     <artifactId>payara-osgi-console-plugin</artifactId>

--- a/appserver/osgi-platforms/pom.xml
+++ b/appserver/osgi-platforms/pom.xml
@@ -47,7 +47,7 @@
     <parent>
       <groupId>org.glassfish.main</groupId>
       <artifactId>glassfish-parent</artifactId>
-      <version>4.1.151</version>
+      <version>4.1.152-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/appserver/packager/appserver-base/pom.xml
+++ b/appserver/packager/appserver-base/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appserver-base</artifactId>

--- a/appserver/packager/external/ant/pom.xml
+++ b/appserver/packager/external/ant/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ant</artifactId>

--- a/appserver/packager/external/javadb/pom.xml
+++ b/appserver/packager/external/javadb/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javadb</artifactId>

--- a/appserver/packager/external/jaxr_ra/pom.xml
+++ b/appserver/packager/external/jaxr_ra/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jaxr-ra</artifactId>

--- a/appserver/packager/external/jmsra/pom.xml
+++ b/appserver/packager/external/jmsra/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jmsra</artifactId>

--- a/appserver/packager/external/libpam4j/pom.xml
+++ b/appserver/packager/external/libpam4j/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/packager/external/pom.xml
+++ b/appserver/packager/external/pom.xml
@@ -51,7 +51,7 @@
     <parent>
       <groupId>org.glassfish.main</groupId>
       <artifactId>glassfish-parent</artifactId>
-      <version>4.1.151</version>
+      <version>4.1.152-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/appserver/packager/felix/pom.xml
+++ b/appserver/packager/felix/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>felix</artifactId>
     <name>Felix Package</name>

--- a/appserver/packager/glassfish-ant-tasks/pom.xml
+++ b/appserver/packager/glassfish-ant-tasks/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-ant-tasks</artifactId>
     <name>GlassFish Ant Tasks Package</name>

--- a/appserver/packager/glassfish-appclient-l10n/pom.xml
+++ b/appserver/packager/glassfish-appclient-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-appclient-l10n</artifactId>
     <name>Glassfish Application Client l10n Package</name>

--- a/appserver/packager/glassfish-appclient/pom.xml
+++ b/appserver/packager/glassfish-appclient/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-appclient</artifactId>
     <name>Glassfish Application Client Package</name>

--- a/appserver/packager/glassfish-cluster-l10n/pom.xml
+++ b/appserver/packager/glassfish-cluster-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-cluster-l10n</artifactId>
     <name>Glassfish cluster l10n Package</name>

--- a/appserver/packager/glassfish-cluster/pom.xml
+++ b/appserver/packager/glassfish-cluster/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-cluster</artifactId>
     <name>Glassfish Clustering Package</name>

--- a/appserver/packager/glassfish-cmp-l10n/pom.xml
+++ b/appserver/packager/glassfish-cmp-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-cmp-l10n</artifactId>
     <name>Glassfish CMP l10n Package</name>

--- a/appserver/packager/glassfish-cmp/pom.xml
+++ b/appserver/packager/glassfish-cmp/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-cmp</artifactId>
     <name>Glassfish CMP Package</name>

--- a/appserver/packager/glassfish-common-full-l10n/pom.xml
+++ b/appserver/packager/glassfish-common-full-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-common-full-l10n</artifactId>
     <name>Glassfish Commons for Full Distribution l10n</name>

--- a/appserver/packager/glassfish-common-full/pom.xml
+++ b/appserver/packager/glassfish-common-full/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-common-full</artifactId>
     <name>Glassfish Commons for Full Distribution </name>

--- a/appserver/packager/glassfish-common-l10n/pom.xml
+++ b/appserver/packager/glassfish-common-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-common-l10n</artifactId>
     <name>Glassfish Commons l10n Package</name>

--- a/appserver/packager/glassfish-common-web-l10n/pom.xml
+++ b/appserver/packager/glassfish-common-web-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-common-web-l10n</artifactId>
     <name>Glassfish Commons Web l10n Package</name>

--- a/appserver/packager/glassfish-common-web/pom.xml
+++ b/appserver/packager/glassfish-common-web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-common-web</artifactId>
     <name>Glassfish Commons for Web Profile Distribution </name>

--- a/appserver/packager/glassfish-common/pom.xml
+++ b/appserver/packager/glassfish-common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-common</artifactId>
     <name>Glassfish Commons Package</name>

--- a/appserver/packager/glassfish-corba-base/pom.xml
+++ b/appserver/packager/glassfish-corba-base/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-corba-base</artifactId>
     <name>Base CORBA APIs Package</name>

--- a/appserver/packager/glassfish-corba/pom.xml
+++ b/appserver/packager/glassfish-corba/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-corba</artifactId>
     <name>Corba Package</name>

--- a/appserver/packager/glassfish-ejb-l10n/pom.xml
+++ b/appserver/packager/glassfish-ejb-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-ejb-l10n</artifactId>
     <name>Glassfish EJB l10n Package</name>

--- a/appserver/packager/glassfish-ejb-lite-l10n/pom.xml
+++ b/appserver/packager/glassfish-ejb-lite-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-ejb-lite-l10n</artifactId>
     <name>Glassfish EJB Lite Container l10n Package</name>

--- a/appserver/packager/glassfish-ejb-lite/pom.xml
+++ b/appserver/packager/glassfish-ejb-lite/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-ejb-lite</artifactId>
     <name>Glassfish EJB Lite Container Package</name>

--- a/appserver/packager/glassfish-ejb/pom.xml
+++ b/appserver/packager/glassfish-ejb/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-ejb</artifactId>
     <name>Glassfish EJB Package</name>

--- a/appserver/packager/glassfish-entitybeans-container/pom.xml
+++ b/appserver/packager/glassfish-entitybeans-container/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-entitybeans-container</artifactId>
     <name>Glassfish EntityBeans Container Package</name>

--- a/appserver/packager/glassfish-full-incorporation/pom.xml
+++ b/appserver/packager/glassfish-full-incorporation/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-full-incorporation</artifactId>
     <name>Glassfish Full Profile Incorporation Package</name>

--- a/appserver/packager/glassfish-full-profile/pom.xml
+++ b/appserver/packager/glassfish-full-profile/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-full-profile</artifactId>
     <name>Glassfish Full Profile Metapackage</name>

--- a/appserver/packager/glassfish-grizzly-full/pom.xml
+++ b/appserver/packager/glassfish-grizzly-full/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-grizzly-full</artifactId>
     <name>Glassfish Grizzly Package</name>

--- a/appserver/packager/glassfish-grizzly/pom.xml
+++ b/appserver/packager/glassfish-grizzly/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-grizzly</artifactId>
     <name>Glassfish Grizzly Package</name>

--- a/appserver/packager/glassfish-gui-l10n/pom.xml
+++ b/appserver/packager/glassfish-gui-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-gui-l10n</artifactId>
     <name>Glassfish Admin GUI Localization Package</name>

--- a/appserver/packager/glassfish-gui/pom.xml
+++ b/appserver/packager/glassfish-gui/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-gui</artifactId>
     <name>Glassfish Admin GUI Package</name>

--- a/appserver/packager/glassfish-ha/pom.xml
+++ b/appserver/packager/glassfish-ha/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-ha</artifactId>
     <name>Glassfish HA Package</name>

--- a/appserver/packager/glassfish-hk2/pom.xml
+++ b/appserver/packager/glassfish-hk2/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-hk2</artifactId>
     <name>GlassFish HK2 Package</name>

--- a/appserver/packager/glassfish-javahelp/pom.xml
+++ b/appserver/packager/glassfish-javahelp/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-javahelp</artifactId>
     <name>Glassfish JavaHelp Package</name>

--- a/appserver/packager/glassfish-jca-l10n/pom.xml
+++ b/appserver/packager/glassfish-jca-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jca-l10n</artifactId>
     <name>Glassfish Connector l10n Package</name>

--- a/appserver/packager/glassfish-jca/pom.xml
+++ b/appserver/packager/glassfish-jca/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jca</artifactId>
     <name>Glassfish Connector Package</name>

--- a/appserver/packager/glassfish-jcdi/pom.xml
+++ b/appserver/packager/glassfish-jcdi/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jcdi</artifactId>
     <name>Glassfish JCDI Package</name>

--- a/appserver/packager/glassfish-jdbc-l10n/pom.xml
+++ b/appserver/packager/glassfish-jdbc-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jdbc-l10n</artifactId>
     <name>Glassfish JDBC l10n Package</name>

--- a/appserver/packager/glassfish-jdbc/pom.xml
+++ b/appserver/packager/glassfish-jdbc/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jdbc</artifactId>
     <name>Glassfish JDBC Package</name>

--- a/appserver/packager/glassfish-jms-l10n/pom.xml
+++ b/appserver/packager/glassfish-jms-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jms-l10n</artifactId>
     <name>Glassfish Java Message Service l10n</name>

--- a/appserver/packager/glassfish-jms/pom.xml
+++ b/appserver/packager/glassfish-jms/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jms</artifactId>
     <name>Glassfish Java Message Service</name>

--- a/appserver/packager/glassfish-jmx/pom.xml
+++ b/appserver/packager/glassfish-jmx/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jmx</artifactId>
     <name>Glassfish JMX Package</name>

--- a/appserver/packager/glassfish-jpa-l10n/pom.xml
+++ b/appserver/packager/glassfish-jpa-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jpa-l10n</artifactId>
     <name>Glassfish JPA l10n Package</name>

--- a/appserver/packager/glassfish-jpa/pom.xml
+++ b/appserver/packager/glassfish-jpa/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jpa</artifactId>
     <name>Glassfish JPA Package</name>

--- a/appserver/packager/glassfish-jsf/pom.xml
+++ b/appserver/packager/glassfish-jsf/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jsf</artifactId>
     <name>Glassfish JSF Package</name>

--- a/appserver/packager/glassfish-jta-l10n/pom.xml
+++ b/appserver/packager/glassfish-jta-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jta-l10n</artifactId>
     <name>Glassfish Transaction Package l10n</name>

--- a/appserver/packager/glassfish-jta/pom.xml
+++ b/appserver/packager/glassfish-jta/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jta</artifactId>
     <name>Glassfish Transaction Package</name>

--- a/appserver/packager/glassfish-jts-l10n/pom.xml
+++ b/appserver/packager/glassfish-jts-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jts-l10n</artifactId>
     <name>Glassfish Java Transaction Service l10n</name>

--- a/appserver/packager/glassfish-jts/pom.xml
+++ b/appserver/packager/glassfish-jts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-jts</artifactId>
     <name>Glassfish Java Transaction Service</name>

--- a/appserver/packager/glassfish-management-l10n/pom.xml
+++ b/appserver/packager/glassfish-management-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-management-l10n</artifactId>
     <name>Glassfish Management Package l10n Package</name>

--- a/appserver/packager/glassfish-management/pom.xml
+++ b/appserver/packager/glassfish-management/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-management</artifactId>
     <name>Glassfish Management Package</name>

--- a/appserver/packager/glassfish-nucleus-l10n/pom.xml
+++ b/appserver/packager/glassfish-nucleus-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-nucleus-l10n</artifactId>
     <name>Glassfish Nucleus l10n Package</name>

--- a/appserver/packager/glassfish-nucleus/pom.xml
+++ b/appserver/packager/glassfish-nucleus/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-nucleus</artifactId>
     <name>Glassfish Nucleus Package</name>

--- a/appserver/packager/glassfish-osgi-feature-pack/pom.xml
+++ b/appserver/packager/glassfish-osgi-feature-pack/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-osgi-feature-pack</artifactId>
     <name>Glassfish OSGi Feature Pack Metapackage</name>

--- a/appserver/packager/glassfish-osgi-gui-l10n/pom.xml
+++ b/appserver/packager/glassfish-osgi-gui-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-osgi-gui-l10n</artifactId>
     <name>Glassfish OSGi Management console l10n Package</name>

--- a/appserver/packager/glassfish-osgi-gui/pom.xml
+++ b/appserver/packager/glassfish-osgi-gui/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-osgi-gui</artifactId>
     <name>Glassfish OSGi Management console package</name>

--- a/appserver/packager/glassfish-osgi-http/pom.xml
+++ b/appserver/packager/glassfish-osgi-http/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-osgi-http</artifactId>
     <name>Glassfish OSGi HTTP Service package</name>

--- a/appserver/packager/glassfish-osgi-incorporation/pom.xml
+++ b/appserver/packager/glassfish-osgi-incorporation/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-osgi-incorporation</artifactId>
     <name>Glassfish OSGi Feature Pack Incorporation Package</name>

--- a/appserver/packager/glassfish-osgi/pom.xml
+++ b/appserver/packager/glassfish-osgi/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-osgi</artifactId>
     <name>Glassfish OSGi Support Package</name>

--- a/appserver/packager/glassfish-registration-l10n/pom.xml
+++ b/appserver/packager/glassfish-registration-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-registration-l10n</artifactId>
     <name>Glassfish Registration l10n Package</name>

--- a/appserver/packager/glassfish-registration/pom.xml
+++ b/appserver/packager/glassfish-registration/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-registration</artifactId>
     <name>Glassfish Registration Package</name>

--- a/appserver/packager/glassfish-verifier-l10n/pom.xml
+++ b/appserver/packager/glassfish-verifier-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-verifier-l10n</artifactId>
     <name>Glassfish verifier l10n Package</name>

--- a/appserver/packager/glassfish-verifier/pom.xml
+++ b/appserver/packager/glassfish-verifier/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-verifier</artifactId>
     <name>Verifier Package</name>

--- a/appserver/packager/glassfish-web-incorporation/pom.xml
+++ b/appserver/packager/glassfish-web-incorporation/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-web-incorporation</artifactId>
     <name>Glassfish Web Profile Incorporation Package</name>

--- a/appserver/packager/glassfish-web-l10n/pom.xml
+++ b/appserver/packager/glassfish-web-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-web-l10n</artifactId>
     <name>Glassfish Web Container l10n Package</name>

--- a/appserver/packager/glassfish-web-profile/pom.xml
+++ b/appserver/packager/glassfish-web-profile/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-web-profile</artifactId>
     <name>Glassfish Web Profile Metapackage</name>

--- a/appserver/packager/glassfish-web/pom.xml
+++ b/appserver/packager/glassfish-web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>glassfish-web</artifactId>
     <name>Glassfish Web Container Package</name>

--- a/appserver/packager/hazelcast/pom.xml
+++ b/appserver/packager/hazelcast/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>hazelcast</artifactId>
     <name>Hazelcast Package</name>

--- a/appserver/packager/javadb/pom.xml
+++ b/appserver/packager/javadb/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>javadb</artifactId>
     <name>Java DB Package</name>

--- a/appserver/packager/jersey/pom.xml
+++ b/appserver/packager/jersey/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>jersey</artifactId>
     <name>Jersey Package</name>

--- a/appserver/packager/json/pom.xml
+++ b/appserver/packager/json/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>json</artifactId>
     <name>JSON Package</name>

--- a/appserver/packager/legal/pom.xml
+++ b/appserver/packager/legal/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legal-fragment</artifactId>

--- a/appserver/packager/metro-l10n/pom.xml
+++ b/appserver/packager/metro-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>metro-l10n</artifactId>
     <name>Metro l10n Package</name>

--- a/appserver/packager/metro/pom.xml
+++ b/appserver/packager/metro/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>metro</artifactId>
     <name>Metro Package</name>

--- a/appserver/packager/mq/pom.xml
+++ b/appserver/packager/mq/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>mq</artifactId>
     <name>MQ Package</name>

--- a/appserver/packager/pkg-bootstrap/pom.xml
+++ b/appserver/packager/pkg-bootstrap/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pkg-bootstrap-fragment</artifactId>

--- a/appserver/packager/pom.xml
+++ b/appserver/packager/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/appserver/packager/shoal/pom.xml
+++ b/appserver/packager/shoal/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>shoal</artifactId>
     <name>Shoal Package</name>

--- a/appserver/payara-admingui/cluster-l10n/pom.xml
+++ b/appserver/payara-admingui/cluster-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-cluster-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/cluster/pom.xml
+++ b/appserver/payara-admingui/cluster/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-cluster-plugin</artifactId>

--- a/appserver/payara-admingui/common-l10n/pom.xml
+++ b/appserver/payara-admingui/common-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/payara-admingui/common/pom.xml
+++ b/appserver/payara-admingui/common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-common</artifactId>

--- a/appserver/payara-admingui/concurrent-l10n/pom.xml
+++ b/appserver/payara-admingui/concurrent-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-concurrent-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/concurrent/pom.xml
+++ b/appserver/payara-admingui/concurrent/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-concurrent-plugin</artifactId>

--- a/appserver/payara-admingui/corba-l10n/pom.xml
+++ b/appserver/payara-admingui/corba-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-corba-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/corba/pom.xml
+++ b/appserver/payara-admingui/corba/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-corba-plugin</artifactId>

--- a/appserver/payara-admingui/core-l10n/pom.xml
+++ b/appserver/payara-admingui/core-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-core-l10n</artifactId>

--- a/appserver/payara-admingui/core/pom.xml
+++ b/appserver/payara-admingui/core/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-core</artifactId>

--- a/appserver/payara-admingui/dataprovider/pom.xml
+++ b/appserver/payara-admingui/dataprovider/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/appserver/payara-admingui/dist-fragment/pom.xml
+++ b/appserver/payara-admingui/dist-fragment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>dist-fragment</artifactId>

--- a/appserver/payara-admingui/ejb-l10n/pom.xml
+++ b/appserver/payara-admingui/ejb-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/ejb-lite-l10n/pom.xml
+++ b/appserver/payara-admingui/ejb-lite-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-lite-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/ejb-lite/pom.xml
+++ b/appserver/payara-admingui/ejb-lite/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-lite-plugin</artifactId>

--- a/appserver/payara-admingui/ejb/pom.xml
+++ b/appserver/payara-admingui/ejb/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-plugin</artifactId>

--- a/appserver/payara-admingui/full-l10n/pom.xml
+++ b/appserver/payara-admingui/full-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-common-full-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/full/pom.xml
+++ b/appserver/payara-admingui/full/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-common-full-plugin</artifactId>

--- a/appserver/payara-admingui/gf-admingui-connector/pom.xml
+++ b/appserver/payara-admingui/gf-admingui-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.admingui.connector</groupId>

--- a/appserver/payara-admingui/jca-l10n/pom.xml
+++ b/appserver/payara-admingui/jca-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jca-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/jca/pom.xml
+++ b/appserver/payara-admingui/jca/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jca-plugin</artifactId>

--- a/appserver/payara-admingui/jdbc-l10n/pom.xml
+++ b/appserver/payara-admingui/jdbc-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jdbc-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/jdbc/pom.xml
+++ b/appserver/payara-admingui/jdbc/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jdbc-plugin</artifactId>

--- a/appserver/payara-admingui/jms-plugin-l10n/pom.xml
+++ b/appserver/payara-admingui/jms-plugin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jms-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/jms-plugin/pom.xml
+++ b/appserver/payara-admingui/jms-plugin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jms-plugin</artifactId>

--- a/appserver/payara-admingui/jts-l10n/pom.xml
+++ b/appserver/payara-admingui/jts-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jts-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/jts/pom.xml
+++ b/appserver/payara-admingui/jts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jts-plugin</artifactId>

--- a/appserver/payara-admingui/payara-console-extras/pom.xml
+++ b/appserver/payara-admingui/payara-console-extras/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-console-extras</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/payara-admingui/payara-theme-l10n/pom.xml
+++ b/appserver/payara-admingui/payara-theme-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>console-payara-branding-plugin-l10n</artifactId>
     

--- a/appserver/payara-admingui/payara-theme/pom.xml
+++ b/appserver/payara-admingui/payara-theme/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-payara-branding-plugin</artifactId>

--- a/appserver/payara-admingui/plugin-service/pom.xml
+++ b/appserver/payara-admingui/plugin-service/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/payara-admingui/pom.xml
+++ b/appserver/payara-admingui/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/payara-admingui/updatecenter-l10n/pom.xml
+++ b/appserver/payara-admingui/updatecenter-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-updatecenter-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/updatecenter/pom.xml
+++ b/appserver/payara-admingui/updatecenter/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-updatecenter-plugin</artifactId>

--- a/appserver/payara-admingui/war/pom.xml
+++ b/appserver/payara-admingui/war/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/payara-admingui/web-l10n/pom.xml
+++ b/appserver/payara-admingui/web-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-web-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/web/pom.xml
+++ b/appserver/payara-admingui/web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>console-web-plugin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/payara-admingui/webui-jsf-plugin-l10n/pom.xml
+++ b/appserver/payara-admingui/webui-jsf-plugin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent> 
     <artifactId>webui-jsf-plugin-l10n</artifactId>

--- a/appserver/payara-admingui/webui-jsf-suntheme-plugin-l10n/pom.xml
+++ b/appserver/payara-admingui/webui-jsf-suntheme-plugin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admingui</groupId>
         <artifactId>payara-admingui</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>  
     <artifactId>webui-jsf-suntheme-plugin-l10n</artifactId>

--- a/appserver/payara-appserver-modules/jsr107-repackaged/pom.xml
+++ b/appserver/payara-appserver-modules/jsr107-repackaged/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>payara-appserver-modules</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>fish.payara.appserver</groupId>
     <artifactId>jsr107-repackaged</artifactId>

--- a/appserver/payara-appserver-modules/payara-jsr107/pom.xml
+++ b/appserver/payara-appserver-modules/payara-jsr107/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>payara-appserver-modules</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>fish.payara.appserver</groupId>
     <artifactId>payara-jsr107</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.glassfish.main.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
-            <version>4.1.151</version>
+            <version>4.1.152-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/appserver/payara-appserver-modules/pom.xml
+++ b/appserver/payara-appserver-modules/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-appserver-modules</artifactId>
     <name>Payara Appserver Modules</name>

--- a/appserver/persistence/cmp-l10n/ejb-mapping-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/ejb-mapping-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-ejb-mapping-l10n</artifactId>

--- a/appserver/persistence/cmp-l10n/enhancer-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/enhancer-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-enhancer-l10n</artifactId>

--- a/appserver/persistence/cmp-l10n/generator-database-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/generator-database-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-generator-database-l10n</artifactId>

--- a/appserver/persistence/cmp-l10n/model-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/model-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-model-l10n</artifactId>

--- a/appserver/persistence/cmp-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/persistence/cmp-l10n/support-ejb-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/support-ejb-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-ejb-l10n</artifactId>

--- a/appserver/persistence/cmp-l10n/support-sqlstore-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/support-sqlstore-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-sqlstore-l10n</artifactId>

--- a/appserver/persistence/cmp-l10n/utility-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/utility-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-utility-l10n</artifactId>

--- a/appserver/persistence/cmp/cmp-all/pom.xml
+++ b/appserver/persistence/cmp/cmp-all/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/persistence/cmp/cmp-scripts/pom.xml
+++ b/appserver/persistence/cmp/cmp-scripts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>cmp-scripts</artifactId>

--- a/appserver/persistence/cmp/ejb-mapping/pom.xml
+++ b/appserver/persistence/cmp/ejb-mapping/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-ejb-mapping</artifactId>

--- a/appserver/persistence/cmp/enhancer/pom.xml
+++ b/appserver/persistence/cmp/enhancer/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-enhancer</artifactId>

--- a/appserver/persistence/cmp/generator-database/pom.xml
+++ b/appserver/persistence/cmp/generator-database/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.persistence.cmp</groupId>
     	<artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-generator-database</artifactId>

--- a/appserver/persistence/cmp/internal-api/pom.xml
+++ b/appserver/persistence/cmp/internal-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-internal-api</artifactId>

--- a/appserver/persistence/cmp/model/pom.xml
+++ b/appserver/persistence/cmp/model/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-model</artifactId>

--- a/appserver/persistence/cmp/pom.xml
+++ b/appserver/persistence/cmp/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.persistence.cmp</groupId>
     <artifactId>cmp</artifactId>

--- a/appserver/persistence/cmp/support-ejb/pom.xml
+++ b/appserver/persistence/cmp/support-ejb/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-ejb</artifactId>

--- a/appserver/persistence/cmp/support-sqlstore/pom.xml
+++ b/appserver/persistence/cmp/support-sqlstore/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-sqlstore</artifactId>

--- a/appserver/persistence/cmp/utility/pom.xml
+++ b/appserver/persistence/cmp/utility/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.persistence.cmp</groupId>
     	<artifactId>cmp</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-utility</artifactId>

--- a/appserver/persistence/common/pom.xml
+++ b/appserver/persistence/common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.persistence</groupId>
     	<artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>persistence-common</artifactId>

--- a/appserver/persistence/eclipselink-wrapper/pom.xml
+++ b/appserver/persistence/eclipselink-wrapper/pom.xml
@@ -46,7 +46,7 @@
     <parent>
     <groupId>org.glassfish.main.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>eclipselink-wrapper</artifactId>

--- a/appserver/persistence/entitybean-container/pom.xml
+++ b/appserver/persistence/entitybean-container/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/persistence/gf-jpa-connector/pom.xml
+++ b/appserver/persistence/gf-jpa-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.persistence</groupId>
     	<artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/persistence/jpa-container-l10n/pom.xml
+++ b/appserver/persistence/jpa-container-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jpa-container-l10n</artifactId>

--- a/appserver/persistence/jpa-container/pom.xml
+++ b/appserver/persistence/jpa-container/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.persistence</groupId>
     	<artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jpa-container</artifactId>

--- a/appserver/persistence/oracle-jdbc-driver-packages/pom.xml
+++ b/appserver/persistence/oracle-jdbc-driver-packages/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-oracle-jdbc-driver-packages</artifactId>

--- a/appserver/persistence/pom.xml
+++ b/appserver/persistence/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.persistence</groupId>
     <artifactId>persistence</artifactId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../nucleus/pom.xml</relativePath>
     </parent>    
     <artifactId>glassfish-parent</artifactId>
@@ -57,7 +57,7 @@
         <connection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</connection>
         <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</developerConnection>
         <url>https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</url>
-      <tag>payara-server-4.1.151</tag>
+      <tag>payara-server-4.1.152-SNAPSHOT</tag>
   </scm>
     
     <properties>

--- a/appserver/registration/glassfish-registration/pom.xml
+++ b/appserver/registration/glassfish-registration/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.registration</groupId>
         <artifactId>registration</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/registration/pom.xml
+++ b/appserver/registration/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.registration</groupId>

--- a/appserver/registration/registration-api/pom.xml
+++ b/appserver/registration/registration-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.registration</groupId>
         <artifactId>registration</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/registration/registration-impl-l10n/pom.xml
+++ b/appserver/registration/registration-impl-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.registration</groupId>
         <artifactId>registration</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>registration-impl-l10n</artifactId>

--- a/appserver/registration/registration-impl/pom.xml
+++ b/appserver/registration/registration-impl/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.registration</groupId>
         <artifactId>registration</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/registration/servicetag-registry/pom.xml
+++ b/appserver/registration/servicetag-registry/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.registration</groupId>
         <artifactId>registration</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>servicetag-registry</artifactId>

--- a/appserver/resources/javamail/javamail-connector-l10n/pom.xml
+++ b/appserver/resources/javamail/javamail-connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>javamail</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javamail-connector-l10n</artifactId>

--- a/appserver/resources/javamail/javamail-connector/pom.xml
+++ b/appserver/resources/javamail/javamail-connector/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>javamail</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>javamail-connector</artifactId>

--- a/appserver/resources/javamail/javamail-runtime/pom.xml
+++ b/appserver/resources/javamail/javamail-runtime/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>javamail</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/resources/javamail/pom.xml
+++ b/appserver/resources/javamail/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>resources</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>javamail</artifactId>
     <packaging>pom</packaging>

--- a/appserver/resources/pom.xml
+++ b/appserver/resources/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.resources</groupId>

--- a/appserver/resources/resources-connector-l10n/pom.xml
+++ b/appserver/resources/resources-connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>resources</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>resources-connector-l10n</artifactId>
     

--- a/appserver/resources/resources-connector/pom.xml
+++ b/appserver/resources/resources-connector/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>resources</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/resources/resources-runtime/pom.xml
+++ b/appserver/resources/resources-runtime/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.resources</groupId>
         <artifactId>resources</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/security/appclient.security/pom.xml
+++ b/appserver/security/appclient.security/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>    
     <artifactId>appclient.security</artifactId>

--- a/appserver/security/core-ee-l10n/pom.xml
+++ b/appserver/security/core-ee-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/security/core-ee/pom.xml
+++ b/appserver/security/core-ee/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>security-ee</artifactId>

--- a/appserver/security/ejb.security/pom.xml
+++ b/appserver/security/ejb.security/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ejb.security</artifactId>

--- a/appserver/security/inmemory.jacc.provider/pom.xml
+++ b/appserver/security/inmemory.jacc.provider/pom.xml
@@ -46,7 +46,7 @@
     <parent>
          <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>    
     <artifactId>inmemory.jacc.provider</artifactId>

--- a/appserver/security/jaspic-provider-framework/pom.xml
+++ b/appserver/security/jaspic-provider-framework/pom.xml
@@ -46,7 +46,7 @@
      <parent>
         <artifactId>securitymodule</artifactId>
         <groupId>org.glassfish.main.security</groupId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jaspic.provider.framework</artifactId>

--- a/appserver/security/pom.xml
+++ b/appserver/security/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>org.glassfish.main.security</groupId>

--- a/appserver/security/security-all/pom.xml
+++ b/appserver/security/security-all/pom.xml
@@ -46,7 +46,7 @@
     <parent>
          <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>    
     <artifactId>security-all</artifactId>

--- a/appserver/security/security-dol-l10n/pom.xml
+++ b/appserver/security/security-dol-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>security-dol-l10n</artifactId>

--- a/appserver/security/webintegration/pom.xml
+++ b/appserver/security/webintegration/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>    
     <artifactId>websecurity</artifactId>

--- a/appserver/security/webservices.security-l10n/pom.xml
+++ b/appserver/security/webservices.security-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/security/webservices.security/pom.xml
+++ b/appserver/security/webservices.security/pom.xml
@@ -46,7 +46,7 @@
      <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>    
     <artifactId>webservices.security</artifactId>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.tests</groupId>

--- a/appserver/transaction/internal-api-l10n/pom.xml
+++ b/appserver/transaction/internal-api-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.transaction</groupId>
         <artifactId>transaction</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>transaction-internal-api-l10n</artifactId>

--- a/appserver/transaction/internal-api/pom.xml
+++ b/appserver/transaction/internal-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.transaction</groupId>
         <artifactId>transaction</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/transaction/jta-l10n/pom.xml
+++ b/appserver/transaction/jta-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.transaction</groupId>
         <artifactId>transaction</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jta-l10n</artifactId>

--- a/appserver/transaction/jta/pom.xml
+++ b/appserver/transaction/jta/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.transaction</groupId>
         <artifactId>transaction</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/transaction/jts-l10n/pom.xml
+++ b/appserver/transaction/jts-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.transaction</groupId>
         <artifactId>transaction</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jts-l10n</artifactId>

--- a/appserver/transaction/jts/pom.xml
+++ b/appserver/transaction/jts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.transaction</groupId>
         <artifactId>transaction</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/transaction/pom.xml
+++ b/appserver/transaction/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.transaction</groupId>

--- a/appserver/verifier/verifier-impl-l10n/pom.xml
+++ b/appserver/verifier/verifier-impl-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>verifier-l10n</artifactId>

--- a/appserver/verifier/verifier-impl/pom.xml
+++ b/appserver/verifier/verifier-impl/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>verifier</artifactId>

--- a/appserver/verifier/verifier-jdk-extension-bundle/pom.xml
+++ b/appserver/verifier/verifier-jdk-extension-bundle/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>        
     </parent>
     <artifactId>verifier-jdk-extension-bundle</artifactId>

--- a/appserver/verifier/verifier-scripts/pom.xml
+++ b/appserver/verifier/verifier-scripts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>        
     </parent>
 

--- a/appserver/web/admin-l10n/pom.xml
+++ b/appserver/web/admin-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-cli-l10n</artifactId>

--- a/appserver/web/admin/pom.xml
+++ b/appserver/web/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>web-cli</artifactId>

--- a/appserver/web/cdi-api-fragment/pom.xml
+++ b/appserver/web/cdi-api-fragment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/web/gf-web-connector/pom.xml
+++ b/appserver/web/gf-web-connector/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/gf-weld-connector/pom.xml
+++ b/appserver/web/gf-weld-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-weld-connector</artifactId>

--- a/appserver/web/gui-plugin-common-l10n/pom.xml
+++ b/appserver/web/gui-plugin-common-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-gui-plugin-common-l10n</artifactId>

--- a/appserver/web/gui-plugin-common/pom.xml
+++ b/appserver/web/gui-plugin-common/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/jersey-mvc-connector/pom.xml
+++ b/appserver/web/jersey-mvc-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jersey-mvc-connector</artifactId>

--- a/appserver/web/jsf-connector/pom.xml
+++ b/appserver/web/jsf-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jsf-connector</artifactId>

--- a/appserver/web/jspcaching-connector/pom.xml
+++ b/appserver/web/jspcaching-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jspcaching-connector</artifactId>

--- a/appserver/web/jstl-connector/pom.xml
+++ b/appserver/web/jstl-connector/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jstl-connector</artifactId>

--- a/appserver/web/pom.xml
+++ b/appserver/web/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.web</groupId>

--- a/appserver/web/war-util-l10n/pom.xml
+++ b/appserver/web/war-util-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>war-util-l10n</artifactId>

--- a/appserver/web/war-util/pom.xml
+++ b/appserver/web/war-util/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-core-l10n/pom.xml
+++ b/appserver/web/web-core-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-core-l10n</artifactId>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-embed/api/pom.xml
+++ b/appserver/web/web-embed/api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web-embed</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>web-embed-api</artifactId>   

--- a/appserver/web/web-embed/pom.xml
+++ b/appserver/web/web-embed/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-embed</artifactId>

--- a/appserver/web/web-glue-l10n/pom.xml
+++ b/appserver/web/web-glue-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/web/web-glue/pom.xml
+++ b/appserver/web/web-glue/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-ha/pom.xml
+++ b/appserver/web/web-ha/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-naming-l10n/pom.xml
+++ b/appserver/web/web-naming-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-naming/pom.xml
+++ b/appserver/web/web-naming/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-sse/pom.xml
+++ b/appserver/web/web-sse/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
         <artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/webtier-all/pom.xml
+++ b/appserver/web/webtier-all/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/weld-integration-fragment/pom.xml
+++ b/appserver/web/weld-integration-fragment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>weld-integration-fragment</artifactId>

--- a/appserver/web/weld-integration-test-fragment/pom.xml
+++ b/appserver/web/weld-integration-test-fragment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>weld-integration-test-fragment</artifactId>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -46,7 +46,7 @@
     <parent>
 	<groupId>org.glassfish.main.web</groupId>
     	<artifactId>web</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>weld-integration</artifactId>

--- a/appserver/webservices/connector-l10n/pom.xml
+++ b/appserver/webservices/connector-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>webservices-connector-l10n</artifactId>

--- a/appserver/webservices/connector/pom.xml
+++ b/appserver/webservices/connector/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
     	<artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/webservices/jsr109-impl-l10n/pom.xml
+++ b/appserver/webservices/jsr109-impl-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jsr109-impl</artifactId>

--- a/appserver/webservices/metro-fragments/pom.xml
+++ b/appserver/webservices/metro-fragments/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-fragments</artifactId>

--- a/appserver/webservices/metro-glue/pom.xml
+++ b/appserver/webservices/metro-glue/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>metro-glue</artifactId>

--- a/appserver/webservices/pom.xml
+++ b/appserver/webservices/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.webservices</groupId>

--- a/appserver/webservices/soap-tcp/pom.xml
+++ b/appserver/webservices/soap-tcp/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>soap-tcp</artifactId>

--- a/appserver/webservices/webservices-scripts/pom.xml
+++ b/appserver/webservices/webservices-scripts/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.webservices</groupId>
         <artifactId>webservices</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-scripts</artifactId>

--- a/nucleus/admin/cli-l10n/pom.xml
+++ b/nucleus/admin/cli-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>admin-cli</artifactId>

--- a/nucleus/admin/config-api-l10n/pom.xml
+++ b/nucleus/admin/config-api-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>config-api</artifactId>

--- a/nucleus/admin/launcher-l10n/pom.xml
+++ b/nucleus/admin/launcher-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/launcher/pom.xml
+++ b/nucleus/admin/launcher/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>launcher</artifactId>

--- a/nucleus/admin/monitor-l10n/pom.xml
+++ b/nucleus/admin/monitor-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/monitor/pom.xml
+++ b/nucleus/admin/monitor/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>monitoring-core</artifactId>

--- a/nucleus/admin/pom.xml
+++ b/nucleus/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.admin</groupId>

--- a/nucleus/admin/rest/gf-restadmin-connector/pom.xml
+++ b/nucleus/admin/rest/gf-restadmin-connector/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>rest-service-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gf-restadmin-connector</artifactId>

--- a/nucleus/admin/rest/pom.xml
+++ b/nucleus/admin/rest/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/rest/rest-client/pom.xml
+++ b/nucleus/admin/rest/rest-client/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>rest-service-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest-client</artifactId>

--- a/nucleus/admin/rest/rest-service-l10n/pom.xml
+++ b/nucleus/admin/rest/rest-service-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>rest-service-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>rest-service-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest-service</artifactId>

--- a/nucleus/admin/rest/rest-testing/pom.xml
+++ b/nucleus/admin/rest/rest-testing/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>rest-service-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest-testing</artifactId>

--- a/nucleus/admin/server-mgmt-l10n/pom.xml
+++ b/nucleus/admin/server-mgmt-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/server-mgmt/pom.xml
+++ b/nucleus/admin/server-mgmt/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>server-mgmt</artifactId>

--- a/nucleus/admin/template/pom.xml
+++ b/nucleus/admin/template/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-domain</artifactId>
     <name>Nucleus template</name>

--- a/nucleus/admin/util-l10n/pom.xml
+++ b/nucleus/admin/util-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/admin/util/pom.xml
+++ b/nucleus/admin/util/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>admin-util</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/cluster/admin-l10n/pom.xml
+++ b/nucleus/cluster/admin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/cluster/admin/pom.xml
+++ b/nucleus/cluster/admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>    
     <artifactId>cluster-admin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/cluster/cli-l10n/pom.xml
+++ b/nucleus/cluster/cli-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/cluster/cli/pom.xml
+++ b/nucleus/cluster/cli/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>cluster-cli</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/cluster/common-l10n/pom.xml
+++ b/nucleus/cluster/common-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/cluster/common/pom.xml
+++ b/nucleus/cluster/common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>    
     <artifactId>cluster-common</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/cluster/gms-adapter/pom.xml
+++ b/nucleus/cluster/gms-adapter/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gms-adapter</artifactId>

--- a/nucleus/cluster/gms-bootstrap-l10n/pom.xml
+++ b/nucleus/cluster/gms-bootstrap-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/cluster/gms-bootstrap/pom.xml
+++ b/nucleus/cluster/gms-bootstrap/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gms-bootstrap</artifactId>

--- a/nucleus/cluster/pom.xml
+++ b/nucleus/cluster/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.cluster</groupId>

--- a/nucleus/cluster/ssh-l10n/pom.xml
+++ b/nucleus/cluster/ssh-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/cluster/ssh/pom.xml
+++ b/nucleus/cluster/ssh/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>cluster-ssh</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/cluster/uc-l10n/pom.xml
+++ b/nucleus/cluster/uc-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.cluster</groupId>
         <artifactId>cluster</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/common/amx-core/pom.xml
+++ b/nucleus/common/amx-core/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>amx-core</artifactId>

--- a/nucleus/common/common-util-l10n/pom.xml
+++ b/nucleus/common/common-util-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>common-util</artifactId>

--- a/nucleus/common/glassfish-api-l10n/pom.xml
+++ b/nucleus/common/glassfish-api-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>  
     <groupId>org.glassfish.main.common</groupId>

--- a/nucleus/common/internal-api-l10n/pom.xml
+++ b/nucleus/common/internal-api-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/common/internal-api/pom.xml
+++ b/nucleus/common/internal-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>internal-api</artifactId>

--- a/nucleus/common/mbeanserver-l10n/pom.xml
+++ b/nucleus/common/mbeanserver-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 

--- a/nucleus/common/mbeanserver/pom.xml
+++ b/nucleus/common/mbeanserver/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish-mbeanserver</artifactId>

--- a/nucleus/common/pom.xml
+++ b/nucleus/common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.common</groupId>

--- a/nucleus/common/scattered-archive-api/pom.xml
+++ b/nucleus/common/scattered-archive-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>  
     <groupId>org.glassfish.main.common</groupId>

--- a/nucleus/common/simple-glassfish-api/pom.xml
+++ b/nucleus/common/simple-glassfish-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>  
     <artifactId>simple-glassfish-api</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/core/api-exporter/pom.xml
+++ b/nucleus/core/api-exporter/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>api-exporter</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/core/bootstrap/pom.xml
+++ b/nucleus/core/bootstrap/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish</artifactId>

--- a/nucleus/core/context-propagation/pom.xml
+++ b/nucleus/core/context-propagation/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>context-propagation</artifactId>

--- a/nucleus/core/extra-jre-packages/pom.xml
+++ b/nucleus/core/extra-jre-packages/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-extra-jre-packages</artifactId>

--- a/nucleus/core/kernel-l10n/pom.xml
+++ b/nucleus/core/kernel-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>kernel</artifactId>

--- a/nucleus/core/logging-l10n/pom.xml
+++ b/nucleus/core/logging-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>logging</artifactId>

--- a/nucleus/core/pom.xml
+++ b/nucleus/core/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>org.glassfish.main.core</groupId>

--- a/nucleus/deployment/admin-l10n/pom.xml
+++ b/nucleus/deployment/admin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/deployment/admin/pom.xml
+++ b/nucleus/deployment/admin/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-admin</artifactId>

--- a/nucleus/deployment/autodeploy-l10n/pom.xml
+++ b/nucleus/deployment/autodeploy-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/deployment/autodeploy/pom.xml
+++ b/nucleus/deployment/autodeploy/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-autodeploy</artifactId>

--- a/nucleus/deployment/common-l10n/pom.xml
+++ b/nucleus/deployment/common-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/deployment/common/pom.xml
+++ b/nucleus/deployment/common/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-common</artifactId>

--- a/nucleus/deployment/dtds/pom.xml
+++ b/nucleus/deployment/dtds/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-dtds</artifactId>
     <packaging>distribution-fragment</packaging>

--- a/nucleus/deployment/pom.xml
+++ b/nucleus/deployment/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.deployment</groupId>

--- a/nucleus/deployment/schemas/pom.xml
+++ b/nucleus/deployment/schemas/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.main.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-schemas</artifactId>
     <packaging>distribution-fragment</packaging>

--- a/nucleus/diagnostics/context/pom.xml
+++ b/nucleus/diagnostics/context/pom.xml
@@ -44,7 +44,7 @@
   <parent>
     <groupId>org.glassfish.main.diagnostics</groupId>
     <artifactId>nucleus-diagnostics</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
   </parent>
   <artifactId>diagnostics-context</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/diagnostics/diagnostics-api/pom.xml
+++ b/nucleus/diagnostics/diagnostics-api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.diagnostics</groupId>
         <artifactId>nucleus-diagnostics</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>diagnostics-api</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/diagnostics/pom.xml
+++ b/nucleus/diagnostics/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.diagnostics</groupId>
     <artifactId>nucleus-diagnostics</artifactId>

--- a/nucleus/distributions/atomic/pom.xml
+++ b/nucleus/distributions/atomic/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>nucleus-distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>atomic</artifactId>
     <name>Glassfish Atomic Distribution</name>

--- a/nucleus/distributions/nucleus/pom.xml
+++ b/nucleus/distributions/nucleus/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>nucleus-distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-new</artifactId>
     <name>Nucleus Distribution</name>

--- a/nucleus/distributions/payara-minimal/pom.xml
+++ b/nucleus/distributions/payara-minimal/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>nucleus-distributions</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>payara-minimal</artifactId>
     <name>Payara Minimal Distribution</name>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>org.glassfish.main.distributions</groupId>

--- a/nucleus/flashlight/agent/pom.xml
+++ b/nucleus/flashlight/agent/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../common/pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.flashlight</groupId>

--- a/nucleus/flashlight/flashlight-extra-jdk-packages/pom.xml
+++ b/nucleus/flashlight/flashlight-extra-jdk-packages/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../common/pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.flashlight</groupId>

--- a/nucleus/flashlight/framework-l10n/pom.xml
+++ b/nucleus/flashlight/framework-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.flashlight</groupId>
         <artifactId>nucleus-flashlight</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.common</groupId>
         <artifactId>nucleus-common</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../../common/pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.flashlight</groupId>

--- a/nucleus/flashlight/pom.xml
+++ b/nucleus/flashlight/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.flashlight</groupId>

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -45,12 +45,12 @@
     <parent>
         <groupId>org.glassfish.main.grizzly</groupId>
         <artifactId>nucleus-grizzly</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-config</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>grizzly-config</name>
     <packaging>glassfish-jar</packaging>
     <build>

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.grizzly</groupId>
         <artifactId>nucleus-grizzly</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/grizzly/pom.xml
+++ b/nucleus/grizzly/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>org.glassfish.main.grizzly</groupId>

--- a/nucleus/osgi-platforms/felix/pom.xml
+++ b/nucleus/osgi-platforms/felix/pom.xml
@@ -64,7 +64,7 @@
     <parent>
       <groupId>org.glassfish.main.osgi-platforms</groupId>
       <artifactId>osgi-platforms</artifactId>
-      <version>4.1.151</version>
+      <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>felix</artifactId>

--- a/nucleus/osgi-platforms/osgi-cli-interactive-l10n/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-interactive-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 

--- a/nucleus/osgi-platforms/osgi-cli-interactive/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-interactive/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>osgi-cli-interactive</artifactId>

--- a/nucleus/osgi-platforms/osgi-cli-remote-l10n/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 

--- a/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.main.osgi-platforms</groupId>

--- a/nucleus/osgi-platforms/osgi-container/pom.xml
+++ b/nucleus/osgi-platforms/osgi-container/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <artifactId>osgi-container</artifactId>

--- a/nucleus/osgi-platforms/pom.xml
+++ b/nucleus/osgi-platforms/pom.xml
@@ -51,7 +51,7 @@
     <parent>
       <groupId>org.glassfish.main</groupId>
       <artifactId>glassfish-nucleus-parent</artifactId>
-      <version>4.1.151</version>
+      <version>4.1.152-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/nucleus/packager/external/antlr/pom.xml
+++ b/nucleus/packager/external/antlr/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
 	<artifactId>nucleus-external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>antlr-repackaged</artifactId>

--- a/nucleus/packager/external/j-interop/pom.xml
+++ b/nucleus/packager/external/j-interop/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>nucleus-external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/packager/external/jmxremote_optional/pom.xml
+++ b/nucleus/packager/external/jmxremote_optional/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>nucleus-external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/packager/external/ldapbp/pom.xml
+++ b/nucleus/packager/external/ldapbp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>nucleus-external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/packager/external/pom.xml
+++ b/nucleus/packager/external/pom.xml
@@ -51,7 +51,7 @@
     <parent>
       <groupId>org.glassfish.main</groupId>
       <artifactId>glassfish-nucleus-parent</artifactId>
-      <version>4.1.151</version>
+      <version>4.1.152-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/nucleus/packager/external/trilead-ssh2/pom.xml
+++ b/nucleus/packager/external/trilead-ssh2/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>nucleus-external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/packager/external/vboxjws/pom.xml
+++ b/nucleus/packager/external/vboxjws/pom.xml
@@ -44,12 +44,12 @@
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>nucleus-external</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>vboxjws</artifactId>
-	<version>4.1.151</version>
+	<version>4.1.152-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>virtualbox client SDK repackaged as module</name>
     <build>

--- a/nucleus/packager/hazelcast-package/pom.xml
+++ b/nucleus/packager/hazelcast-package/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>hazelcast-package</artifactId>
     <name>Nucleus Hazelcast Package</name>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.glassfish.main.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
-            <version>4.1.151</version>
+            <version>4.1.152-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>

--- a/nucleus/packager/nucleus-cluster-l10n/pom.xml
+++ b/nucleus/packager/nucleus-cluster-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-cluster-l10n</artifactId>
     <name>Nucleus Clustering l10n Package</name>

--- a/nucleus/packager/nucleus-cluster/pom.xml
+++ b/nucleus/packager/nucleus-cluster/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-cluster</artifactId>
     <name>Nucleus Clustering Package</name>

--- a/nucleus/packager/nucleus-common-l10n/pom.xml
+++ b/nucleus/packager/nucleus-common-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-common-l10n</artifactId>
     <name>Nucleus Commons Package l10n package</name>

--- a/nucleus/packager/nucleus-common/pom.xml
+++ b/nucleus/packager/nucleus-common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-common</artifactId>
     <name>Nucleus Commons Package</name>

--- a/nucleus/packager/nucleus-corba-base/pom.xml
+++ b/nucleus/packager/nucleus-corba-base/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-corba-base</artifactId>
     <name>Nucleus Base CORBA APIs Package</name>

--- a/nucleus/packager/nucleus-felix/pom.xml
+++ b/nucleus/packager/nucleus-felix/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-felix</artifactId>
     <name>Felix Nucleus Package</name>

--- a/nucleus/packager/nucleus-grizzly/pom.xml
+++ b/nucleus/packager/nucleus-grizzly/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-grizzly</artifactId>
     <name>Nucleus Grizzly Package</name>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-hk2</artifactId>
     <name>Nucleus HK2 Package</name>

--- a/nucleus/packager/nucleus-jersey/pom.xml
+++ b/nucleus/packager/nucleus-jersey/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-jersey</artifactId>
     <name>Nucleus Jersey Package</name>

--- a/nucleus/packager/nucleus-jmx/pom.xml
+++ b/nucleus/packager/nucleus-jmx/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-jmx</artifactId>
     <name>Glassfish JMX Package</name>

--- a/nucleus/packager/nucleus-l10n/pom.xml
+++ b/nucleus/packager/nucleus-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-l10n</artifactId>
     <name>Nucleus l10n Package</name>

--- a/nucleus/packager/nucleus-management-l10n/pom.xml
+++ b/nucleus/packager/nucleus-management-l10n/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-management-l10n</artifactId>
     <name>Nucleus Management l10n Package</name>

--- a/nucleus/packager/nucleus-management/pom.xml
+++ b/nucleus/packager/nucleus-management/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-management</artifactId>
     <name>Nucleus Management Package</name>

--- a/nucleus/packager/nucleus-osgi/pom.xml
+++ b/nucleus/packager/nucleus-osgi/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-osgi</artifactId>
     <name>Glassfish OSGi Support Package</name>

--- a/nucleus/packager/nucleus-shoal/pom.xml
+++ b/nucleus/packager/nucleus-shoal/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus-shoal</artifactId>
     <name>Nucleus Shoal Package</name>

--- a/nucleus/packager/nucleus/pom.xml
+++ b/nucleus/packager/nucleus/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.packager</groupId>
         <artifactId>nucleus-packages</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>nucleus</artifactId>
     <name>Nucleus Package</name>

--- a/nucleus/packager/pom.xml
+++ b/nucleus/packager/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/nucleus/payara-modules/hazelcast-bootstrap/pom.xml
+++ b/nucleus/payara-modules/hazelcast-bootstrap/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.glassfish.main.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/payara-modules/pom.xml
+++ b/nucleus/payara-modules/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.main.payara-modules</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -52,7 +52,7 @@
 
     <groupId>org.glassfish.main</groupId>
     <artifactId>glassfish-nucleus-parent</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>GlassFish Nucleus Parent Project</name>
 
@@ -60,7 +60,7 @@
         <connection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/nucleus</connection>
         <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/nucleus</developerConnection>
         <url>https://svn.java.net/svn/glassfish~svn/tags/4.1/main/nucleus</url>
-      <tag>payara-server-4.1.151</tag>
+      <tag>payara-server-4.1.152-SNAPSHOT</tag>
   </scm>
 
     <issueManagement>

--- a/nucleus/resources-l10n/pom.xml
+++ b/nucleus/resources-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/resources/pom.xml
+++ b/nucleus/resources/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.resourcebase.resources</groupId>
     <artifactId>nucleus-resources</artifactId>    

--- a/nucleus/security/core-l10n/pom.xml
+++ b/nucleus/security/core-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>nucleus-security</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/security/core/pom.xml
+++ b/nucleus/security/core/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>nucleus-security</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>security</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/security/pom.xml
+++ b/nucleus/security/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.security</groupId>
     <artifactId>nucleus-security</artifactId>

--- a/nucleus/security/services-l10n/pom.xml
+++ b/nucleus/security/services-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>nucleus-security</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/security/services/pom.xml
+++ b/nucleus/security/services/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main.security</groupId>
         <artifactId>nucleus-security</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>security-services</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/security/ssl-impl/pom.xml
+++ b/nucleus/security/ssl-impl/pom.xml
@@ -46,12 +46,12 @@
     <parent>
         <artifactId>nucleus-security</artifactId>
         <groupId>org.glassfish.main.security</groupId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <artifactId>ssl-impl</artifactId>
     <packaging>glassfish-jar</packaging>
     
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <name>GlassFish SSL Implementation Module</name>
     <developers>
         <developer>

--- a/nucleus/test-utils/pom.xml
+++ b/nucleus/test-utils/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>test-utils</artifactId>

--- a/nucleus/test-utils/utils-ng/pom.xml
+++ b/nucleus/test-utils/utils-ng/pom.xml
@@ -45,11 +45,11 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>test-utils</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.main.tests</groupId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <artifactId>utils-ng</artifactId>
     <name>nucleus.tests.utils-ng</name>
 

--- a/nucleus/test-utils/utils/pom.xml
+++ b/nucleus/test-utils/utils/pom.xml
@@ -45,11 +45,11 @@
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>test-utils</artifactId>
-        <version>4.1.151</version>
+        <version>4.1.152-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.main.tests</groupId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <artifactId>utils</artifactId>
     <name>Test utilities</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.main</groupId>
     <artifactId>glassfish-main-aggregator</artifactId>
-    <version>4.1.151</version>
+    <version>4.1.152-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <name>GlassFish Project</name>
@@ -54,7 +54,7 @@
         <connection>scm:git:git@github.com:payara/payara.git</connection>
 	<url>scm:git:git@github.com:payara/payara.git</url>
         <developerConnection>scm:git:git@github.com:payara/payara.git</developerConnection>
-      <tag>payara-server-4.1.151</tag>
+      <tag>payara-server-4.1.152-SNAPSHOT</tag>
   </scm>
     
     <profiles>


### PR DESCRIPTION
Re-updating Payara to version 4.1.152-SNAPSHOT after the re-release.
This was done using `sed` instead of the maven-release plugin, due to the issues from last time.