### PR TITLE
Fix component list for versioned apps

### DIFF
--- a/appserver/deployment/javaee-core/src/main/java/org/glassfish/javaee/core/deployment/GetContextRootCommand.java
+++ b/appserver/deployment/javaee-core/src/main/java/org/glassfish/javaee/core/deployment/GetContextRootCommand.java
@@ -98,7 +98,10 @@ public class GetContextRootCommand implements AdminCommand {
         if (appInfo != null) {
             Application app = appInfo.getMetaData(Application.class);
             if (app != null) {
-                BundleDescriptor bundleDesc = app.getModuleByUri(modulename);
+                // strip the version suffix (delimited by colon), if present
+                int versionSuffix = modulename.indexOf(':');
+                String versionLessModuleName = versionSuffix > 0 ? modulename.substring(0, versionSuffix) : modulename;
+                BundleDescriptor bundleDesc = app.getModuleByUri(versionLessModuleName);
                 if (bundleDesc != null &&
                     bundleDesc instanceof WebBundleDescriptor) {
                     String contextRoot = ((WebBundleDescriptor)bundleDesc).getContextRoot();

--- a/appserver/deployment/javaee-core/src/main/java/org/glassfish/javaee/core/deployment/ListSubComponentsCommand.java
+++ b/appserver/deployment/javaee-core/src/main/java/org/glassfish/javaee/core/deployment/ListSubComponentsCommand.java
@@ -186,7 +186,10 @@ public class ListSubComponentsCommand implements AdminCommand {
         if (appname == null) {
             subComponents = getAppLevelComponents(app, type, subComponentsMap);
         } else {
-            BundleDescriptor bundleDesc = app.getModuleByUri(modulename);
+            // strip the version suffix (delimited by colon), if present
+            int versionSuffix = modulename.indexOf(':');
+            String versionLessModuleName = versionSuffix > 0 ? modulename.substring(0, versionSuffix) : modulename;
+            BundleDescriptor bundleDesc = app.getModuleByUri(versionLessModuleName);
             if (bundleDesc == null) {
                 report.setMessage(localStrings.getLocalString("listsubcomponents.invalidmodulename", "Invalid module name", appname, modulename));
                 report.setActionExitCode(ActionReport.ExitCode.FAILURE);


### PR DESCRIPTION
Bugfix: always strip off the app's version suffix (apps with rolling updates) when looking up the app's modules.

This is probably a dirty hack to solve issue #702, and partly also #461 (note: only the GUI issue, when components were listed), because:
1.  it leaves the GUI in a kind of unpolished state: it will still show the app's main moduleName with the version suffix, even though it does not seem right (before this hack the  the REST resource did not accept module names with version suffix).
2. it does not enforce the correct naming of the module in various calls, rather makes the REST resource more forgiving
3. certain REST resources may return URLs with incorrect moduleName (with the suffix)

However! 
1. It works and is just a 6 line change. Simplicity matters.
2. The potential of regressions is practically zero, because this change affects only versioned apps, which did not work before at all.
3. The alternative is to review/change the admin_gui Handlers (ApplicationHandler.java and MonitoringHandler.java) and the Management REST Resource generator(s) and maybe a couple of more files, where unwanted regressions are basically guaranteed.

