### PR TITLE
Prevent duplicate server respawn when run under supervision. Fixes #732.

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherInfo.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherInfo.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 
 package com.sun.enterprise.admin.launcher;
 
@@ -281,7 +282,7 @@ public class GFLauncherInfo {
             map.put("-instancedir", SmartFile.sanitize(instanceRootDir.getPath()));
         }
 
-        // no need for watchdog here.  It is a client-side phenomenon only!
+        map.put("-watchdog", Boolean.toString(watchdog));
         map.put("-verbose", Boolean.toString(verbose));
         map.put("-debug", Boolean.toString(debug));
         map.put("-instancename", instanceName);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/RestartServer.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/RestartServer.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 package com.sun.enterprise.v3.admin;
 
 import com.sun.enterprise.module.ModulesRegistry;
@@ -107,7 +108,7 @@ public class RestartServer {
                 gfKernel = glassfishProvider.get();
             }
             
-            if (!verbose) {
+            if (!supervised) {
                 // do it now while we still have the Logging service running...
                 reincarnate();
             }
@@ -134,7 +135,8 @@ public class RestartServer {
     private void init(AdminCommandContext context) throws IOException {
         logger = context.getLogger();
         props = Globals.get(StartupContext.class).getArguments();
-        verbose = Boolean.parseBoolean(props.getProperty("-verbose", "false"));
+        supervised = Boolean.parseBoolean(props.getProperty("-verbose", "false"))
+                || Boolean.parseBoolean(props.getProperty("-watchdog", "false"));
         logger.info(strings.get("restart.server.init"));
     }
 
@@ -308,7 +310,7 @@ public class RestartServer {
     private Boolean debug = null;
     private Properties props;
     private Logger logger;
-    private boolean verbose;
+    private boolean supervised;
     private String classpath;
     private String classname;
     private String argsString;


### PR DESCRIPTION
Service wrapper runs instances / domains with `--watchdog true`. This causes server to be relaunched once it exits with predefined exit code. See `StartDomainCommand.executeCommand` and `StartLocalInstanceCommand.executeCommand`.

On the other hand, RestartServer will also relaunch the server by starting separate process just before the process exits. See `RestartServer.doReincarnation()`.

RestartServer doesn't take` --watchdog` argument into account in its `doExecute` method, and therefore two server instances are started, from each of the code paths.