### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
Add _.gitattributes_ file so that the _.gitignore_ file is excluded from the `git archive` command.