### PR TITLE
PAYARA-388 - Server log displays webappClassLoader severe warnings on shutdown

### DIFF
--- a/appserver/admin/runtime/mgmt-infra/pom.xml
+++ b/appserver/admin/runtime/mgmt-infra/pom.xml
@@ -57,7 +57,7 @@
     <dependencies>
         <dependency>
           <groupId>org.glassfish.hk2</groupId>
-          <artifactId>core</artifactId>
+          <artifactId>hk2-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/extras/embedded-shell/pom.xml
+++ b/appserver/extras/embedded-shell/pom.xml
@@ -84,7 +84,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.common</groupId>

--- a/appserver/orb/orb-connector/pom.xml
+++ b/appserver/orb/orb-connector/pom.xml
@@ -97,10 +97,10 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-core</artifactId>
         </dependency>
-            <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-            </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+        </dependency>
        <dependency>
             <groupId>org.glassfish.main.deployment</groupId>
             <artifactId>dol</artifactId>

--- a/appserver/resources/resources-connector/pom.xml
+++ b/appserver/resources/resources-connector/pom.xml
@@ -85,10 +85,10 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-core</artifactId>
         </dependency>
-            <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-            </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>common-util</artifactId>

--- a/appserver/security/security-dol/pom.xml
+++ b/appserver/security/security-dol/pom.xml
@@ -87,7 +87,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.deployment</groupId>

--- a/appserver/tests/paas/multiple-spe-test/mydb-plugin/pom.xml
+++ b/appserver/tests/paas/multiple-spe-test/mydb-plugin/pom.xml
@@ -89,7 +89,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.common</groupId>

--- a/appserver/transaction/jta-xa/pom.xml
+++ b/appserver/transaction/jta-xa/pom.xml
@@ -83,7 +83,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -183,8 +183,8 @@
         <servlet-api.version>3.1.0</servlet-api.version>
         <grizzly.version>2.3.23</grizzly.version>
         <saaj-api.version>1.3.4</saaj-api.version>
-        <hk2.version>2.4.0-b31</hk2.version>
-        <hk2.plugin.version>2.4.0-b31</hk2.plugin.version>
+        <hk2.version>2.4.0-b32</hk2.version>
+        <hk2.plugin.version>2.4.0-b32</hk2.plugin.version>
         <javax.el.version>3.0.1-b03</javax.el.version>
         <javax.el-api.version>3.0.1-b03</javax.el-api.version>
         <trilead-ssh2.version>build212-hudson-6</trilead-ssh2.version>


### PR DESCRIPTION
upgraded hk2.version and hk2.plugin.version to 2.4.0.b32
also used hk2-core instead of -core dependency since -core looked obsolete.