### PR TITLE
master-password file locations

### DIFF
--- a/appserver/packager/glassfish-ha/pom.xml
+++ b/appserver/packager/glassfish-ha/pom.xml
@@ -132,7 +132,7 @@
               <version>${project.version}</version>
           </dependency>
            <dependency>
-              <groupId>org.glassfish.main.ha</groupId>
+              <groupId>fish.payara.ha</groupId>
               <artifactId>ha-hazelcast-store</artifactId>
               <version>${project.version}</version>
           </dependency>

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -531,7 +531,7 @@ public abstract class LocalServerCommand extends CLICommand {
         if (serverDirs == null)
             return null;
 
-        File mp = new File(serverDirs.getServerDir(), "master-password");
+        File mp = new File(serverDirs.getConfigDir(), "master-password");
         if (!mp.canRead())
             return null;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
@@ -771,7 +771,7 @@ public class PEFileLayout
     public static final String MASTERPASSWORD_FILE = "master-password";
     public File getMasterPasswordFile()
     {
-        return new File(getRepositoryDir(), MASTERPASSWORD_FILE);
+        return new File(getConfigRoot(), MASTERPASSWORD_FILE);
     }
 
     public static final String PASSWORD_ALIAS_KEYSTORE = PasswordAdapter.PASSWORD_ALIAS_KEYSTORE;

--- a/nucleus/common/common-util/src/main/java/org/glassfish/server/ServerEnvironmentImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/server/ServerEnvironmentImpl.java
@@ -369,7 +369,7 @@ public class ServerEnvironmentImpl implements ServerEnvironment, PostConstruct {
 
     @Override
     public File getMasterPasswordFile() {
-        return new File (getInstanceRoot(), "master-password");
+        return new File (getConfigDirPath(), "master-password");
     }
 
     @Override


### PR DESCRIPTION
Addresses issue #316 for master-password file management.

DAS, local instances colocated with the DAS and remote nodes are all working now.

In cluster configurations, changing the master password on the DAS will update the master passwords on all nodes with the new master password specified, but the master-password files must be manually created/updated on each node (via asadmin change-master-password --savemasterpassword)to adhere to "no master passwords over the wire" guideline.

Once the master-password file is handled on each node... the remote instances can be started normally.