### PR TITLE
Adds cluster back into payara-minimal

### DIFF
--- a/nucleus/distributions/payara-minimal/pom.xml
+++ b/nucleus/distributions/payara-minimal/pom.xml
@@ -51,7 +51,7 @@
     <artifactId>payara-minimal</artifactId>
     <name>Payara Minimal Distribution</name>
     <packaging>glassfish-distribution</packaging>
-    <description>This pom describes how to assemble the Payara Minimal (single server) Distribution</description>
+    <description>This pom describes how to assemble the Payara Minimal Distribution</description>
 
     <build>
         <plugins>
@@ -157,6 +157,13 @@
             <optional>true</optional>
         </dependency>
 	<dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>nucleus-cluster</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.packager</groupId>
             <artifactId>hazelcast-package</artifactId>
             <version>${project.version}</version>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -81,12 +81,15 @@
         <stage.dir>${project.build.directory}/${stage.dir.name}</stage.dir>
         <temp.dir>${project.build.directory}/dependency</temp.dir>
         <include.group.ids>org.glassfish.main.packager</include.group.ids>
-        <create-domain.args>--user admin create-domain --nopassword --savelogin=true --checkports=false --adminport 4848 --instanceport 8080 --keytooloptions CN=localhost domain1</create-domain.args>
+        <create-domain.args>--user admin create-domain --nopassword --savelogin=true --checkports=false --portbase=5000 --keytooloptions CN=localhost domain1</create-domain.args>
     </properties>
 
     <modules>
+<!--
+        Forget the other distributions
 	<module>atomic</module>
         <module>nucleus</module>
+-->        
         <module>payara-minimal</module>
     </modules>
 


### PR DESCRIPTION
Add cluster commands back into payara-minimal. This means create-instance and start-instance commands can be used to create additional standalone instances of payara-minimal. 

This is very useful for creating hazelcast "storage" nodes for a full Payara installation.