### PR TITLE
GLASSFISH-20818: Pass passwords from passwordfile to commands (PAYARA-658)

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/CommandExecutorImpl.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/CommandExecutorImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.enterprise.admin.cli.embeddable;
 
@@ -122,7 +123,7 @@ public class CommandExecutorImpl implements org.glassfish.embeddable.CommandRunn
         if (globalOptions.size() > 0) {
             String pwfile = globalOptions.getOne(ProgramOptions.PASSWORDFILE);
             if (pwfile != null && pwfile.length() > 0) {
-                Map<String, String> passwords = CLIUtil.readPasswordFileOptions(pwfile, true);
+                Map<String, String> passwords = CLIUtil.readPasswordFileOptions(pwfile, false);
                 for (CommandModel.ParamModel opt : commandModel.getParameters()) {
                     if (opt.getParam().password()) {
                         String pwdname = opt.getName();


### PR DESCRIPTION
…dded glassfish

When CLIUtil.readPasswordFileOptions is invoked with boolean parameter of true, then Map
`passwords` contains keys prefixed with `AS_ADMIN_`. This is never the parameter name and
therefore the password parameters didn't get filled.

I couldn't locate the origin of bug, because the code is same in Glassfish 3.1.2, I suppose it
either used some side channel, or command model transformation.