### PR TITLE
Set eclipselink version to 2.6.0.payara-p2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -110,7 +110,7 @@
         <jaxb-api.version>2.2.12-b140109.1041</jaxb-api.version>
         <jaxb.version>2.2.10-b140802.1033</jaxb.version>
         <stax2-api.version>3.1.1</stax2-api.version>
-        <eclipselink.version>2.6.0.payara-p1</eclipselink.version>
+        <eclipselink.version>2.6.0.payara-p2</eclipselink.version>
         <javax.xml.registry-api.version>1.0.7</javax.xml.registry-api.version>
         <javax-persistence-api.version>2.1.0</javax-persistence-api.version> 
         <dbschema.version>3.1.1</dbschema.version>


### PR DESCRIPTION
Fixes #475 

Depends on https://github.com/payara/Payara_PatchedProjects/pull/4 being pulled first.