### PR TITLE
Changed the way to load payara-bootstrap.properties.

### DIFF
--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1005,7 +1005,8 @@ public class PayaraMicro {
     private void setSystemProperties() {
         try {
             Properties embeddedBootProperties = new Properties();
-            embeddedBootProperties.load(ClassLoader.getSystemResourceAsStream("payara-boot.properties"));
+            ClassLoader loader = getClass().getClassLoader();
+            embeddedBootProperties.load(loader.getResourceAsStream("payara-boot.properties"));
             for (Object key : embeddedBootProperties.keySet()) {
                 String keyStr = (String)key;
                 if (System.getProperty(keyStr) == null) {


### PR DESCRIPTION
- In order for `PayaraMicro` class to load `payara-bootstrap.properties` in Gradle task execution context, chage the way to load it.
  - Project : payara-modules/payara-micro
  - Class : `fish.payara.micro.PayaraMicro`
  - Line : 1008
  - Before : `ClassLoader.getSystemResourceAsStream(String)`
  - After : `getClass().getClassLoader().getResourceAsStream(String)`
- Reason : In Gradle task execution context, `ClassLoader.getSystemResourceAsStream("payara-bootstrap.properties")` returns `null` so that payara-micro server cannot get started.