### PR TITLE
Fixes PAYARA-813 and PAYARA-690 spurious "resource not found" messages

### DIFF
--- a/appserver/core/javaee-kernel/src/main/java/org/glassfish/kernel/javaee/MEJBNamingObjectProxy.java
+++ b/appserver/core/javaee-kernel/src/main/java/org/glassfish/kernel/javaee/MEJBNamingObjectProxy.java
@@ -37,11 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package org.glassfish.kernel.javaee;
 
 import com.sun.enterprise.config.serverbeans.Server;
-import com.sun.logging.LogDomains;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.deployment.DeployCommandParameters;
@@ -76,8 +76,7 @@ public class MEJBNamingObjectProxy implements NamingObjectProxy {
 
     private ServiceLocator habitat;
 
-    private static final Logger _logger = LogDomains.getLogger(
-            MEJBNamingObjectProxy.class, LogDomains.EJB_LOGGER);
+    private static final Logger _logger = Logger.getLogger(MEJBService.class.getName());
 
 
     public MEJBNamingObjectProxy(ServiceLocator habitat) {

--- a/appserver/core/javaee-kernel/src/main/java/org/glassfish/kernel/javaee/MEJBService.java
+++ b/appserver/core/javaee-kernel/src/main/java/org/glassfish/kernel/javaee/MEJBService.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
 
 package org.glassfish.kernel.javaee;
 
@@ -51,7 +52,6 @@ import org.glassfish.internal.api.InitRunLevel;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.api.naming.GlassfishNamingManager;
 
-import com.sun.logging.LogDomains;
 
 import java.util.logging.Logger;
 import java.util.logging.Level;
@@ -75,8 +75,7 @@ public class MEJBService implements PostConstruct {
     @Inject 
     Provider<GlassfishNamingManager> gfNamingManagerProvider;
 
-    private static final Logger _logger = LogDomains.getLogger(
-        MEJBService.class, LogDomains.EJB_LOGGER);
+    private static final Logger _logger = Logger.getLogger(MEJBService.class.getName());
   
     public void postConstruct() {
         GlassfishNamingManager gfNamingManager =

--- a/appserver/ejb/ejb-container/src/main/resources/com/sun/logging/enterprise/system/core/LogStrings.properties
+++ b/appserver/ejb/ejb-container/src/main/resources/com/sun/logging/enterprise/system/core/LogStrings.properties
@@ -1,0 +1,41 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+# or packager/legal/LICENSE.txt.  See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at packager/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# Oracle designates this particular file as subject to the "Classpath"
+# exception as provided by Oracle in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+# Portions Copyright [2016] [C2B2 Consulting Limited and/or its affiliates]
+
+# No messages so far


### PR DESCRIPTION
added log strings file to EJB container to quiet the "resource bundle not found" messages

Also fixed logging in JavaEE kernel (MEJBService and it's proxy) to quiet similar warning messages
