### PR TITLE
Payara 738 references to weld osgi bundle.jar should be fixed

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/default-web.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
@@ -339,7 +340,7 @@
         javax.transaction-api.jar
         javax.xml.rpc-api.jar
         webservices-osgi.jar
-        weld-osgi-bundle.jar
+        weld-osgi-bundle-glassfish4.jar
         jersey-mvc-jsp.jar
       </param-value>
     </init-param>

--- a/appserver/admin/payara_template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/payara_template/src/main/resources/config/default-web.xml
@@ -14,6 +14,7 @@
  * When distributing the software, include this License Header Notice in each
  * file and include the License file at packager/legal/LICENSE.txt.
  -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
@@ -313,7 +314,7 @@
         javax.transaction-api.jar
         javax.xml.rpc-api.jar
         webservices-osgi.jar
-        weld-osgi-bundle.jar
+        weld-osgi-bundle-glassfish4.jar
         jersey-mvc-jsp.jar
       </param-value>
     </init-param>

--- a/appserver/appclient/client/acc-standalone/fixup.xml
+++ b/appserver/appclient/client/acc-standalone/fixup.xml
@@ -83,6 +83,7 @@
             <replacefilter token="../modules/jaxb-api.jar" value="../modules/endorsed/jaxb-api.jar"/>
             <replacefilter token="../modules/webservices-api-osgi.jar" value="../modules/endorsed/webservices-api-osgi.jar"/>
             <replacefilter token="../modules/weld-se-core.jar" value="../lib/appclient/weld-se-core.jar"/>
+            <replacefilter token="../modules/weld-environment-common.jar" value="../lib/appclient/weld-environment-common.jar"/>
 
             <!--
                 The javax.mail JAR will reference activation.jar, because it is

--- a/appserver/appclient/client/acc-standalone/fixup.xml
+++ b/appserver/appclient/client/acc-standalone/fixup.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <project name="glassfish v3, app client library fix-up" default="fixup.library" basedir=".">
     <property name="mq.dir.path" value="../../mq"/>
@@ -60,7 +61,7 @@
     <property name="jdbc-config.classpath.additions" value="../modules/jdbc-config.jar"/>
     <property name="aix.additions" value="../modules/aixporting-repackaged.jar"/>
     <property name="entitybean-container.additions" value="../modules/entitybean-container.jar"/>
-    <property name="weld.classpath.additions" value="../modules/weld-osgi-bundle.jar"/>
+    <property name="weld.classpath.additions" value="../modules/weld-osgi-bundle-glassfish4.jar"/>
     
     <property name="classpath.additions" value=" ${resources-runtime.classpath.additions} ${javamail-connector.classpath.additions} ${javamail-runtime.classpath.additions} ${mq.classpath.additions} ${ds-jdbcra.classpath.additions} ${cp-jdbcra.classpath.additions} ${xa-jdbcra.classpath.additions} ${dm-jdbcra.classpath.additions} ${derby.jar.classpath.additions} ${jaxr-ra.classpath.additions} ${entitybean-container.additions} ${jdbc-runtime.classpath.additions} ${jdbc-config.classpath.additions} ${weld.classpath.additions}"/>
     <property name="classpath.conditional.additions" value="${aix.additions}"/>

--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <project name="glassfish-embedded-all" default="create.distribution" basedir=".">
     <property name="rootdir" value="target"/>
@@ -102,8 +103,9 @@
 	  <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
 	  <fileset dir="${gfdir}" includes="**/appserver-domain.jar"/>
 	  <fileset dir="${gfdir}" includes="**/nucleus-domain.jar"/>
-          <fileset dir="${gfdir}" includes="**/payara-domain.jar"/>
+      <fileset dir="${gfdir}" includes="**/payara-domain.jar"/>
 	  <fileset dir="${gfdir}" includes="**/weld-se-core.jar"/>
+	  <fileset dir="${gfdir}" includes="**/weld-environment-common.jar"/>
 	</delete>
 	<delete file="${modulesdir}/autostart/osgi-cdi.jar" failonerror="false"/>
      </target>

