### PR TITLE
PAYARA-554 modified and improved SQL Tracing

### DIFF
--- a/appserver/admingui/jdbc/src/main/resources/advancePool.inc
+++ b/appserver/admingui/jdbc/src/main/resources/advancePool.inc
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-
+Portions Copyright [2015] [C2B2 Consulting Limited]
 -->
 
 <!-- jdbc/advancePool.inc -->
@@ -67,12 +67,20 @@
 
             </sun:textField>
         </sun:property>
+        <sun:property id="slowSQLProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.slowSQL}" helpText="$resource{i18njdbc.jdbcPool.slowSQLHelp}">
+            <sun:textField id="slowQueryThresholdInSeconds" columns="$int{10}" maxLength="#{sessionScope.fieldLengths['maxLength.jdbcPool.slowSQL']}" text="#{pageSession.valueMap['slowQueryThresholdInSeconds']}" >
+            </sun:textField>
+            <sun:staticText id="vasec" text="$resource{i18n.common.Seconds}"/>
+        </sun:property>
+         <sun:property id="logJDBCCalls"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.logJdbcCalls}" helpText="$resource{i18njdbc.jdbcPool.logJdbcCallsHelp}">
+            <sun:checkbox  selected="#{pageSession.valueMap['logJdbcCalls']}" label="$resource{i18n.common.Enabled}" selectedValue="true" />
+       </sun:property>
         <sun:property id="sqlTLProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.sqlTL}"  helpText="$resource{i18njdbc.jdbcPool.sqlTLHelp}">
             <sun:textField id="sqlTL" columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.jdbcPool.sqlTL']}" text="#{pageSession.valueMap['sqlTraceListeners']}" >
 
             </sun:textField>
         </sun:property>
-         <sun:property id="p1"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.wrapJdbcObjects}" helpText="$resource{i18njdbc.jdbcPool.wrapJdbcObjectsHelp}">
+        <sun:property id="p1"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.wrapJdbcObjects}" helpText="$resource{i18njdbc.jdbcPool.wrapJdbcObjectsHelp}">
             <sun:checkbox  selected="#{pageSession.valueMap['wrapJdbcObjects']}" label="$resource{i18n.common.Enabled}" selectedValue="true" />
        </sun:property>
        <sun:property id="poolingProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.pooling}" helpText="$resource{i18njdbc.jdbcPool.poolingHelp}">

--- a/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvance.jsf
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvance.jsf
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-
+Portions Copyright [2015] [C2B2 Consulting Limited and/or its affiliates]
 -->
 
 <!-- jdbc/jdbcConnectionPoolAdvance.jsf -->
@@ -102,7 +102,7 @@
         setPageSessionAttribute(key="convertToFalseList" value={"wrapJdbcObjects" "pooling" "connectionLeakReclaim"
                                                                 "lazyConnectionAssociation" "lazyConnectionEnlistment"
                                                                 "associateWithThread" "matchConnections" "allowNonComponentCallers"
-                                                                "isConnectionValidationRequired" "failAllConnections"});
+                                                                "isConnectionValidationRequired" "failAllConnections" "logJdbcCalls"});
         setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
         gf.createAttributeMap(keys={"poolName"} values={"$pageSession{encodedName}"} map="#{pageSession.attrMap}");
         if(#{pageSession.isAppScopedRes}){

--- a/appserver/admingui/jdbc/src/main/resources/org/glassfish/jdbc/admingui/Strings.properties
+++ b/appserver/admingui/jdbc/src/main/resources/org/glassfish/jdbc/admingui/Strings.properties
@@ -36,7 +36,7 @@
 # and therefore, elected the GPL Version 2 license, then the option applies
 # only if the new code is made subject to such option by the copyright
 # holder.
-#
+# Portions Copyright [2015] [C2B2 Consulting Limited and/or its affiliates]
 
 button.Flush=Flush
 tree.jdbcResources=JDBC Resources
@@ -74,6 +74,10 @@ jdbcPool.general=General Settings
 jdbcPool.poolName=Pool Name:
 jdbcPool.datasource=Datasource Classname:
 jdbcPool.driver=Driver Classname:
+jdbcPool.slowSQL=Slow Query Log Threshold:
+jdbcPool.slowSQLHelp=SQL queries that exceed this time in seconds will be logged. Any value <= 0 disables Slow Query Logging
+jdbcPool.logJdbcCalls=Log JDBC Calls:
+jdbcPool.logJdbcCallsHelp=When set to true, all JDBC calls will be logged allowing tracing of all JDBC interactions including SQL
 
 ## do not translate DataSource and XADataSource
 jdbcPool.datasourceHelpEnter=Select or enter vendor-specific classname that implements the DataSource and/or XADataSource APIs

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited and/or its affiliates]
 
 package org.glassfish.jdbc.config;
 
