### PR TITLE
Fix failing transaction recovery when OSGi applications are present. (Payara-659)

### DIFF
--- a/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/InboundRecoveryHandler.java
+++ b/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/InboundRecoveryHandler.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.connectors.inbound;
 
@@ -261,7 +262,8 @@ public class InboundRecoveryHandler implements RecoveryResourceHandler {
 
         if(ResourcesUtil.createInstance().isEnabled(application)){
             ApplicationInfo appInfo = appsRegistry.get(application.getName());
-            if(appInfo != null){
+            // non java-ee apps do not have ejbs, and they dont't have Application entry, leading to NPE            
+            if(appInfo != null && appInfo.isJavaEEApp()){
                 com.sun.enterprise.deployment.Application app =
                         appInfo.getMetaData(com.sun.enterprise.deployment.Application.class);
                 Set<BundleDescriptor> descriptors = app.getBundleDescriptors();


### PR DESCRIPTION
…Fixes #679

OSGi applications do not have (EE) Application metadata, leading to NPE at line 267