### PR TITLE
PAYARA-592 Monitoring for Concurrent Resources

### DIFF
--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -41,6 +41,8 @@
 
 -->
 
+<!-- Portions Copyright [2016] [C2B2 Consulting Ltd and/or its affiliates]-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -117,6 +117,11 @@
             <version>3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.admin</groupId>
+            <artifactId>monitoring-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ConcurrentMonitoringUtils.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ConcurrentMonitoringUtils.java
@@ -1,0 +1,116 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright (c) 2016 C2B2 Consulting Limited and/or its affiliates.
+ * All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.concurrent.monitoring;
+
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.glassfish.concurrent.LogFacade;
+import org.glassfish.external.probe.provider.PluginPoint;
+import org.glassfish.external.probe.provider.StatsProviderManager;
+
+/**
+ * Utility class for Concurrent monitoring.
+ * 
+ * @author Andrew Pielage
+ */
+public class ConcurrentMonitoringUtils
+{
+    private static final Logger _logger = LogFacade.getLogger();
+    
+    static final String NODE = "/";
+    static final String SEP = "-";
+    static final String APPLICATION_NODE = "applications" + NODE;
+    static final String CONCURRENT_MONITORING_NODE = "thread-pool";
+    static final String METHOD_NODE = NODE + "bean-methods" + NODE;
+
+    static String registerSingleComponent(String nodeItemName, 
+            Object listener) {
+        String beanTreeNode = "executorService/" + nodeItemName;
+        try {
+            StatsProviderManager.register(CONCURRENT_MONITORING_NODE, 
+                    PluginPoint.APPLICATIONS, beanTreeNode, listener);
+        } catch (Exception ex) {
+            _logger.log(Level.SEVERE, "[**ConcurrentMonitoringUtils**] Could not "
+                    + "register listener for " + nodeItemName,
+                    ex);
+            return null;
+        }
+        return beanTreeNode;
+    }
+
+    public static String stringify(Method m) {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("==> Converting method to String: " + m);
+        }
+        StringBuffer sb = new StringBuffer();
+        sb.append(m.getName());
+        Class[] args = m.getParameterTypes();
+        for (Class c : args) {
+            sb.append(SEP).append(c.getName().replaceAll("_", "\\."));
+        }
+        String result = sb.toString().replaceAll("\\.", "\\\\.");
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("==> Converted method String: " + result);
+        }
+        return result;
+    }
+
+    static String getBeanNode(String appName, String moduleName, String beanName) {
+        StringBuffer sb = new StringBuffer();
+        /** sb.append(APPLICATION_NODE); **/
+
+        if (appName != null) {
+            sb.append(appName).append(NODE);
+        }
+        sb.append(moduleName).append(NODE).append(beanName);
+
+        String beanSubTreeNode = sb.toString().replaceAll("\\.", "\\\\.").
+               replaceAll("_jar", "\\\\.jar").replaceAll("_war", "\\\\.war");
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("BEAN NODE NAME: " + beanSubTreeNode);
+        }
+        return beanSubTreeNode;
+    }
+
+    public static String getInvokerId(String appName, String modName, String beanName) {
+        if (appName == null) {
+            return "_" + modName + "_" + beanName;
+        }
+
+        return "_" + appName + "_" + modName + "_" + beanName;
+    }
+
+
+    public static String getDetailedLoggingName(String appName, String modName, String beanName) {
+        if (appName == null) {
+            return "modName=" + modName + "; beanName=" + beanName;
+        }
+
+        return "appName=" + appName + "; modName=" + modName + "; beanName=" + beanName;
+    }
+
+    public static String getLoggingName(String appName, String modName, String beanName) {
+        if (appName == null) {
+            return modName + ":" + beanName;
+        }
+
+        return appName + ":" + modName + ":" + beanName;
+    }
+}

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
@@ -1,0 +1,128 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright (c) 2016 C2B2 Consulting Limited and/or its affiliates.
+ * All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.concurrent.monitoring;
+
+import org.glassfish.concurrent.config.ManagedExecutorService;
+import org.glassfish.concurrent.runtime.ConcurrentRuntime;
+import org.glassfish.concurrent.runtime.deployer.ManagedExecutorServiceConfig;
+import org.glassfish.enterprise.concurrent.ManagedExecutorServiceImpl;
+import org.glassfish.external.probe.provider.StatsProviderManager;
+import org.glassfish.external.statistics.CountStatistic;
+import org.glassfish.external.statistics.impl.CountStatisticImpl;
+import org.glassfish.gmbal.AMXMetadata;
+import org.glassfish.gmbal.Description;
+import org.glassfish.gmbal.ManagedAttribute;
+import org.glassfish.gmbal.ManagedObject;
+
+/**
+ * Class that provides monitoring stats for the ManagedExecutorService
+ * @author Andrew Pielage
+ */
+@AMXMetadata(type="managed-executor-service-mon", group="monitoring", 
+        isSingleton=false)
+@ManagedObject
+@Description("ManagedExecutorService Statistics")
+public class ManagedExecutorServiceStatsProvider
+{   
+    private final String name;
+    private boolean registered = false;
+    private final ManagedExecutorServiceImpl managedExecutorServiceImpl;
+    
+    private CountStatisticImpl completedTaskCount = new CountStatisticImpl(
+            "CompletedTaskCount", "count", 
+            "Number of tasks completed");
+    private CountStatisticImpl taskCount = new CountStatisticImpl(
+            "TaskCount", "count",
+            "Total number of tasks ever scheduled");
+    
+    private CountStatisticImpl activeCount = new CountStatisticImpl(
+            "ActiveCount", "count",
+            "The approximate number of active threads");
+    
+    private CountStatisticImpl largestPoolSize = new CountStatisticImpl(
+            "LargestPoolSize", "count",
+            "The largest number of threads that have ever simultaneously "
+                    + "been in the pool.");
+    
+    private CountStatisticImpl poolSize = new CountStatisticImpl(
+            "PoolSize", "count",
+            "The current number of threads in the pool.");
+    
+    public ManagedExecutorServiceStatsProvider(ManagedExecutorService 
+            managedExecutorService) {            
+        ManagedExecutorServiceConfig managedExecutorServiceConfig = 
+                new ManagedExecutorServiceConfig(managedExecutorService);  
+        ConcurrentRuntime concurrentRuntime = ConcurrentRuntime.getRuntime();
+        
+        managedExecutorServiceImpl = concurrentRuntime.
+                getManagedExecutorService(null, managedExecutorServiceConfig);
+        name = this.managedExecutorServiceImpl.getName();     
+    }
+    
+    public void register() {
+        String node = ConcurrentMonitoringUtils.registerSingleComponent(
+                name, this);
+        if (node != null) {
+            registered = true;
+        }
+    }
+
+    public void unregister() {
+        if (registered) {
+            registered = false;
+            StatsProviderManager.unregister(this);
+        }
+    }
+    
+    @ManagedAttribute(id="CompletedTaskCount")
+    @Description("Number of tasks completed")
+    public CountStatistic getCompletedTaskCount() {
+        completedTaskCount.setCount(
+                managedExecutorServiceImpl.getCompletedTaskCount());
+        return completedTaskCount;
+    }
+    
+    @ManagedAttribute(id="TaskCount")
+    @Description("Total number of tasks ever scheduled")
+    public CountStatistic getTaskCount() {
+        taskCount.setCount(managedExecutorServiceImpl.getTaskCount());
+        return taskCount;
+    }
+    
+    @ManagedAttribute(id="ActiveCount")
+    @Description("The approximate number of active threads")
+    public CountStatistic getActiveCount() {
+        activeCount.setCount(managedExecutorServiceImpl.getActiveCount());
+        return activeCount;
+    }
+    
+    @ManagedAttribute(id="LargestPoolSize")
+    @Description("The largest number of threads that have ever simultaneously "
+                    + "been in the pool")
+    public CountStatistic getLargestPoolSize() {
+        largestPoolSize.setCount(managedExecutorServiceImpl.getLargestPoolSize());
+        return largestPoolSize;
+    }
+    
+    @ManagedAttribute(id="PoolSize")
+    @Description("The current number of threads in the pool")
+    public CountStatistic getPoolSize() {
+        poolSize.setCount(managedExecutorServiceImpl.getPoolSize());
+        return poolSize;
+    }
+}

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
@@ -1,0 +1,135 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright (c) 2016 C2B2 Consulting Limited and/or its affiliates.
+ * All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ */
+package fish.payara.concurrent.monitoring;
+
+import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
+import org.glassfish.concurrent.runtime.ConcurrentRuntime;
+import org.glassfish.concurrent.runtime.deployer.ManagedScheduledExecutorServiceConfig;
+import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl;
+import org.glassfish.external.probe.provider.StatsProviderManager;
+import org.glassfish.external.statistics.CountStatistic;
+import org.glassfish.external.statistics.impl.CountStatisticImpl;
+import org.glassfish.gmbal.AMXMetadata;
+import org.glassfish.gmbal.Description;
+import org.glassfish.gmbal.ManagedAttribute;
+import org.glassfish.gmbal.ManagedObject;
+
+/**
+ * Class that provides monitoring stats for the ManagedScheduledExecutorService
+ * @author Andrew Pielage
+ */
+@AMXMetadata(type="managed-scheduled-executor-service-mon", group="monitoring", 
+        isSingleton=false)
+@ManagedObject
+@Description("ManagedScheduledExecutorService Statistics")
+public class ManagedScheduledExecutorServiceStatsProvider
+{
+    private final String name;
+    private boolean registered = false;
+    private final ManagedScheduledExecutorServiceImpl 
+            managedScheduledExecutorServiceImpl;
+    
+    private CountStatisticImpl completedTaskCount = new CountStatisticImpl(
+            "CompletedTaskCount", "count", 
+            "Number of tasks completed");
+    private CountStatisticImpl taskCount = new CountStatisticImpl(
+            "TaskCount", "count",
+            "Total number of tasks ever scheduled");
+    
+    private CountStatisticImpl activeCount = new CountStatisticImpl(
+            "ActiveCount", "count",
+            "The approximate number of active threads");
+    
+    private CountStatisticImpl largestPoolSize = new CountStatisticImpl(
+            "LargestPoolSize", "count",
+            "The largest number of threads that have ever simultaneously "
+                    + "been in the pool.");
+    
+    private CountStatisticImpl poolSize = new CountStatisticImpl(
+            "PoolSize", "count",
+            "The current number of threads in the pool.");
+    
+    public ManagedScheduledExecutorServiceStatsProvider(
+            ManagedScheduledExecutorService managedScheduledExecutorService) { 
+        
+        ManagedScheduledExecutorServiceConfig 
+                managedScheduledExecutorServiceConfig = new 
+                        ManagedScheduledExecutorServiceConfig(
+                                managedScheduledExecutorService);  
+        ConcurrentRuntime concurrentRuntime = ConcurrentRuntime.getRuntime();
+        
+        managedScheduledExecutorServiceImpl = concurrentRuntime.
+                getManagedScheduledExecutorService(null, 
+                        managedScheduledExecutorServiceConfig);
+        name = this.managedScheduledExecutorServiceImpl.getName();     
+    }
+    
+    public void register() {
+        String node = ConcurrentMonitoringUtils.registerSingleComponent(
+                name, this);
+        if (node != null) {
+            registered = true;
+        }
+    }
+
+    public void unregister() {
+        if (registered) {
+            registered = false;
+            StatsProviderManager.unregister(this);
+        }
+    }
+    
+    @ManagedAttribute(id="CompletedTaskCount")
+    @Description( "Number of tasks completed")
+    public CountStatistic getCompletedTaskCount() {
+        completedTaskCount.setCount(
+                managedScheduledExecutorServiceImpl.getCompletedTaskCount());
+        return completedTaskCount;
+    }
+    
+    @ManagedAttribute(id="TaskCount")
+    @Description( "Total number of tasks ever scheduled")
+    public CountStatistic getTaskCount() {
+        taskCount.setCount(managedScheduledExecutorServiceImpl.getTaskCount());
+        return taskCount;
+    }
+    
+    @ManagedAttribute(id="ActiveCount")
+    @Description("The approximate number of active threads")
+    public CountStatistic getActiveCount() {
+        activeCount.setCount(managedScheduledExecutorServiceImpl.
+                getActiveCount());
+        return activeCount;
+    }
+    
+    @ManagedAttribute(id="LargestPoolSize")
+    @Description("The largest number of threads that have ever simultaneously "
+                    + "been in the pool")
+    public CountStatistic getLargestPoolSize() {
+        largestPoolSize.setCount(managedScheduledExecutorServiceImpl.
+                getLargestPoolSize());
+        return largestPoolSize;
+    }
+    
+    @ManagedAttribute(id="PoolSize")
+    @Description("The current number of threads in the pool")
+    public CountStatistic getPoolSize() {
+        poolSize.setCount(managedScheduledExecutorServiceImpl.getPoolSize());
+        return poolSize;
+    }
+}

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
@@ -42,7 +42,6 @@ package org.glassfish.concurrent.admin;
 
 import com.sun.enterprise.config.serverbeans.Resources;
 import com.sun.enterprise.config.serverbeans.ServerTags;