@@ -610,7 +611,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *              {@link String }
      */
     void setConnectionCreationRetryIntervalInSeconds(String value) throws PropertyVetoException;
-
+    
     /**
      * Gets the value of the statementTimeoutInSeconds property.
      *
@@ -632,6 +633,27 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *              {@link String }
      */
     void setStatementTimeoutInSeconds(String value) throws PropertyVetoException;
+   
+    /**
+     * Gets the value of the sloqSQLLogThreshold property.
+     *
+     * gets the SLow SQL Log Threshold property if a query exceeds this time in seconds
+     * it will be logged as a WARNING
+     * 
+     * @return possible object is
+     *         {@link String }
+     */
+    @Attribute (defaultValue="-1", dataType=Integer.class)
+    @Min(value=-1)
+    String getSlowQueryThresholdInSeconds();
+
+    /**
+     * Sets the value of the slowQueryThreasholdInSeconds property.
+     *
+     * @param value allowed object is
+     *              {@link String }
+     */
+    void setSlowQueryThresholdInSeconds(String value) throws PropertyVetoException;
 
     /**
      * Gets the value of the lazyConnectionEnlistment property.
@@ -860,8 +882,8 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *              {@link String }
      */
     void setMaxConnectionUsageCount(String value) throws PropertyVetoException;
-
-    /**
+    
+        /**
      * Gets the value of the wrapJdbcObjects property.
      *
      * When set to true, application will get wrapped jdbc objects for
@@ -881,6 +903,25 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *              {@link String }
      */
     void setWrapJdbcObjects(String value) throws PropertyVetoException;
+
+    /**
+     * Gets the value of the logJDBCCalls property.
+     *
+     * When set to true, application log all JDBC method calls. Defaults to false.
+     * 
+     * @return possible object is
+     *         {@link String }
+     */
+    @Attribute (defaultValue="false", dataType=Boolean.class)
+    String getLogJdbcCalls();
+
+    /**
+     * Sets the value of the LogJdbcCalls property.
+     *
+     * @param value allowed object is
+     *              {@link String }
+     */
+    void setLogJdbcCalls(String value) throws PropertyVetoException;
     
     /**
      * Gets the value of the SqlTraceListeners property.

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/common/DataSourceSpec.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/common/DataSourceSpec.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.gjc.common;
 
@@ -104,6 +105,9 @@ public class DataSourceSpec implements java.io.Serializable {
     public static final int POOLNAME = 45;
     public static final int APPLICATIONNAME = 46;
     public static final int MODULENAME = 47;
+    public static final int SLOWSQLLOGTHRESHOLD = 48;
+    public static final int LOGJDBCCALLS = 49;
+    
 
     private ConcurrentHashMap<Integer, String> details = new ConcurrentHashMap<Integer, String>();
 

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/JdbcRAConstants.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/JdbcRAConstants.java
@@ -37,12 +37,15 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.gjc.monitoring;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Interface that contains all the constants used in the jdbc-ra module.
@@ -113,9 +116,9 @@ public interface JdbcRAConstants {
     /**
      * List of valid method names that can be used for sql trace monitoring.
      */
