### PR TITLE
PAYARA-989 Fix Windows Admin Console Redirect

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java
@@ -283,7 +283,12 @@ final class StandardContextValve
         // START CR 6415120
         if (request.getCheckRestrictedResources()) {
         // END CR 6415120
-            String requestPathDC = Paths.get(hreq.getRequestPathMB().toString(Charsets.UTF8_CHARSET)).normalize().toString().toUpperCase();
+            // PAYARA-989 Help Windows find index.jsf by removing the double slash
+            String requestPath = hreq.getRequestPathMB().toString(Charsets.UTF8_CHARSET);
+            if (requestPath.equals("//index.jsf")) {
+                requestPath = requestPath.replace("//", "/");
+            }
+            String requestPathDC = Paths.get(requestPath).normalize().toString().toUpperCase();
             if ((requestPathDC.startsWith("/META-INF/", 0))
                     || (requestPathDC.equalsIgnoreCase("/META-INF"))
                     || (requestPathDC.startsWith("/WEB-INF/", 0))


### PR DESCRIPTION
Related to fix done in #1024 
I'm restricting this fix to **just** the issue we've currently got of redirecting to index.jsf by matching the URI String so as to keep the initial fix intact. I can't think of a way that this could be abused, but if someone comes up with anything let me know.