### PR TITLE
Unique IDs are kept based on the name of the EJB -

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.enterprise.deployment;
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -76,6 +76,7 @@ import com.sun.enterprise.deployment.util.ApplicationVisitor;
 import com.sun.enterprise.deployment.util.ComponentVisitor;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+import java.util.TreeSet;
 import java.util.UUID;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.deployment.common.DeploymentUtils;
@@ -1320,11 +1321,17 @@ public class Application extends CommonResourceBundleDescriptor
 
         EjbDescriptor[] descs = getSortedEjbDescriptors();
 
+        Set<Long> uniqueIds = new TreeSet<>();
         for (int i = 0; i < descs.length; i++) {
             // Maximum of 2^16 beans max per application
             String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
             long uid = Math.abs(UUID.nameUUIDFromBytes((module.replaceFirst("\\..*", "")
                     + descs[i].getName()).getBytes()).getLeastSignificantBits() % 65535);
+            // in case of an id collision, increment until find empty elot
+            while(uniqueIds.contains(uid)) {
+                ++uid;
+            }
+            uniqueIds.add(uid);
             descs[i].setUniqueId((id | uid));
             if (_logger.isLoggable(Level.FINE)) {
                 _logger.log(Level.FINE, "Ejb  " + module + ":" + descs[i].getName() + " id = " +

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -76,6 +76,7 @@ import com.sun.enterprise.deployment.util.ApplicationVisitor;
 import com.sun.enterprise.deployment.util.ComponentVisitor;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+import java.util.UUID;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.deployment.common.DeploymentUtils;
 import org.glassfish.deployment.common.Descriptor;
@@ -1321,9 +1322,10 @@ public class Application extends CommonResourceBundleDescriptor
 
         for (int i = 0; i < descs.length; i++) {
             // Maximum of 2^16 beans max per application
-            descs[i].setUniqueId((id | i));
+            String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
+            long uid = Math.abs(UUID.nameUUIDFromBytes((module + descs[i].getName()).getBytes()).getLeastSignificantBits() % 50000);
+            descs[i].setUniqueId((id | uid));
             if (_logger.isLoggable(Level.FINE)) {
-                String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
                 _logger.log(Level.FINE, "Ejb  " + module + ":" + descs[i].getName() + " id = " +
                         descs[i].getUniqueId());
             }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -1322,10 +1322,10 @@ public class Application extends CommonResourceBundleDescriptor
 
         for (int i = 0; i < descs.length; i++) {
             // Maximum of 2^16 beans max per application
-            String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
-            long uid = Math.abs(UUID.nameUUIDFromBytes((module + descs[i].getName()).getBytes()).getLeastSignificantBits() % 50000);
+            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 65535);
             descs[i].setUniqueId((id | uid));
             if (_logger.isLoggable(Level.FINE)) {
+                String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
                 _logger.log(Level.FINE, "Ejb  " + module + ":" + descs[i].getName() + " id = " +
                         descs[i].getUniqueId());
             }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -1326,10 +1326,10 @@ public class Application extends CommonResourceBundleDescriptor
             // Maximum of 2^16 beans max per application
             String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
             long uid = Math.abs(UUID.nameUUIDFromBytes((module.replaceFirst("\\..*", "")
-                    + descs[i].getName()).getBytes()).getLeastSignificantBits() % 65535);
+                    + descs[i].getName()).getBytes()).getLeastSignificantBits() % 65536);
             // in case of an id collision, increment until find empty elot
             while(uniqueIds.contains(uid)) {
-                ++uid;
+                uid = ++uid % 65536;
             }
             uniqueIds.add(uid);
             descs[i].setUniqueId((id | uid));

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -1322,10 +1322,11 @@ public class Application extends CommonResourceBundleDescriptor
 
         for (int i = 0; i < descs.length; i++) {
             // Maximum of 2^16 beans max per application
-            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 65535);
+            String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
+            long uid = Math.abs(UUID.nameUUIDFromBytes((module.replaceFirst("\\..*", "")
+                    + descs[i].getName()).getBytes()).getLeastSignificantBits() % 65535);
             descs[i].setUniqueId((id | uid));
             if (_logger.isLoggable(Level.FINE)) {
-                String module = descs[i].getEjbBundleDescriptor().getModuleDescriptor().getArchiveUri();
                 _logger.log(Level.FINE, "Ejb  " + module + ":" + descs[i].getName() + " id = " +
                         descs[i].getUniqueId());
             }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
@@ -667,10 +667,10 @@ public class EjbBundleDescriptorImpl extends com.sun.enterprise.deployment.EjbBu
         for (int i=0; i<descs.length; i++)
         {
             // 2^16 beans max per stand alone module
-            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 65535);
+            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 65536);
             // in case of an id collision, increment until find empty elot
             while(uniqueIds.contains(uid)) {
-                ++uid;
+                uid = ++uid % 65536;
             }
             uniqueIds.add(uid);
             descs[i].setUniqueId( (id | uid) );

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
@@ -665,7 +665,7 @@ public class EjbBundleDescriptorImpl extends com.sun.enterprise.deployment.EjbBu
         for (int i=0; i<descs.length; i++)
         {
             // 2^16 beans max per stand alone module
-            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 50000);
+            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 65535);
             descs[i].setUniqueId( (id | uid) );
         }
     }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
@@ -83,6 +83,7 @@ import com.sun.enterprise.deployment.util.ComponentVisitor;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.deployment.util.EjbBundleVisitor;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+import java.util.TreeSet;
 import java.util.UUID;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.deployment.common.Descriptor;
@@ -662,10 +663,16 @@ public class EjbBundleDescriptorImpl extends com.sun.enterprise.deployment.EjbBu
             }
         );
 
+        Set<Long> uniqueIds = new TreeSet<>();
         for (int i=0; i<descs.length; i++)
         {
             // 2^16 beans max per stand alone module
             long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 65535);
+            // in case of an id collision, increment until find empty elot
+            while(uniqueIds.contains(uid)) {
+                ++uid;
+            }
+            uniqueIds.add(uid);
             descs[i].setUniqueId( (id | uid) );
         }
     }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package org.glassfish.ejb.deployment.descriptor;
 

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbBundleDescriptorImpl.java
@@ -83,6 +83,7 @@ import com.sun.enterprise.deployment.util.ComponentVisitor;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.deployment.util.EjbBundleVisitor;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+import java.util.UUID;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.deployment.common.Descriptor;
 import org.glassfish.deployment.common.DescriptorVisitor;
@@ -664,7 +665,8 @@ public class EjbBundleDescriptorImpl extends com.sun.enterprise.deployment.EjbBu
         for (int i=0; i<descs.length; i++)
         {
             // 2^16 beans max per stand alone module
-            descs[i].setUniqueId( (id | i) );
+            long uid = Math.abs(UUID.nameUUIDFromBytes(descs[i].getName().getBytes()).getLeastSignificantBits() % 50000);
+            descs[i].setUniqueId( (id | uid) );
         }
     }
 


### PR DESCRIPTION
- facilitating rolling upgrade

This is another issue I have encountered with rolling updates.
When serializing / deserializing local EJB references within a web session, the unique IDs have to be the same (right now they are sorted by EJB name) .
This pull request is a solution for this problem.  Instead of sorted EJB index, a UUID chunk is used for unique ID of EJBs

Related ticket #455