### PR TITLE
PAYARA-931 Payara Micro Request Tracing

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1472,7 +1472,9 @@ public class PayaraMicro {
                                 + "  --logProperties <file-path> Allows user to set their own logging properties file\n"
                                 + "  --accessLog <directory-path> Sets user defined directory path for the access log\n"
                                 + "  --accessLogFormat Sets user defined log format for the access log\n"
-                                + "  --enableRequestTracing Enables the Request Tracing Service"
+                                + "  --enableRequestTracing Enables the Request Tracing Service\n"
+                                + "  --requestTracingThresholdUnit Sets the time unit for the requestTracingThresholdValue option\n"
+                                + "  --requestTracingThresholdValue Sets the threshold time before a request is traced\n"
                                 + "  --help Shows this message and exits\n");
                         System.exit(1);
                         break;

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1572,6 +1572,7 @@ public class PayaraMicro {
                                 + "  --logProperties <file-path> Allows user to set their own logging properties file\n"
                                 + "  --accessLog <directory-path> Sets user defined directory path for the access log\n"
                                 + "  --accessLogFormat Sets user defined log format for the access log\n"
+                                + "  --requestTracing Enables the Request Tracing Service and optionally sets the threshold unit and/or value\n"
                                 + "  --enableRequestTracing Enables the Request Tracing Service\n"
                                 + "  --requestTracingThresholdUnit Sets the time unit for the requestTracingThresholdValue option\n"
                                 + "  --requestTracingThresholdValue Sets the threshold time before a request is traced\n"

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1483,9 +1483,7 @@ public class PayaraMicro {
                                 } 
                                 // If the first entry is a String
                                 else if (requestTracing[0].matches("\\D+")) {
-                                    
-                                    String parsedUnit = 
-                                                parseRequestTracingUnit(
+                                    String parsedUnit = parseRequestTracingUnit(
                                                         requestTracing[0]);
                                     try {
                                         TimeUnit.valueOf(parsedUnit.

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -2334,14 +2334,16 @@ public class PayaraMicro {
         switch (option.toLowerCase()) {
             case "nanosecond":
             case "ns":
-                returnValue = 
-                        "NANOSECONDS";
+                returnValue = "NANOSECONDS";
                 break;
             case "microsecond":
             case "us":
             case "µs":
-                returnValue = 
-                        "MICROSECONDS";
+                returnValue = "MICROSECONDS";
+                break;
+            case "millisecond":
+            case "ms":
+                returnValue = "MILLISECONDS";
                 break;
             case "second":
             case "s":

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1100,7 +1100,8 @@ public class PayaraMicro {
                 requestTracing.getExecutionOptions().setEnabled(true);
                 
                 if (!requestTracingThresholdUnit.equals("SECONDS")) {  
-                    requestTracing.getExecutionOptions().setThresholdUnit(TimeUnit.valueOf(requestTracingThresholdUnit));
+                    requestTracing.getExecutionOptions().setThresholdUnit(
+                            TimeUnit.valueOf(requestTracingThresholdUnit));
                 }
 
                 if (requestTracingThresholdValue != 30) {
@@ -1432,11 +1433,28 @@ public class PayaraMicro {
                         enableRequestTracing = true;
                         break;
                     case "--requestTracingThresholdUnit":
-                        requestTracingThresholdUnit = args[i + 1];
+                        try {
+                            TimeUnit.valueOf(args[i + 1].toUpperCase());
+                            requestTracingThresholdUnit = 
+                                    args[i + 1].toUpperCase();
+                        } catch (IllegalArgumentException e) {
+                            logger.log(Level.WARNING, "{0} is not a valid value"
+                                    + " for --requestTracingThresholdUnit, "
+                                    + "defaulting to SECONDS", 
+                                    requestTracingThresholdUnit);
+                        }
                         i++;
                         break;
                     case "--requestTracingThresholdValue":
-                        requestTracingThresholdValue = Long.parseLong(args[i + 1]);
+                        try {
+                            requestTracingThresholdValue = 
+                                    Long.parseLong(args[i + 1]);
+                        } catch (NumberFormatException e) {
+                            logger.log(Level.WARNING, "{0} is not a valid value"
+                                    + " for --requestTracingThresholdValue, "
+                                    + "defaulting to 30", 
+                                    args[i + 1]);
+                        }
                         i++;
                         break;
                     case "--help":

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1439,9 +1439,9 @@ public class PayaraMicro {
                                     args[i + 1].toUpperCase();
                         } catch (IllegalArgumentException e) {
                             logger.log(Level.WARNING, "{0} is not a valid value"
-                                    + " for --requestTracingThresholdUnit, "
-                                    + "defaulting to SECONDS", 
+                                    + " for --requestTracingThresholdUnit", 
                                     requestTracingThresholdUnit);
+                            throw e;
                         }
                         i++;
                         break;
@@ -1451,9 +1451,9 @@ public class PayaraMicro {
                                     Long.parseLong(args[i + 1]);
                         } catch (NumberFormatException e) {
                             logger.log(Level.WARNING, "{0} is not a valid value"
-                                    + " for --requestTracingThresholdValue, "
-                                    + "defaulting to 30", 
+                                    + " for --requestTracingThresholdValue", 
                                     args[i + 1]);
+                            throw e;
                         }
                         i++;
                         break;

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1431,7 +1431,7 @@ public class PayaraMicro {
                     case "--disablePhoneHome":
                         disablePhoneHome = true;
                         break;
-                    case "--requestTracing":
+                    case "--enableRequestTracing":
                         enableRequestTracing = true;
                         // Check if a value has actually been given
                         if (args.length > i + 1 && 
@@ -1507,9 +1507,6 @@ public class PayaraMicro {
                             }        
                         }
                         break;
-                    case "--enableRequestTracing":
-                        enableRequestTracing = true;
-                        break;
                     case "--requestTracingThresholdUnit":
                         try {
                             String parsedUnit = 
@@ -1570,8 +1567,7 @@ public class PayaraMicro {
                                 + "  --logProperties <file-path> Allows user to set their own logging properties file\n"
                                 + "  --accessLog <directory-path> Sets user defined directory path for the access log\n"
                                 + "  --accessLogFormat Sets user defined log format for the access log\n"
-                                + "  --requestTracing Enables the Request Tracing Service and optionally sets the threshold unit and/or value\n"
-                                + "  --enableRequestTracing Enables the Request Tracing Service\n"
+                                + "  --enableRequestTracing Enables the Request Tracing Service and optionally sets the threshold unit and/or value\n"
                                 + "  --requestTracingThresholdUnit Sets the time unit for the requestTracingThresholdValue option\n"
                                 + "  --requestTracingThresholdValue Sets the threshold time before a request is traced\n"
                                 + "  --help Shows this message and exits\n");

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -2349,6 +2349,11 @@ public class PayaraMicro {
             case "s":
                 returnValue = "SECONDS";
                 break;
+            case "minute":
+            case "min":
+            case "mins":
+                returnValue = "MINUTES";
+                break;
             case "hour":
             case "h":
                 returnValue = "HOURS";

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1102,8 +1102,7 @@ public class PayaraMicro {
                 requestTracing.getExecutionOptions().setEnabled(true);
                 
                 if (!requestTracingThresholdUnit.equals("SECONDS")) {  
-                    requestTracing.getExecutionOptions().setThresholdUnit(
-                            TimeUnit.valueOf(requestTracingThresholdUnit));
+                    requestTracing.getExecutionOptions().setThresholdUnit(TimeUnit.valueOf(requestTracingThresholdUnit));
                 }
 
                 if (requestTracingThresholdValue != 30) {
@@ -1434,67 +1433,46 @@ public class PayaraMicro {
                     case "--enableRequestTracing":
                         enableRequestTracing = true;
                         // Check if a value has actually been given
-                        if (args.length > i + 1 && 
-                                !args[i + 1].contains("--")) {
+                        if (args.length > i + 1 && !args[i + 1].contains("--")) {
                             // Split strings from numbers
-                            String[] requestTracing = args[i + 1].split(
-                                    "(?<=\\d)(?=\\D)|(?=\\d)(?<=\\D)");
+                            String[] requestTracing = args[i + 1].split("(?<=\\d)(?=\\D)|(?=\\d)(?<=\\D)");
                             // If valid, there should be no more than 2 entries
                             if (requestTracing.length <= 2) {
                                 // If the first entry is a number
                                 if (requestTracing[0].matches("\\d+")) {
                                     try {
-                                        requestTracingThresholdValue = 
-                                        Long.parseLong(requestTracing[0]);
+                                        requestTracingThresholdValue = Long.parseLong(requestTracing[0]);
                                     } catch (NumberFormatException e) {
-                                        logger.log(Level.WARNING, "{0} is not "
-                                                + "a valid request tracing "
-                                                + "threshold value", 
-                                                requestTracing[0]);
+                                        logger.log(Level.WARNING, "{0} is not a valid request tracing "
+                                                + "threshold value", requestTracing[0]);
                                         throw e;
                                     }
-                                    // If there is a second entry, and it's a
-                                    // String
-                                    if (requestTracing.length == 2 && 
-                                            requestTracing[1].matches("\\D+")) {
-                                        String parsedUnit = 
-                                                parseRequestTracingUnit(
-                                                        requestTracing[1]);
+                                    // If there is a second entry, and it's a String
+                                    if (requestTracing.length == 2 && requestTracing[1].matches("\\D+")) {
+                                        String parsedUnit = parseRequestTracingUnit(requestTracing[1]);
                                         try {    
-                                            TimeUnit.valueOf(parsedUnit.
-                                                    toUpperCase());
-                                            requestTracingThresholdUnit = 
-                                                    parsedUnit.toUpperCase();
+                                            TimeUnit.valueOf(parsedUnit.toUpperCase());
+                                            requestTracingThresholdUnit = parsedUnit.toUpperCase();
                                         } catch (IllegalArgumentException e) {
-                                            logger.log(Level.WARNING, "{0} is "
-                                                    + "not a valid request "
-                                                    + "tracing threshold unit", 
-                                                    requestTracing[1]);
+                                            logger.log(Level.WARNING, "{0} is not a valid request "
+                                                    + "tracing threshold unit", requestTracing[1]);
                                             throw e;
                                         }
                                     } 
-                                    // If there is a second entry, and it's not 
-                                    // a String
-                                    else if (requestTracing.length == 2 && 
-                                            !requestTracing[1].matches(
-                                                    "\\D+")) {
+                                    // If there is a second entry, and it's not a String
+                                    else if (requestTracing.length == 2 && !requestTracing[1].matches("\\D+")) {
                                         throw new IllegalArgumentException();
                                     }
                                 } 
                                 // If the first entry is a String
                                 else if (requestTracing[0].matches("\\D+")) {
-                                    String parsedUnit = parseRequestTracingUnit(
-                                                        requestTracing[0]);
+                                    String parsedUnit = parseRequestTracingUnit(requestTracing[0]);
                                     try {
-                                        TimeUnit.valueOf(parsedUnit.
-                                                toUpperCase());
-                                        requestTracingThresholdUnit = 
-                                                parsedUnit.toUpperCase();
+                                        TimeUnit.valueOf(parsedUnit.toUpperCase());
+                                        requestTracingThresholdUnit = parsedUnit.toUpperCase();
                                         } catch (IllegalArgumentException e) {
-                                            logger.log(Level.WARNING, "{0} is "
-                                                    + "not a valid request "
-                                                    + "tracing threshold unit", 
-                                                    requestTracing[0]);
+                                            logger.log(Level.WARNING, "{0} is not a valid request "
+                                                    + "tracing threshold unit", requestTracing[0]);
                                             throw e;
                                         }
                                     // There shouldn't be a second entry
@@ -1509,14 +1487,11 @@ public class PayaraMicro {
                         break;
                     case "--requestTracingThresholdUnit":
                         try {
-                            String parsedUnit = 
-                                    parseRequestTracingUnit(args[i + 1]);
+                            String parsedUnit = parseRequestTracingUnit(args[i + 1]);
                             TimeUnit.valueOf(parsedUnit.toUpperCase());
-                            requestTracingThresholdUnit = 
-                                    parsedUnit.toUpperCase();
+                            requestTracingThresholdUnit = parsedUnit.toUpperCase();
                         } catch (IllegalArgumentException e) {
-                            logger.log(Level.WARNING, "{0} is not a valid value"
-                                    + " for --requestTracingThresholdUnit", 
+                            logger.log(Level.WARNING, "{0} is not a valid value for --requestTracingThresholdUnit", 
                                     args[i + 1]);
                             throw e;
                         }
@@ -1524,11 +1499,9 @@ public class PayaraMicro {
                         break;
                     case "--requestTracingThresholdValue":
                         try {
-                            requestTracingThresholdValue = 
-                                    Long.parseLong(args[i + 1]);
+                            requestTracingThresholdValue = Long.parseLong(args[i + 1]);
                         } catch (NumberFormatException e) {
-                            logger.log(Level.WARNING, "{0} is not a valid value"
-                                    + " for --requestTracingThresholdValue", 
+                            logger.log(Level.WARNING, "{0} is not a valid value for --requestTracingThresholdValue", 
                                     args[i + 1]);
                             throw e;
                         }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -2349,6 +2349,7 @@ public class PayaraMicro {
             case "s":
                 returnValue = "SECONDS";
                 break;
+            case "m":
             case "minute":
             case "min":
             case "mins":

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/resources/microdomain-nocluster.xml
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/resources/microdomain-nocluster.xml
@@ -159,6 +159,12 @@ Portions Copyright [2016] [Payara Foundation and/or its affiliates]
             </transaction-service>
             <hazelcast-runtime-configuration enabled="false" multicastGroup="224.2.2.4" multicastPort="2904" ></hazelcast-runtime-configuration>
             <batch-runtime-configuration table-prefix="jbatch" data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
+            <request-tracing-service-configuration>
+                <log-notifier enabled="true"></log-notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
             <availability-service availability-enabled="false" >
                 <web-container-availability availability-enabled="false"></web-container-availability>
                 <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"></ejb-container-availability>

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/resources/microdomain.xml
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/resources/microdomain.xml
@@ -155,6 +155,12 @@ Portions Copyright [2016] [Payara Foundation and/or its affiliates]
             </transaction-service>
             <hazelcast-runtime-configuration enabled="true" multicastGroup="224.2.2.4" multicastPort="2904" ></hazelcast-runtime-configuration>
             <batch-runtime-configuration table-prefix="jbatch" data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
+            <request-tracing-service-configuration>
+                <log-notifier enabled="true"></log-notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration>
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
             <availability-service availability-enabled="true" >
                 <web-container-availability availability-enabled="true" persistence-scope="modified-session" sso-failover-enabled="true" persistence-type="hazelcast"></web-container-availability>
                 <ejb-container-availability sfsb-ha-persistence-type="hazelcast" sfsb-persistence-type="hazelcast" ></ejb-container-availability>

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/resources/microdomain.xml
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/resources/microdomain.xml
@@ -158,7 +158,7 @@ Portions Copyright [2016] [Payara Foundation and/or its affiliates]
             <request-tracing-service-configuration>
                 <log-notifier enabled="true"></log-notifier>
             </request-tracing-service-configuration>
-            <notification-service-configuration>
+            <notification-service-configuration enabled="true">
                 <log-notifier-configuration enabled="true"></log-notifier-configuration>
             </notification-service-configuration>
             <availability-service availability-enabled="true" >


### PR DESCRIPTION
Adds in command line options to enable and configure request tracing in Payara Micro.
Also turns on the Notification service by default.

The new options are:

* `--enableRequestTracing` - Just a flag; you **don't** need to add _true_ or _false_ afterwards. 
* `--requestTracingThresholdUnit` - Accepts a String value determining the time unit, defaulting to seconds if no value is given. The accepted strings are (case insensitive): _NANOSECONDS_, _MICROSECONDS_, _MILLISECONDS_, _SECONDS_, _MINUTES_, _HOURS_, and _DAYS_.
* `--requestTracingThresholdValue` - Accepts a _long_ to determine the threshold value before a request is traced, defaulting to 30 if no value is entered.

As an example of usage:
`java -jar payaramicro.jar --enableRequestTracing --requestTracingThresholdUnit NANOSECONDS --requestTracingThresholdValue 7`

