### PR TITLE
Payara issue 512 - actual descriptors and replacing SunAS9 with Glassfish

### DIFF
--- a/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/orm.xml
+++ b/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/orm.xml
@@ -39,6 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2015] [C2B2 Consulting Limited]
 -->
 <entity-mappings
   xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/orm"

--- a/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/orm.xml
+++ b/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/orm.xml
@@ -40,12 +40,16 @@
     holder.
 
 -->
-
-<entity-mappings version="1.0" xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm orm_1_0.xsd">
-    <description>Empty mapping to be overrided if needed.</description>
+<entity-mappings
+  xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/orm"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.eclipse.org/eclipselink/xsds/persistence/orm http://www.eclipse.org/eclipselink/xsds/eclipselink_orm_2_1.xsd"
+  version="2.1">
+    <description>Empty mapping to be overridden if needed.</description>
     <persistence-unit-metadata>
         <persistence-unit-defaults>
             <delimited-identifiers/>
         </persistence-unit-defaults>
     </persistence-unit-metadata>
 </entity-mappings>
+

--- a/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml
+++ b/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml
@@ -38,6 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2015] [C2B2 Consulting Limited]
 -->
 
 <persistence version="2.1"

--- a/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml
+++ b/appserver/ejb/ejb-timer-service-app/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml
@@ -40,10 +40,14 @@
 
 -->
 
-<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">
+<persistence version="2.1"
+  xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+    http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/persistence/persistence_2_1.xsd">
     <persistence-unit name="__EJB__Timer__App">
           <jta-data-source>jdbc/__TimerPool</jta-data-source>
-          <mapping-file>__ejb_timer_mappings.xml</mapping-file>
+          <mapping-file>META-INF/orm.xml</mapping-file>
           <class>org.glassfish.ejb.persistent.timer.TimerState</class>
           <exclude-unlisted-classes/>
           <properties>
@@ -51,6 +55,7 @@
             <property name="eclipselink.weaving" value="false"/>
             <property name="eclipselink.ddl-generation" value="create-tables"/>
             <property name="eclipselink.logging.level" value="INFO"/>
+            <property name="eclipselink.target-server" value="Glassfish" />
         </properties>
     </persistence-unit>
 </persistence>

--- a/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/PersistenceUnitLoader.java
+++ b/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/PersistenceUnitLoader.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package org.glassfish.persistence.jpa;
 

--- a/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/PersistenceUnitLoader.java
+++ b/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/PersistenceUnitLoader.java
@@ -81,7 +81,7 @@ public class PersistenceUnitLoader {
 
     private static Logger logger = LogDomains.getLogger(PersistenceUnitLoader.class, LogDomains.PERSISTENCE_LOGGER);
 
-    private static final StringManager localStrings = StringManager.getManager(PersistenceUnitLoader.class);    
+    private static final StringManager localStrings = StringManager.getManager(PersistenceUnitLoader.class);
 
     private static Map<String, String> integrationProperties;
 
@@ -400,7 +400,7 @@ public class PersistenceUnitLoader {
 
         final String ECLIPSELINK_SERVER_PLATFORM_CLASS_NAME_PROPERTY = "eclipselink.target-server"; // NOI18N
         props.put(ECLIPSELINK_SERVER_PLATFORM_CLASS_NAME_PROPERTY,
-                System.getProperty(ECLIPSELINK_SERVER_PLATFORM_CLASS_NAME_PROPERTY, "SunAS9")); // NOI18N
+                System.getProperty(ECLIPSELINK_SERVER_PLATFORM_CLASS_NAME_PROPERTY, "Glassfish")); // NOI18N
 
         // TopLink specific properties:
         // See https://glassfish.dev.java.net/issues/show_bug.cgi?id=249


### PR DESCRIPTION
Only actual headers and target-server property. It did not resolved the exception in server.log, but it is correct at least. SunAS9 replaced with Glassfish.