### PR TITLE
Don't cast cached Throwable to Exception as it's too narrow. (PAYARA-1126)

### DIFF
--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/CacheResultInterceptor.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/CacheResultInterceptor.java
@@ -60,7 +60,7 @@ public class CacheResultInterceptor extends AbstractJSR107Interceptor {
                 // check exception cache
                 if (cacheExceptions) {
                     Cache exceptionCache = resolverF.getExceptionCacheResolver(pctx).resolveCache(pctx);
-                    Exception e = (Exception) exceptionCache.get(key);
+                    Throwable e = (Throwable) exceptionCache.get(key);
                     if (e != null) {
                         throw e;
                     }


### PR DESCRIPTION
Reasoning:
JCache spec and Payara implementation allows caching of exceptions.
In theory everything extending Throwable can be cached -> casting to
Exception is  not safe as it can throw ClassCastException