### PR TITLE
PAYARA-934 Alias substitution configuration issue

### DIFF
--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -37,11 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.config.support;
 
 import com.sun.enterprise.security.store.DomainScopedPasswordAliasStore;
-import org.glassfish.api.admin.PasswordAliasStore;
 import org.jvnet.hk2.config.ConfigView;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 //import org.glassfish.security.common.RelativePathResolver;
@@ -72,12 +72,21 @@ public class TranslatedConfigView implements ConfigView {
 
     private static final String ALIAS_TOKEN = "ALIAS";
     private static int MAX_SUBSTITUTION_DEPTH = 100;
-    
-    
+    public static final ThreadLocal<Boolean> doSubstitution = new ThreadLocal<Boolean>() {
+        @Override
+        protected Boolean initialValue() {
+            return Boolean.TRUE;
+        }
+    };
+
+
     public static Object getTranslatedValue(Object value) {
         if (value!=null && value instanceof String) {
             String stringValue = value.toString();
             if (stringValue.indexOf('$')==-1) {
+                return value;
+            }
+            if(doSubstitution.get() == false) {
                 return value;
             }
             if (domainPasswordAliasStore() != null) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CreateSystemProperties.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CreateSystemProperties.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.admin;
 
@@ -62,6 +63,7 @@ import org.glassfish.api.admin.ExecuteOn;
 import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.config.support.CommandTarget;
 import org.glassfish.config.support.TargetType;
+import org.glassfish.config.support.TranslatedConfigView;
 import org.glassfish.hk2.api.PerLookup;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigSupport;
@@ -143,9 +145,14 @@ public class CreateSystemProperties implements AdminCommand, AdminCommandSecurit
                     
                 // skip create-system property requests that do not change the
                 // value of an existing property
-                if (spb.containsProperty(sysPropName) && 
-                    spb.getSystemProperty(sysPropName).getValue().equals(properties.getProperty(propName))) {
-                    continue;
+                try {
+                    TranslatedConfigView.doSubstitution.set(Boolean.FALSE);
+                    if (spb.containsProperty(sysPropName) &&
+                        spb.getSystemProperty(sysPropName).getValue().equals(properties.getProperty(propName))) {
+                        continue;
+                    }
+                } finally {
+                    TranslatedConfigView.doSubstitution.set(Boolean.TRUE);
                 }
                 ConfigSupport.apply(new SingleConfigCode<SystemPropertyBag>() {
 


### PR DESCRIPTION
Disable alias substitution when checking whether config value truly changed
Fixes a rare instance when the alias is changed into non-alias and the change is ignored