### PR TITLE
Add support for access-logging of session attributes

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/accesslog/DefaultAccessLogFormatterImpl.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/accesslog/DefaultAccessLogFormatterImpl.java
@@ -386,7 +386,8 @@ public class DefaultAccessLogFormatterImpl extends AccessLogFormatter {
                     && !component.startsWith(HEADER_BY_NAME_PREFIX)
                     && !component.startsWith(HEADERS_BY_NAME_PREFIX)
                     && !component.startsWith(RESPONSE_HEADER_BY_NAME_PREFIX)
-                    && !component.startsWith(RESPONSE_HEADERS_BY_NAME_PREFIX)) {
+                    && !component.startsWith(RESPONSE_HEADERS_BY_NAME_PREFIX)
+                    && !component.startsWith(SESSION_ATTRIBUTE_BY_NAME_PREFIX)) {
                 _logger.log(
                     Level.SEVERE,
                     INVALID_ACCESS_LOG_PATTERN_COMPONENT,


### PR DESCRIPTION
Was working on glassfish 3.1.2.2, fails on glassfish 4.1.