### PR TITLE
PAYARA-178 Request tracing for JDBC context events.

### DIFF
--- a/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
@@ -41,6 +41,8 @@
 
 -->
 
+<!-- Portions Copyright [2016] [Payara Foundation and/or its affiliates] -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <artifactId>jdbc-ra</artifactId>
@@ -97,6 +99,11 @@
       <dependency>
           <groupId>org.glassfish.gmbal</groupId>
           <artifactId>gmbal</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>fish.payara.payara-modules</groupId>
+          <artifactId>requesttracing-core</artifactId>
+          <version>${project.version}</version>
       </dependency>
   </dependencies>
 </project>

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates.]
+
 package com.sun.gjc.spi;
 
 import com.sun.appserv.connectors.internal.spi.BadConnectionEventListener;
@@ -49,6 +51,8 @@ import com.sun.gjc.spi.base.datastructure.CacheFactory;
 import com.sun.gjc.util.SQLTraceDelegator;
 import com.sun.gjc.util.StatementLeakDetector;
 import com.sun.logging.LogDomains;
+import fish.payara.jdbc.RequestTracingListener;
+import fish.payara.nucleus.requesttracing.RequestTracingService;
 import org.glassfish.resourcebase.resources.api.PoolInfo;
 
 import javax.resource.NotSupportedException;
@@ -70,6 +74,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.internal.api.Globals;
 
 /**
  * <code>ManagedConnection</code> implementation for Generic JDBC Connector.
@@ -144,6 +149,8 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
     private DatabaseMetaData cachedDatabaseMetaData = null;
     private Boolean isClientInfoSupported = null;
     
+    private RequestTracingService requestTracing;
+    
     /**
      * Constructor for <code>ManagedConnectionImpl</code>. The pooledConn parameter is expected
      * to be null and sqlConn parameter is the actual connection in case where
@@ -201,6 +208,13 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
         ce = new ConnectionEvent(this, ConnectionEvent.CONNECTION_CLOSED);
         tuneStatementCaching(poolInfo, statementCacheSize, statementCacheType);
         tuneStatementLeakTracing(poolInfo, statementLeakTimeout, statementLeakReclaim);
+        
+        try {
+            requestTracing = Globals.getDefaultHabitat().getService(RequestTracingService.class);
+        } catch (NullPointerException ex) {
+            _logger.log(Level.INFO, "Error retrieving Request Tracing service "
+                    + "during initialisation of ManagedConnectionImpl - NullPointerException");
+        }
     }
 
     public StatementLeakDetector getLeakDetector() {
@@ -462,10 +476,46 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
             }
         }
         
+        /**
+         * Register a RequestTracingListener if request tracing is enabled,
+         * creating a SQLTraceDelegator if one does not already exist.
+         * This check is required here to prevent having to
+         * recreate the connection pool to accommodate dynamic request tracing
+         * enabling/disabling.
+         */
+        if (sqlTraceDelegator == null) {
+            if (requestTracing.isRequestTracingEnabled()) {
+                sqlTraceDelegator = new SQLTraceDelegator(spiMCF.getPoolName(), spiMCF.getApplicationName(), spiMCF.getModuleName());
+                // This method will only register a request tracing listener if one doesn't already exist
+                sqlTraceDelegator.registerSQLTraceListener(new RequestTracingListener());
+            }
+        } else {
+            if (requestTracing.isRequestTracingEnabled()) {
+                sqlTraceDelegator.registerSQLTraceListener(new RequestTracingListener());
+            } else { 
+                /** 
+                 * If request tracing is not enabled, but there is a SQL trace
+                 * delegator, deregister the request tracing listener if one is 
+                 * registered.
+                 */
+                sqlTraceDelegator.deregisterSQLTraceListener(RequestTracingListener.class);
+                
+                /**
+                 * If there are no longer any listeners registered, set the 
+                 * delegator to null to prevent 
+                 * JdbcObjectsFactory().getConnection(...) from using a profiled
+                 * wrapper unnecessarily.
+                 */ 
+                if (!sqlTraceDelegator.listenersRegistered()) {
+                    sqlTraceDelegator = null;
+                }
+            }              
+        }
+        
         myLogicalConnection = spiMCF.getJdbcObjectsFactory().getConnection(
                 actualConnection, this, cxReqInfo, spiMCF.isStatementWrappingEnabled(),
                 sqlTraceDelegator);
