### PR TITLE
PAYARA 626 added support for Hazelcast Lite Members 

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
+++ b/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
@@ -23,7 +23,7 @@ hazelcast.configuration.enabled=Enabled
 hazelcast.configuration.enabledHelp=Determines whether the Hazelcast distributed caching capabilites are enabled
 hazelcast.configuration.configFile=Override configuration file
 hazelcast.configuration.configFileHelp=Path to the Hazelcast configuration file (relative to the domain config directory) which overrides all the settings on this page<br\>\
-If this is set all the settings below are ignored and are taken from the specified configuration file.
+If this is set, and the file exists, all the settings below are ignored and are taken from the specified configuration file.
 hazelcast.configuration.startPort=Start Port
 hazelcast.configuration.startPortHelp=Default port Hazelcast will listen on. Hazelcast will increment this number until it finds a valid port.
 hazelcast.configuration.multicastPort=Multicast Port
@@ -43,3 +43,5 @@ hazelcast.members.members =Cluster Members
 hazelcast.members.membersHelp=The Hazelcast Cluster Members
 hazelcast.configuration.dynamic=Dynamic
 hazelcast.configuration.dynamicHelp=Starts or Stops the Hazelcast Member embedded in Payara if required.
+hazelcast.configuration.lite =Lite Cluster Member
+hazelcast.configuration.liteHelp=If set to true this member is a lite cluster member. i.e. It clusters but stores no cluster data within its heap.

--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationCluster.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationCluster.jsf
@@ -101,6 +101,9 @@
     <sun:property id="jndiNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.jndiName}"  helpText="$resource{i18nhc.hazelcast.configuration.jndiNameHelp}">
         <sun:textField id="jndiName" columns="$int{40}" maxLength="30" text="#{pageSession.valueMap['jndiName']}" />
     </sun:property>
+    <sun:property id="liteProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.lite}"  helpText="$resource{i18nhc.hazelcast.configuration.liteHelp}">
+        <sun:checkbox id="lite" selected="#{pageSession.valueMap['lite']}" selectedValue="true" />
+    </sun:property>
 </sun:propertySheetSection>
 
 <sun:hidden id="helpKey" value="$resource{help_full.batchConfiguration}" />

--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationServer.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationServer.jsf
@@ -101,6 +101,9 @@
     <sun:property id="jndiNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.jndiName}"  helpText="$resource{i18nhc.hazelcast.configuration.jndiNameHelp}">
         <sun:textField id="jndiName" columns="$int{40}" maxLength="30" text="#{pageSession.valueMap['jndiName']}" />
     </sun:property>
+    <sun:property id="liteProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.lite}"  helpText="$resource{i18nhc.hazelcast.configuration.liteHelp}">
+        <sun:checkbox id="lite" selected="#{pageSession.valueMap['lite']}" selectedValue="true" />
+    </sun:property>
 </sun:propertySheetSection>
 
 <sun:hidden id="helpKey" value="$resource{help_full.batchConfiguration}" />

--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationStandalone.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcastConfigurationStandalone.jsf
@@ -100,6 +100,9 @@
     <sun:property id="jndiNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.jndiName}"  helpText="$resource{i18nhc.hazelcast.configuration.jndiNameHelp}">
         <sun:textField id="jndiName" columns="$int{40}" maxLength="30" text="#{pageSession.valueMap['jndiName']}" />
     </sun:property>
+    <sun:property id="liteProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.lite}"  helpText="$resource{i18nhc.hazelcast.configuration.liteHelp}">
+        <sun:checkbox id="lite" selected="#{pageSession.valueMap['lite']}" selectedValue="true" />
+    </sun:property>
 </sun:propertySheetSection>
 
 <sun:hidden id="helpKey" value="$resource{help_full.batchConfiguration}" />

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastRuntimeConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastRuntimeConfiguration.java
@@ -65,4 +65,8 @@ public interface HazelcastRuntimeConfiguration
     @Attribute(defaultValue = "payara/CachingProvider")
     String getCachingProviderJNDIName();
     public void setCachingProviderJNDIName(String value);
