### PR TITLE
PAYARA-1033 upgrade to Grizzly 2.3.27

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -240,6 +240,7 @@
         <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
         <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
         <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -431,6 +432,9 @@
              <!-- End of OSGi bundle configurations -->
              <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
              <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+             <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
+             <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+             
         </java-config>
          <availability-service>
              <web-container-availability/>

--- a/appserver/admin/payara_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/payara_template/src/main/resources/config/domain.xml
@@ -189,6 +189,7 @@
         <jvm-options>-Xms2g</jvm-options>
         <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
         <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -357,6 +358,7 @@
         <jvm-options>-Xms2g</jvm-options>
         <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
         <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>        
       </java-config>
          <availability-service>
              <web-container-availability/>

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/resources/payara-boot.properties
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/resources/payara-boot.properties
@@ -27,3 +27,4 @@ java.awt.headless=true
 java.net.preferIPv4Stack=true
 org.jboss.weld.serialization.beanIdentifierIndexOptimization=false
 com.sun.enterprise.security.httpsOutboundKeyAlias=s1as
+org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
 package org.glassfish.grizzly.config;
 
 import java.io.IOException;
@@ -386,6 +387,12 @@ public class SSLConfigurator extends SSLEngineConfigurator {
 
         @Override
         public SSLContext createSSLContext() {
+            return configureSSL();
+        }
+        
+        // Grizzly 2.3.28 introduced a new method on the base class which must be overridden
+        @Override
+        public SSLContext createSSLContext(boolean throwException) {
             return configureSSL();
         }
 

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
@@ -37,11 +37,12 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+
+// Portions Copyright [2016] [Payara Foundation]
 package org.glassfish.grizzly.config;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.Socket;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -57,6 +58,7 @@ import org.glassfish.grizzly.http.server.Response;
 import org.glassfish.grizzly.memory.ByteBufferManager;
 import org.glassfish.grizzly.memory.HeapMemoryManager;
 import org.glassfish.grizzly.memory.MemoryManager;
+import org.glassfish.grizzly.memory.PooledMemoryManager;
 import org.glassfish.grizzly.nio.NIOTransport;
 import org.glassfish.grizzly.strategies.SameThreadIOStrategy;
 import org.glassfish.grizzly.strategies.WorkerThreadIOStrategy;
@@ -150,7 +152,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
             GenericGrizzlyListener genericGrizzlyListener =
                     (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-1");
             MemoryManager mm = genericGrizzlyListener.getTransport().getMemoryManager();
-            assertEquals(HeapMemoryManager.class.getName(), mm.getClass().getName());
+            assertEquals(PooledMemoryManager.class.getName(), mm.getClass().getName());
         } finally {
             if (grizzlyConfig != null) {
                 grizzlyConfig.shutdownNetwork();

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -192,8 +192,7 @@
         <stax-api.version>1.0-2</stax-api.version>
         <management-api.version>1.1-rev-1</management-api.version>
         <servlet-api.version>3.1.0</servlet-api.version>
-        <grizzly.version>2.3.26</grizzly.version>
-        <grizzly.version>2.3.27</grizzly.version>
+        <grizzly.version>2.3.28</grizzly.version>
         <saaj-api.version>1.3.4</saaj-api.version>
         <hk2.version>2.4.0</hk2.version>
         <hk2.plugin.version>2.4.0</hk2.plugin.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -193,6 +193,7 @@
         <management-api.version>1.1-rev-1</management-api.version>
         <servlet-api.version>3.1.0</servlet-api.version>
         <grizzly.version>2.3.26</grizzly.version>
+        <grizzly.version>2.3.27</grizzly.version>
         <saaj-api.version>1.3.4</saaj-api.version>
         <hk2.version>2.4.0</hk2.version>
         <hk2.plugin.version>2.4.0</hk2.plugin.version>


### PR DESCRIPTION
DO NOT MERGE UNTIL AFTER THE 163.1 customer release as Grizzly changes the default buffer type used internally between 2.3.26 and 2.3.27