### PR TITLE
Wait before all applications are loaded before executing disable and deploy commands. Fixes #985

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2015] [C2B2 Consulting Limited]
+// Portions Copyright [2015,2016] [C2B2 Consulting Limited]
 
 package org.glassfish.deployment.admin;
 
@@ -48,6 +48,7 @@ import org.glassfish.api.admin.FailurePolicy;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.admin.util.ClusterOperationUtil;
 import com.sun.enterprise.config.serverbeans.*;
+import com.sun.enterprise.v3.server.ApplicationLoaderService;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.glassfish.api.ActionReport;
@@ -84,6 +85,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import javax.inject.Provider;
 import org.glassfish.api.admin.AccessRequired.AccessCheck;
 import org.glassfish.api.admin.AdminCommandSecurity;
 import org.glassfish.api.admin.RestEndpoint;
@@ -140,6 +142,10 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
 
     @Inject
     ServiceLocator habitat;
+    
+    @Inject		
+    @Named("ApplicationLoaderService")		
+    private Provider<ApplicationLoaderService> startupProvider;    
     
     private ActionReport report;
     private Logger logger;
@@ -369,9 +375,7 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
                 return;
             }
         }
-
-        ApplicationInfo appInfo = deployment.get(appName);
-        
+                
         try {
             
 
@@ -381,6 +385,10 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
             // SHOULD CHECK THAT WE ARE THE CORRECT TARGET BEFORE DISABLING 
             String serverName = server.getName();
             if (serverName.equals(target) || (server.getCluster() != null && server.getCluster().getName().equals(target)) ) {
+                // wait until all applications are loaded. Otherwise we get "Application not registered"
+                startupProvider.get();        
+                ApplicationInfo appInfo = deployment.get(appName);
+                
                 final DeploymentContext basicDC = deployment.disable(this, app, appInfo, report, logger);           
                 suppInfo.setDeploymentContext((ExtendedDeploymentContext)basicDC);  
             }

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/InstanceDeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/InstanceDeployCommand.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [C2B2 Consulting Limited]
 
 package org.glassfish.deployment.admin;
 
@@ -81,8 +82,10 @@ import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.config.serverbeans.Applications;
 import com.sun.enterprise.config.serverbeans.Application;
 import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.v3.server.ApplicationLoaderService;
 import java.io.FileOutputStream;
 import java.util.Collection;
+import javax.inject.Provider;
 import org.glassfish.api.admin.AccessRequired.AccessCheck;
 import org.glassfish.api.admin.AdminCommandSecurity;
 import org.glassfish.api.admin.RestEndpoint;
@@ -129,6 +132,10 @@ public class InstanceDeployCommand extends InstanceDeployCommandParameters
 
     @Inject
     private Domain domain;
+    
+    @Inject		
+    @Named("ApplicationLoaderService")		
+    private Provider<ApplicationLoaderService> startupProvider;    
     
     @Override
     public Collection<? extends AccessCheck> getAccessChecks() {
@@ -185,6 +192,9 @@ public class InstanceDeployCommand extends InstanceDeployCommandParameters
                 report.failure(logger,localStrings.getLocalString("deploy.unknownarchivetype","Archive type of {0} was not recognized",path.getName()));
                 return;
             }
+            // wait until all applications are loaded as we may have dependency on these, or the previous app is still
+            // starting
+            startupProvider.get();
 
             // clean up any left over repository files
             if ( ! keepreposdir.booleanValue()) {
@@ -208,7 +218,7 @@ public class InstanceDeployCommand extends InstanceDeployCommandParameters
             } else {
                 t = deployment.prepareAppConfigChanges(deploymentContext);
             }
-
+            
             ApplicationInfo appInfo;
             appInfo = deployment.deploy(deploymentContext);
 


### PR DESCRIPTION
My testcase for this was repeatably launch `asadmin restart-instance && asadmin deploy --force` against an instance with few applications loaded.

During forced deployment the DAS first executed disable command, followed by instance deploy command.