### PR TITLE
PAYARA-510 fixes 505 ensures resources are enlisted into the transaction

### DIFF
--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -178,5 +178,11 @@
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequired.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequired.java
@@ -37,17 +37,19 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package org.glassfish.cdi.transaction;
 
-import org.glassfish.logging.annotation.LoggerInfo;
 
+import com.sun.enterprise.transaction.TransactionManagerHelper;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import javax.transaction.Status;
 import javax.transaction.TransactionalException;
 import java.util.logging.Logger;
+import javax.transaction.TransactionManager;
 
 /**
  * Transactional annotation Interceptor class for Required transaction type,
@@ -78,6 +80,11 @@ public class TransactionalInterceptorRequired extends TransactionalInterceptorBa
                 _logger.log(java.util.logging.Level.INFO, CDI_JTA_MBREQUIRED);
                 try {
                     getTransactionManager().begin();
+                    TransactionManager tm = getTransactionManager();
+                    if (tm instanceof TransactionManagerHelper) {
+                       ((TransactionManagerHelper)tm).preInvokeTx(true);
+                    }
+                    
                 } catch (Exception exception) {
                     String messageString =
                             "Managed bean with Transactional annotation and TxType of REQUIRED " +
@@ -95,6 +102,10 @@ public class TransactionalInterceptorRequired extends TransactionalInterceptorBa
             } finally {
                 if (isTransactionStarted) {
                     try {
+                        TransactionManager tm = getTransactionManager();
+                        if (tm instanceof TransactionManagerHelper) {
+                           ((TransactionManagerHelper)tm).postInvokeTx(false,true);
+                        }
                         // Exception handling for proceed method call above can set TM/TRX as setRollbackOnly
                         if(getTransactionManager().getTransaction().getStatus() == Status.STATUS_MARKED_ROLLBACK) {
                             getTransactionManager().rollback();

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
@@ -37,10 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package org.glassfish.cdi.transaction;
 
-import org.glassfish.logging.annotation.LoggerInfo;
+import com.sun.enterprise.transaction.TransactionManagerHelper;
 
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -49,6 +50,7 @@ import javax.transaction.Status;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionalException;
 import java.util.logging.Logger;
+import javax.transaction.TransactionManager;
 
 /**
  * Transactional annotation Interceptor class for RequiresNew transaction type,
@@ -83,6 +85,10 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
                 //todo catch, wrap in new transactional exception and throw
             }
             try {
+                TransactionManager tm = getTransactionManager();
+                if (tm instanceof TransactionManagerHelper) {
+                   ((TransactionManagerHelper)tm).preInvokeTx(true);
+                }
                 getTransactionManager().begin();
             } catch (Exception exception) {
                 String messageString =
@@ -97,6 +103,10 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
                 proceed = proceed(ctx);
             } finally {
                 try {
+                    TransactionManager tm = getTransactionManager();
+                    if (tm instanceof TransactionManagerHelper) {
+                       ((TransactionManagerHelper)tm).postInvokeTx(false,true);
+                    }
                     // Exception handling for proceed method call above can set TM/TRX as setRollbackOnly
                     if(getTransactionManager().getTransaction().getStatus() == Status.STATUS_MARKED_ROLLBACK) {
                         getTransactionManager().rollback();

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionScopedBeanTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionScopedBeanTest.java
@@ -37,9 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited]
 
 package org.glassfish.cdi.transaction;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Test;
 
 import javax.enterprise.context.spi.Contextual;
@@ -61,6 +63,7 @@ public class TransactionScopedBeanTest {
         Contextual<LocalBean> contextual = (Contextual<LocalBean>) mockSupport.createMock(Contextual.class);
         CreationalContext<LocalBean> creationalContext = (CreationalContext<LocalBean>) mockSupport.createMock(CreationalContext.class);
         TransactionScopedContextImpl transactionScopedContext = mockSupport.createMock(TransactionScopedContextImpl.class);
+        transactionScopedContext.beansPerTransaction = new ConcurrentHashMap<>();
 
         // test getContextualInstance
         TransactionScopedBean<LocalBean> transactionScopedBean = getTransactionScopedBean(mockSupport,


### PR DESCRIPTION
Fixes #505 
Even though a transaction is created correctly by the interceptor. Resources e.g. DataSources are not enlisted into the global transaction so do not behave as expected.