### PR TITLE
Revert early creation of TX Manager due to OSGI circular dependencies

### DIFF
--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
@@ -142,7 +142,6 @@ public class JavaEETransactionManagerJTSDelegate
         initTransactionProperties();
 
         setInstance(this);
-        transactionManagerImpl = TransactionManagerImpl.getTransactionManagerImpl();
     }
 
     public boolean useLAO() {


### PR DESCRIPTION
Early creation of TX Manager is creating OSGI circular dependency problems. Reverting TX Manager change.