### PR TITLE
Fixes #341

### DIFF
--- a/nucleus/payara-modules/payara-micro/src/main/resources/payara-boot.properties
+++ b/nucleus/payara-modules/payara-micro/src/main/resources/payara-boot.properties
@@ -24,3 +24,4 @@ com.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.co
 com.ctc.wstx.returnNullForDefaultNamespace=true
 jdk.corba.allowOutputStreamSubclass=true
 java.awt.headless=true
+java.net.preferIPv4Stack=true


### PR DESCRIPTION
added default system property java.net.preferIPv4Stack=true. This can still be overridden by setting to false on the command line.