-    public static final List<String> validSqlTracingMethodNames =
-            Collections.unmodifiableList(
-            Arrays.asList(
+    public static final Set<String> validSqlTracingMethodNames =
+            Collections.unmodifiableSet(
+            new HashSet(Arrays.asList(
                 "nativeSQL",
                 "prepareCall",
                 "prepareStatement",
@@ -123,5 +126,5 @@ public interface JdbcRAConstants {
                 "execute",
                 "executeQuery",
                 "executeUpdate"
-            ));
+            )));
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/JdbcObjectsFactory.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/JdbcObjectsFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2015] [C2B2 Consulting Limited and/or its affiliates]
 package com.sun.gjc.spi;
 
 import com.sun.gjc.common.DataSourceObjectBuilder;
@@ -139,8 +139,11 @@ public abstract class JdbcObjectsFactory implements Serializable {
                 record.setThreadName(Thread.currentThread().getName());
                 record.setThreadID(Thread.currentThread().getId());
                 record.setTimeStamp(System.currentTimeMillis());
+                long startTime = System.currentTimeMillis();
+                Object methodResult = method.invoke(actualObject, args);
+                record.setExecutionTime(System.currentTimeMillis() - startTime);
                 sqlTraceDelegator.sqlTrace(record);
-                return method.invoke(actualObject, args);
+                return methodResult;
             }
         };
         result = (T) Proxy.newProxyInstance(actualObject.getClass().getClassLoader(), ifaces, ih);        

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SQLQuery.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SQLQuery.java
@@ -1,0 +1,70 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 C2B2 Consulting Limited and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.jdbc;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ * @author steve
+ */
+class SQLQuery {
+    
+    List<String> gatheredSQL;
+    
+    SQLQuery() {
+        gatheredSQL = new LinkedList<>();
+    }
+
+    void addSQL(String sql) {
+        if (sql != null)
+            gatheredSQL.add(sql);
+    }
+
+    String getSQL() {
+        StringBuilder sb = new StringBuilder();
+        for (String sql : gatheredSQL) {
+            sb.append(sql).append(";\n");
+        }
+        return sb.toString();
+    }
+    
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SlowSQLLogger.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SlowSQLLogger.java
@@ -1,0 +1,133 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 C2B2 Consulting Limited and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.jdbc;
+
+import com.sun.gjc.util.SQLTraceLogger;
+import com.sun.logging.LogDomains;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.glassfish.api.jdbc.SQLTraceListener;
+import org.glassfish.api.jdbc.SQLTraceRecord;
+
+/**
+ * Logs a message when it detects that a SQL query is slow.
+ * @author steve
+ */
+public class SlowSQLLogger implements SQLTraceListener {
+    
+    private static final Logger logger = LogDomains.getLogger(SQLTraceLogger.class, LogDomains.SQL_TRACE_LOGGER);
+    private static ThreadLocal<SQLQuery> currentQuery = new ThreadLocal<>();
+    private long threshold = 10000; // 10 second default threshold
+    
+    public SlowSQLLogger(long threshold) {
+       this.threshold = threshold; 
+    }
+    
+    public SlowSQLLogger() {
+        
+    }
+
+    public long getThreshold() {
+        return threshold;
+    }
+
+    public void setThreshold(long threshold) {
+        this.threshold = threshold;
+    }
+    
+    @Override
+    public void sqlTrace(SQLTraceRecord record) {
+        if (record != null) {    
+            switch (record.getMethodName()) {
+
+                // these calls capture a query string
+                case "nativeSQL":
+                case "prepareCall":
+                case "prepareStatement":
+                case "addBatch":
+                {
+                    // acquire the SQL
+                    SQLQuery query = currentQuery.get();
+                    if (query == null) {
+                        query = new SQLQuery();
+                        currentQuery.set(query);
+                    }  
+                    if (record.getParams() != null && record.getParams().length > 0)
+                        query.addSQL((String)record.getParams()[0]);
+                    break;
+                }
+                case "execute":
+                case "executeQuery":
+                case "executeUpdate":
+                {
+                    // acquire the SQL
+                    SQLQuery query = currentQuery.get();
+                    if (query == null) {
+                        query = new SQLQuery();
+                        currentQuery.set(query);
+                    }                      // these can all run the SQL and contain SQL
+                    long executionTime = record.getExecutionTime();
+                    // see if we have more SQL
+                    if (record.getParams() != null && record.getParams().length > 0) {
+                        // gather the SQL
+                        query.addSQL((String) record.getParams()[0]);
+                    }
+                    
+                    // check the execution time
+                    
+                    if (executionTime > threshold) {
+                        StringBuilder messageBuilder = new StringBuilder("SQL Query Exceeded Threshold Time: ");
+                        messageBuilder.append(threshold)
+                                .append("(ms): Time Taken: ")
+                                .append(executionTime)
+                                .append("(ms)\n")
+                                .append("Query was ")
+                                .append(query.getSQL());
+                        logger.log(Level.WARNING,messageBuilder.toString(),new Exception("Stack Trace shows code path to SQL"));
+                    }
+                    // clean the thread local
+                    currentQuery.set(null);
+                    break;
+                }
+            }
+        }
+    }
+    
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-ra-distribution/build.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-ra-distribution/build.xml
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-
+Portions Copyright 2015 [C2B2 Consulting Limited and/or its affiliates]
 -->
 
 <project name="JDBCRA bundler" default="build">
@@ -68,7 +68,7 @@
         </jar>
 
         <jar jarfile="${component.lib.home}/__ds_jdbc_ra.jar" update="true" basedir="${component.classes.dir}"
-		includes="${pkg.dir}/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
+		includes="${pkg.dir}/**/*, fish/payara/jdbc/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
             <exclude name="com/sun/gjc/spi/XAManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/CPManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/DMManagedConnectionFactory.class"/>
@@ -95,7 +95,7 @@
 
 
         <jar jarfile="${component.lib.home}/__cp_jdbc_ra.jar" update="true" basedir="${component.classes.dir}"
-		includes="${pkg.dir}/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
+		includes="${pkg.dir}/**/*, fish/payara/jdbc/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
             <exclude name="com/sun/gjc/spi/XAManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/DSManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/DMManagedConnectionFactory.class"/>
@@ -124,7 +124,7 @@
 
 
         <jar jarfile="${component.lib.home}/__xa_jdbc_ra.jar" update="true" basedir="${component.classes.dir}"
-		includes="${pkg.dir}/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
+		includes="${pkg.dir}/**/*, fish/payara/jdbc/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
             <exclude name="com/sun/gjc/spi/CPManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/DSManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/DMManagedConnectionFactory.class"/>
@@ -151,7 +151,7 @@
         </jar>
 
         <jar jarfile="${component.lib.home}/__dm_jdbc_ra.jar" update="true" basedir="${component.classes.dir}"
-		includes="${pkg.dir}/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
+		includes="${pkg.dir}/**/*, fish/payara/jdbc/**/*, com/sun/gjc/util/**/*, com/sun/gjc/monitoring/**/*, com/sun/gjc/common/**/*, **/LocalStrings.properties">
             <exclude name="com/sun/gjc/spi/DSManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/CPManagedConnectionFactory.class"/>
             <exclude name="com/sun/gjc/spi/XAManagedConnectionFactory.class"/>

--- a/appserver/jdbc/jdbc-ra/jdbc30/src/main/java/com/sun/gjc/spi/jdbc30/ProfiledConnectionWrapper30.java
+++ b/appserver/jdbc/jdbc-ra/jdbc30/src/main/java/com/sun/gjc/spi/jdbc30/ProfiledConnectionWrapper30.java
@@ -455,9 +455,11 @@ public class ProfiledConnectionWrapper30 extends ConnectionHolder30 implements C
                 record.setThreadName(Thread.currentThread().getName());
                 record.setThreadID(Thread.currentThread().getId());
                 record.setTimeStamp(System.currentTimeMillis());
-                sqlTraceDelegator.sqlTrace(record);
                 try {
-                    return method.invoke(actualObject, args);
+                    long startTime = System.currentTimeMillis();
+                    Object methodResult =  method.invoke(actualObject, args);
+                    record.setExecutionTime(System.currentTimeMillis() - startTime);
+                    return methodResult;
                 } catch (InvocationTargetException ex) {
                     Throwable cause = ex.getCause();
                     if (cause != null) {
@@ -465,7 +467,9 @@ public class ProfiledConnectionWrapper30 extends ConnectionHolder30 implements C
                     } else {
                         throw ex;
                     }
-                }
+                } finally {
+                    sqlTraceDelegator.sqlTrace(record);
+                }  
             }
         };
         result = (T) Proxy.newProxyInstance(actualObject.getClass().getClassLoader(), ifaces, ih);

