### PR TITLE
PAYARA-1134 make ROOT.war deploy to / context root 

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1862,7 +1862,11 @@ public class PayaraMicro {
                 deploymentURLsMap = new LinkedHashMap<>();
             }
 
-            deploymentURLsMap.put(artefactMapEntry.getKey(),
+            String contextRoot = artefactMapEntry.getKey();
+            if ("ROOT".equals(contextRoot)) {
+                contextRoot = "/";
+            }
+            deploymentURLsMap.put(contextRoot,
                     artefactMapEntry.getValue());
         }
     }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -1585,7 +1585,11 @@ public class PayaraMicro {
         if (deployments != null) {
             for (File war : deployments) {
                 if (war.exists() && war.canRead()) {
-                    deployer.deploy(war, "--availabilityenabled=true", "--force=true");
+                    if (war.getName().startsWith("ROOT.")) {
+                        deployer.deploy(war, "--availabilityenabled=true", "--force=true", "--contextroot=/");
+                    } else {
+                        deployer.deploy(war, "--availabilityenabled=true", "--force=true");
+                    }  
                     deploymentCount++;
                 } else {
                     logger.log(Level.WARNING, "{0} is not a valid deployment", war.getAbsolutePath());
@@ -1598,7 +1602,11 @@ public class PayaraMicro {
             for (File war : deploymentRoot.listFiles()) {
                 String warPath = war.getAbsolutePath();
                 if (war.isFile() && war.canRead() && (warPath.endsWith(".war") || warPath.endsWith(".ear") || warPath.endsWith(".jar") || warPath.endsWith(".rar"))) {
-                    deployer.deploy(war, "--availabilityenabled=true", "--force=true");
+                    if (war.getName().startsWith("ROOT.")) {
+                        deployer.deploy(war, "--availabilityenabled=true", "--force=true", "--contextroot=/");
+                    } else {
+                        deployer.deploy(war, "--availabilityenabled=true", "--force=true");
+                    }  
                     deploymentCount++;
                 }
             }


### PR DESCRIPTION
In Payara Micro make ROOT.war deploy to the / context root as it does after packaging as an Uber Jar
