### PR TITLE
Resolve com.sun.aas.instanceName in JVM arguments (PAYARA-660)

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2014-2015] [C2B2 Consulting Limited]
+// Portions Copyright [2014-2016] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.admin.launcher;
 
@@ -726,6 +726,7 @@ public abstract class GFLauncher {
         all.putAll(envProps);
         all.putAll(asenvProps);
         all.putAll(sysProps);
+        all.put(SystemPropertyConstants.SERVER_NAME, getInfo().getInstanceName());
         all.putAll(sysPropsFromXml);
         all.putAll(jvmOptions.getCombinedMap());
         all.putAll(profiler.getConfig());


### PR DESCRIPTION
`com.sun.aas.instanceName` is the only glassfish system property that will not resolve when passed as JVM argument, which is strange omission.

In my use case I redirect all logging to logback, and logback gets initialized earlier than the system property is set during appserver startup. Passing it in JVM arguments guarantees it is available right from the process start.