### PR TITLE
master-password & gfclient pass file permissions via NIO2 file attribute api rather than chmod-via-ProcessBuilder

### DIFF
--- a/appserver/packager/glassfish-ha/pom.xml
+++ b/appserver/packager/glassfish-ha/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2014] [C2B2 Consulting Limited] -->
+<!-- Portions Copyright [2015] [C2B2 Consulting Limited] -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
 /*
  * RepositoryManager.java
  *

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
@@ -50,6 +50,8 @@ import com.sun.enterprise.admin.servermgmt.pe.PEFileLayout;
 import com.sun.enterprise.security.store.PasswordAdapter;
 import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.enterprise.util.io.FileUtils;
+import org.glassfish.security.common.FileProtectionUtility;
+
 import java.io.File;
 
 
@@ -111,7 +113,7 @@ public class MasterPasswordFileManager extends KeystoreManager {
             PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), 
                 getMasterPasswordPassword());
             p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, masterPassword.getBytes());
-            chmod("600", pwdFile);
+            FileProtectionUtility.chmod0600(pwdFile);
         } catch (Exception ex) {                        
             throw new RepositoryException(_strMgr.getString("masterPasswordFileNotCreated", pwdFile),
                 ex);
@@ -175,7 +177,7 @@ public class MasterPasswordFileManager extends KeystoreManager {
                  PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), 
                      getMasterPasswordPassword());
                  p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, newPassword.getBytes());
-                 chmod("600", pwdFile);
+                 FileProtectionUtility.chmod0600(pwdFile);
              } catch (Exception ex) {                        
                  throw new RepositoryException(_strMgr.getString("masterPasswordFileNotCreated", pwdFile),
                      ex);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -38,6 +38,7 @@
  * holder.
  */
 // Portions Copyright [2015] [Zenthis Limited]
+// Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -43,12 +43,10 @@ package com.sun.enterprise.admin.servermgmt.cli;
 
 import com.sun.enterprise.admin.servermgmt.DomainConfig;
 import com.sun.enterprise.admin.servermgmt.pe.PEDomainsManager;
-import com.sun.enterprise.admin.util.CommandModelData.ParamModelData;
 import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.util.HostAndPort;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
-
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -37,6 +37,9 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
 package com.sun.enterprise.admin.servermgmt.cli;
 
 import com.sun.enterprise.admin.cli.CLICommand;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
 package com.sun.enterprise.admin.servermgmt.pe;
 
 import java.util.HashMap;

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
 
 package com.sun.enterprise.admin.cli.cluster;
 

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -49,16 +49,15 @@ import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.universal.xml.MiniXmlParser;
 import com.sun.enterprise.universal.xml.MiniXmlParserException;
 import com.sun.enterprise.util.HostAndPort;
-import com.sun.enterprise.util.OS;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 
+import org.glassfish.security.common.FileProtectionUtility;
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -181,26 +180,10 @@ public  class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
             PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(),
                 MASTER_PASSWORD_ALIAS.toCharArray());
             p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, newPassword.getBytes());
-            chmod("600", pwdFile);
+            FileProtectionUtility.chmod0600(pwdFile);
         } catch (Exception ex) {
             throw new CommandException(strings.get("masterPasswordFileNotCreated", pwdFile),
                 ex);
-        }
-    }
-
-
-    protected void chmod(String args, File file) throws IOException {
-        if (OS.isUNIX()) {
-            if (!file.exists()) throw new IOException(Strings.get("fileNotFound", file.getAbsolutePath()));
-
-            // " +" regular expression for 1 or more spaces
-            final String[] argsString = args.split(" +");
-            List<String> cmdList = new ArrayList<String>();
-            cmdList.add("/bin/chmod");
-            for (String arg : argsString)
-                cmdList.add(arg);
-            cmdList.add(file.getAbsolutePath());
-            new ProcessBuilder(cmdList).start();
         }
     }
 

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -38,6 +38,9 @@
  * holder.
  */
 
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
+
 package com.sun.enterprise.admin.cli.cluster;
 
 import com.sun.enterprise.admin.cli.CLIConstants;

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -56,15 +56,14 @@ import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
 
+import org.glassfish.security.common.FileProtectionUtility;
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Level;
 
 
@@ -314,27 +313,13 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
             PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(),
                 MASTER_PASSWORD_ALIAS.toCharArray());
             p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, masterPassword.getBytes());
