### PR TITLE
Add build profiles

### DIFF
--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -84,18 +84,6 @@
         <create-domain.payara.args>--user admin create-domain --template=${payara.template.jar} --nopassword --savelogin=true --checkports=false --adminport 4848 --instanceport 8080 --keytooloptions CN=localhost payaradomain</create-domain.payara.args>
     </properties>
 
-    <modules>
-<!--        <module>minnow</module> -->
-<!--        <module>web</module> -->
-<!--        <module>glassfish</module> -->
-        <module>payara</module>
-	<module>payara-ml</module>
-        <module>payara-web</module>
-	<module>payara-web-ml</module>
-        <!-- disable appclient distribution build since we're not using it yet -->
-        <!-- 	<module>appclient</module> -->
-    </modules>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -289,6 +277,38 @@
                     <type>zip</type>
                 </dependency>
             </dependencies>
+        </profile>
+        
+        <!-- Profile to just build main Payara Distribution -->
+        <profile>
+            <id>QuickBuild</id>
+            <activation>
+                <property>
+                    <name>QuickBuild</name>
+                </property>
+            </activation>
+            <modules>
+                <module>payara</module>
+            </modules>
+        </profile>
+        
+        <!-- Default build profile -->
+        <profile>
+            <id>DefaultBuild</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <!-- <module>minnow</module> -->
+                <!-- <module>web</module> -->
+                <!-- <module>glassfish</module> -->
+                <module>payara</module>
+                <module>payara-ml</module>
+                <module>payara-web</module>
+                <module>payara-web-ml</module>
+                <!-- disable appclient distribution build since we're not using it yet -->
+                <!--    <module>appclient</module> -->
+            </modules>
         </profile>
     </profiles>  
 </project>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -57,7 +57,6 @@
         <!--module>embedded-shell</module-->
         <module>javaee</module>
         <module>appserv-rt</module>
-        <module>payara-micro</module>
     </modules>
 
     <profiles>
@@ -72,6 +71,33 @@
             </activation>
             <modules>
                 <module>embedded</module>
+            </modules>
+        </profile>
+        
+        <!-- Profile to build Embedded and Micro distributions -->
+        <profile>
+            <id>FullBuild</id>
+            <activation>
+                <property>
+                    <name>FullBuild</name>
+                </property>
+            </activation>
+            <modules>
+                <module>payara-micro</module>
+                <module>embedded</module>
+            </modules>
+        </profile>
+       
+        <!-- Profile to build Payara Micro -->
+        <profile>
+            <id>BuildMicro</id>
+            <activation>
+                <property>
+                    <name>BuildMicro</name>
+                </property>
+            </activation>
+            <modules>
+                <module>payara-micro</module>
             </modules>
         </profile>
     </profiles>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -76,10 +76,10 @@
         
         <!-- Profile to build Embedded and Micro distributions -->
         <profile>
-            <id>FullBuild</id>
+            <id>BuildExtras</id>
             <activation>
                 <property>
-                    <name>FullBuild</name>
+                    <name>BuildExtras</name>
                 </property>
             </activation>
             <modules>


### PR DESCRIPTION
Edits the default build procedure, and adds additional build options.

Doing a standard build (`mvn clean install`) will build:
* payara
* payara-ml
* payara-web
* payara-web-ml
* payara-minimal

Running a build with the _QuickBuild_ profile (`mvn clean install -PQuickBuild`) will just build:
* payara
* payara-minimal

Running a build with the _BuildExtras_ profile will add the Embedded and Micro distributions to the build. For example, `mvn clean install -PQuickBuild,BuildExtras` will build:
* payara
* payara-minimal
* payara-micro
* payara-embedded-all
* payara-embedded-web

Finally, running a build with the _BuildMicro_ profile will add Payara Micro to the build. For example, `mvn clean install -PBuildMicro` will build:
* payara
* payara-ml
* payara-web
* payara-web-ml
* payara-minimal
* payara-micro