### PR TITLE
Remove duplicate dependency

### DIFF
--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -115,10 +115,6 @@
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>aopalliance-repackaged</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>asm-all-repackaged</artifactId>
-        </dependency>
    </dependencies>
 </project>
 


### PR DESCRIPTION
Dependency is listed twice in the same POM. Should remove the warning message at the beginning of builds.