### PR TITLE
Serialize jcache cdi Fixes #230

### DIFF
--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/CachePutInterceptor.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/CachePutInterceptor.java
@@ -18,6 +18,7 @@
 package fish.payara.cdi.jsr107;
 
 import fish.payara.cdi.jsr107.impl.PayaraCacheKeyInvocationContext;
+import fish.payara.cdi.jsr107.impl.PayaraValueHolder;
 import javax.annotation.Priority;
 import javax.cache.Cache;
 import javax.cache.annotation.CacheKeyGenerator;
@@ -66,14 +67,14 @@ public class CachePutInterceptor extends AbstractJSR107Interceptor {
         return result;
     }
 
-    private void doPut(PayaraCacheKeyInvocationContext<CachePut> pctx) {
+    private void doPut(PayaraCacheKeyInvocationContext<CachePut> pctx) throws Throwable{
         CacheKeyGenerator generator = pctx.getGenerator();
         CacheResolverFactory resolverF = pctx.getFactory();
         CacheResolver cacheResolver = resolverF.getCacheResolver(pctx);
         Cache cache = cacheResolver.resolveCache(pctx);
         GeneratedCacheKey key = generator.generateCacheKey(pctx);
         Object value = pctx.getValueParameter().getValue();
-        cache.put(key, value);
+        cache.put(key, new PayaraValueHolder(value));
     }
 
 }

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/JSR107Producer.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/JSR107Producer.java
@@ -41,12 +41,14 @@ public class JSR107Producer {
     @Dependent
     @Produces
     CachingProvider getCachingProvider() {
+        // TBD look for scoped Caching Providers in JNDI
         return hazelcastCore.getCachingProvider();
     }
     
     @Dependent
     @Produces
     CacheManager getCacheManager(InjectionPoint point) {
+        // TBD look for scoped caching providers in JNDI
         return hazelcastCore.getCachingProvider().getCacheManager();
     }
     

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraCacheResolverFactory.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraCacheResolverFactory.java
@@ -37,6 +37,7 @@ public class PayaraCacheResolverFactory implements CacheResolverFactory, CacheRe
     private CacheManager cacheManager;
 
     public PayaraCacheResolverFactory() {
+        // TBD resolve scoped Caching Providers via JNDI eg. java:comp and java:app
         cacheManager = HazelcastCore.getCore().getCachingProvider().getCacheManager();
     }
     

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraGeneratedCacheKey.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraGeneratedCacheKey.java
@@ -28,6 +28,8 @@ import javax.cache.annotation.GeneratedCacheKey;
  */
 public class PayaraGeneratedCacheKey implements GeneratedCacheKey, Serializable {
     
+    private static final long serialVersionUID = -3982698381435289430L;
+    
     private final int hashCode;
     private final Object values[];
     

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraTCCLObjectInputStream.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraTCCLObjectInputStream.java
@@ -1,0 +1,40 @@
+/*
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright (c) 2014 C2B2 Consulting Limited. All rights reserved.
+
+ The contents of this file are subject to the terms of the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ or packager/legal/LICENSE.txt.  See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.cdi.jsr107.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+/**
+ *
+ * @author steve
+ */
+public class PayaraTCCLObjectInputStream extends ObjectInputStream {
+    
+    public PayaraTCCLObjectInputStream(InputStream is) throws IOException {
+        super(is);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        return Thread.currentThread().getContextClassLoader().loadClass(desc.getName());
+    }  
+    
+}

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraValueHolder.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraValueHolder.java
@@ -1,0 +1,54 @@
+/*
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright (c) 2014 C2B2 Consulting Limited. All rights reserved.
+
+ The contents of this file are subject to the terms of the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ or packager/legal/LICENSE.txt.  See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.cdi.jsr107.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Packages up an object into a Serializable value
+ * @author steve
+ */
+public class PayaraValueHolder implements Serializable {
+   
+    private static final long serialVersionUID = -4600378937394648370L;
+    
+    private byte data[];
+    
+    public PayaraValueHolder(Object value) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos  = new ObjectOutputStream(baos);
+        oos.writeObject(value);
+        data = baos.toByteArray();
+        oos.close();
+        baos.close();
+    }
+    
+    public Object getValue() throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        PayaraTCCLObjectInputStream ois = new PayaraTCCLObjectInputStream(bais);
+        Object result = ois.readObject();
+        ois.close();
+        bais.close();
+        return result;
+    }
+    
+}

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraValueHolder.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/impl/PayaraValueHolder.java
@@ -19,7 +19,10 @@ package fish.payara.cdi.jsr107.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Externalizable;
 import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
@@ -27,11 +30,15 @@ import java.io.Serializable;
  * Packages up an object into a Serializable value
  * @author steve
  */
-public class PayaraValueHolder implements Serializable {
+public class PayaraValueHolder implements Externalizable {
    
     private static final long serialVersionUID = -4600378937394648370L;
     
     private byte data[];
+    
+    public PayaraValueHolder() {
+        
+    }
     
     public PayaraValueHolder(Object value) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -50,5 +57,20 @@ public class PayaraValueHolder implements Serializable {
         bais.close();
         return result;
     }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(data.length);
+        out.write(data,0,data.length);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        int length = in.readInt();
+        data = new byte[length];
+        in.read(data, 0, length);
+    }
+    
+    
     
 }


### PR DESCRIPTION
Fix #230 by Holding value objects serialized into a Payara Holder class for CDI. This ensures CDI works as expected on war defined classes.