### PR TITLE
Removed cause of spurious warning RAR8705

### DIFF
--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -1004,8 +1004,12 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public Property getProperty(String name) {
+            Property result = null;
             String value = (String) desc.getProperties().get(name);
-            return new DataSourceProperty(name, value);
+            if (value != null) {
+                result = new DataSourceProperty(name, value);
+            }
+            return result;
         }
 
         @Override


### PR DESCRIPTION
DataSourceDeployer was not returning null for non-existent properties. 