--- a/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ProfiledConnectionWrapper40.java
+++ b/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ProfiledConnectionWrapper40.java
@@ -432,9 +432,11 @@ public class ProfiledConnectionWrapper40 extends ConnectionHolder40 implements C
                 record.setThreadName(Thread.currentThread().getName());
                 record.setThreadID(Thread.currentThread().getId());
                 record.setTimeStamp(System.currentTimeMillis());
-                sqlTraceDelegator.sqlTrace(record);
                 try {
-                    return method.invoke(actualObject, args);
+                    long startTime = System.currentTimeMillis();
+                    Object methodResult =  method.invoke(actualObject, args);
+                    record.setExecutionTime(System.currentTimeMillis() - startTime);
+                    return methodResult;
                 } catch (InvocationTargetException ex) {
                     Throwable cause = ex.getCause();
                     if (cause != null) {
@@ -442,6 +444,8 @@ public class ProfiledConnectionWrapper40 extends ConnectionHolder40 implements C
                     } else {
                         throw ex;
                     }
+                } finally {
+                    sqlTraceDelegator.sqlTrace(record);
                 }            
             }
         };

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2015] [C2B2 Consulting Limited]
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 
 package org.glassfish.jdbc.deployer;
 
@@ -1127,7 +1127,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getSlowQueryThresholdInSeconds() {
-            return getPropertyValue("fish.payara.slow-query-threshold-in-seconds", null);
+            return getPropertyValue("fish.payara.slow-query-threshold-in-seconds", "-1");
         }
 
         @Override
