### PR TITLE
Prevent null pointer exception when GMS is not enabled.

### DIFF
--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationWebEventPersistentManager.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationWebEventPersistentManager.java
@@ -241,7 +241,11 @@ public class ReplicationWebEventPersistentManager<T extends Storeable> extends R
         if (isDisableJreplica()) {
             return null;
         }
-        HACookieInfo cookieInfo = predictor.makeCookie(gmsAdapterService.getGMSAdapter().getClusterName(), sessionId, oldJreplicaValue);
+        String gmsClusterName = "";
+        if (gmsAdapterService.isGmsEnabled()) {
+            gmsClusterName = gmsAdapterService.getGMSAdapter().getClusterName();
+        }
+        HACookieInfo cookieInfo = predictor.makeCookie(gmsClusterName, sessionId, oldJreplicaValue);
         HACookieManager.setCurrrent(cookieInfo);
         return cookieInfo.getNewReplicaCookie();
     }


### PR DESCRIPTION
In a standalone instance with Availability enabled in the server config and on the deployment and with Hazelcast selected as a persistent session store a null pointer is thrown.

Preventing the null pointer allows standalone instances to share session state within Hazelcast and to act as a "cluster". Now standalone instances can share session state within hazelcast and therefore have persistent sessions similar to a "cluster".