### PR TITLE
PAYARA-662 Set TLSv1.2 as default for the asadmin client

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -187,6 +187,12 @@ public final class HttpConnectorAddress {
                                                 AdminLoggerInfo.settingHttpsProtocol,
                                                 protocol);
                                         break;
+                                        
+                        case "TLSv1.2": protocol = "TLSv1.2";
+                                        logger.log(Level.FINE, 
+                                                AdminLoggerInfo.settingHttpsProtocol,
+                                                protocol);
+                                        break;
                         
                         default:        protocol = "TLSv1.2";
                                         String[] logParams = {protocol, 

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -172,24 +172,23 @@ public final class HttpConnectorAddress {
                  * Check if the system property has been set to determine the
                  * HTTPS protocol to use, and set the protocol to be used to
                  * this value if it has. If it hasn't, or an unrecognised 
-                 * protocol is entered, log a message and use the GlassFish
-                 * default of TLSv1.
+                 * protocol is entered, log a message and use TLSv1.2
                  */
                 if (System.getProperty("fish.payara.clientHttpsProtocol") != null) {
                     switch (System.getProperty("fish.payara.clientHttpsProtocol")) {
-                        case "TLSv1.1": protocol = "TLSV1.1";
+                        case "TLSv1": protocol = "TLSV1";
                                         logger.log(Level.FINE, 
                                                 AdminLoggerInfo.settingHttpsProtocol,
                                                 protocol);
                                         break;
                         
-                        case "TLSv1.2": protocol = "TLSv1.2";
+                        case "TLSv1.1": protocol = "TLSv1.1";
                                         logger.log(Level.FINE, 
                                                 AdminLoggerInfo.settingHttpsProtocol,
                                                 protocol);
                                         break;
                         
-                        default:        protocol = "TLSv1";
+                        default:        protocol = "TLSv1.2";
                                         String[] logParams = {protocol, 
                                                 System.getProperty("fish.payara.clientHttpsProtocol")};
                                         
@@ -199,7 +198,7 @@ public final class HttpConnectorAddress {
                                         break;
                     }
                 } else {
-                    protocol = "TLSv1";
+                    protocol = "TLSv1.2";
                     logger.log(Level.FINE, AdminLoggerInfo.usingDefaultHttpsProtocol, protocol);
                 }
             }


### PR DESCRIPTION
TLSv1 is now pretty old and has security flaws, so updating to use TLSv1.2 if possible.
By default TLS rollback is enabled, so there should be no change to default behaviour (my own testing has not revealed any).