+    
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    String getLite();
+    public void setLite(String value);
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MulticastConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MulticastConfiguration.java
@@ -29,6 +29,7 @@ public class MulticastConfiguration {
     private int startPort = 5900;
     private String memberName;
     private File alternateConfigFile;
+    private boolean lite = false;
 
     public MulticastConfiguration() {
     }
@@ -79,6 +80,14 @@ public class MulticastConfiguration {
 
     public File getAlternateConfigFile() {
         return alternateConfigFile;
+    }
+
+    public boolean isLite() {
+        return lite;
+    }
+
+    public void setLite(boolean lite) {
+        this.lite = lite;
     }
     
     

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/GetHazelcastConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/GetHazelcastConfiguration.java
@@ -73,15 +73,16 @@ public class GetHazelcastConfiguration implements AdminCommand {
         
         HazelcastRuntimeConfiguration runtimeConfiguration = config.getExtensionByType(HazelcastRuntimeConfiguration.class);
         final ActionReport actionReport = context.getActionReport();
-        String headers[] = {"Configuration File","Enabled","Start Port","MulticastGroup","MulticastPort","JNDIName"};
+        String headers[] = {"Configuration File","Enabled","Start Port","MulticastGroup","MulticastPort","JNDIName","Lite Member"};
         ColumnFormatter columnFormatter = new ColumnFormatter(headers);
-        Object values[] = new Object[6];
+        Object values[] = new Object[7];
         values[0] = runtimeConfiguration.getHazelcastConfigurationFile();
         values[1] = runtimeConfiguration.getEnabled();
         values[2] = runtimeConfiguration.getStartPort();
         values[3] = runtimeConfiguration.getMulticastGroup();
         values[4] = runtimeConfiguration.getMulticastPort();
         values[5] = runtimeConfiguration.getJNDIName();
+        values[6] = runtimeConfiguration.getLite();
         columnFormatter.addRow(values);
         
         Map<String, Object> map = new HashMap<String,Object>(6);
@@ -92,6 +93,7 @@ public class GetHazelcastConfiguration implements AdminCommand {
         map.put("multicastGroup", values[3]);
         map.put("multicastPort", values[4]);
         map.put("jndiName", values[5]);
+        map.put("lite", values[6]);
         extraProps.put("getHazelcastConfiguration",map);
                 
         actionReport.setExtraProperties(extraProps);

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ListHazelcastMembers.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ListHazelcastMembers.java
@@ -86,6 +86,10 @@ public class ListHazelcastMembers implements AdminCommand {
                     if (member.localMember()) {
                         builder.append("-this");
                     }
+                    
+                    if (member.isLiteMember()) {
+                        builder.append("-LITE");
+                    }
                     builder.append(" ");
                 }
                 builder.append('}');

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
@@ -100,6 +100,9 @@ public class SetHazelcastConfiguration implements AdminCommand {
 
     @Param(name = "jndiName", shortName = "j", optional = true)
     private String jndiName;
+    
+    @Param(name = "lite", optional = true, defaultValue = "false")
+    private Boolean lite;
 
     @Inject
     ServiceLocator serviceLocator;
@@ -143,6 +146,9 @@ public class SetHazelcastConfiguration implements AdminCommand {
                         }
                         if (configFile != null) {
                             hazelcastRuntimeConfigurationProxy.setHazelcastConfigurationFile(configFile);
+                        }
+                        if (lite != null) {
+                            hazelcastRuntimeConfigurationProxy.setLite(lite.toString());
                         }
                         actionReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
                         return null;

--- a/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/nucleus/payara-modules/payara-micro/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -73,6 +73,7 @@ public class PayaraMicro {
     private boolean noCluster = false;
     private boolean autoBindHttp = false;
     private boolean autoBindSsl = false;
+    private boolean liteMember = false;
     private boolean generateLogo = false;
     private int autoBindRange = 5;
     private String bootImage = "boot.txt";
@@ -100,6 +101,7 @@ public class PayaraMicro {
      * pool<br/>
      * --maxHttpThreads the maximum number of threads in the HTTP thread
      * pool<br/>
+     * --lite Sets this Payara Micro to not store Cluster Data
      * --help Shows this message and exits\n
      * @throws BootstrapException If there is a problem booting the server
      */
@@ -424,6 +426,30 @@ public class PayaraMicro {
         this.noCluster = noCluster;
         return this;
     }
+    
+    /**
+     * Indicates whether this is a lite cluster member which means it stores no
+     * cluster data although it participates fully in the cluster.
+     * @return
+     */
+    public boolean isLite() {
+        return liteMember;
+    }
+
+    /**
+     * Sets the lite status of this cluster member. If true the Payara Micro is a lite
+     * cluster member which means it stores no cluster data.
+     * @param liteMember set to true to set as a lite cluster member with no data storage
+     * @return 
+     */
+    public PayaraMicro setLite(boolean liteMember) {
+        //if (runtime != null) {
+        if(isRunning()){
+            throw new IllegalStateException("Payara Micro is already running, setting attributes has no effect");
+        }
+        this.liteMember = liteMember;
+        return this;
+    }   
 
     /**
      * The maximum threads in the HTTP(S) threadpool processing HTTP(S) requests.
@@ -594,6 +620,7 @@ public class PayaraMicro {
         if (alternateHZConfigFile != null) {
             mc.setAlternateConfiguration(alternateHZConfigFile);
         }
+        mc.setLite(liteMember);
         HazelcastCore.setMulticastOverride(mc);
         
         setSystemProperties();
@@ -922,6 +949,9 @@ public class PayaraMicro {
                 case "--noCluster":
                     noCluster = true;
                     break;
+                case "--lite":
+                    liteMember = true;
+                    break;
                 case "--hzConfigFile":
                     alternateHZConfigFile = new File(args[i+1]);
                     if (!alternateHZConfigFile.exists() || !alternateHZConfigFile.isFile() || !alternateHZConfigFile.canRead() || !alternateHZConfigFile.getAbsolutePath().endsWith(".xml")) {
@@ -967,6 +997,7 @@ public class PayaraMicro {
                             + "--autoBindHttp sets autobinding of the http port to a non-bound port\n"
                             + "--autoBindSsl sets autobinding of the https port to a non-bound port\n"
                             + "--autoBindRange sets the maximum number of ports to look at for port autobinding\n"
+                            + "--lite sets the micro container to lite mode which means it clusters with other Payara Micro instances but does not store any cluster data\n"
                             + "--logo reveal the #BadAssFish\n"
                             + "--help Shows this message and exits\n");
                     System.exit(1);


### PR DESCRIPTION
Lite members are full cluster members but do not store any JCache or web session data. This provides more flexibility for cluster configurations.

Also corrects instance names in list-cluster-members to be the instance name and the name set in payara micro using --name