### PR TITLE
Added error logging when unable to bind to port.

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
@@ -54,6 +54,7 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import com.sun.enterprise.util.Result;
+import java.net.*;
 import java.util.concurrent.Callable;
 import org.glassfish.api.logging.LogHelper;
 import org.glassfish.grizzly.Grizzly;
@@ -264,7 +265,16 @@ public class GrizzlyProxy implements NetworkProxy {
     protected void start0() throws IOException {
         final long t1 = System.currentTimeMillis();
 
-        grizzlyListener.start();
+        try {
+            grizzlyListener.start();
+        } catch (BindException e) {
+            if (logger.isLoggable(Level.SEVERE)) {
+                logger.log(Level.SEVERE, KernelLoggerInfo.grizzlyUnableToBind,
+                    new Object[]{Grizzly.getDotedVersion(),
+                    grizzlyListener.getAddress() + ":" + grizzlyListener.getPort()});
+            }
+            throw e;
+        }
 
         if (logger.isLoggable(Level.INFO)) {
             logger.log(Level.INFO, KernelLoggerInfo.grizzlyStarted,

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
@@ -646,4 +646,9 @@ public class KernelLoggerInfo {
             level = "INFO")
     public static final String checkpointAutoResumeDone = LOGMSG_PREFIX + "-00096";
 
+    @LogMessageInfo(
+            message = "Grizzly Framework {0} could not start - unable to bind to [{1}]",
+            level = "INFO")
+    public static final String grizzlyUnableToBind = LOGMSG_PREFIX + "-00097";
+    
 }


### PR DESCRIPTION
A very often error that prevents server startup is that a port cannot be bound because it is already occupied. Payara server just logs a stacktrace and shuts down.

This update adds error logging of address and port, which could not be bound.