### PR TITLE
Fixes #673 PAYARA-642 do explicit check for OSGi classloader 

### DIFF
--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/GlassFishORBManager.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/GlassFishORBManager.java
@@ -585,11 +585,10 @@ public final class GlassFishORBManager {
             orb = ORBFactory.create() ;
             prevCL = Utility.getClassLoader();
             try {
-               if (processType != processType.Other) {
+              if (processType != processType.Other && !prevCL.getClass().getName().contains("OSGi")) {
                 Utility.setContextClassLoader(prevCL.getParent());
                }
-            
-                ORBFactory.initialize( orb, args, orbInitProperties, useOSGI);
+               ORBFactory.initialize( orb, args, orbInitProperties, useOSGI);
             } finally {
                 Utility.setContextClassLoader(prevCL);
             }


### PR DESCRIPTION
and don't switch to parent in that case.

Bit of a hack that needs fixing by the Janitor Service in the future to clear up threads context classloader as the ORB spawns a bunch of threads.