--- a/appserver/extras/embedded/payara-micro/build.xml
+++ b/appserver/extras/embedded/payara-micro/build.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <project name="payara-micro" default="create.distribution" basedir=".">
     <property name="rootdir" value="target"/>
@@ -101,6 +102,7 @@
 	  <fileset dir="${gfdir}" includes="**/payara-domain.jar"/>
 	  <fileset dir="${gfdir}" includes="**/nucleus-domain.jar"/>
 	  <fileset dir="${gfdir}" includes="**/weld-se-core.jar"/>
+	  <fileset dir="${gfdir}" includes="**/weld-environment-common.jar"/>
 	</delete>
 	<delete file="${modulesdir}/autostart/osgi-cdi.jar" failonerror="false"/>
      </target>

--- a/appserver/packager/glassfish-appclient/pom.xml
+++ b/appserver/packager/glassfish-appclient/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -164,6 +165,10 @@
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.environment</groupId>
+            <artifactId>weld-environment-common</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/packager/glassfish-appclient/src/main/assembly/glassfish-appclient.xml
+++ b/appserver/packager/glassfish-appclient/src/main/assembly/glassfish-appclient.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2016] [C2B2 Consulting Limited] -->
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
@@ -57,6 +58,7 @@
             <excludes>
                 <exclude>modules/gf-client.jar</exclude>
                 <exclude>modules/weld-se-core.jar</exclude>
+                <exclude>modules/weld-environment-common.jar</exclude>
                 <exclude>pkg_proto.py</exclude>
             </excludes>            
         </fileSet>
@@ -71,6 +73,13 @@
             <directory>${temp.dir}/glassfish/modules</directory>
             <includes>
                 <include>weld-se-core.jar</include>
+            </includes>
+            <outputDirectory>${install.dir.name}/glassfish/lib/appclient</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}/glassfish/modules</directory>
+            <includes>
+                <include>weld-environment-common.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/lib/appclient</outputDirectory>
         </fileSet>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -41,6 +41,7 @@
 
 -->
 <!--"Portions Copyright [2014-2016] [C2B2 Consulting Limited and/or its affiliates]" -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -690,6 +691,11 @@
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>
+                <version>${weld.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.environment</groupId>
+                <artifactId>weld-environment-common</artifactId>
                 <version>${weld.version}</version>
             </dependency>
             <dependency>

--- a/appserver/tests/quicklook/weld/osgiweld/README
+++ b/appserver/tests/quicklook/weld/osgiweld/README
@@ -1,6 +1,6 @@
 This test is meant to do two things:
 
-1. Verify that the weld-osgi-bundle.jar has been installed and is 
+1. Verify that the weld-osgi-bundle-glassfish4.jar has been installed and is 
    running in a GlassFish instance.
 
 2. Verify the exported packages in the osgi bundle.  It does this 

--- a/appserver/tests/quicklook/weld/osgiweld/src/java/osgiweld/OsgiWeldServlet.java
+++ b/appserver/tests/quicklook/weld/osgiweld/src/java/osgiweld/OsgiWeldServlet.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 
 package osgiweld;
 
@@ -81,7 +82,7 @@ public class OsgiWeldServlet extends HttpServlet {
             if (gfhome != null) {
                 String jarFile = gfhome + File.separator + ".."
                         + File.separator + ".." + File.separator
-                        + "modules" + File.separator + "weld-osgi-bundle.jar";
+                        + "modules" + File.separator + "weld-osgi-bundle-glassfish4.jar";
                 //System.out.println("Weld Osgi module = " + jarFile);
                 JarFile jar = new JarFile(jarFile);
                 Manifest manifest = jar.getManifest();


### PR DESCRIPTION
weld-osgi-bundle.jar text references replaced with weld-osgi-bundle-glassfish4.jar.
Also staged the weld-environment-common.jar to lib/appclient folder by first putting it into modules folder like weld-se-core and that propagating it to lib/appclient during the build process.

These actions fix the quicklook tests that were failing and the MDBTests to be specific.