### PR TITLE
Fixes PAYARA-638 - NPE on logout in EAR files

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -117,7 +118,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
     // is not necessary.
     private static final String WELD_LISTENER = "org.jboss.weld.servlet.WeldListener";
 
-    private static final String WELD_TERMINATION_LISTENER = "org.jboss.weld.servlet.WeldTerminalListener";
+    static final String WELD_TERMINATION_LISTENER = "org.jboss.weld.servlet.WeldTerminalListener";
 
     private static final String WELD_SHUTDOWN = "weld_shutdown";
 
@@ -513,7 +514,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
                 // Weld 2.2.1.Final.  There is a tck test for this: org.jboss.cdi.tck.tests.context.session.listener.SessionContextHttpSessionListenerTest
                 // This WeldTerminationListener must come after all application-defined listeners
-                wDesc.addAppListenerDescriptor(new AppListenerDescriptorImpl(WELD_TERMINATION_LISTENER));
+                wDesc.addAppListenerDescriptor(new AppListenerDescriptorImpl(WeldTerminationListenerProxy.class.getName()));
 
                 // Adding Weld ConverstationFilter if there is filterMapping for it and it doesn't exist already.
                 // However, it will be applied only if web.xml has mapping for it.
@@ -586,7 +587,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
                     // Add the Weld Listener if it does not already exist..
                     // we have to do this regardless because the war may not be cdi-enabled but an ejb is.
                     oneWebBundleDescriptor.addAppListenerDescriptorToFirst(new AppListenerDescriptorImpl(WELD_LISTENER));
-                    oneWebBundleDescriptor.addAppListenerDescriptor(new AppListenerDescriptorImpl(WELD_TERMINATION_LISTENER));
+                    oneWebBundleDescriptor.addAppListenerDescriptor(new AppListenerDescriptorImpl(WeldTerminationListenerProxy.class.getName()));
                 }
             }
         }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldTerminationListenerProxy.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldTerminationListenerProxy.java
@@ -1,0 +1,86 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.weld;
+
+import com.sun.enterprise.container.common.spi.util.InjectionException;
+import com.sun.enterprise.container.common.spi.util.InjectionManager;
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.weld.util.Util;
+
+/**
+ * checks whether bean manager exists before calling the real listener
+ * 
+ * @author lprimak
+ */
+public class WeldTerminationListenerProxy implements HttpSessionListener {
+    @PostConstruct
+    private void init() {
+        try {
+            origTermListener = Globals.getDefaultHabitat().getService(InjectionManager.class)
+                    .createManagedObject(Util.<HttpSessionListener>classForName(WeldDeployer.WELD_TERMINATION_LISTENER));
+        } catch (InjectionException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public void sessionCreated(HttpSessionEvent se) {
+        if(bm != null) {
+            origTermListener.sessionCreated(se);
+        }
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        if(bm != null) {
+            origTermListener.sessionDestroyed(se);
+        }
+    }
+    
+    
+    @Inject
+    private BeanManager bm;
+    private HttpSessionListener origTermListener;
+}


### PR DESCRIPTION
added WeldTerminationListenerProxy to check if BeanManager is available since all WARs in an EAR are always assumed to be CDI

removes NPE that was caused by this
Fixes PAYARA-638 and Issue #662