-import com.sun.enterprise.util.LocalStringManagerImpl;
 import org.glassfish.api.I18n;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfiguredBy;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -171,13 +171,16 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
 
     public synchronized ManagedExecutorServiceImpl getManagedExecutorService(ResourceInfo resource, ManagedExecutorServiceConfig config) {
         String jndiName = config.getJndiName();
+        
         if (managedExecutorServiceMap != null && managedExecutorServiceMap.containsKey(jndiName)) {
             return managedExecutorServiceMap.get(jndiName);
         }
+        
         ManagedThreadFactoryImpl managedThreadFactory = new ManagedThreadFactoryImpl(
                 config.getJndiName() + "-managedThreadFactory",
                 null,
                 config.getThreadPriority());
+        
         ManagedExecutorServiceImpl mes = new ManagedExecutorServiceImpl(config.getJndiName(),
                 managedThreadFactory,
                 config.getHungAfterSeconds() * 1000L, // in millseconds
@@ -190,13 +193,17 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                 createContextService(config.getJndiName() + "-contextservice",
                         config.getContextInfo(), config.getContextInfoEnabled(), true),
                 AbstractManagedExecutorService.RejectPolicy.ABORT);
+        
         if (managedExecutorServiceMap == null) {
             managedExecutorServiceMap = new HashMap();
         }
+        
         managedExecutorServiceMap.put(jndiName, mes);
+        
         if (config.getHungAfterSeconds() > 0L && !config.isLongRunningTasks()) {
             scheduleInternalTimer();
         }
+        
         return mes;
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceDeployer.java
@@ -38,12 +38,15 @@
  * holder.
  */
 
+// Portions Copyright [2016] [C2B2 Consulting Ltd and/or its affiliates]
+
 package org.glassfish.concurrent.runtime.deployer;
 
 
 import com.sun.enterprise.config.serverbeans.Application;
 import com.sun.enterprise.config.serverbeans.Resource;
 import com.sun.enterprise.config.serverbeans.Resources;
+import fish.payara.concurrent.monitoring.ManagedExecutorServiceStatsProvider;
 import org.glassfish.api.logging.LogHelper;
 import org.glassfish.concurrent.LogFacade;
 import org.glassfish.concurrent.config.ManagedExecutorService;
@@ -113,6 +116,8 @@ public class ManagedExecutorServiceDeployer implements ResourceDeployer {
         } catch (NamingException ex) {
             LogHelper.log(_logger, Level.SEVERE, LogFacade.UNABLE_TO_BIND_OBJECT, ex, "ManagedExecutorService", jndiName);
         }
+        
+        registerMonitorableComponent(managedExecutorServiceRes);
     }
 
     @Override
