### PR TITLE
PAYARA-1067 Check of InvocationContext argument for AroundInvoke and AroundTimeout.

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/LifecycleCallbackDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/LifecycleCallbackDescriptor.java
@@ -126,7 +126,7 @@ public class LifecycleCallbackDescriptor extends Descriptor {
             for(Method next : clazz.getDeclaredMethods()) {
                 if( next.getName().equals(lifecycleCallbackMethod) ) {
                     if ( !requiresInvocationContextArgument
-                           || (next.getParameterCount() == 1 
+                           || (next.getParameterTypes().length == 1 
                                && "javax.interceptor.InvocationContext".equals(next.getParameterTypes()[0].getName()))) {
                         method = next;
                         break;

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/LifecycleCallbackDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/LifecycleCallbackDescriptor.java
@@ -55,6 +55,7 @@ public class LifecycleCallbackDescriptor extends Descriptor {
     private String lifecycleCallbackMethod;
     private String defaultLifecycleCallbackClass;
     private MetadataSource metadataSource = MetadataSource.XML;
+    private boolean requiresInvocationContextArgument = false;
 
     public enum CallbackType {
 
@@ -95,6 +96,14 @@ public class LifecycleCallbackDescriptor extends Descriptor {
         return lifecycleCallbackMethod;
     }
 
+    public boolean isRequiresInvocationContextArgument() {
+        return requiresInvocationContextArgument;
+    }
+
+    public void setRequiresInvocationContextArgument(boolean requiresInvocationContextArgument) {
+        this.requiresInvocationContextArgument = requiresInvocationContextArgument;
+    }
+
     /**
      * Given a classloader, find the Method object corresponding to this
      * lifecycle callback.  
@@ -116,8 +125,12 @@ public class LifecycleCallbackDescriptor extends Descriptor {
         while ( method == null && ! clazz.equals( Object.class ) ) {
             for(Method next : clazz.getDeclaredMethods()) {
                 if( next.getName().equals(lifecycleCallbackMethod) ) {
-                    method = next;
-                    break;
+                    if ( !requiresInvocationContextArgument
+                           || (next.getParameterCount() == 1 
+                               && "javax.interceptor.InvocationContext".equals(next.getParameterTypes()[0].getName()))) {
+                        method = next;
+                        break;
+                    }
                 }
             }
             if ( method == null ) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
@@ -294,9 +294,11 @@ public class EjbServicesImpl implements EjbServices {
                             ejbInt.addPostActivateDescriptor(lifecycleDesc);
                             break;
                         case AROUND_INVOKE :
+                            lifecycleDesc.setRequiresInvocationContextArgument(true);
                             ejbInt.addAroundInvokeDescriptor(lifecycleDesc);
                             break;
                         case AROUND_TIMEOUT :
+                            lifecycleDesc.setRequiresInvocationContextArgument(true);
                             ejbInt.addAroundTimeoutDescriptor(lifecycleDesc);
                             break;
                         default :


### PR DESCRIPTION
For method and timeout CDI interceptors in EJB, choose only the method having argument of InvocationContext type, not only based on the name, as there may be multiple methods with the same name in a single interceptor class.

A fix for #1078 