### PR TITLE
PAYARA-542 Cannot enable secure ciphers for admin listener

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AdminLoggerInfo.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AdminLoggerInfo.java
@@ -212,7 +212,7 @@ public class AdminLoggerInfo {
 
     @LogMessageInfo(
             message = "Unrecognised HTTPS protocol provided, reverting to default: {0}",
-            cause = "Unrecognised protocol provided by system property fish.payara.asadminHttpsProtocol: {1}",
+            cause = "Unrecognised protocol provided by system property fish.payara.clientHttpsProtocol: {1}",
             action = "Edit the system property to use a supported protocol.",
             level = "INFO")
     public final static String unrecognisedHttpsProtocol = LOGMSG_PREFIX + "-00019";
@@ -220,14 +220,14 @@ public class AdminLoggerInfo {
     @LogMessageInfo(
             message = "Using default HTTPS protocol: {0}",
             cause = "No protocol provided.",
-            action = "Use the fish.payara.asadminHttpsProtocol system property "
+            action = "Use the fish.payara.clientHttpsProtocol system property "
                     + "to set an alternative protocol to use.",
             level = "FINE")
     public final static String usingDefaultHttpsProtocol = LOGMSG_PREFIX + "-00020";
     
     @LogMessageInfo(
             message = "Setting HTTPS protocol to: {0}",
-            cause = "Protocol set using fish.payara.asadminHttpsProtocol system property.",
+            cause = "Protocol set using fish.payara.clientHttpsProtocol system property.",
             level = "FINE"
             )
     public final static String settingHttpsProtocol = LOGMSG_PREFIX + "-00021";

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AdminLoggerInfo.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AdminLoggerInfo.java
@@ -37,6 +37,9 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+
+// Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
+
 package com.sun.enterprise.admin.util;
 
 import java.util.logging.Logger;

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AdminLoggerInfo.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AdminLoggerInfo.java
@@ -207,4 +207,25 @@ public class AdminLoggerInfo {
             level = "WARNING")
     public final static String mExceptionFromEventListener = LOGMSG_PREFIX + "-00018";
 
+    @LogMessageInfo(
+            message = "Unrecognised HTTPS protocol provided, reverting to default: {0}",
+            cause = "Unrecognised protocol provided by system property fish.payara.asadminHttpsProtocol: {1}",
+            action = "Edit the system property to use a supported protocol.",
+            level = "INFO")
+    public final static String unrecognisedHttpsProtocol = LOGMSG_PREFIX + "-00019";
+    
+    @LogMessageInfo(
+            message = "Using default HTTPS protocol: {0}",
+            cause = "No protocol provided.",
+            action = "Use the fish.payara.asadminHttpsProtocol system property "
+                    + "to set an alternative protocol to use.",
+            level = "FINE")
+    public final static String usingDefaultHttpsProtocol = LOGMSG_PREFIX + "-00020";
+    
+    @LogMessageInfo(
+            message = "Setting HTTPS protocol to: {0}",
+            cause = "Protocol set using fish.payara.asadminHttpsProtocol system property.",
+            level = "FINE"
+            )
+    public final static String settingHttpsProtocol = LOGMSG_PREFIX + "-00021";
 }

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
+
 package com.sun.enterprise.admin.util;
 
 import java.io.IOException;

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -175,8 +175,8 @@ public final class HttpConnectorAddress {
                  * protocol is entered, log a message and use the GlassFish
                  * default of TLSv1.
                  */
-                if (System.getProperty("fish.payara.asadminHttpsProtocol") != null) {
-                    switch (System.getProperty("fish.payara.asadminHttpsProtocol")) {
+                if (System.getProperty("fish.payara.clientHttpsProtocol") != null) {
+                    switch (System.getProperty("fish.payara.clientHttpsProtocol")) {
                         case "TLSv1.1": protocol = "TLSV1.1";
                                         logger.log(Level.FINE, 
                                                 AdminLoggerInfo.settingHttpsProtocol,
@@ -191,7 +191,7 @@ public final class HttpConnectorAddress {
                         
                         default:        protocol = "TLSv1";
                                         String[] logParams = {protocol, 
-                                                System.getProperty("fish.payara.asadminHttpsProtocol")};
+                                                System.getProperty("fish.payara.clientHttpsProtocol")};
                                         
                                         logger.log(Level.INFO, 
                                                 AdminLoggerInfo.unrecognisedHttpsProtocol, 


### PR DESCRIPTION
Fixes #657 

Allows you to set a system property that determines what version of TLS a client should use for HTTPS connections, allowing you to secure the sec-admin-listener to a greater level than TLSv1.

Currently only supports setting one protocol at a time.

Also adds some logging for clarity.