### PR TITLE
Payara #154 - Removed the Classloader hack for older Hazelcast versions

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -176,13 +176,9 @@ public class HazelcastCore implements EventListener {
 
     private void bootstrapHazelcast() {
         Config config = buildConfiguration();
-        // hack to prevent Hazelcast barfing on multiple classloaders for portable hooks during boot
-        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(Hazelcast.class.getClassLoader());
         theInstance = Hazelcast.newHazelcastInstance(config);
         theInstance.getCluster().getLocalMember().setStringAttribute(INSTANCE_ATTRIBUTE, context.getInstanceName());
         hazelcastCachingProvider = HazelcastServerCachingProvider.createCachingProvider(theInstance);
-        Thread.currentThread().setContextClassLoader(tccl);
     }
 
     private void bindToJNDI() {


### PR DESCRIPTION
- caused random problems with restarts
- related to problems in ear applications
- related Hazelcast code will be changed in it's later versions(!)(after 3.4)