### PR TITLE
PAYARA-935 Fix illegal non string type errors

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2014-2016] [C2B2 Consulting Limited]
+// Portions Copyright [2014-2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.enterprise.web;
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
@@ -960,7 +960,7 @@ public final class PEAccessLogValve
         }
         
         // log to console
-        accessLogToConsole = accessLogConfig.getLogToConsoleEnabled();
+        accessLogToConsole = Boolean.parseBoolean(accessLogConfig.getLogToConsoleEnabled());
     }
 
 

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/AccessLog.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/AccessLog.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2014-2016] [C2B2 Consulting Limited]
+// Portions Copyright [2014-2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package com.sun.enterprise.config.serverbeans;
 

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/AccessLog.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/AccessLog.java
@@ -203,7 +203,7 @@ public interface AccessLog extends ConfigBeanProxy, PropertyBag {
      * @return true if logging to console
      */
     @Attribute (defaultValue="false", dataType=Boolean.class)
-    boolean getLogToConsoleEnabled();
+    String getLogToConsoleEnabled();
     /**
      * specifies whether to display access logs to console
      * 

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
@@ -30,11 +30,11 @@ import org.jvnet.hk2.config.Configured;
 public interface AsadminRecorderConfiguration extends ConfigBeanProxy, ConfigExtension
 {
     @Attribute(defaultValue = "false", dataType = Boolean.class)
-    public Boolean isEnabled();
+    public String isEnabled();
     public void setEnabled(Boolean enabled);
     
     @Attribute(defaultValue = "true", dataType = Boolean.class)
-    public Boolean filterCommands();
+    public String filterCommands();
     public void setFilterCommands(Boolean filterCommands);
     
     @Attribute(defaultValue = 

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
@@ -103,7 +103,7 @@ public class AsadminRecorderService implements EventListener {
                             + "found, it is likely missing from the domain.xml."
                             + " Setting enabled to default of false");
         } else {
-            enabled = asadminRecorderConfiguration.isEnabled();
+            enabled = Boolean.parseBoolean(asadminRecorderConfiguration.isEnabled());
         }
         return enabled;
     }
@@ -123,7 +123,7 @@ public class AsadminRecorderService implements EventListener {
             splitFilteredCommands();
         }
         
-        if (asadminRecorderConfiguration.filterCommands()) {
+        if (Boolean.parseBoolean(asadminRecorderConfiguration.filterCommands())) {
             if (!(filteredCommands.contains(commandName))) {
                 boolean regexMatched = false;
                 

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/AsadminRecorderEnabled.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/AsadminRecorderEnabled.java
@@ -80,7 +80,7 @@ public class AsadminRecorderEnabled implements AdminCommand
         
         Properties extraProps = new Properties();
         
-        if (asadminRecorderConfiguration.isEnabled()) {
+        if (Boolean.parseBoolean(asadminRecorderConfiguration.isEnabled())) {
             extraProps.put("asadminRecorderEnabled", true);
             actionReport.setMessage("Asadmin Recorder Service is enabled");
         } else {

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/DisableAsadminRecorder.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/DisableAsadminRecorder.java
@@ -68,7 +68,7 @@ public class DisableAsadminRecorder implements AdminCommand {
                         asadminRecorderConfigurationProxy) 
                         throws PropertyVetoException, TransactionFailure {
                     
-                    if (asadminRecorderConfiguration.isEnabled()) {
+                    if (Boolean.parseBoolean(asadminRecorderConfiguration.isEnabled())) {
                         asadminRecorderConfigurationProxy.setEnabled(false);
                         Logger.getLogger(DisableAsadminRecorder.class.getName())
                                 .log(Level.INFO, 

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/EnableAsadminRecorder.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/EnableAsadminRecorder.java
@@ -68,7 +68,7 @@ public class EnableAsadminRecorder implements AdminCommand {
                         asadminRecorderConfigurationProxy) 
                         throws PropertyVetoException, TransactionFailure {
                     
-                    if (asadminRecorderConfiguration.isEnabled()) {
+                    if (Boolean.parseBoolean(asadminRecorderConfiguration.isEnabled())) {
                         Logger.getLogger(EnableAsadminRecorder.class.getName())
                                 .log(Level.INFO, 
                                         "Asadmin Recorder already enabled");                       

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckService.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckService.java
@@ -79,7 +79,7 @@ public class HealthCheckService implements EventListener {
 
     @PostConstruct
     void postConstruct() {
-        if (configuration != null && configuration.getEnabled()) {
+        if (configuration != null && Boolean.parseBoolean(configuration.getEnabled())) {
             enabled = true;
             bootstrapHealthCheck();
         }

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/configuration/Checker.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/configuration/Checker.java
@@ -19,6 +19,7 @@ import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.Configured;
 
 import java.beans.PropertyVetoException;
+import javax.validation.constraints.Min;
 
 /**
  * @author mertcaliskan
@@ -34,6 +35,7 @@ public interface Checker extends ConfigBeanProxy, ConfigExtension {
     void setEnabled(String value) throws PropertyVetoException;
 
     @Attribute(defaultValue = "5", dataType = Long.class)
+    @Min(value = 0)
     String getTime();
     void setTime(String value) throws PropertyVetoException;
 

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/configuration/Checker.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/configuration/Checker.java
@@ -33,8 +33,8 @@ public interface Checker extends ConfigBeanProxy, ConfigExtension {
     String getEnabled();
     void setEnabled(String value) throws PropertyVetoException;
 
-    @Attribute(defaultValue = "5")
-    Long getTime();
+    @Attribute(defaultValue = "5", dataType = Long.class)
+    String getTime();
     void setTime(String value) throws PropertyVetoException;
 
     @Attribute(defaultValue = "MINUTES")

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/configuration/HealthCheckServiceConfiguration.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/configuration/HealthCheckServiceConfiguration.java
@@ -28,7 +28,7 @@ import java.util.List;
 public interface HealthCheckServiceConfiguration extends ConfigBeanProxy, ConfigExtension {
 
     @Attribute(defaultValue="false",dataType=Boolean.class)
-    Boolean getEnabled();
+    String getEnabled();
     void enabled(String value) throws PropertyVetoException;
 
     @Element("*")

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseHealthCheck.java
@@ -71,7 +71,7 @@ public abstract class BaseHealthCheck<O extends HealthCheckExecutionOptions, C e
     protected HealthCheckExecutionOptions constructBaseOptions(Checker checker) {
         return new HealthCheckExecutionOptions(
                 Boolean.valueOf(checker.getEnabled()),
-                checker.getTime(),
+                Long.parseLong(checker.getTime()),
                 asTimeUnit(checker.getUnit()));
     }
 

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseThresholdHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseThresholdHealthCheck.java
@@ -28,7 +28,7 @@ public abstract class BaseThresholdHealthCheck<O extends HealthCheckWithThreshol
     public HealthCheckWithThresholdExecutionOptions constructThresholdOptions(ThresholdDiagnosticsChecker checker) {
         return new HealthCheckWithThresholdExecutionOptions(
                 Boolean.valueOf(checker.getEnabled()),
-                checker.getTime(),
+                Long.parseLong(checker.getTime()),
                 asTimeUnit(checker.getUnit()),
                 checker.getPropertyValue(THRESHOLD_CRITICAL, THRESHOLD_DEFAULTVAL_CRITICAL),
                 checker.getPropertyValue(THRESHOLD_WARNING, THRESHOLD_DEFAULTVAL_WARNING),

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/ConnectionPoolHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/ConnectionPoolHealthCheck.java
@@ -62,7 +62,7 @@ public class ConnectionPoolHealthCheck extends BaseThresholdHealthCheck<HealthCh
 
     public HealthCheckConnectionPoolExecutionOptions constructOptions(ConnectionPoolChecker checker) {
         return new HealthCheckConnectionPoolExecutionOptions(Boolean.valueOf(checker.getEnabled()),
-                checker.getTime(),
+                Long.parseLong(checker.getTime()),
                 asTimeUnit(checker.getUnit()),
                 checker.getPropertyValue(THRESHOLD_CRITICAL, THRESHOLD_DEFAULTVAL_CRITICAL),
                 checker.getPropertyValue(THRESHOLD_WARNING, THRESHOLD_DEFAULTVAL_WARNING),

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HoggingThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HoggingThreadsHealthCheck.java
@@ -50,8 +50,9 @@ public class HoggingThreadsHealthCheck extends BaseHealthCheck<HealthCheckHoggin
 
     @Override
     public HealthCheckHoggingThreadsExecutionOptions constructOptions(HoggingThreadsChecker checker) {
-        return new HealthCheckHoggingThreadsExecutionOptions(Boolean.valueOf(checker.getEnabled()), checker.getTime(),
-                asTimeUnit(checker.getUnit()), checker.getThresholdPercentage(), checker.getRetryCount());
+        return new HealthCheckHoggingThreadsExecutionOptions(Boolean.valueOf(checker.getEnabled()),
+                Long.parseLong(checker.getTime()), asTimeUnit(checker.getUnit()), checker.getThresholdPercentage(), 
+                checker.getRetryCount());
     }
 
     @Override

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationService.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationService.java
@@ -69,7 +69,7 @@ public class NotificationService implements EventListener {
     @PostConstruct
     void postConstruct() {
         if (configuration != null) {
-            executionOptions.setEnabled(configuration.getEnabled());
+            executionOptions.setEnabled(Boolean.parseBoolean(configuration.getEnabled()));
             for (NotifierConfiguration notifierConfiguration : configuration.getNotifierConfigurationList()) {
                 executionOptions.addNotifierConfigurationExecutionOption(executionOptionsFactory.build(notifierConfiguration));
             }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/configuration/NotificationServiceConfiguration.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/configuration/NotificationServiceConfiguration.java
@@ -27,7 +27,7 @@ import java.util.List;
 public interface NotificationServiceConfiguration extends ConfigBeanProxy, ConfigExtension {
 
     @Attribute(defaultValue = "false", dataType = Boolean.class)
-    Boolean getEnabled();
+    String getEnabled();
     void enabled(String value) throws PropertyVetoException;
 
     @Element("*")

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/configuration/Notifier.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/configuration/Notifier.java
@@ -28,6 +28,6 @@ import java.beans.PropertyVetoException;
 public interface Notifier extends ConfigBeanProxy {
 
     @Attribute(defaultValue = "false", dataType = Boolean.class)
-    Boolean getEnabled();
+    String getEnabled();
     void enabled(Boolean value) throws PropertyVetoException;
 }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/configuration/NotifierConfiguration.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/configuration/NotifierConfiguration.java
@@ -28,6 +28,6 @@ import java.beans.PropertyVetoException;
 public interface NotifierConfiguration extends ConfigBeanProxy {
 
     @Attribute(defaultValue = "false", dataType = Boolean.class)
-    Boolean getEnabled();
+    String getEnabled();
     void enabled(Boolean value) throws PropertyVetoException;
 }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/domain/execoptions/NotifierConfigurationExecutionOptionsFactory.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/domain/execoptions/NotifierConfigurationExecutionOptionsFactory.java
@@ -31,7 +31,7 @@ public class NotifierConfigurationExecutionOptionsFactory {
     public NotifierConfigurationExecutionOptions build(NotifierConfiguration notifierConfiguration) {
         if (notifierConfiguration instanceof LogNotifierConfiguration) {
             LogNotifierConfigurationExecutionOptions executionOptions = new LogNotifierConfigurationExecutionOptions();
-            executionOptions.setEnabled(notifierConfiguration.getEnabled());
+            executionOptions.setEnabled(Boolean.parseBoolean(notifierConfiguration.getEnabled()));
             return executionOptions;
         }
         return null;

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTracingService.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTracingService.java
@@ -80,8 +80,8 @@ public class RequestTracingService implements EventListener {
     @PostConstruct
     void postConstruct() {
         if (configuration != null) {
-            executionOptions.setEnabled(configuration.getEnabled());
-            executionOptions.setThresholdValue(configuration.getThresholdValue());
+            executionOptions.setEnabled(Boolean.parseBoolean(configuration.getEnabled()));
+            executionOptions.setThresholdValue(Long.parseLong(configuration.getThresholdValue()));
             executionOptions.setThresholdUnit(TimeUnit.valueOf(configuration.getThresholdUnit()));
 
             for (Notifier notifier : configuration.getNotifierList()) {

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/configuration/RequestTracingServiceConfiguration.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/configuration/RequestTracingServiceConfiguration.java
@@ -19,6 +19,7 @@ import org.jvnet.hk2.config.*;
 
 import java.beans.PropertyVetoException;
 import java.util.List;
+import javax.validation.constraints.Min;
 
 /**
  * @author mertcaliskan
@@ -33,6 +34,7 @@ public interface RequestTracingServiceConfiguration extends ConfigBeanProxy, Con
     void enabled(String value) throws PropertyVetoException;
 
     @Attribute(defaultValue = "3", dataType = Long.class)
+    @Min(value = 0)
     String getThresholdValue();
     void setThresholdValue(String value) throws PropertyVetoException;
 

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/configuration/RequestTracingServiceConfiguration.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/configuration/RequestTracingServiceConfiguration.java
@@ -29,11 +29,11 @@ import java.util.List;
 public interface RequestTracingServiceConfiguration extends ConfigBeanProxy, ConfigExtension {
 
     @Attribute(defaultValue = "false", dataType = Boolean.class)
-    Boolean getEnabled();
+    String getEnabled();
     void enabled(String value) throws PropertyVetoException;
 
-    @Attribute(defaultValue = "3")
-    Long getThresholdValue();
+    @Attribute(defaultValue = "3", dataType = Long.class)
+    String getThresholdValue();
     void setThresholdValue(String value) throws PropertyVetoException;
 
     @Attribute(defaultValue = "MINUTES")

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/domain/execoptions/NotifierExecutionOptionsFactory.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/domain/execoptions/NotifierExecutionOptionsFactory.java
@@ -31,7 +31,7 @@ public class NotifierExecutionOptionsFactory {
     public NotifierExecutionOptions build(Notifier notifier) {
         if (notifier instanceof LogNotifier) {
             LogNotifierExecutionOptions executionOptions = new LogNotifierExecutionOptions();
-            executionOptions.setEnabled(notifier.getEnabled());
+            executionOptions.setEnabled(Boolean.parseBoolean(notifier.getEnabled()));
             return executionOptions;
         }
         return null;


### PR DESCRIPTION
Some of our services were using non-String values, which AMX monitoring is apparently not fond of.