### PR TITLE
Fix for Payara #627 - Invocation Webservice deployed from directory f…

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ModuleContentValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ModuleContentValidator.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.enterprise.deployment.util;
 
@@ -188,7 +189,7 @@ public class ModuleContentValidator extends ModuleContentLinker implements Compo
                 }
             } else {
                 // let's look in the wsdl directory
-                String fullFileUri = webService.getBundleDescriptor().getWsdlDir() + File.separator + wsdlFileUri;
+                String fullFileUri = webService.getBundleDescriptor().getWsdlDir() + "/" + wsdlFileUri;
                 wsdlFileInputStream = archive_.getEntry(fullFileUri);
 
                 if( wsdlFileInputStream != null ) {        


### PR DESCRIPTION
…ails

Fix for GLASSFISH-17039 contained a change in ModuleContextValidator where a
slash in fullFileUri was replaced with File.separator. However URIs are not
platform dependant and cannot contain backslashes.