### PR TITLE
Fix bug whereby could not set context root 

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/DeployerImpl.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/DeployerImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.admin.cli.embeddable;
 
@@ -159,10 +160,10 @@ public class DeployerImpl implements Deployer {
         CommandExecutorImpl executer = habitat.getService(CommandExecutorImpl.class);
         try {
             ActionReport actionReport = executer.executeCommand("undeploy", newParams);
-            actionReport.writeReport(System.out);
+            if (actionReport.hasSuccesses()) {
+                logger.log(Level.INFO, "{0} was successfully undeployed", appName);
+            }
         } catch (CommandException e) {
-            throw new GlassFishException(e);
-        } catch (IOException e) {
             throw new GlassFishException(e);
         }
     }

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicroRuntime.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicroRuntime.java
@@ -211,10 +211,29 @@ public class PayaraMicroRuntime  {
         }
         return result;
     }
+    
+        /**
+     * Deploy from an InputStream which can load the Java EE archive
+     * @param name The name of the deployment
+     * @param contextRoot The context root to deploy the application to
+     * @param is InputStream to load the war through
+     * @return true if deployment was successful
+     */
+    public boolean deploy(String name, String contextRoot, InputStream is) {
+        checkState();
+        boolean result = false;
+        try{
+            runtime.getDeployer().deploy(is,"--availabilityenabled=true","--name",name, "--contextroot", contextRoot);
+            result = true;
+        }catch (GlassFishException gfe) {
+                logger.log(Level.WARNING, "Failed to deploy archive ", gfe);            
+        }
+        return result;
+    }
        
     /**
      * Deploy from an InputStream which can load the Java EE archive
-     * @param name The name of the deployment
+     * @param name The name of the deployment and the context root of the deployment if a war file
      * @param is InputStream to load the war through
      * @return true if deployment was successful
      */
@@ -222,7 +241,7 @@ public class PayaraMicroRuntime  {
         checkState();
         boolean result = false;
         try{
-            runtime.getDeployer().deploy(is,"--availabilityenabled=true","--name",name);
+            runtime.getDeployer().deploy(is,"--availabilityenabled=true","--name",name, "--contextroot", name);
             result = true;
         }catch (GlassFishException gfe) {
                 logger.log(Level.WARNING, "Failed to deploy archive ", gfe);            
@@ -249,6 +268,18 @@ public class PayaraMicroRuntime  {
             logger.log(Level.WARNING, "{0} is not a valid deployment", war.getAbsolutePath());
         }
         return result;
+    }
+    
+    /**
+     * Undeploys the named application 
+     * @param name Name of the application to undeploy
+     */
+    public void undeploy(String name) {
+        try {
+            runtime.getDeployer().undeploy(name);
+        } catch (GlassFishException ex) {
+            logger.log(Level.WARNING, "Failed to undeploy application {0}", name);
+        }
     }
     
     public void removeClusterListener(PayaraClusterListener listener) {


### PR DESCRIPTION
When deploying from an Input Stream in the new PayaraRuntime api a temp context root was created. This is now by default the application name and can be configured.

Also added an undeploy api