### PR TITLE
Edit PAYARA-496 fix

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminTruststore.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminTruststore.java
@@ -40,6 +40,7 @@
 
 package com.sun.enterprise.security.store;
 
+import com.sun.enterprise.util.CULoggerInfo;
 import com.sun.enterprise.util.SystemPropertyConstants;
 
 import java.io.File;
@@ -53,6 +54,8 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.Certificate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -68,6 +71,7 @@ public class AsadminTruststore {
     private KeyStore _keyStore = null;
     private File _keyFile = null;        
     private char[] _password = null;
+    private static final Logger _logger = CULoggerInfo.getLogger();
       
     public static File getAsadminTruststore()
     {
@@ -137,9 +141,16 @@ public class AsadminTruststore {
         NoSuchAlgorithmException, CertificateException
     {
         _keyStore.setCertificateEntry(alias, cert);
+        
+        // PAYARA-496 Check if truststore exists, and create it if it doesn't
+        _keyFile.createNewFile();
+    
+        // PAYARA-496 Check if the keystore can be written to
         if (_keyFile.canWrite()) {
             writeStore();            
-        } 
+        } else {
+            _logger.log(Level.INFO, CULoggerInfo.exceptionWritingToAsadminTruststore, _keyFile.getAbsolutePath());
+        }
     }
     
     public void writeStore() throws KeyStoreException, IOException, 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminTruststore.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminTruststore.java
@@ -142,11 +142,8 @@ public class AsadminTruststore {
     {
         _keyStore.setCertificateEntry(alias, cert);
         
-        // PAYARA-496 Check if truststore exists, and create it if it doesn't
-        _keyFile.createNewFile();
-    
-        // PAYARA-496 Check if the keystore can be written to
-        if (_keyFile.canWrite()) {
+        // PAYARA-496 Check if the keystore exists, and can be written to
+        if (!_keyFile.exists() || _keyFile.canWrite()) {
             writeStore();            
         } else {
             _logger.log(Level.INFO, CULoggerInfo.exceptionWritingToAsadminTruststore, _keyFile.getAbsolutePath());

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/CULoggerInfo.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/CULoggerInfo.java
@@ -317,7 +317,9 @@ public class CULoggerInfo {
                     level="WARNING")
     public static final String NULL_BUNDLE = LOGMSG_PREFIX + "-00042";
 
-
+    @LogMessageInfo(message = "Could not write to Asadmin Truststore: {0}",
+            level="INFO")
+    public static final String exceptionWritingToAsadminTruststore = LOGMSG_PREFIX + "-00043";
 /*
 
 


### PR DESCRIPTION
The original fix prevented the asadmin truststore being created if it doesn't exist, stopping you from saving certificates. This remedies that by making sure to create it first.

Also adds some logging for if a certificate can't be added.