### PR TITLE
Use name from CacheDefaults when injecting JCache (PAYARA-1106)

### DIFF
--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/JSR107Producer.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/JSR107Producer.java
@@ -22,12 +22,14 @@ import com.hazelcast.core.HazelcastInstance;
 import fish.payara.nucleus.hazelcast.HazelcastCore;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.annotation.CacheDefaults;
 import javax.cache.configuration.Factory;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.configuration.MutableConfiguration;
 import javax.cache.spi.CachingProvider;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 /**
@@ -123,6 +125,17 @@ public class JSR107Producer {
                 result = manager.createCache(cacheName, config);                
             }
         } else {  // configure a "raw" cache
+            Bean<?> bean = ip.getBean();
+            if (bean != null) {
+                Class<?> beanClass = bean.getBeanClass();
+                CacheDefaults defaults = beanClass.getAnnotation(CacheDefaults.class);
+                if (defaults != null) {
+                    String cacheNameFromAnnotation = defaults.cacheName();
+                    if (!"".equals(cacheNameFromAnnotation)) {
+                        cacheName = cacheNameFromAnnotation;
+                    }
+                }
+            }
             result = manager.getCache(cacheName);
             if (result == null) {
                 MutableConfiguration<Object, Object> config = new MutableConfiguration<>();


### PR DESCRIPTION
Fixes #1124

Disclaimer: I don't really understand CDI lifecycle. I assume the producer method is called for each injection point. 

[Example usage](https://github.com/jerrinot/microprofile-conference/commit/53a08594d6ce36896becc4e7d6a0a07aee57dd71) (depends also on https://github.com/payara/Payara/pull/1125)