### PR TITLE
PAYARA-753 

### DIFF
--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -55,7 +55,7 @@
     
     <name>flashlight-framework</name>
 
-    <profiles>
+   <!--<profiles>
         <profile>
             <id>aix-jdk</id>
             <activation>
@@ -87,7 +87,7 @@
                 </plugins>
             </build>
         </profile>
-    </profiles>
+    </profiles>-->
 
     <dependencies>
         <dependency>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -228,7 +228,7 @@
         <mail.version>1.5.4</mail.version>
         <javax.annotation-api.version>1.2</javax.annotation-api.version>
         <copyright-plugin.version>1.39</copyright-plugin.version>
-        <jdk.version>1.7.0-09</jdk.version>
+        <jdk.version>1.7.0</jdk.version>
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>


### PR DESCRIPTION
Lower required JDK version, as IBM JDK on AIX does not have an update number. Also remove aix profile from flashlight, as properties file doesn't exist