### PR TITLE
PAYARA-1056 Global thread pool statistics incorrect

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor;
 
 import com.sun.enterprise.v3.services.impl.monitor.probes.ConnectionQueueProbeProvider;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
@@ -158,7 +158,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
-        if (name.equals(monitoringId)) {
+        if (name.equals(monitoringId) && currentThreadCount.getCount() != 0) {
             currentThreadCount.decrement();
         }
     }
@@ -182,7 +182,9 @@ public class ThreadPoolStatsProvider implements StatsProvider {
 
         if (name.equals(monitoringId)) {
             totalExecutedTasksCount.increment();
-            currentThreadsBusy.decrement();
+            if (currentThreadsBusy.getCount() != 0) {
+                currentThreadsBusy.decrement();
+            }  
         }
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
@@ -38,8 +38,13 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor.stats;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import org.glassfish.external.probe.provider.annotations.ProbeListener;
 import org.glassfish.external.probe.provider.annotations.ProbeParam;
 import org.glassfish.external.statistics.CountStatistic;
@@ -110,12 +115,18 @@ public class ThreadPoolStatsProvider implements StatsProvider {
     @ManagedAttribute(id = "currentthreadcount")
     @Description("Provides the number of request processing threads currently in the listener thread pool")
     public CountStatistic getCurrentThreadCount() {
+        if (threadPoolConfig != null) {
+            countThreadsinThreadPool(threadPoolConfig.getPoolName());
+        }
         return currentThreadCount;
     }
 
     @ManagedAttribute(id = "currentthreadsbusy")
     @Description("Provides the number of request processing threads currently in use in the listener thread pool serving requests.")
     public CountStatistic getCurrentThreadsBusy() {
+        if (threadPoolConfig != null) {
+            countThreadsinThreadPool(threadPoolConfig.getPoolName());
+        }
         return currentThreadsBusy;
     }
 
@@ -158,7 +169,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
-        if (name.equals(monitoringId) && currentThreadCount.getCount() != 0) {
+        if (name.equals(monitoringId) && currentThreadCount.getCount() > 0) {
             currentThreadCount.decrement();
         }
     }
@@ -182,7 +193,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
 
         if (name.equals(monitoringId)) {
             totalExecutedTasksCount.increment();
-            if (currentThreadsBusy.getCount() != 0) {
+            if (currentThreadsBusy.getCount() > 0) {
                 currentThreadsBusy.decrement();
             }  
         }
@@ -198,5 +209,34 @@ public class ThreadPoolStatsProvider implements StatsProvider {
         }
 
         totalExecutedTasksCount.setCount(0);
+    }
+    
+    /**
+     * Counts the threads in the given thread pool by querying the JVM. Also 
+     * counts the number of threads that are running.
+     * @param threadPoolName The name of the thread pool to count the threads of
+     */
+    private void countThreadsinThreadPool(String threadPoolName) {     
+        // Set to 0 as we want to reset them
+        currentThreadCount.setCount(0);
+        currentThreadsBusy.setCount(0);
+        
+        // Get all the threads currently in the JVM
+        Set<Thread> threads = Thread.getAllStackTraces().keySet();
+        
+        // If multiple listeners use the same thread pool, you will get 
+        // duplicate named threads, so we want to filter these out
+        List<String> alreadyCounted = new ArrayList<>();
+        for (Thread thread : threads) {
+            String threadName = thread.getName();
+            if (thread.isAlive() && threadName.contains(threadPoolName 
+                    + "(") && !alreadyCounted.contains(threadName)) {
+                alreadyCounted.add(threadName);
+                currentThreadCount.increment();
+                if (thread.getState() == Thread.State.RUNNABLE) {
+                    currentThreadsBusy.increment();
+                }
+            }
+        }
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -61,7 +61,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     public ThreadPoolStatsProviderGlobal(String name) {
         super(name);
     }
-    
+
     @ProbeListener("glassfish:kernel:thread-pool:setMaxThreadsEvent")
     @Override
     public void setMaxThreadsEvent(

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -59,8 +59,9 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     public ThreadPoolStatsProviderGlobal(String name) {
         super(name);
     }
-
+    
     @ProbeListener("glassfish:kernel:thread-pool:setMaxThreadsEvent")
+    @Override
     public void setMaxThreadsEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -70,6 +71,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:setCoreThreadsEvent")
+    @Override
     public void setCoreThreadsEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -79,6 +81,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadAllocatedEvent")
+    @Override
     public void threadAllocatedEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -88,15 +91,19 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadReleasedEvent")
+    @Override
     public void threadReleasedEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
-
-        currentThreadCount.decrement();
+        
+        if (currentThreadCount.getCount() != 0) {
+            currentThreadCount.decrement();
+        }
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadDispatchedFromPoolEvent")
+    @Override
     public void threadDispatchedFromPoolEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -106,13 +113,16 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadReturnedToPoolEvent")
+    @Override
     public void threadReturnedToPoolEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
         totalExecutedTasksCount.increment();
-        currentThreadsBusy.decrement();
+        if (currentThreadsBusy.getCount() != 0) {
+            currentThreadsBusy.decrement();
+        }
     }
     
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor.stats;
 
 import org.glassfish.external.probe.provider.annotations.ProbeListener;
@@ -97,7 +99,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
         
-        if (currentThreadCount.getCount() != 0) {
+        if (currentThreadCount.getCount() > 0) {
             currentThreadCount.decrement();
         }
     }
@@ -120,9 +122,8 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
             @ProbeParam("threadId") long threadId) {
 
         totalExecutedTasksCount.increment();
-        if (currentThreadsBusy.getCount() != 0) {
+        if (currentThreadsBusy.getCount() > 0) {
             currentThreadsBusy.decrement();
         }
     }
-    
 }


### PR DESCRIPTION
This pull request makes the global thread pool statistics much more complete, with it now counting the total maximum and minimum threads in all of the thread pools of a config.

It also edits the way the monitoring works so that it is more accurate by querying the JVM for the actual current number of threads, rather than just relying upon events to alter internally stored values (which may have been missed or reset).