@@ -1136,7 +1136,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getLogJdbcCalls() {
-            return getPropertyValue("fish.payara.log-jdbc-calls", null);
+            return getPropertyValue("fish.payara.log-jdbc-calls", "false");
         }
 
         @Override

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -655,7 +655,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getMaxWaitTimeInMillis() {
-            return String.valueOf(60000);
+            return getPropertyValue("fish.payara.max-wait-time-in-millis", "60000");
         }
 
         @Override
@@ -665,7 +665,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getPoolResizeQuantity() {
-            return String.valueOf(2);
+            return getPropertyValue("fish.payara.pool-resize-quantity", "2");
         }
 
         @Override
@@ -713,7 +713,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getIsConnectionValidationRequired() {
-            return String.valueOf("false");
+            return getPropertyValue("fish.payara.is-connection-validation-required", "false");
         }
 
         @Override
@@ -723,7 +723,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getConnectionValidationMethod() {
-            return null;
+            return getPropertyValue("fish.payara.connection-validation-method", "table");
         }
 
         @Override
@@ -733,7 +733,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getValidationTableName() {
-            return null;
+            return getPropertyValue("fish.payara.validation-table-name", null);
         }
 
         @Override
@@ -743,7 +743,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getValidationClassname() {
-            return null;
+            return getPropertyValue("fish.payara.validation-classname", null);
         }
 
         @Override
@@ -753,7 +753,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getFailAllConnections() {
-            return String.valueOf("false");
+            return getPropertyValue("fish.payara.fail-all-connections", "false");
         }
 
         @Override
@@ -773,7 +773,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getAllowNonComponentCallers() {
-            return String.valueOf("false");
+            return getPropertyValue("fish.payara.allow-non-component-callers", "false");
         }
 
         @Override
