### PR TITLE
PAYARA-671 Always perform clean up on application on DAS upon undeployment.

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.v3.server;
 
@@ -1093,11 +1094,9 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
         events.send(new Event(Deployment.UNDEPLOYMENT_START, info));
 
-        // for DAS target, the undeploy should unload the application
-        // as well
-        if (DeploymentUtils.isDASTarget(params.target) || DeploymentUtils.isDomainTarget(params.target)) {
-            unload(info, context);
-        }
+        // we unconditionally unload the application, even if it is not loaded, because we must clean the
+        // application, especially the classloaders need to be closed to release file handles
+        unload(info, context);
 
         if (report.getActionExitCode().equals(ActionReport.ExitCode.SUCCESS)) {
             events.send(new Event(Deployment.UNDEPLOYMENT_SUCCESS, context));


### PR DESCRIPTION
`EarLibClassloader` of an EAR app deployed on non-DAS instance was initialized but not destroyed on DAS upon deployment.
That lead to JarFile handles to its lib directory being held, and the DAS was unable to clear its application directory.
Calling unload unconditionally gurantees ApplicationInfo.clean to be called, which in turns calls preDestroy() / done() on all application
class loaders.