### PR TITLE
PAYARA-956 ManagedExecutorService MBean attempts to register multiple times

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceDeployer.java
@@ -81,6 +81,9 @@ public class ManagedExecutorServiceDeployer implements ResourceDeployer {
 
     // logger for this deployer
     private static Logger _logger = LogFacade.getLogger();
+    
+    // Monitoring provider
+    private ManagedExecutorServiceStatsProvider managedExecutorServiceProbeListener;
 
     @Override
     public void deployResource(Object resource, String applicationName, String moduleName) throws Exception {
@@ -141,6 +144,7 @@ public class ManagedExecutorServiceDeployer implements ResourceDeployer {
         ManagedExecutorService managedExecutorServiceRes = (ManagedExecutorService) resource;
         ResourceInfo resourceInfo = new ResourceInfo(managedExecutorServiceRes.getJndiName(), applicationName, moduleName);
         namingService.unpublishObject(resourceInfo, managedExecutorServiceRes.getJndiName());
+        unregisterMonitorableComponent();
         // stop the runtime object
         concurrentRuntime.shutdownManagedExecutorService(managedExecutorServiceRes.getJndiName());
     }
@@ -191,12 +195,21 @@ public class ManagedExecutorServiceDeployer implements ResourceDeployer {
         // do nothing
     }
     
-    protected void registerMonitorableComponent(ManagedExecutorService 
-            managedExecutorService) {
-        ManagedExecutorServiceStatsProvider managedExecutorServiceProbeListener 
-                = new ManagedExecutorServiceStatsProvider(
-                        managedExecutorService);
+    /**
+     * Registers the ManagedExecutorService for monitoring.
+     * @param managedExecutorService The ManagedExecutorService to register for monitoring
+     */
+    private void registerMonitorableComponent(ManagedExecutorService managedExecutorService) {
+        managedExecutorServiceProbeListener = new ManagedExecutorServiceStatsProvider(managedExecutorService);
         
         managedExecutorServiceProbeListener.register();
+    }
+    
+    /**
+     * Unregisters the ManagedExecutorService defined by the 
+     * managedExecutorServiceProbeLister from the monitoring tree.
+     */
+    private void unregisterMonitorableComponent() {
+        managedExecutorServiceProbeListener.unregister();
     }
 }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceDeployer.java
@@ -78,6 +78,9 @@ public class ManagedScheduledExecutorServiceDeployer implements ResourceDeployer
 
     @Inject
     ConcurrentRuntime concurrentRuntime;
+    
+    // Monitoring provider
+    private ManagedScheduledExecutorServiceStatsProvider managedScheduledExecutorServiceProbeListener;
 
     // logger for this deployer
     private static Logger _logger = LogFacade.getLogger();
@@ -191,13 +194,22 @@ public class ManagedScheduledExecutorServiceDeployer implements ResourceDeployer
         // do nothing
     }
     
-    protected void registerMonitorableComponent(ManagedScheduledExecutorService 
-            managedScheduledExecutorService) {
-        ManagedScheduledExecutorServiceStatsProvider 
-                managedScheduledExecutorServiceProbeListener = new 
-                        ManagedScheduledExecutorServiceStatsProvider(
-                                managedScheduledExecutorService);
+    /**
+     * Registers a ManagedScheduledExecutorService for monitoring.
+     * @param managedScheduledExecutorService The ManagedScheduledExecutorService to register for monitoring.
+     */
+    private void registerMonitorableComponent(ManagedScheduledExecutorService managedScheduledExecutorService) {
+        managedScheduledExecutorServiceProbeListener = 
+                new ManagedScheduledExecutorServiceStatsProvider(managedScheduledExecutorService);
         
         managedScheduledExecutorServiceProbeListener.register();
+    }
+    
+    /**
+     * Unregisters a ManagedScheduledExecutorService defined by the 
+     * managedScheduledExecutorServiceProbeListener from the monitoring tree.
+     */
+    private void unregisterMonitableComponent() {
+        managedScheduledExecutorServiceProbeListener.unregister();
     }
 }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
@@ -504,11 +504,15 @@ public final class AMXConfigLoader
 
             //System.out.println( "AMXConfigLoader.createAndRegister(): REGISTERED: " + objectName + " at " + System.currentTimeMillis() );
             //System.out.println( JMXUtil.toString( mServer.getMBeanInfo(objectName) ) );
+        } catch (InstanceAlreadyExistsException ex) {
+            mLogger.log(Level.FINE, ExceptionUtil.toString(ex));
+            
+            objectName = null;
         } catch (final JMException e) {
             debug(ExceptionUtil.toString(e));
 
             objectName = null;
-        }
+        } 
         return objectName;
     }
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
@@ -37,6 +37,9 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+ 
+ // Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+ 
 package org.glassfish.admin.amx.impl.config;
 
 import com.sun.enterprise.config.serverbeans.Domain;


### PR DESCRIPTION
Changes the log level to FINE to silence this log message, as it isn't useful information pertaining to normal running procedure.

Also adds in the unregister methods for the ManagedExecutorService monitoring.