-            chmod("600", pwdFile);
+            FileProtectionUtility.chmod0600(pwdFile);
         } catch (Exception ex) {
             throw new CommandException(Strings.get("masterPasswordFileNotCreated", pwdFile),
                 ex);
         }
     }
 
-    protected void chmod(String args, File file) throws IOException {
-        if (OS.isUNIX()) {
-            if (!file.exists()) throw new IOException(Strings.get("fileNotFound", file.getAbsolutePath()));
-
-            // " +" regular expression for 1 or more spaces
-            final String[] argsString = args.split(" +");
-            List<String> cmdList = new ArrayList<String>();
-            cmdList.add("/bin/chmod");
-            for (String arg : argsString)
-                cmdList.add(arg);
-            cmdList.add(file.getAbsolutePath());
-            new ProcessBuilder(cmdList).start();
-        }
-    }
 
     private boolean rendezvousWithDAS() {
         try {

--- a/nucleus/common/common-util/src/main/java/com/sun/appserv/management/client/prefs/MemoryHashLoginInfoStore.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/appserv/management/client/prefs/MemoryHashLoginInfoStore.java
@@ -43,6 +43,8 @@ package com.sun.appserv.management.client.prefs;
 import com.sun.enterprise.security.store.AsadminSecurityUtil;
 import com.sun.enterprise.universal.GFBase64Decoder;
 import com.sun.enterprise.universal.GFBase64Encoder;
+import org.glassfish.security.common.FileProtectionUtility;
+
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -202,8 +204,7 @@ public class MemoryHashLoginInfoStore implements LoginInfoStore {
             if(store == null || !store.exists())
                 return;
 
-            ProcessBuilder pb = new ProcessBuilder("chmod", "0600", store.getAbsolutePath());
-            pb.start();
+            FileProtectionUtility.chmod0600(store);
         }
         catch(Exception e)
         {

--- a/nucleus/common/common-util/src/main/java/com/sun/appserv/management/client/prefs/MemoryHashLoginInfoStore.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/appserv/management/client/prefs/MemoryHashLoginInfoStore.java
@@ -102,6 +102,7 @@ public class MemoryHashLoginInfoStore implements LoginInfoStore {
             }
             catch(final Exception ee) {} //ignore
         }
+        protect();
     }
 
     @Override

--- a/nucleus/common/common-util/src/main/java/org/glassfish/security/common/FileProtectionUtility.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/security/common/FileProtectionUtility.java
@@ -1,0 +1,42 @@
+package org.glassfish.security.common;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+
+
+/**
+ * Provides common functionality for protecting files.
+ *
+ * @author Phillip Ross
+ */
+public class FileProtectionUtility {
+
+
+    /**
+     * Set permissions on the specified file equivalent to file mode 0600.
+     *
+     * NOTE: This method will only set permissions on files that exist on filesystems which support POSIX file
+     * permissions.  Manipulation of permissions is silently skipped for filesystems that do not support POSIX file
+     * permissions (such as Windows NTFS).
+     *
+     * @param file The file to set permissions on
+     * @throws IOException if an I/O error occurs
+     */
+    public static void chmod0600(File file) throws IOException {
+        Path filePath = file.toPath();
+        PosixFileAttributeView posixFileAttributeView = Files.getFileAttributeView(filePath, PosixFileAttributeView.class);
+        if (posixFileAttributeView != null) {
+            Files.setPosixFilePermissions(filePath,
+                    EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+            );
+        }
+    }
+
+
+}

--- a/nucleus/common/common-util/src/main/java/org/glassfish/security/common/FileProtectionUtility.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/security/common/FileProtectionUtility.java
@@ -1,3 +1,5 @@
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
 package org.glassfish.security.common;
 
 

--- a/nucleus/common/common-util/src/main/java/org/glassfish/server/ServerEnvironmentImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/server/ServerEnvironmentImpl.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2015] [C2B2 Consulting Limited]
+
 package org.glassfish.server;
 
 import com.sun.enterprise.module.bootstrap.StartupContext;


### PR DESCRIPTION
Addresses issues #333, #334, and #335 

Factors out functionality for setting 0600 file mode on a specific file to a common utility class which uses NIO2 Files api with PosixFilePermission to set the mode.  Various classes have been updated to use this utility class rather than using ProcessBuilder.  Proper detection of PosixFileAttributeSupport has been implemented in the utility class to make it safe for platforms such as Windows using filesystems that do not support posix file permissions.

These changes do NOT replace all places in the source code where ProcessBuilder+chmod are used... only the places where explicitly setting 0600 with chmod were used.