### PR TITLE
Automatically increment busy payara micro http and https ports

### DIFF
--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -483,12 +483,22 @@ public class PayaraMicro {
         setSystemProperties();
         BootstrapProperties bprops = new BootstrapProperties();
         GlassFishRuntime gfruntime;
+        PortBinder portBinder = new PortBinder();
+        
         try {
             gfruntime = GlassFishRuntime.bootstrap(bprops,Thread.currentThread().getContextClassLoader());
             GlassFishProperties gfproperties = new GlassFishProperties();
 
             if (httpPort != Integer.MIN_VALUE) {
-                gfproperties.setPort("http-listener", httpPort);
+                gfproperties.setPort("http-listener", 
+                        portBinder.findAvailablePort(httpPort));
+            }
+            
+            else
+            {
+                gfproperties.setPort("http-listener", 
+                        portBinder.findAvailablePort(gfproperties
+                                .getPort("http-listener")));
             }
 
             if (sslPort != Integer.MIN_VALUE) {

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -22,6 +22,7 @@ import fish.payara.nucleus.hazelcast.HazelcastCore;
 import fish.payara.nucleus.hazelcast.MulticastConfiguration;
 import java.io.File;
 import java.io.IOException;
+import java.net.BindException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -489,21 +490,44 @@ public class PayaraMicro {
             gfruntime = GlassFishRuntime.bootstrap(bprops,Thread.currentThread().getContextClassLoader());
             GlassFishProperties gfproperties = new GlassFishProperties();
 
-            if (httpPort != Integer.MIN_VALUE) {
-                gfproperties.setPort("http-listener", 
-                        portBinder.findAvailablePort(httpPort));
+            if (httpPort != Integer.MIN_VALUE) 
+            {   
+                try
+                {
+                    gfproperties.setPort("http-listener",
+                            portBinder.findAvailablePort(httpPort));
+                }
+                
+                catch (BindException ex)
+                {
+                    Logger.getLogger(PayaraMicro.class.getName())
+                            .log(Level.SEVERE, 
+                                    "No available port found in range: "
+                                            + httpPort + " - " 
+                                            + (httpPort + 10), ex);
+                    
+                    throw new GlassFishException("Could not bind http port");
+                }
             }
-            
-            else
+
+            if (sslPort != Integer.MIN_VALUE) 
             {
-                gfproperties.setPort("http-listener", 
-                        portBinder.findAvailablePort(gfproperties
-                                .getPort("http-listener")));
-            }
-
-            if (sslPort != Integer.MIN_VALUE) {
-                gfproperties.setPort("https-listener", sslPort);
-
+                try
+                {
+                    gfproperties.setPort("https-listener",
+                            portBinder.findAvailablePort(sslPort));
+                }
+                
+                catch (BindException ex)
+                {
+                    Logger.getLogger(PayaraMicro.class.getName())
+                            .log(Level.SEVERE, 
+                                    "No available port found in range: "
+                                            + sslPort + " - " 
+                                            + (sslPort + 10), ex);
+                    
+                    throw new GlassFishException("Could not bind SSL port");
+                }
             }
 
             if (alternateDomainXML != null) {

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -70,8 +70,8 @@ public class PayaraMicro {
     private GlassFish gf;
     private PayaraMicroRuntime runtime;
     private boolean noCluster = false;
-    private boolean httpAutoBind = false;
-    private boolean sslAutoBind = false;
+    private boolean autoBindHttp = false;
+    private boolean autoBindSsl = false;
     private int autoBindRange = 5;
 
     /**
@@ -459,7 +459,7 @@ public class PayaraMicro {
      */
     public boolean getHttpAutoBind()
     {
-        return httpAutoBind;
+        return autoBindHttp;
     }
 
     /**
@@ -469,7 +469,7 @@ public class PayaraMicro {
      */
     public PayaraMicro setHttpAutoBind(boolean httpAutoBind)
     {
-        this.httpAutoBind = httpAutoBind;
+        this.autoBindHttp = httpAutoBind;
         return this;
     }
     
@@ -479,7 +479,7 @@ public class PayaraMicro {
      */
     public boolean getSslAutoBind()
     {
-        return sslAutoBind;
+        return autoBindSsl;
     }
     
     /**
@@ -489,7 +489,7 @@ public class PayaraMicro {
      */
     public PayaraMicro setSslAutoBind(boolean sslAutoBind)
     {
-        this.sslAutoBind = sslAutoBind;
+        this.autoBindSsl = sslAutoBind;
         return this;
     }
     
@@ -556,7 +556,7 @@ public class PayaraMicro {
             if (httpPort != Integer.MIN_VALUE) 
             {   
                 // If httpAutoBind is set to true
-                if (httpAutoBind == true)
+                if (autoBindHttp == true)
                 {
                     // Search for an available port and set it as the http port
                     try
@@ -587,11 +587,39 @@ public class PayaraMicro {
                 }
                 
             }
+            
+            // If the port has not been set
+            else
+            {
+                // If httpAutoBind is set to true
+                if (autoBindHttp == true)
+                {
+                    // Search for an available port and set it as the http port
+                    try
+                    {
+                        gfproperties.setPort("http-listener",
+                                portBinder.findAvailablePort(8080, 
+                                        autoBindRange));
+                    }
+
+                    // If no available port is found, log an exception and throw a GlassFish Exception to fail the bootstrap
+                    catch (BindException ex)
+                    {
+                        Logger.getLogger(PayaraMicro.class.getName())
+                                .log(Level.SEVERE, 
+                                        "No available port found in range: "
+                                                + 8080 + " - " 
+                                                + (8080 + autoBindRange), ex);
+
+                        throw new GlassFishException("Could not bind http port");
+                    }
+                }
+            }
 
             if (sslPort != Integer.MIN_VALUE) 
             {
                 // If sslAutoBind is set to true
-                if (sslAutoBind == true)
+                if (autoBindSsl == true)
                 {     
                     // Search for an available port and set it as the ssl port
                     try
@@ -840,11 +868,11 @@ public class PayaraMicro {
                         throw new IllegalArgumentException();
                     }   i++;                    
                     break;
-                case "--httpAutoBind":
-                    httpAutoBind = true;
+                case "--autoBindHttp":
+                    autoBindHttp = true;
                     break;
-                case "--sslAutoBind":
-                    sslAutoBind = true;
+                case "--autoBindSsl":
+                    autoBindSsl = true;
                     break;
                 case "--autoBindRange":
                     String autoBindRangeString = args[i + 1];
@@ -874,8 +902,8 @@ public class PayaraMicro {
                             + "--minHttpThreads the minimum number of threads in the HTTP thread pool\n"
                             + "--maxHttpThreads the maximum number of threads in the HTTP thread pool\n"
                             + "--hzConfigFile the hazelcast-configuration file to use to override the in-built hazelcast cluster configuration"
-                            + "--httpAutoBind sets autobinding of the http port to a non-bound port\n"
-                            + "--sslAutoBind sets autobinding of the https port to a non-bound port\n"
+                            + "--autoBindHttp sets autobinding of the http port to a non-bound port\n"
+                            + "--autoBindSsl sets autobinding of the https port to a non-bound port\n"
                             + "--autoBindRange sets the maximum number of ports to look at for port autobinding\n"
                             + "--help Shows this message and exits\n");
                     System.exit(1);

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -882,9 +882,10 @@ public class PayaraMicro {
                             throw new NumberFormatException("Not a valid auto bind range");
                         }
                     } catch (NumberFormatException nfe) {
-                        System.err.println(autoBindRangeString
-                                + " is not a valid auto bind range number and will be ignored. Defaulting to 5");
-                        autoBindRange = 5;
+                        logger.log(Level.SEVERE, 
+                                "{0} is not a valid auto bind range number", 
+                                autoBindRangeString);
+                        throw new IllegalArgumentException();
                     }   i++;
                     break;
                 case "--help":

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -575,7 +575,7 @@ public class PayaraMicro {
                                                 + httpPort + " - " 
                                                 + (httpPort + autoBindRange), ex);
 
-                        throw new GlassFishException("Could not bind http port");
+                        throw new GlassFishException("Could not bind HTTP port");
                     }
                 }
                 
@@ -611,7 +611,7 @@ public class PayaraMicro {
                                                 + 8080 + " - " 
                                                 + (8080 + autoBindRange), ex);
 
-                        throw new GlassFishException("Could not bind http port");
+                        throw new GlassFishException("Could not bind HTTP port");
                     }
                 }
             }

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
@@ -28,13 +28,8 @@ import java.net.ServerSocket;
  */
 public class PortBinder
 {
-    
-    
-    public int findAvailablePort(int port) throws BindException
+    public int findAvailablePort(int port, int autoBindRange) throws BindException
     {
-        // Set the number of times to try and bind to new ports
-        final int PORT_COUNT = 2;
-
         // Initialise a return variable equal to parameter passed in
         int returnPort = port;
         
@@ -44,7 +39,7 @@ public class PortBinder
         /**
          * Loop through, incrementing the port to bind to by 1 for each failure, until PORT_COUNT is reached
          */
-        for (int i = 0; i < PORT_COUNT; i++)
+        for (int i = 0; i < autoBindRange; i++)
         {        
             // Try to bind to the port                     
             try (ServerSocket serverSocket = new ServerSocket(port);)

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
@@ -1,0 +1,86 @@
+/*
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright (c) 2015 C2B2 Consulting Limited. All rights reserved.
+
+ The contents of this file are subject to the terms of the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ or packager/legal/LICENSE.txt.  See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at packager/legal/LICENSE.txt.
+ */
+
+package fish.payara.micro;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.nio.channels.ServerSocketChannel;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Andrew Pielage
+ */
+public class PortBinder
+{
+    
+    
+    public void findAvailablePort(int port)
+    {
+        if (port == Integer.MIN_VALUE)
+        {
+            
+        }
+        
+        try
+        {
+            final int PORT_COUNT = 10;
+            ServerSocket serverSocket = null;
+            ServerSocketChannel serverSocketChannel = null;
+            InetSocketAddress inetSocketAddress;
+
+
+            for (int i = 0; i < PORT_COUNT; i++)
+            {
+                serverSocketChannel = ServerSocketChannel.open();
+                serverSocket = serverSocketChannel.socket();
+                serverSocket.setSoTimeout(1000);
+                
+                try
+                {
+                    inetSocketAddress = new InetSocketAddress(port);
+                    
+                    serverSocket.bind(inetSocketAddress, 100);
+                    
+                    break;
+                }
+                
+                catch (final Exception e) 
+                {
+                    serverSocket.close();
+                    serverSocketChannel.close();
+                    
+                    port++;
+                }  
+            }
+            
+            serverSocketChannel.configureBlocking(false);
+        }
+          
+        catch (IOException ex)
+        {
+            Logger.getLogger(PortBinder.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        
+    }
+}

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
@@ -19,13 +19,7 @@
 package fish.payara.micro;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.nio.channels.ServerSocketChannel;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *
@@ -35,52 +29,35 @@ public class PortBinder
 {
     
     
-    public void findAvailablePort(int port)
+    public int findAvailablePort(int port)
     {
-        if (port == Integer.MIN_VALUE)
-        {
-            
-        }
+        // Set the number of times to try and bind to new ports
+        final int PORT_COUNT = 10;
+
+        // Initialise a return variable equal to parameter passed in
+        int returnPort = port;
         
-        try
-        {
-            final int PORT_COUNT = 10;
-            ServerSocket serverSocket = null;
-            ServerSocketChannel serverSocketChannel = null;
-            InetSocketAddress inetSocketAddress;
-
-
-            for (int i = 0; i < PORT_COUNT; i++)
+        /**
+         * Loop through, incrementing the port to bind to by 1 for each failure, until PORT_COUNT is reached
+         */
+        for (int i = 0; i < PORT_COUNT; i++)
+        {        
+            // Try to bind to the port                     
+            try (ServerSocket serverSocket = new ServerSocket(port);)
             {
-                serverSocketChannel = ServerSocketChannel.open();
-                serverSocket = serverSocketChannel.socket();
-                serverSocket.setSoTimeout(1000);
-                
-                try
-                {
-                    inetSocketAddress = new InetSocketAddress(port);
-                    
-                    serverSocket.bind(inetSocketAddress, 100);
-                    
-                    break;
-                }
-                
-                catch (final Exception e) 
-                {
-                    serverSocket.close();
-                    serverSocketChannel.close();
-                    
-                    port++;
-                }  
+                // If no exception thrown, set returnPort to the open port and break out of loop
+                returnPort = port;
+                break;
             }
-            
-            serverSocketChannel.configureBlocking(false);
-        }
-          
-        catch (IOException ex)
-        {
-            Logger.getLogger(PortBinder.class.getName()).log(Level.SEVERE, null, ex);
+
+            catch (IOException ex)
+            {
+                // Increment port to try again on next port
+                port++;
+            }
         }
         
+        // Return either the found port, or the original port passed in if no open port found
+        return returnPort;
     }
 }

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
@@ -39,7 +39,7 @@ public class PortBinder
         /**
          * Loop through, incrementing the port to bind to by 1 for each failure, until PORT_COUNT is reached
          */
-        for (int i = 0; i < autoBindRange; i++)
+        for (int i = 0; i <= autoBindRange; i++)
         {        
             // Try to bind to the port                     
             try (ServerSocket serverSocket = new ServerSocket(port);)

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PortBinder.java
@@ -19,6 +19,7 @@
 package fish.payara.micro;
 
 import java.io.IOException;
+import java.net.BindException;
 import java.net.ServerSocket;
 
 /**
@@ -29,13 +30,16 @@ public class PortBinder
 {
     
     
-    public int findAvailablePort(int port)
+    public int findAvailablePort(int port) throws BindException
     {
         // Set the number of times to try and bind to new ports
-        final int PORT_COUNT = 10;
+        final int PORT_COUNT = 2;
 
         // Initialise a return variable equal to parameter passed in
         int returnPort = port;
+        
+        // Initialise a flag for throwing a custom error if no available ports within range
+        boolean foundAvailablePort = false;
         
         /**
          * Loop through, incrementing the port to bind to by 1 for each failure, until PORT_COUNT is reached
@@ -45,8 +49,9 @@ public class PortBinder
             // Try to bind to the port                     
             try (ServerSocket serverSocket = new ServerSocket(port);)
             {
-                // If no exception thrown, set returnPort to the open port and break out of loop
+                // If no exception thrown, set returnPort to the open port, set the "found" flag to true, and break out of loop
                 returnPort = port;
+                foundAvailablePort = true;
                 break;
             }
 
@@ -57,7 +62,14 @@ public class PortBinder
             }
         }
         
-        // Return either the found port, or the original port passed in if no open port found
+        // Check if an available port has been found
+        if (foundAvailablePort == false)
+        {
+            // If a port hasn't been found, throw a BindException
+            throw new BindException();
+        }
+        
+        // Return the available port, or the original port passed in if no available port found
         return returnPort;
     }
 }


### PR DESCRIPTION
Adds auto bind functionality to the `--port` and `--sslPort` options.

Similar to how Hazelcast works, if the HTTP or HTTPS port is busy and auto bind is enabled, it will now try to find an empty port on the next x ports.