### PR TITLE
PAYARA-406 - Wrong thread name in server log

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -875,7 +875,7 @@ PostConstruct, PreDestroy, LogEventBroadcaster, LoggingRuntime {
         if (record.getClass().getSimpleName().equals("GFLogRecord")) {
             recordWrapper = (GFLogRecord) record;
             
-            // Double check there is actually a set thread name
+            // Check there is actually a set thread name
             if (recordWrapper.getThreadName() == null) {
                 recordWrapper.setThreadName(Thread.currentThread().getName());
             }

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -874,6 +874,11 @@ PostConstruct, PreDestroy, LogEventBroadcaster, LoggingRuntime {
         GFLogRecord recordWrapper;
         if (record.getClass().getSimpleName().equals("GFLogRecord")) {
             recordWrapper = (GFLogRecord) record;
+            
+            // Double check there is actually a set thread name
+            if (recordWrapper.getThreadName() == null) {
+                recordWrapper.setThreadName(Thread.currentThread().getName());
+            }
         }    
         else {
             recordWrapper = new GFLogRecord(record);            

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -868,12 +868,20 @@ PostConstruct, PreDestroy, LogEventBroadcaster, LoggingRuntime {
         // capture the name of the logging thread so that a formatter can
         // output correct thread-name if done asynchronously. Note that 
         // this fix is limited to records published through this handler only.
-        GFLogRecord recordWrapper = new GFLogRecord(record);
-        recordWrapper.setThreadName(Thread.currentThread().getName());
-
-        try {
+        // ***
+        // PAYARA-406 Check if the LogRecord passed in is already a GFLogRecord,
+        // and just cast the passed record if it is
+        GFLogRecord recordWrapper;
+        if (record.getClass().getSimpleName().equals("GFLogRecord")) {
+            recordWrapper = (GFLogRecord) record;
+        }    
+        else {
+            recordWrapper = new GFLogRecord(record);            
             // set the thread id to be the current thread that is logging the message
-//            record.setThreadID((int)Thread.currentThread().getId());
+            recordWrapper.setThreadName(Thread.currentThread().getName());
+        }
+        
+        try {
             pendingRecords.add(recordWrapper);
         } catch (IllegalStateException e) {
             // queue is full, start waiting.


### PR DESCRIPTION
Add check to GFFileHandler to make sure passed GFLogRecord doesn't get overwritten.