### PR TITLE
Remove verifier from build

### DIFF
--- a/appserver/packager/pom.xml
+++ b/appserver/packager/pom.xml
@@ -117,7 +117,6 @@
         <module>glassfish-ejb</module>
         <module>glassfish-cmp</module>
         <module>metro</module>
-        <module>glassfish-verifier</module>	
         <module>glassfish-appclient</module>
         <module>javadb</module>
         <module>jersey</module>
@@ -149,7 +148,6 @@
         <module>glassfish-jta-l10n</module>
         <module>glassfish-jts-l10n</module>
         <module>glassfish-nucleus-l10n</module>
-        <module>glassfish-verifier-l10n</module>
         <module>glassfish-web-l10n</module>
         <module>metro-l10n</module>
         <module>glassfish-management-l10n</module>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -170,10 +170,6 @@
         <module>webservices</module>
         <module>orb</module>
         <module>appclient</module>
-        <module>verifier/verifier-impl</module>
-        <module>verifier/verifier-impl-l10n</module>
-        <module>verifier/verifier-scripts</module>
-        <module>verifier/verifier-jdk-extension-bundle</module>
         <module>ant-tasks</module>
         <module>payara-appserver-modules</module>
     </modules>


### PR DESCRIPTION
Removes the verifier packages from the build, since they are not used in the final packages