### PR TITLE
Payara 724 Admin Console cannot handle escape characters

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
 
 import org.glassfish.admingui.common.util.GuiUtil;
 import org.glassfish.admingui.common.util.RestUtil;
@@ -169,7 +170,10 @@ public class LoggingHandlers {
         StringBuilder sb = new StringBuilder();
         String sep = "";
         for (String logger : oldLoggers) {
-            if (!newLoggers.contains(logger)) {
+            if (logger.contains(":")) {
+                logger = logger.replace(":", "\\:");
+            }
+            if (!newLoggers.contains(logger)) {                      
                 sb.append(sep).append(logger);
                 sep=":";
             }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
@@ -135,9 +135,14 @@ public class LoggingHandlers {
         try{
             StringBuilder sb = new StringBuilder();
             String sep = "";
-            for(Map<String, Object> oneRow : allRows){
-                if ( !GuiUtil.isEmpty((String) oneRow.get("loggerName"))){
-                    sb.append(sep).append(oneRow.get("loggerName")).append("=").append(oneRow.get("level"));
+            for(Map<String, Object> oneRow : allRows) {
+                String loggerName = (String) oneRow.get("loggerName");
+                if ( !GuiUtil.isEmpty(loggerName)){
+                    if (loggerName.contains(":")) {
+                        loggerName = loggerName.replace(":", "\\:");
+                    }
+                    
+                    sb.append(sep).append(loggerName).append("=").append(oneRow.get("level"));
                     sep=":";
                 }
             }
@@ -170,10 +175,10 @@ public class LoggingHandlers {
         StringBuilder sb = new StringBuilder();
         String sep = "";
         for (String logger : oldLoggers) {
-            if (logger.contains(":")) {
-                logger = logger.replace(":", "\\:");
-            }
-            if (!newLoggers.contains(logger)) {                      
+            if (!newLoggers.contains(logger)) {  
+                if (logger.contains(":")) {
+                    logger = logger.replace(":", "\\:");
+                }
                 sb.append(sep).append(logger);
                 sep=":";
             }

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
@@ -408,6 +408,11 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
             if (key == null) {
                 key = e.getKey();
             }
+            
+            if (key.contains("\\:")) {
+                key = key.replace("\\:", ":");
+            }
+            
             props.remove(key);
         }
 

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
@@ -438,6 +438,11 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
             if (key == null) {
                 key = e.getKey();
             }
+            
+            if (key.contains("\\:")) {
+                key = key.replace("\\:", ":");
+            }
+            
             props.remove(key);
         }
 

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/DeleteLogLevel.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/DeleteLogLevel.java
@@ -111,7 +111,7 @@ public class DeleteLogLevel implements AdminCommand {
         Map<String, String> m = new HashMap<String, String>();
         try {
 
-            String loggerNames[] = properties.split(":");
+            String loggerNames[] = properties.split("(?<!\\\\):");
 
             for (final Object key : loggerNames) {
                 final String logger_name = (String) key;


### PR DESCRIPTION
The admin console cannot deal with log level properties that have colons in them (e.g. _test:test_), as the colon is the delimiter for when dealing with multiple log levels. This fix allows you to add and delete log level properties that have delimiters in them.

Note, you will still have to escape the colon on the command line (e.g. `set-log-levels "test\:test"`), and it will be stored with the escape character in the _logging.properties_ file. It will be displayed without the escape character in the admin console, and in the response from the `list-log-levels` command.