@@ -783,7 +783,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getValidateAtmostOncePeriodInSeconds() {
-            return String.valueOf(0);
+            return getPropertyValue("fish.payara.validate-atmost-once-period-in-seconds", "0");
         }
 
         @Override
@@ -793,7 +793,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getConnectionLeakTimeoutInSeconds() {
-            return String.valueOf(0);
+            return getPropertyValue("fish.payara.connection-leak-timeout-in-seconds", "0");
         }
 
         @Override
@@ -803,7 +803,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getConnectionLeakReclaim() {
-            return String.valueOf(false);
+            return getPropertyValue("fish.payara.connection-leak-reclaim", "false");
         }
 
         @Override
@@ -813,7 +813,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getConnectionCreationRetryAttempts() {
-            return String.valueOf(0);
+            return getPropertyValue("fish.payara.connection-creation-retry-attempts", "0");
         }
 
         @Override
@@ -823,7 +823,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getConnectionCreationRetryIntervalInSeconds() {
-            return String.valueOf(10);
+            return getPropertyValue("fish.payara.connection-creation-retry-interval-in-seconds", "10");
         }
 
         @Override
@@ -833,7 +833,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getStatementTimeoutInSeconds() {
-            return String.valueOf(-1);
+            return getPropertyValue("fish.payara.statement-timeout-in-seconds", "-1");
         }
 
         @Override
@@ -843,7 +843,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getLazyConnectionEnlistment() {
-            return String.valueOf(false);
+            return getPropertyValue("fish.payara.lazy-connection-enlistment", "false");
         }
 
         @Override
@@ -853,7 +853,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getLazyConnectionAssociation() {
-            return String.valueOf(false);
+            return getPropertyValue("fish.payara.lazy-connection-association", "false");
         }
 
         @Override
@@ -863,7 +863,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getAssociateWithThread() {
-            return String.valueOf(false);
+            return getPropertyValue("fish.payara.associate-with-thread", "false");
         }
 
         @Override
@@ -873,7 +873,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getPooling() {
-            return String.valueOf(true);
+            return getPropertyValue("fish.payara.pooling", "true");
         }
 
         @Override
@@ -883,7 +883,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getStatementCacheSize() {
-            return String.valueOf(0);
+            return getPropertyValue("fish.payara.statement-cache-size", "0");
         }
 
         @Override
@@ -893,7 +893,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getMatchConnections() {
-            return String.valueOf(true);
+            return getPropertyValue("fish.payara.match-connections", "true");
         }
 
         @Override
@@ -903,7 +903,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getMaxConnectionUsageCount() {
-            return String.valueOf(0);
+            return getPropertyValue("fish.payara.max-connection-usage-count", "0");
         }
 
         @Override
@@ -913,7 +913,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getWrapJdbcObjects() {
-            return String.valueOf(true);
+            return getPropertyValue("fish.payara.wrap-jdbc-objects", "true");
         }
 
         @Override
@@ -1044,7 +1044,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getSqlTraceListeners() {
-            return null;
+            return getPropertyValue("fish.payara.sql-trace-listeners");
         }
 
         @Override
@@ -1054,7 +1054,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getPing() {
-            return String.valueOf(false);
+            return getPropertyValue("fish.payara.ping", "false");
         }
 
         @Override
@@ -1064,7 +1064,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getInitSql() {
-            return null;
+            return getPropertyValue("fish.payara.init-sql", null);
         }
 
         @Override
@@ -1087,7 +1087,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getStatementLeakTimeoutInSeconds() {
-            return String.valueOf(0);
+            return getPropertyValue("fish.payara.statement-leak-timeout-in-seconds", "0");
         }
 
         @Override
@@ -1097,7 +1097,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getStatementLeakReclaim() {
-            return String.valueOf(false);
+            return getPropertyValue("fish.payara.statement-leak-reclaim", "false");
         }
 
         @Override
@@ -1107,7 +1107,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
 
         @Override
         public String getStatementCacheType() {
-                return null;
+            return getPropertyValue("fish.payara.statement-cache-type", null);
         }
 
         @Override