@@ -184,5 +189,14 @@ public class ManagedExecutorServiceDeployer implements ResourceDeployer {
     @Override
     public void validatePreservedResource(Application oldApp, Application newApp, Resource resource, Resources allResources) throws ResourceConflictException {
         // do nothing
+    }
+    
+    protected void registerMonitorableComponent(ManagedExecutorService 
+            managedExecutorService) {
+        ManagedExecutorServiceStatsProvider managedExecutorServiceProbeListener 
+                = new ManagedExecutorServiceStatsProvider(
+                        managedExecutorService);
+        
+        managedExecutorServiceProbeListener.register();
     }
 }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceDeployer.java
@@ -38,12 +38,15 @@
  * holder.
  */
 
+// Portions Copyright [2016] [C2B2 Consulting Ltd and/or its affiliates]
+
 package org.glassfish.concurrent.runtime.deployer;
 
 
 import com.sun.enterprise.config.serverbeans.Application;
 import com.sun.enterprise.config.serverbeans.Resource;
 import com.sun.enterprise.config.serverbeans.Resources;
+import fish.payara.concurrent.monitoring.ManagedScheduledExecutorServiceStatsProvider;
 import org.glassfish.api.logging.LogHelper;
 import org.glassfish.concurrent.LogFacade;
 import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
