### PR TITLE
PAYARA-519 Update EclipseLink to patched 2.6.2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -111,7 +111,7 @@
         <jaxb-api.version>2.2.13-b141020.1521</jaxb-api.version>
         <jaxb.version>2.2.12-b141219.1637</jaxb.version>
         <stax2-api.version>3.1.1</stax2-api.version>
-        <eclipselink.version>2.6.1.payara-p1</eclipselink.version>
+        <eclipselink.version>2.6.2.payara-p1</eclipselink.version>
         <javax.xml.registry-api.version>1.0.7</javax.xml.registry-api.version>
         <javax-persistence-api.version>2.1.0</javax-persistence-api.version> 
         <dbschema.version>3.1.1</dbschema.version>


### PR DESCRIPTION
Updates EclipseLink to a patched 2.6.2.

Fixes #512 
Depends upon https://github.com/payara/Payara_PatchedProjects/pull/13