### PR TITLE
PAYARA-1056 global thread pool statistics incorrect

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor;
 
 import com.sun.enterprise.v3.services.impl.monitor.probes.ConnectionQueueProbeProvider;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
@@ -58,8 +58,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.glassfish.external.probe.provider.PluginPoint;
 import org.glassfish.external.probe.provider.StatsProviderManager;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
@@ -185,9 +183,7 @@ public class GrizzlyMonitoring {
         }
         
         int coreThreadTotal = 0;
-        int maxThreadTotal = 0;
-        int busyThreadTotal = 0;
-        int currentThreadTotal = 0;       
+        int maxThreadTotal = 0;    
         
         // If multiple listeners use the same thread pool, we don't want to
         // count the threads twice, so we'll store the names of those we've
@@ -213,11 +209,6 @@ public class GrizzlyMonitoring {
                                 .getValue().getCoreThreadsCount().getCount();
                         maxThreadTotal += (int) (long) threadPoolStatsProvider
                                 .getValue().getMaxThreadsCount().getCount();
-                        busyThreadTotal += (int) (long) threadPoolStatsProvider
-                                .getValue().getCurrentThreadsBusy().getCount();
-                        currentThreadTotal += (int) (long) 
-                                threadPoolStatsProvider.getValue()
-                                        .getCurrentThreadCount().getCount();
 
                         // Add to the list of counted thread pools so we don't
                         // count the threads twice
@@ -227,35 +218,11 @@ public class GrizzlyMonitoring {
             }
         }
         
-        // Set the core and max values
+        // Now that we've calculated the global core and max values, set them
         globalThreadPoolStatsProvider.setCoreThreadsEvent("", "", 
                 coreThreadTotal);
         globalThreadPoolStatsProvider.setMaxThreadsEvent("", "", 
                 maxThreadTotal);
-        
-        // If the total busy or current threads value differ from those held
-        // by the global stats provider, increment or decrement them till
-        // they match
-        while ((int) (long) globalThreadPoolStatsProvider
-                .getCurrentThreadsBusy().getCount() < busyThreadTotal) {
-            globalThreadPoolStatsProvider.threadDispatchedFromPoolEvent("", "", 
-                    0);
-        }
-        
-        while ((int) (long) globalThreadPoolStatsProvider
-                .getCurrentThreadsBusy().getCount() > busyThreadTotal) {
-            globalThreadPoolStatsProvider.threadReturnedToPoolEvent("", "", 0);
-        }
-        
-        while ((int) (long) globalThreadPoolStatsProvider
-                .getCurrentThreadCount().getCount() < currentThreadTotal) {
-            globalThreadPoolStatsProvider.threadAllocatedEvent("", "", 0);
-        }
-        
-        while ((int) (long) globalThreadPoolStatsProvider
-                .getCurrentThreadCount().getCount() > currentThreadTotal) {
-            globalThreadPoolStatsProvider.threadReleasedEvent("", "", 0);
-        }
     }
 
     /**

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
@@ -158,7 +158,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
-        if (name.equals(monitoringId)) {
+        if (name.equals(monitoringId) && currentThreadCount.getCount() != 0) {
             currentThreadCount.decrement();
         }
     }
@@ -182,7 +182,9 @@ public class ThreadPoolStatsProvider implements StatsProvider {
 
         if (name.equals(monitoringId)) {
             totalExecutedTasksCount.increment();
-            currentThreadsBusy.decrement();
+            if (currentThreadsBusy.getCount() != 0) {
+                currentThreadsBusy.decrement();
+            }  
         }
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
@@ -161,39 +161,6 @@ public class ThreadPoolStatsProvider implements StatsProvider {
         }
     }
 
-    @ProbeListener("glassfish:kernel:thread-pool:threadAllocatedEvent")
-    public void threadAllocatedEvent(
-            @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
-            @ProbeParam("threadId") long threadId) {
-
-        if (name.equals(monitoringId)) {
-            currentThreadCount.increment();
-        }
-    }
-
-    @ProbeListener("glassfish:kernel:thread-pool:threadReleasedEvent")
-    public void threadReleasedEvent(
-            @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
-            @ProbeParam("threadId") long threadId) {
-
-        if (name.equals(monitoringId) && currentThreadCount.getCount() > 0) {
-            currentThreadCount.decrement();
-        }
-    }
-
-    @ProbeListener("glassfish:kernel:thread-pool:threadDispatchedFromPoolEvent")
-    public void threadDispatchedFromPoolEvent(
-            @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
-            @ProbeParam("threadId") long threadId) {
-
-        if (name.equals(monitoringId)) {
-            currentThreadsBusy.increment();
-        }
-    }
-
     @ProbeListener("glassfish:kernel:thread-pool:threadReturnedToPoolEvent")
     public void threadReturnedToPoolEvent(
             @ProbeParam("monitoringId") String monitoringId,
@@ -202,9 +169,6 @@ public class ThreadPoolStatsProvider implements StatsProvider {
 
         if (name.equals(monitoringId)) {
             totalExecutedTasksCount.increment();
-            if (currentThreadsBusy.getCount() > 0) {
-                currentThreadsBusy.decrement();
-            }  
         }
     }
 
@@ -213,8 +177,6 @@ public class ThreadPoolStatsProvider implements StatsProvider {
         if (threadPoolConfig != null) {
             maxThreadsCount.setCount(threadPoolConfig.getMaxPoolSize());
             coreThreadsCount.setCount(threadPoolConfig.getCorePoolSize());
-            currentThreadCount.setCount(0);
-            currentThreadsBusy.setCount(0);
         }
 
         totalExecutedTasksCount.setCount(0);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
@@ -75,7 +75,11 @@ public class ThreadPoolStatsProvider implements StatsProvider {
     protected final CountStatisticImpl currentThreadsBusy = new CountStatisticImpl("CurrentThreadsBusy", "count", "Provides the number of request processing threads currently in use in the listener thread pool serving requests");
 
     protected volatile ThreadPoolConfig threadPoolConfig;
-
+    
+    // We need to keep track of the thread pool names for calculating the
+    // global values
+    protected volatile static List<String> threadPoolNames = new ArrayList<>();
+    
     public ThreadPoolStatsProvider(String name) {
         this.name = name;
     }
@@ -89,6 +93,11 @@ public class ThreadPoolStatsProvider implements StatsProvider {
     public void setStatsObject(Object object) {
         if (object instanceof ThreadPoolConfig) {
             threadPoolConfig = (ThreadPoolConfig) object;
+            
+            // We don't want to add the global thread pool
+            if (!threadPoolConfig.getPoolName().equals("")) {
+                threadPoolNames.add(threadPoolConfig.getPoolName());
+            }
         } else {
             threadPoolConfig = null;
         }
@@ -116,7 +125,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
     @Description("Provides the number of request processing threads currently in the listener thread pool")
     public CountStatistic getCurrentThreadCount() {
         if (threadPoolConfig != null) {
-            countThreadsinThreadPool(threadPoolConfig.getPoolName());
+            countThreadsInThreadPool(threadPoolConfig.getPoolName());
         }
         return currentThreadCount;
     }
@@ -125,7 +134,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
     @Description("Provides the number of request processing threads currently in use in the listener thread pool serving requests.")
     public CountStatistic getCurrentThreadsBusy() {
         if (threadPoolConfig != null) {
-            countThreadsinThreadPool(threadPoolConfig.getPoolName());
+            countThreadsInThreadPool(threadPoolConfig.getPoolName());
         }
         return currentThreadsBusy;
     }
@@ -216,7 +225,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
      * counts the number of threads that are running.
      * @param threadPoolName The name of the thread pool to count the threads of
      */
