### PR TITLE
rollbacked pax-logging and patched the webservices-osgi again

### DIFF
--- a/appserver/packager/metro/pom.xml
+++ b/appserver/packager/metro/pom.xml
@@ -166,10 +166,6 @@
             <artifactId>webservices-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-extra-jdk-packages</artifactId>
         </dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -104,8 +104,7 @@
         <jsftemplating.version>2.1.1</jsftemplating.version>
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
-        <pax.logging.version>1.8.4</pax.logging.version>
-        <webservices.version>2.3.2-b608.payara-p2</webservices.version>
+        <webservices.version>2.3.2-b608.payara-p3</webservices.version>
         <jsr181-api.version>1.0-MR1</jsr181-api.version>
         <woodstox.version>4.2.0</woodstox.version>
         <jaxb-api.version>2.2.13-b141020.1521</jaxb-api.version>
@@ -613,11 +612,6 @@
                 <groupId>org.glassfish.metro</groupId>
                 <artifactId>webservices-osgi</artifactId>
                 <version>${webservices.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
-                <artifactId>pax-logging-api</artifactId>
-                <version>${pax.logging.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.metro</groupId>

--- a/appserver/security/webservices.security/pom.xml
+++ b/appserver/security/webservices.security/pom.xml
@@ -117,10 +117,6 @@
             <artifactId>webservices-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
-        <dependency>
            <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-api-osgi</artifactId>
         </dependency>

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -151,10 +151,6 @@
             <artifactId>webservices-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-api-osgi</artifactId>
         </dependency>

--- a/appserver/webservices/metro-glue/pom.xml
+++ b/appserver/webservices/metro-glue/pom.xml
@@ -95,10 +95,6 @@
             <artifactId>webservices-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.main.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/webservices/soap-tcp/pom.xml
+++ b/appserver/webservices/soap-tcp/pom.xml
@@ -87,10 +87,6 @@
             <artifactId>webservices-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-api-osgi</artifactId>
         </dependency>


### PR DESCRIPTION
rollbacked pax-logging and patched webservices-osgi by moving the org.apache.xml.security package from xmlsec to webservices-osgi for overriding commons-logging dependency with java util logging.