### PR TITLE
PAYARA-270 enable hazelcast-configuration synchronisation

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationCluster.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationCluster.jsf
@@ -2,7 +2,7 @@
 
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
- Copyright (c) 2014 C2B2 Consulting Limited. All rights reserved.
+ Copyright (c) 2015 C2B2 Consulting Limited. All rights reserved.
 
  The contents of this file are subject to the terms of the Common Development
  and Distribution License("CDDL") (collectively, the "License").  You
@@ -87,7 +87,7 @@
         <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
     </sun:property>
     <sun:property id="configFileProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.configFile}"  helpText="$resource{i18nhc.hazelcast.configuration.configFileHelp}">
-        <sun:textField id="hazelcastConfigurationFile" columns="$int{40}" maxLength="30" text="#{pageSession.valueMap['hazelcastConfigurationFile']}" />
+        <sun:textField id="hazelcastConfigurationFile" columns="$int{40}" maxLength="250" text="#{pageSession.valueMap['hazelcastConfigurationFile']}" />
     </sun:property>
     <sun:property id="startPortProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.startPort}"  helpText="$resource{i18nhc.hazelcast.configuration.startPortHelp}">
         <sun:textField id="startPort" columns="$int{40}"  styleClass="integer" maxLength="30" text="#{pageSession.valueMap['startPort']}" />

--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationServer.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationServer.jsf
@@ -87,7 +87,7 @@
         <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
     </sun:property>
     <sun:property id="configFileProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.configFile}"  helpText="$resource{i18nhc.hazelcast.configuration.configFileHelp}">
-        <sun:textField id="hazelcastConfigurationFile" columns="$int{40}" maxLength="30" text="#{pageSession.valueMap['hazelcastConfigurationFile']}" />
+        <sun:textField id="hazelcastConfigurationFile" columns="$int{40}" maxLength="250" text="#{pageSession.valueMap['hazelcastConfigurationFile']}" />
     </sun:property>
     <sun:property id="startPortProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.startPort}"  helpText="$resource{i18nhc.hazelcast.configuration.startPortHelp}">
         <sun:textField id="startPort" columns="$int{40}"  styleClass="integer" maxLength="30" text="#{pageSession.valueMap['startPort']}" />

--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationStandalone.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationStandalone.jsf
@@ -86,7 +86,7 @@
         <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
     </sun:property>
     <sun:property id="configFileProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.configFile}"  helpText="$resource{i18nhc.hazelcast.configuration.configFileHelp}">
-        <sun:textField id="hazelcastConfigurationFile" columns="$int{40}" maxLength="30" text="#{pageSession.valueMap['hazelcastConfigurationFile']}" />
+        <sun:textField id="hazelcastConfigurationFile" columns="$int{40}" maxLength="250" text="#{pageSession.valueMap['hazelcastConfigurationFile']}" />
     </sun:property>
     <sun:property id="startPortProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.startPort}"  helpText="$resource{i18nhc.hazelcast.configuration.startPortHelp}">
         <sun:textField id="startPort" columns="$int{40}"  styleClass="integer" maxLength="30" text="#{pageSession.valueMap['startPort']}" />

--- a/nucleus/cluster/admin/src/main/resources/META-INF/config-files
+++ b/nucleus/cluster/admin/src/main/resources/META-INF/config-files
@@ -41,6 +41,7 @@
 #
 # files in the config directory to synchronize to server instances on startup
 #
+# Portions Copyright [2015] [C2B2 Consulting Limited]
 domain.xml
 admin-keyfile
 cacerts.jks
@@ -57,3 +58,4 @@ wss-server-config-1.0.xml
 wss-server-config-2.0.xml
 javaee.server.policy
 restrict.server.policy
+hazelcast-config.xml


### PR DESCRIPTION
Also fix length of hazelcast configuration path in admin console so that custom hazelcast configuration files can be placed into the instance configuration directory and replicated to the instance