-    private void countThreadsinThreadPool(String threadPoolName) {     
+    private void countThreadsInThreadPool(String threadPoolName) {     
         // Set to 0 as we want to reset them
         currentThreadCount.setCount(0);
         currentThreadsBusy.setCount(0);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProvider.java
@@ -38,8 +38,13 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor.stats;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import org.glassfish.external.probe.provider.annotations.ProbeListener;
 import org.glassfish.external.probe.provider.annotations.ProbeParam;
 import org.glassfish.external.statistics.CountStatistic;
@@ -110,12 +115,18 @@ public class ThreadPoolStatsProvider implements StatsProvider {
     @ManagedAttribute(id = "currentthreadcount")
     @Description("Provides the number of request processing threads currently in the listener thread pool")
     public CountStatistic getCurrentThreadCount() {
+        if (threadPoolConfig != null) {
+            countThreadsinThreadPool(threadPoolConfig.getPoolName());
+        }
         return currentThreadCount;
     }
 
     @ManagedAttribute(id = "currentthreadsbusy")
     @Description("Provides the number of request processing threads currently in use in the listener thread pool serving requests.")
     public CountStatistic getCurrentThreadsBusy() {
+        if (threadPoolConfig != null) {
+            countThreadsinThreadPool(threadPoolConfig.getPoolName());
+        }
         return currentThreadsBusy;
     }
 
@@ -158,7 +169,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
-        if (name.equals(monitoringId) && currentThreadCount.getCount() != 0) {
+        if (name.equals(monitoringId) && currentThreadCount.getCount() > 0) {
             currentThreadCount.decrement();
         }
     }
@@ -182,7 +193,7 @@ public class ThreadPoolStatsProvider implements StatsProvider {
 
         if (name.equals(monitoringId)) {
             totalExecutedTasksCount.increment();
-            if (currentThreadsBusy.getCount() != 0) {
+            if (currentThreadsBusy.getCount() > 0) {
                 currentThreadsBusy.decrement();
             }  
         }
@@ -198,5 +209,34 @@ public class ThreadPoolStatsProvider implements StatsProvider {
         }
 
         totalExecutedTasksCount.setCount(0);
+    }
+    
+    /**
+     * Counts the threads in the given thread pool by querying the JVM. Also 
+     * counts the number of threads that are running.
+     * @param threadPoolName The name of the thread pool to count the threads of
+     */
+    private void countThreadsinThreadPool(String threadPoolName) {     
+        // Set to 0 as we want to reset them
+        currentThreadCount.setCount(0);
+        currentThreadsBusy.setCount(0);
+        
+        // Get all the threads currently in the JVM
+        Set<Thread> threads = Thread.getAllStackTraces().keySet();
+        
+        // If multiple listeners use the same thread pool, you will get 
+        // duplicate named threads, so we want to filter these out
+        List<String> alreadyCounted = new ArrayList<>();
+        for (Thread thread : threads) {
+            String threadName = thread.getName();
+            if (thread.isAlive() && threadName.contains(threadPoolName 
+                    + "(") && !alreadyCounted.contains(threadName)) {
+                alreadyCounted.add(threadName);
+                currentThreadCount.increment();
+                if (thread.getState() == Thread.State.RUNNABLE) {
+                    currentThreadsBusy.increment();
+                }
+            }
+        }
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -61,7 +61,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     public ThreadPoolStatsProviderGlobal(String name) {
         super(name);
     }
-    
+
     @ProbeListener("glassfish:kernel:thread-pool:setMaxThreadsEvent")
     @Override
     public void setMaxThreadsEvent(

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -59,8 +59,9 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     public ThreadPoolStatsProviderGlobal(String name) {
         super(name);
     }
-
+    
     @ProbeListener("glassfish:kernel:thread-pool:setMaxThreadsEvent")
+    @Override
     public void setMaxThreadsEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -70,6 +71,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:setCoreThreadsEvent")
+    @Override
     public void setCoreThreadsEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -79,6 +81,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadAllocatedEvent")
+    @Override
     public void threadAllocatedEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -88,15 +91,19 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadReleasedEvent")
+    @Override
     public void threadReleasedEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
-
-        currentThreadCount.decrement();
+        
+        if (currentThreadCount.getCount() != 0) {
+            currentThreadCount.decrement();
+        }
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadDispatchedFromPoolEvent")
+    @Override
     public void threadDispatchedFromPoolEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
@@ -106,13 +113,16 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     }
 
     @ProbeListener("glassfish:kernel:thread-pool:threadReturnedToPoolEvent")
+    @Override
     public void threadReturnedToPoolEvent(
             @ProbeParam("monitoringId") String monitoringId,
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
         totalExecutedTasksCount.increment();
-        currentThreadsBusy.decrement();
+        if (currentThreadsBusy.getCount() != 0) {
+            currentThreadsBusy.decrement();
+        }
     }
     
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -103,38 +103,6 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
         coreThreadsCount.setCount(coreNumberOfThreads);
     }
 
-    @ProbeListener("glassfish:kernel:thread-pool:threadAllocatedEvent")
-    @Override
-    public void threadAllocatedEvent(
-            @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
-            @ProbeParam("threadId") long threadId) {
-
-        currentThreadCount.increment();
-    }
-
-    @ProbeListener("glassfish:kernel:thread-pool:threadReleasedEvent")
-    @Override
-    public void threadReleasedEvent(
-            @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
-            @ProbeParam("threadId") long threadId) {
-        
-        if (currentThreadCount.getCount() > 0) {
-            currentThreadCount.decrement();
-        }
-    }
-
-    @ProbeListener("glassfish:kernel:thread-pool:threadDispatchedFromPoolEvent")
-    @Override
-    public void threadDispatchedFromPoolEvent(
-            @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
-            @ProbeParam("threadId") long threadId) {
-
-        currentThreadsBusy.increment();
-    }
-
     @ProbeListener("glassfish:kernel:thread-pool:threadReturnedToPoolEvent")
     @Override
     public void threadReturnedToPoolEvent(
@@ -143,13 +111,10 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
             @ProbeParam("threadId") long threadId) {
 
         totalExecutedTasksCount.increment();
-        if (currentThreadsBusy.getCount() > 0) {
-            currentThreadsBusy.decrement();
-        }
     }
     
     /**
-     * Counts the threads in the all thread pools by querying the JVM. Also 
+     * Counts the threads in all thread pools by querying the JVM. Also 
      * counts the number of threads that are running.
      */
     private void countThreadsInThreadPools() {     

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor.stats;
 
 import org.glassfish.external.probe.provider.annotations.ProbeListener;
@@ -97,7 +99,7 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
             @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
         
-        if (currentThreadCount.getCount() != 0) {
+        if (currentThreadCount.getCount() > 0) {
             currentThreadCount.decrement();
         }
     }
@@ -120,9 +122,8 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
             @ProbeParam("threadId") long threadId) {
 
         totalExecutedTasksCount.increment();
-        if (currentThreadsBusy.getCount() != 0) {
+        if (currentThreadsBusy.getCount() > 0) {
             currentThreadsBusy.decrement();
         }
     }
-    
 }


### PR DESCRIPTION
This pull request makes the global thread pool statistics much more complete, with it now counting the total maximum and minimum threads in all of the thread pools of a config.

It also edits the way the monitoring works so that it is more accurate by querying the JVM for the actual current number of threads, rather than relying upon events to alter internally stored values (which may have been missed or reset depending on when the monitor listener was registered).

Also renames the global thread pool stats from _thread-pool_ to _global-thread-pool-stats_ to make it more clear.