-
+        
         //TODO : need to see if this should be executed for every getConnection
         if (!initSqlExecuted) {
             //Check if Initsql is set and execute it

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -484,21 +484,28 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
          * enabling/disabling.
          */
         if (sqlTraceDelegator == null) {
-            if (requestTracing.isRequestTracingEnabled()) {
-                sqlTraceDelegator = new SQLTraceDelegator(spiMCF.getPoolName(), spiMCF.getApplicationName(), spiMCF.getModuleName());
-                // This method will only register a request tracing listener if one doesn't already exist
-                sqlTraceDelegator.registerSQLTraceListener(new RequestTracingListener());
+            if (requestTracing != null && 
+                    requestTracing.isRequestTracingEnabled()) {
+                sqlTraceDelegator = new SQLTraceDelegator(spiMCF.getPoolName(), 
+                        spiMCF.getApplicationName(), spiMCF.getModuleName());
+                // This method will only register a request tracing listener 
+                // if one doesn't already exist
+                sqlTraceDelegator.registerSQLTraceListener(
+                        new RequestTracingListener());
             }
         } else {
-            if (requestTracing.isRequestTracingEnabled()) {
-                sqlTraceDelegator.registerSQLTraceListener(new RequestTracingListener());
+            if (requestTracing != null && 
+                    requestTracing.isRequestTracingEnabled()) {
+                sqlTraceDelegator.registerSQLTraceListener(
+                        new RequestTracingListener());
             } else { 
                 /** 
                  * If request tracing is not enabled, but there is a SQL trace
                  * delegator, deregister the request tracing listener if one is 
                  * registered.
                  */
-                sqlTraceDelegator.deregisterSQLTraceListener(RequestTracingListener.class);
+                sqlTraceDelegator.deregisterSQLTraceListener(
+                        RequestTracingListener.class);
                 
                 /**
                  * If there are no longer any listeners registered, set the 

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceDelegator.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceDelegator.java
@@ -68,7 +68,6 @@ public class SQLTraceDelegator implements SQLTraceListener {
     private static final Logger logger = LogDomains.getLogger(SQLTraceLogger.class, LogDomains.SQL_TRACE_LOGGER);
 
     private SQLTraceProbeProvider probeProvider = null;
-    
 
     public SQLTraceProbeProvider getProbeProvider() {
         return probeProvider;
@@ -101,7 +100,7 @@ public class SQLTraceDelegator implements SQLTraceListener {
      */
     public void registerSQLTraceListener(SQLTraceListener listener) {
         if (sqlTraceListenersList == null) {
-            sqlTraceListenersList = new ArrayList<SQLTraceListener>();
+            sqlTraceListenersList = new ArrayList<>();
         }
         // check there isn't already a listener of the specified type
         for (SQLTraceListener test : sqlTraceListenersList) {
@@ -112,6 +111,38 @@ public class SQLTraceDelegator implements SQLTraceListener {
         sqlTraceListenersList.add(listener);
     }
 
+    /**
+     * Removes a listener from the list of SQL trace listeners maintained by
+     * this registry.
+     * @param listener The class of listener to remove
+     */
+    public void deregisterSQLTraceListener(Class listener) {
+        if (sqlTraceListenersList == null) {
+            return;
+        }
+        
+        for (SQLTraceListener registeredListener : sqlTraceListenersList) {
+            if (registeredListener.getClass().equals(listener)) {
+                sqlTraceListenersList.remove(registeredListener);
+                break;
+            }
+        }
+    }
+    
+    /**
+     * Checks whether any SQLTraceListeners are registered to this delegator.
+     * @return true if there are listeners registered.
+     */
+    public boolean listenersRegistered() {
+        boolean listenersRegistered = false;
+        
+        if (!sqlTraceListenersList.isEmpty()) {
+            listenersRegistered = true;
+        }
+        
+        return listenersRegistered;
+    }
+    
     @Override
     public void sqlTrace(SQLTraceRecord record) {
         if (record != null) {
@@ -145,17 +176,17 @@ public class SQLTraceDelegator implements SQLTraceListener {
             }
         }
     }
-
-/**
- * Check if the method name from the sql trace record can be used to retrieve a
- * sql string for caching purpose. Most of the method names do not contain a sql
- * string and hence are unusable for caching the sql strings. These method names
- * are filtered in this method.
- *
- * @param methodName
- * @return true if method name can be used to get a sql string for caching.
- */
-private boolean isMethodValidForCaching(String methodName) {
+    
+    /**
+     * Check if the method name from the sql trace record can be used to retrieve a
+     * sql string for caching purpose. Most of the method names do not contain a sql
+     * string and hence are unusable for caching the sql strings. These method names
+     * are filtered in this method.
+     *
+     * @param methodName
+     * @return true if method name can be used to get a sql string for caching.
+     */
+    private boolean isMethodValidForCaching(String methodName) {
         return JdbcRAConstants.validSqlTracingMethodNames.contains(methodName);
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/RequestTracingListener.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/RequestTracingListener.java
@@ -58,14 +58,18 @@ public class RequestTracingListener implements SQLTraceListener {
 
     private RequestTracingService requestTracing;
     
-    private static final Logger logger = LogDomains.getLogger(SQLTraceLogger.class, LogDomains.SQL_TRACE_LOGGER);
+    private static final Logger logger = 
+            LogDomains.getLogger(SQLTraceLogger.class, 
+                    LogDomains.SQL_TRACE_LOGGER);
     
     public RequestTracingListener() {
         try {
-            requestTracing = Globals.getDefaultHabitat().getService(RequestTracingService.class);
+            requestTracing = Globals.getDefaultHabitat().getService(
+                    RequestTracingService.class);
         } catch (NullPointerException ex) {
             logger.log(Level.INFO, "Error retrieving Request Tracing service "
-                    + "during initialisation of RequestTracingListener - NullPointerException");
+                    + "during initialisation of RequestTracingListener - "
+                    + "NullPointerException");
         }
     }
     
@@ -73,7 +77,9 @@ public class RequestTracingListener implements SQLTraceListener {
     public void sqlTrace(SQLTraceRecord record) {
         // Construct request event and trace
         RequestEvent requestEvent = constructJDBCEvent(record);
-        requestTracing.traceRequestEvent(requestEvent);
+        if (requestTracing != null) {
+            requestTracing.traceRequestEvent(requestEvent);
+        } 
     }
     
     /**
@@ -85,11 +91,14 @@ public class RequestTracingListener implements SQLTraceListener {
         RequestEvent requestEvent = new RequestEvent("JDBCContextTrace");
         
         requestEvent.addProperty("Method Name", record.getMethodName());
-        requestEvent.addProperty("Parameters", Arrays.toString(record.getParams()));
+        requestEvent.addProperty("Parameters", 
+                Arrays.toString(record.getParams()));
         requestEvent.addProperty("Pool Name", record.getPoolName());
-        requestEvent.addProperty("Thread ID", Long.toString(record.getThreadID()));
+        requestEvent.addProperty("Thread ID", 
+                Long.toString(record.getThreadID()));
         requestEvent.addProperty("Thread Name", record.getThreadName());
-        requestEvent.addProperty("Execution Time", Long.toString(record.getExecutionTime()));
+        requestEvent.addProperty("Execution Time", 
+                Long.toString(record.getExecutionTime()));
              
         return requestEvent;
     }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/RequestTracingListener.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/RequestTracingListener.java
@@ -1,0 +1,96 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.jdbc;
+
+import com.sun.gjc.util.SQLTraceLogger;
+import com.sun.logging.LogDomains;
+import fish.payara.nucleus.requesttracing.RequestTracingService;
+import fish.payara.nucleus.requesttracing.domain.RequestEvent;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.glassfish.api.jdbc.SQLTraceListener;
+import org.glassfish.api.jdbc.SQLTraceRecord;
+import org.glassfish.internal.api.Globals;
+
+/**
+ * A SQLTraceListener for the Request Tracing service.
+ * @author Andrew Pielage
+ */
+public class RequestTracingListener implements SQLTraceListener {
+
+    private RequestTracingService requestTracing;
+    
+    private static final Logger logger = LogDomains.getLogger(SQLTraceLogger.class, LogDomains.SQL_TRACE_LOGGER);
+    
+    public RequestTracingListener() {
+        try {
+            requestTracing = Globals.getDefaultHabitat().getService(RequestTracingService.class);
+        } catch (NullPointerException ex) {
+            logger.log(Level.INFO, "Error retrieving Request Tracing service "
+                    + "during initialisation of RequestTracingListener - NullPointerException");
+        }
+    }
+    
+    @Override
+    public void sqlTrace(SQLTraceRecord record) {
+        // Construct request event and trace
+        RequestEvent requestEvent = constructJDBCEvent(record);
+        requestTracing.traceRequestEvent(requestEvent);
+    }
+    
+    /**
+     * Constructs a Request tracing event for the JDBC event
+     * @param record The SQL record to log
+     * @return RequestEvent to be traced
+     */
+    private RequestEvent constructJDBCEvent(SQLTraceRecord record) {
+        RequestEvent requestEvent = new RequestEvent("JDBCContextTrace");
+        
+        requestEvent.addProperty("Method Name", record.getMethodName());
+        requestEvent.addProperty("Parameters", Arrays.toString(record.getParams()));
+        requestEvent.addProperty("Pool Name", record.getPoolName());
+        requestEvent.addProperty("Thread ID", Long.toString(record.getThreadID()));
+        requestEvent.addProperty("Thread Name", record.getThreadName());
+        requestEvent.addProperty("Execution Time", Long.toString(record.getExecutionTime()));
+             
+        return requestEvent;
+    }
+}


### PR DESCRIPTION
Adds in request tracing for JDBC context events.

Request tracing can be enabled/disabled without requiring the connection pool to be recreated.
JDBC wrapping is required for the request tracing events to appear in the log (enabled by default).