@@ -1123,6 +1123,24 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public void setDeploymentOrder(String value) {
             //do nothing
+        }
+
+        @Override
+        public String getSlowQueryThresholdInSeconds() {
+            return getPropertyValue("fish.payara.slow-query-threshold-in-seconds", null);
+        }
+
+        @Override
+        public void setSlowQueryThresholdInSeconds(String value) throws PropertyVetoException {
+        }
+
+        @Override
+        public String getLogJdbcCalls() {
+            return getPropertyValue("fish.payara.log-jdbc-calls", null);
+        }
+
+        @Override
+        public void setLogJdbcCalls(String value) throws PropertyVetoException {
         }
     }
 }

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
@@ -359,7 +359,16 @@ public class JdbcConnectionPoolDeployer implements ResourceDeployer {
                 adminPool.getWrapJdbcObjects() + "",
                 "Statement Wrapping",
                 "java.lang.String"));
-
+        
+        propList.add(new ConnectorConfigProperty("LogJdbcCalls",
+                adminPool.getLogJdbcCalls() + "",
+                "Log JDBC Calls",
+                "java.lang.String"));
+                
+        propList.add(new ConnectorConfigProperty("SlowQueryThresholdInSeconds",
+                adminPool.getSlowQueryThresholdInSeconds() + "",
+                "Slow Query Threshold In Seconds",
+                "java.lang.String"));
 
         propList.add(new ConnectorConfigProperty("StatementTimeout",
                 adminPool.getStatementTimeoutInSeconds() + "",

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/jdbc/SQLTraceRecord.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/jdbc/SQLTraceRecord.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2015] [nC2B2 Consulting Limited and/or its affiliates]
 
 package org.glassfish.api.jdbc;
 
@@ -82,6 +83,11 @@ public class SQLTraceRecord implements Serializable {
      * Time of execution of query.
      */
     private long timeStamp;
+    
+    /**
+     * Execution time
+     */
+    private long executionTime;
     
     /**
      * Parameters of the method that executed the SQL query. Includes information
@@ -198,6 +204,22 @@ public class SQLTraceRecord implements Serializable {
     }
 
     /**
+     * Gets the time taken to execute the SQL
+     * @return  executionTime of the SQL statement
+     */
+    public long getExecutionTime() {
+        return executionTime;
+    }
+
+    /**
+     * Sets the time taken to execute the SQL
+     * @param executionTime the time taken to execute the SQL
+     */
+    public void setExecutionTime(long executionTime) {
+        this.executionTime = executionTime;
+    }
+
+    /**
      * Gets the parameters of the method that executed the SQL query. 
      * Includes information like SQL query, arguments and so on.
      * 
@@ -220,9 +242,8 @@ public class SQLTraceRecord implements Serializable {
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
-        sb.append("ThreadID=" + getThreadID() + " | ");
-        sb.append("ThreadName=" + getThreadName() + " | ");
-        sb.append("TimeStamp=" + getTimeStamp() + " | ");
+        sb.append("PoolName=" + getPoolName() + " | ");
+        sb.append("ExecutionTime=" + getExecutionTime() + "ms | ");
         sb.append("ClassName=" + getClassName() + " | ");
         sb.append("MethodName=" + getMethodName() + " | ");
         if(params != null && params.length > 0) {
@@ -231,7 +252,6 @@ public class SQLTraceRecord implements Serializable {
                 sb.append("arg[" + index++ + "]=" + param.toString() + " | ");
             }
         }
-        //TODO add poolNames and other fields of this record.
         return sb.toString();
     }
 }


### PR DESCRIPTION
Execution time of the JDBC method is now recorded in the SQL Trace.
Also SQLTraceCache now also displays number of executions in the console.#
Now enable custom connection pool properties for application defined datasource using DataSourceDefinition
Removed synchronized block from SQLTraceCache and replaced with Concurrent collection
Created SlowSQLLogger to report SQL queries that exceed a threshold time.
Plumbed the SQL tracing and Slow SQL Logging into the admin console and incorporated the two in-built SQL tracers directly