### PR TITLE
Revert "PAYARA-446-Multiple cookies cannot be added using Headers.put…

### DIFF
--- a/appserver/packager/metro/pom.xml
+++ b/appserver/packager/metro/pom.xml
@@ -164,7 +164,6 @@
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-osgi</artifactId>
-            <classifier>payara</classifier>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -104,7 +104,7 @@
         <jsftemplating.version>2.1.1</jsftemplating.version>
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
-        <webservices.version>2.3.2-b620</webservices.version>
+        <webservices.version>2.3.2-b608</webservices.version>
         <jsr181-api.version>1.0-MR1</jsr181-api.version>
         <woodstox.version>4.2.0</woodstox.version>
         <jaxb-api.version>2.2.13-b141020.1521</jaxb-api.version>
@@ -612,7 +612,6 @@
                 <groupId>org.glassfish.metro</groupId>
                 <artifactId>webservices-osgi</artifactId>
                 <version>${webservices.version}</version>
-                <classifier>payara</classifier>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.metro</groupId>

--- a/appserver/security/webservices.security/pom.xml
+++ b/appserver/security/webservices.security/pom.xml
@@ -115,7 +115,6 @@
         <dependency>
            <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-osgi</artifactId>
-            <classifier>payara</classifier>
         </dependency>
         <dependency>
            <groupId>org.glassfish.metro</groupId>

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -149,7 +149,6 @@
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-osgi</artifactId>
-            <classifier>payara</classifier>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>

--- a/appserver/webservices/metro-glue/pom.xml
+++ b/appserver/webservices/metro-glue/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-osgi</artifactId>
-            <classifier>payara</classifier>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.admin</groupId>

--- a/appserver/webservices/soap-tcp/pom.xml
+++ b/appserver/webservices/soap-tcp/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-osgi</artifactId>
-            <classifier>payara</classifier>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>


### PR DESCRIPTION
…All()"

This reverts commit d2dbfefcd402f549a3126ddf945d4ffda54933d0.

The version was changed incorrectly and not in line with our previous patches. Also, the JAR file uploaded to Payara patched projects looks to be version b608, not b620.