@@ -81,22 +84,22 @@ public class ManagedScheduledExecutorServiceDeployer implements ResourceDeployer
 
     @Override
     public void deployResource(Object resource, String applicationName, String moduleName) throws Exception {
-        ManagedScheduledExecutorService ManagedScheduledExecutorServiceRes = (ManagedScheduledExecutorService) resource;
+        ManagedScheduledExecutorService managedScheduledExecutorServiceRes = (ManagedScheduledExecutorService) resource;
 
-        if (ManagedScheduledExecutorServiceRes == null) {
+        if (managedScheduledExecutorServiceRes == null) {
             _logger.log(Level.WARNING, LogFacade.DEPLOY_ERROR_NULL_CONFIG, "ManagedScheduledExecutorService");
             return;
         }
 
-        String jndiName = ManagedScheduledExecutorServiceRes.getJndiName();
+        String jndiName = managedScheduledExecutorServiceRes.getJndiName();
 
         if(_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "ManagedScheduledExecutorServiceDeployer.deployResource() : jndi-name ["+jndiName+"]");
         }
 
 
-        ResourceInfo resourceInfo = new ResourceInfo(ManagedScheduledExecutorServiceRes.getJndiName(), applicationName, moduleName);
-        ManagedScheduledExecutorServiceConfig config = new ManagedScheduledExecutorServiceConfig(ManagedScheduledExecutorServiceRes);
+        ResourceInfo resourceInfo = new ResourceInfo(managedScheduledExecutorServiceRes.getJndiName(), applicationName, moduleName);
+        ManagedScheduledExecutorServiceConfig config = new ManagedScheduledExecutorServiceConfig(managedScheduledExecutorServiceRes);
 
         javax.naming.Reference ref= new  javax.naming.Reference(
                 javax.enterprise.concurrent.ManagedScheduledExecutorService.class.getName(),
@@ -113,6 +116,8 @@ public class ManagedScheduledExecutorServiceDeployer implements ResourceDeployer
         } catch (NamingException ex) {
             LogHelper.log(_logger, Level.SEVERE, LogFacade.UNABLE_TO_BIND_OBJECT, ex, "ManagedScheduledExecutorService", jndiName);
         }
+        
+        registerMonitorableComponent(managedScheduledExecutorServiceRes);
     }
 
     @Override
