### PR TITLE
Add hazelcast dependency to payara-web-embedded pom

### DIFF
--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -262,6 +262,14 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
+	<!-- hazelcast package -->
+	<dependency>
+	    <groupId>org.glassfish.main.packager</groupId>
+	    <artifactId>hazelcast</artifactId>
+	    <version>${project.version}</version>
+	    <type>zip</type>
+	    <optional>true</optional>
+	</dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Added the hazelcast package to the payara-web-embedded distribution.

Tested by checking if the hazelcast jar is packaged in the jar, which it is.
Also tested by adding the embedded jar to NetBeans and seeing if the Hazelcast packages were available, which they are.