### PR TITLE
PAYARA-900 Fixed NPE in Cluster Store if HZ is not enabled

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/store/ClusteredStore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/store/ClusteredStore.java
@@ -76,7 +76,11 @@ public class ClusteredStore {
     }
     
     public Serializable get(String storeName, Serializable key) {
-        return (Serializable) hzCore.getInstance().getMap(storeName).get(key);
+        Serializable result = null;
+        if (isEnabled()) {
+            result = (Serializable) hzCore.getInstance().getMap(storeName).get(key);
+        }
+        return result;
     }
     
 }


### PR DESCRIPTION
get on the cluster store did not check whether the store was enabled resulting in a NPE 