### PR TITLE
PAYARA-551 Fixes #536

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -734,6 +734,7 @@ public class Request
             return;
         }
 
+        handlerInitialised = false;
         context = null;
         servletContext = null;
         contextPath = null;


### PR DESCRIPTION
 sets handler initialised variable to false when the Request is recycled.