### PR TITLE
JCache beans created by JSR107Producer use generics (PAYARA-1107)

### DIFF
--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/JSR107Producer.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/JSR107Producer.java
@@ -73,9 +73,8 @@ public class JSR107Producer {
      * @return 
      */
     @Produces
-    @SuppressWarnings("unchecked")
-    public Cache createCache(InjectionPoint ip) {
-        Cache result = null;
+    public <K,V> Cache<K, V> createCache(InjectionPoint ip) {
+        Cache<K, V> result;
 
         //determine the cache name first start with the default name
         String cacheName = ip.getMember().getDeclaringClass().getCanonicalName();
@@ -92,7 +91,7 @@ public class JSR107Producer {
             Class valueClass = ncqualifier.valueClass();           
             result = manager.getCache(cacheName, keyClass, valueClass);
             if (result == null) {
-                MutableConfiguration<Object, Object> config = new MutableConfiguration<>();
+                MutableConfiguration<K, V> config = new MutableConfiguration<>();
                 config.setTypes(keyClass, valueClass);
                 
                 // determine the expiry policy
@@ -125,7 +124,7 @@ public class JSR107Producer {
         } else {  // configure a "raw" cache
             result = manager.getCache(cacheName);
             if (result == null) {
-                MutableConfiguration<Object, Object> config = new MutableConfiguration<>();
+                MutableConfiguration<K, V> config = new MutableConfiguration<>();
                 config.setManagementEnabled(true);
                 config.setStatisticsEnabled(true);
                 result = manager.createCache(cacheName, config);


### PR DESCRIPTION
This allows to use JCache beans to be applied into injection sites with
type parameters.

For example this works now:
```java
@Inject
private Cache<LongKey, Schedule> scheduleCache;
```