@@ -184,5 +189,15 @@ public class ManagedScheduledExecutorServiceDeployer implements ResourceDeployer
     @Override
     public void validatePreservedResource(Application oldApp, Application newApp, Resource resource, Resources allResources) throws ResourceConflictException {
         // do nothing
+    }
+    
+    protected void registerMonitorableComponent(ManagedScheduledExecutorService 
+            managedScheduledExecutorService) {
+        ManagedScheduledExecutorServiceStatsProvider 
+                managedScheduledExecutorServiceProbeListener = new 
+                        ManagedScheduledExecutorServiceStatsProvider(
+                                managedScheduledExecutorService);
+        
+        managedScheduledExecutorServiceProbeListener.register();
     }
 }

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -141,12 +141,12 @@
         <jsonp-ri.version>1.0.4</jsonp-ri.version>
         <jsonp-jaxrs.version>1.0</jsonp-jaxrs.version>
         <concurrent-api.version>1.0</concurrent-api.version>
-        <concurrent.version>1.0</concurrent.version>
+        <concurrent.version>1.0.payara-p1</concurrent.version>
         <javax.batch-api.version>1.0.1</javax.batch-api.version>
         <com.ibm.jbatch.container.version>1.0.1</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.1</com.ibm.jbatch.spi.version>
         <javax.xml.soap-api.version>1.3.7</javax.xml.soap-api.version>
