### PR TITLE
PAYARA-511 fixes #492

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -380,7 +380,7 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
 
             // SHOULD CHECK THAT WE ARE THE CORRECT TARGET BEFORE DISABLING 
             String serverName = server.getName();
-            if (serverName.equals(target)) {
+            if (serverName.equals(target) || (server.getCluster() != null && server.getCluster().getName().equals(target)) ) {
                 final DeploymentContext basicDC = deployment.disable(this, app, appInfo, report, logger);           
                 suppInfo.setDeploymentContext((ExtendedDeploymentContext)basicDC);  
             }


### PR DESCRIPTION
Disable command was not executing correctly on a cluster during undeployment due to not matching the cluster target name with the server name. This is a regression introduced by fixing #433 and had the effect of JNDI names not being removed even though the application was correctly unloaded.