### PR TITLE
used @WithAnnotations to narrow down the generic type used.

### DIFF
--- a/appserver/jms/gf-jms-injection/src/main/java/org/glassfish/jms/injection/JMSCDIExtension.java
+++ b/appserver/jms/gf-jms-injection/src/main/java/org/glassfish/jms/injection/JMSCDIExtension.java
@@ -101,7 +101,7 @@ public class JMSCDIExtension implements Extension {
     public <T> void processInjectionTarget(@Observes ProcessInjectionTarget<T> pit) {
     }
 
-    public <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> pat) {
+    public <T> void processAnnotatedType(@Observes @WithAnnotations(Void.class) ProcessAnnotatedType<T> pat) {
     }
 
     public <T, X> void processProducer(@Observes ProcessProducer<T, X> event) {
@@ -224,3 +224,5 @@ public class JMSCDIExtension implements Extension {
         }
     }
 }
+
+@interface Void {}

--- a/appserver/web/web-sse/src/main/java/org/glassfish/sse/impl/ServerSentEventCdiExtension.java
+++ b/appserver/web/web-sse/src/main/java/org/glassfish/sse/impl/ServerSentEventCdiExtension.java
@@ -189,7 +189,7 @@ public class ServerSentEventCdiExtension implements Extension {
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> pat,
+    <T> void processAnnotatedType(@Observes @WithAnnotations(ServerSentEvent.class) ProcessAnnotatedType<T> pat,
             BeanManager beanManager) {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("scanning type: " + pat.getAnnotatedType().getJavaClass().getName());


### PR DESCRIPTION
We have 2 extensions on board within our codebase, ServerSentEventCdiExtension and JMSCDIExtension. With Weld 2.x these warning occur when we handle generic types in ProcessAnnotatedType.
They need to be narrowed down by using the @WithAnnotations annotation, as advised in the warning message. I first did some tricks with <weld:exclude> but didn't turned out good so moved 
over by modifying the extensions' code.