-	    <javax.management.j2ee-api.version>1.1.1</javax.management.j2ee-api.version>
+	<javax.management.j2ee-api.version>1.1.1</javax.management.j2ee-api.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>
         <guava.version>18.0</guava.version>
     </properties>

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/MonitoringService.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/MonitoringService.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [C2B2 Consulting Ltd and/or its affiliates]
+
 package com.sun.enterprise.config.serverbeans;
 
 import com.sun.enterprise.util.LocalStringManagerImpl;
@@ -350,12 +352,19 @@ public interface MonitoringService extends ConfigExtension, PropertyBag {
                 }
             }
 
-
-            if (!isLevelUpdated) {
+            if (!isLevelUpdated) {              
                 // container-monitoring
                 for (ContainerMonitoring cm : ms.getContainerMonitoring()) {
+                    // Needs to be done using transaction semantics
+                    Transaction tx = Transaction.getTransaction(ms); 
+                    if (tx == null) {
+                        throw new TransactionFailure(localStrings.getLocalString(
+                        "noTransaction", "Internal Error - Cannot obtain transaction object"));
+                    }
+                    
                     if (cm.getName().equals(name)) {
-                        cm.setLevel(level);
+                        ContainerMonitoring containerMonitoring = tx.enroll(cm);
+                        containerMonitoring.setLevel(level);
                         isLevelUpdated = true;
                     }
                 }

--- a/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/StatsProviderRegistry.java
+++ b/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/StatsProviderRegistry.java
@@ -40,12 +40,9 @@
 
 package org.glassfish.admin.monitor;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.glassfish.flashlight.MonitoringRuntimeDataRegistry;
 import org.glassfish.flashlight.client.ProbeClientMethodHandle;
 import org.glassfish.gmbal.ManagedObjectManager;

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/cli/MonitoringConfig.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/cli/MonitoringConfig.java
@@ -42,8 +42,6 @@ package org.glassfish.flashlight.cli;
 
 import com.sun.enterprise.config.serverbeans.ModuleMonitoringLevels;
 import org.glassfish.api.ActionReport;
-import org.glassfish.api.I18n;
-import org.glassfish.api.Param;
 import org.jvnet.hk2.annotations.Service;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import java.beans.PropertyVetoException;
@@ -52,7 +50,6 @@ import org.jvnet.hk2.config.SingleConfigCode;
 import org.jvnet.hk2.config.ConfigSupport;
 import com.sun.enterprise.config.serverbeans.MonitoringService;
 import org.glassfish.api.monitoring.ContainerMonitoring;
-import org.jvnet.hk2.config.ConfigBean;
 import org.jvnet.hk2.config.Dom;
 import java.util.concurrent.atomic.AtomicBoolean;
 


### PR DESCRIPTION
Adds monitoring for `ManagedExecutorService` and `ManagedScheduledExecutorServices`. Currently has the limitation of only registering the pools for monitoring once an application tries to use them.

The monitoring is registered to the "_Threal Pool_" module, so monitoring of this will need to be enabled to see the statistics.

Also contains some minor clean up of unused imports, and somewhat of a fix for container-monitoring (as opposed to module-monitoring). Registering and editing monitoring requires transaction semantics, and container-monitoring was lacking this (see changes made to `MonitoringService.java`). Container-monitoring is still in a sorry state though, as I believe this was either intended to be deprecated, or the two monitoring types were intended to be merged together, but was given up on halfway through.