### PR TITLE
PAYARA-1133 Log the Slowest SQL Traces

### DIFF
--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
@@ -132,7 +132,7 @@ public class CreateJdbcConnectionPool implements AdminCommand {
     @Param(name="creationRetryInterval", alias = "connectionCreationRetryIntervalInSeconds",  optional=true, defaultValue = "10")
     String creationretryinterval = "10";
 
-    @Param(name = "sqlTraceListeners", optional=true)
+    @Param(name = "sqlTraceListeners", optional=true, defaultValue = "fish.payara.jdbc.SilentSqlTraceListener")
     String sqltracelisteners;
     
     @Param(name="statementTimeout", alias = "statementTimeoutInSeconds",  optional=true, defaultValue = "-1")

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -98,7 +98,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
     private String connectionCreationRetryAttempts = "0";
     private String connectionCreationRetryInterval = "10";
     private String driverclassname = null;
-    private String sqltracelisteners = null;
+    private String sqltracelisteners = "fish.payara.jdbc.SilentSqlTraceListener";
     private String statementTimeout = "-1";
     private String statementcachesize = "0";
     private String lazyConnectionEnlistment = Boolean.FALSE.toString();

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -63,6 +63,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import java.beans.PropertyVetoException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Defines configuration used to create and manage a pool physical database
@@ -654,7 +655,19 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *              {@link String }
      */
     void setSlowQueryThresholdInSeconds(String value) throws PropertyVetoException;
+    
+    @Attribute (defaultValue="0", dataType=String.class)
+    @Min(value=0)
+    String getSlowQueryFrequencyMonitoringRange();
+    
+    void setSlowQueryFrequencyMonitoringRange(String value) throws PropertyVetoException;
 
+    @Attribute (defaultValue="0", dataType=String.class)
+    @Min(value=0)
+    String getSlowQueryTimeMonitoringRange();
+    
+    void setSlowQueryTimeMonitoringRange(String value) throws PropertyVetoException;
+    
     /**
      * Gets the value of the lazyConnectionEnlistment property.
      *
@@ -934,7 +947,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute
+    @Attribute (defaultValue = "fish.payara.jdbc.SilentSqlTraceListener")
     String getSqlTraceListeners();
 
     /**

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -63,7 +63,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import java.beans.PropertyVetoException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Defines configuration used to create and manage a pool physical database
@@ -655,18 +654,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *              {@link String }
      */
     void setSlowQueryThresholdInSeconds(String value) throws PropertyVetoException;
-    
-    @Attribute (defaultValue="0", dataType=String.class)
-    @Min(value=0)
-    String getSlowQueryFrequencyMonitoringRange();
-    
-    void setSlowQueryFrequencyMonitoringRange(String value) throws PropertyVetoException;
-
-    @Attribute (defaultValue="0", dataType=String.class)
-    @Min(value=0)
-    String getSlowQueryTimeMonitoringRange();
-    
-    void setSlowQueryTimeMonitoringRange(String value) throws PropertyVetoException;
     
     /**
      * Gets the value of the lazyConnectionEnlistment property.

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/JdbcStatsProvider.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/JdbcStatsProvider.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.gjc.monitoring;
 
 import com.sun.gjc.util.SQLTrace;
@@ -94,18 +96,7 @@ public class JdbcStatsProvider {
         poolInfo = new PoolInfo(poolName, appName, moduleName);
         if(sqlTraceCacheSize > 0) {
             this.freqSqlTraceCache = new FrequentSQLTraceCache(poolName, sqlTraceCacheSize, timeToKeepQueries);
-        }
-    }
-    
-    public JdbcStatsProvider(String poolName, String appName, String moduleName, int sqlTraceCacheSize,
-            long timeToKeepQueries, boolean slowSqlLoggingEnabled) {
-        poolInfo = new PoolInfo(poolName, appName, moduleName);
-        if(sqlTraceCacheSize > 0) {
-            this.freqSqlTraceCache = new FrequentSQLTraceCache(poolName, sqlTraceCacheSize, timeToKeepQueries);
-            
-            if (slowSqlLoggingEnabled) {
-                this.slowSqlTraceCache = new SlowSqlTraceCache(poolName, sqlTraceCacheSize, timeToKeepQueries);
-            }
+            this.slowSqlTraceCache = new SlowSqlTraceCache(poolName, sqlTraceCacheSize, timeToKeepQueries);
         }
     }
 
@@ -145,7 +136,7 @@ public class JdbcStatsProvider {
      * Whenever a sql statement that is traced is to be cache for monitoring
      * purpose, the SQLTrace object is created for the specified sql and
      * updated in the SQLTraceCache. This is used to update the
-     * frequently used sql queries.
+     * frequently used and slowest sql queries.
      *
      * @param poolName
      * @param appName
@@ -165,12 +156,13 @@ public class JdbcStatsProvider {
         if(this.poolInfo.equals(poolInfo)){
             if(freqSqlTraceCache != null) {
                 if (sql != null) {
-                    SQLTrace cacheObj = new SQLTrace(sql, 1,
-                            System.currentTimeMillis());
+                    SQLTrace cacheObj = new SQLTrace(sql, 1, System.currentTimeMillis());
                     freqSqlTraceCache.checkAndUpdateCache(cacheObj);
                 }
             }
             
+            // If the slowSqlTraceCache has been initialised, create a new SlowSqlTrace object and add it to or update 
+            // the cache
             if (slowSqlTraceCache != null && sql != null) {
                 SQLTrace cacheObj = new SlowSqlTrace(sql, 1, System.currentTimeMillis(), executionTime);
                 slowSqlTraceCache.checkAndUpdateCache(cacheObj);
@@ -229,17 +221,17 @@ public class JdbcStatsProvider {
     }
     
     /**
-     * Get the SQLTraceCache associated with this stats provider.
-     * @return SQLTraceCache
-     */    
-    /**
-     * Get the SQLTraceCache associated with this stats provider.
-     * @return SQLTraceCache
+     * Get the FrequentSQLTraceCache associated with this stats provider.
+     * @return FrequentSQLTraceCache The FrequentSQLTraceCache associated with this stats provider
      */
     public FrequentSQLTraceCache getFreqSqlTraceCache() {
         return freqSqlTraceCache;
     }
     
+    /**
+     * Get the SlowSqlTraceCache associated with this stats provider.
+     * @return SlowSqlTraceCache The SlowSqlTraceCache associated with this stats provider
+     */
     public SlowSqlTraceCache getSlowSqlTraceCache() {
         return slowSqlTraceCache;
     }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/SQLTraceProbeProvider.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/SQLTraceProbeProvider.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.gjc.monitoring;
 
 import org.glassfish.external.probe.provider.annotations.Probe;
@@ -58,7 +60,10 @@ public class SQLTraceProbeProvider {
      * <code>poolName</code>has got an event to cache a sql query
      *
      * @param poolName for which sql query should be cached
+     * @param appName
+     * @param moduleName
      * @param sql sql query that should be cached
+     * @param executionTime the sql query execution time
      */
     @Probe(name=JdbcRAConstants.TRACE_SQL)
     public void traceSQLEvent(@ProbeParam("poolName") String poolName, 

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/SQLTraceProbeProvider.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/monitoring/SQLTraceProbeProvider.java
@@ -61,10 +61,11 @@ public class SQLTraceProbeProvider {
      * @param sql sql query that should be cached
      */
     @Probe(name=JdbcRAConstants.TRACE_SQL)
-    public void traceSQLEvent(@ProbeParam("poolName") String poolName,
-                                   @ProbeParam("appName") String appName,
-                                   @ProbeParam("moduleName") String moduleName,
-            @ProbeParam("sql") String sql) {
+    public void traceSQLEvent(@ProbeParam("poolName") String poolName, 
+            @ProbeParam("appName") String appName,
+            @ProbeParam("moduleName") String moduleName, 
+            @ProbeParam("sql") String sql, 
+            @ProbeParam("executionTime") long executionTime) {
 
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
@@ -1469,19 +1469,29 @@ public abstract class ManagedConnectionFactoryImpl implements javax.resource.spi
                 (sqlTraceListeners != null && !sqlTraceListeners.equals("null")) ||
                 statementLeakTimeout > 0) {
             jdbcStatsProvider = new JdbcStatsProvider(getPoolName(), getApplicationName(), getModuleName(),
-                    sqlTraceCacheSize, timeToKeepQueries);
+                    sqlTraceCacheSize, timeToKeepQueries, true);
             //get the poolname and use it to initialize the stats provider n register
             StatsProviderManager.register(
                     "jdbc-connection-pool",
                     PluginPoint.SERVER,
                     poolMonitoringSubTreeRoot, jdbcStatsProvider);
-            if(jdbcStatsProvider.getSqlTraceCache() != null) {
+            if(jdbcStatsProvider.getFreqSqlTraceCache() != null) {
                 if(_logger.isLoggable(Level.FINEST)) {
-                    _logger.finest("Scheduling timer task for sql trace caching");
+                    _logger.finest("Scheduling timer task for frequent sql trace caching");
                 }
                 Timer timer = ((com.sun.gjc.spi.ResourceAdapterImpl) ra).getTimer();
-                jdbcStatsProvider.getSqlTraceCache().scheduleTimerTask(timer);
+                jdbcStatsProvider.getFreqSqlTraceCache().scheduleTimerTask(timer);
             }
+            
+            if (jdbcStatsProvider.getSlowSqlTraceCache() != null) {
+                if (_logger.isLoggable(Level.FINEST)) {
+                    _logger.finest("Scheduling timer task for slow sql trace caching");
+                }
+                
+                Timer timer = ((com.sun.gjc.spi.ResourceAdapterImpl) ra).getTimer();
+                jdbcStatsProvider.getSlowSqlTraceCache().scheduleTimerTask(timer);
+            }
+            
             if(_logger.isLoggable(Level.FINEST)) {
                 _logger.finest("Registered JDBCRA Stats Provider");
             }
@@ -1494,12 +1504,20 @@ public abstract class ManagedConnectionFactoryImpl implements javax.resource.spi
             _logger.finest("MCF Destroyed");
         }
         if(jdbcStatsProvider != null) {
-            if(jdbcStatsProvider.getSqlTraceCache() != null) {
+            if(jdbcStatsProvider.getFreqSqlTraceCache() != null) {
                 if(_logger.isLoggable(Level.FINEST)) {
-                    _logger.finest("Canceling timer task for sql trace caching");
+                    _logger.finest("Canceling timer task for frequent sql trace caching");
                 }
-                jdbcStatsProvider.getSqlTraceCache().cancelTimerTask();
+                jdbcStatsProvider.getFreqSqlTraceCache().cancelTimerTask();
             }
+            
+            if(jdbcStatsProvider.getSlowSqlTraceCache() != null) {
+                if(_logger.isLoggable(Level.FINEST)) {
+                    _logger.finest("Canceling timer task for slow sql trace caching");
+                }
+                jdbcStatsProvider.getSlowSqlTraceCache().cancelTimerTask();
+            }
+            
             StatsProviderManager.unregister(jdbcStatsProvider);
             jdbcStatsProvider = null;
             if(_logger.isLoggable(Level.FINEST)) {

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
@@ -1469,7 +1469,7 @@ public abstract class ManagedConnectionFactoryImpl implements javax.resource.spi
                 (sqlTraceListeners != null && !sqlTraceListeners.equals("null")) ||
                 statementLeakTimeout > 0) {
             jdbcStatsProvider = new JdbcStatsProvider(getPoolName(), getApplicationName(), getModuleName(),
-                    sqlTraceCacheSize, timeToKeepQueries, true);
+                    sqlTraceCacheSize, timeToKeepQueries);
             //get the poolname and use it to initialize the stats provider n register
             StatsProviderManager.register(
                     "jdbc-connection-pool",

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/FrequentSQLTraceCache.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/FrequentSQLTraceCache.java
@@ -1,0 +1,109 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
+package com.sun.gjc.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maintains the Sql Tracing Cache used to store SQL statements used by the
+ * applications. This is used by the JDBCRA monitoring to display the most
+ * frequently used queries by applications.
+ *
+ * @author Shalini M
+ */
+public class FrequentSQLTraceCache extends SQLTraceCache {
+
+    public FrequentSQLTraceCache(String poolName, int maxSize, long timeToKeepQueries) {
+        super(poolName, maxSize, timeToKeepQueries);
+    }
+
+    /**
+     * Request for adding a sql query in the form of SQLTrace to this cache.
+     * If the query is already found
+     * in the list, the number of times it is executed is incremented by one
+     * along with the timestamp.
+     * If the query is a new one, it is added to the list.
+     * 
+     * @param cacheObj
+     * @return
+     */
+    @Override
+    public void checkAndUpdateCache(SQLTrace cacheObj) {
+        if (cacheObj != null) {
+            SQLTrace trace = cache.get(cacheObj.getQueryName());
+            if (trace != null) {
+                //If already found in the cache
+                //equals is invoked here and hence comparison based on query name is done
+                //Get the object at the index to update the numExecutions
+                trace.setNumExecutions(trace.getNumExecutions() + 1);
+                trace.setLastUsageTime(System.currentTimeMillis());
+            } else {
+                cache.put(cacheObj.getQueryName(), cacheObj);
+            }
+        }
+    }
+
+    /**
+     * Returns the String representation of the list of traced sql queries
+     * ordered by the number most frequently used, followed by the usage
+     * timestamp. Only the top 'n' queries represented by the numTopQueriesToReport are
+     * chosen for display.
+     *
+     * @return string representation of the list of sql queries sorted
+     */
+    public String getTopQueries() {
+        purgeEntries();
+        
+        List<SQLTrace> sqlTraceList = new ArrayList(cache.values());
+        Collections.sort(sqlTraceList, SQLTrace.SQLTraceFrequencyComparator);
+        
+        StringBuilder sb = new StringBuilder();
+        for (SQLTrace sqlTrace : sqlTraceList) {
+            sb.append(LINE_BREAK);
+            sb.append(sqlTrace.getQueryName());
+            sb.append(" executions: ").append(sqlTrace.getNumExecutions());
+        }
+        return sb.toString();
+    }
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/FrequentSQLTraceCache.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/FrequentSQLTraceCache.java
@@ -66,7 +66,6 @@ public class FrequentSQLTraceCache extends SQLTraceCache {
      * If the query is a new one, it is added to the list.
      * 
      * @param cacheObj
-     * @return
      */
     @Override
     public void checkAndUpdateCache(SQLTrace cacheObj) {
@@ -74,8 +73,6 @@ public class FrequentSQLTraceCache extends SQLTraceCache {
             SQLTrace trace = cache.get(cacheObj.getQueryName());
             if (trace != null) {
                 //If already found in the cache
-                //equals is invoked here and hence comparison based on query name is done
-                //Get the object at the index to update the numExecutions
                 trace.setNumExecutions(trace.getNumExecutions() + 1);
                 trace.setLastUsageTime(System.currentTimeMillis());
             } else {

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTrace.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTrace.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.gjc.util;
 
 import java.util.Comparator;
@@ -49,7 +51,7 @@ import java.util.Comparator;
  * 
  * @author Shalini M
  */
-public class SQLTrace implements Comparable {
+public class SQLTrace {
 
     private String queryName;
     private int numExecutions;
@@ -114,55 +116,8 @@ public class SQLTrace implements Comparable {
     public void setLastUsageTime(long lastUsageTime) {
         this.lastUsageTime = lastUsageTime;
     }
-
-    /**
-     * Check for equality of the SQLTrace with the object passed by
-     * comparing the queryName stored.
-     *
-     * @param obj against which the equality is to be checked.
-     * @return true or false
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if(!(obj instanceof SQLTrace)) {
-            return false;
-        }
-        final SQLTrace other = (SQLTrace) obj;
-        if ((this.queryName == null) || (other.queryName == null) ||
-                !this.queryName.equals(other.queryName)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Generate hash code for this object using all the fields.
-     * @return
-     */
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 23 * hash + (this.queryName != null ? this.queryName.hashCode() : 0);
-        return hash;
-    }
-
-    @Override
-    public int compareTo(Object o) {
-        if (!(o instanceof SQLTrace)) {
-            throw new ClassCastException("SqlTraceCache object is expected");
-        }
-        
-        int compare = 0;
-        if (!equals(o)) {
-            compare = 1;
-        }
-        
-        return compare;
-    }
     
+    // Comparator that orders based upon the number of executions and the last usage time.
     public static Comparator<SQLTrace> SQLTraceFrequencyComparator = new Comparator<SQLTrace>() {
         
         @Override
@@ -170,14 +125,17 @@ public class SQLTrace implements Comparable {
             final int sqlTrace1Frequency = sqlTrace1.getNumExecutions();
             final int sqlTrace2Frequency = sqlTrace2.getNumExecutions();
             
-            
+            // Initialise the comparison variable to be equal
             int compare = 0;
+            
+            // Compare the number of executions
             if (sqlTrace1Frequency < sqlTrace2Frequency) {
                 compare = 1;
             } else if (sqlTrace1Frequency > sqlTrace2Frequency) {
                 compare = -1;
             }
             
+            // If the number of executions are the same, compare the last usage time
             if (compare == 0) {
                 final long sqlTrace1LastUsageTime = sqlTrace1.getLastUsageTime();
                 final long sqlTrace2LastUsageTime = sqlTrace2.getLastUsageTime();

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTrace.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTrace.java
@@ -40,6 +40,8 @@
 
 package com.sun.gjc.util;
 
+import java.util.Comparator;
+
 /**
  * Store the sql queries executed by applications along with the number of
  * times executed and the time stamp of the last usage.
@@ -137,7 +139,7 @@ public class SQLTrace implements Comparable {
     }
 
     /**
-     * Generate hash code for this obejct using all the fields.
+     * Generate hash code for this object using all the fields.
      * @return
      */
     @Override
@@ -152,30 +154,42 @@ public class SQLTrace implements Comparable {
         if (!(o instanceof SQLTrace)) {
             throw new ClassCastException("SqlTraceCache object is expected");
         }
-        int number = ((SQLTrace) o).numExecutions;
-        long t = ((SQLTrace) o).getLastUsageTime();
-
+        
         int compare = 0;
-        if (number == this.numExecutions) {
-            compare = 0;
-        } else if (number < this.numExecutions) {
-            compare = -1;
-        } else {
+        if (!equals(o)) {
             compare = 1;
         }
-        if (compare == 0) {
-            //same number of executions. Hence compare based on time.
-            long timeCompare = this.getLastUsageTime() - t;
-            if(timeCompare == 0) {
-                compare = 0;
-            } else if(timeCompare < 0) {
-                //compare = -1;
-                compare = 1;
-            } else {
-                //compare = 1;
-                compare = -1;
-            }
-        }
+        
         return compare;
     }
+    
+    public static Comparator<SQLTrace> SQLTraceFrequencyComparator = new Comparator<SQLTrace>() {
+        
+        @Override
+        public int compare(SQLTrace sqlTrace1, SQLTrace sqlTrace2) {
+            final int sqlTrace1Frequency = sqlTrace1.getNumExecutions();
+            final int sqlTrace2Frequency = sqlTrace2.getNumExecutions();
+            
+            
+            int compare = 0;
+            if (sqlTrace1Frequency < sqlTrace2Frequency) {
+                compare = 1;
+            } else if (sqlTrace1Frequency > sqlTrace2Frequency) {
+                compare = -1;
+            }
+            
+            if (compare == 0) {
+                final long sqlTrace1LastUsageTime = sqlTrace1.getLastUsageTime();
+                final long sqlTrace2LastUsageTime = sqlTrace2.getLastUsageTime();
+                
+                if (sqlTrace1LastUsageTime < sqlTrace2LastUsageTime) {
+                    compare = 1;
+                } else if (sqlTrace1LastUsageTime > sqlTrace2LastUsageTime) {
+                    compare = -1;
+                }
+            }
+            
+            return compare;
+        }
+    };
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceCache.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceCache.java
@@ -52,9 +52,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Maintains the Sql Tracing Cache used to store SQL statements used by the
- * applications. This is used by the JDBCRA monitoring to display the most
- * frequently used queries by applications.
+ * Base class for Sql Tracing Caches used to store SQL statements used by applications.
  *
  * @author Shalini M
  */
@@ -141,7 +139,6 @@ public abstract class SQLTraceCache {
      * If the query is a new one, it is added to the list.
      * 
      * @param cacheObj
-     * @return
      */
     public abstract void checkAndUpdateCache(SQLTrace cacheObj);
 
@@ -161,16 +158,5 @@ public abstract class SQLTraceCache {
             sqlTraceList.remove(sqlTrace);
             elementCount --;
         }
-
-//        Iterator i = cache..keySet().descendingIterator();
-//        int elementCount = cache.size(); // avoid using size in the loop as expensive in time
-//        while (i.hasNext() && elementCount > numTopQueriesToReport) {
-//            SQLTrace cacheObj = (SQLTrace) i.next();
-//            if(_logger.isLoggable(Level.FINEST)) {
-//                _logger.finest("removing sql=" + cacheObj.getQueryName());
-//            }
-//            i.remove();
-//            elementCount--;
-//        }
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceCache.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceCache.java
@@ -42,8 +42,10 @@
 package com.sun.gjc.util;
 
 import com.sun.logging.LogDomains;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
+import java.util.List;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Level;
@@ -56,32 +58,28 @@ import java.util.logging.Logger;
  *
  * @author Shalini M
  */
-public class SQLTraceCache {
+public abstract class SQLTraceCache {
 
-    //List of sql trace objects
-    private final ConcurrentSkipListMap<SQLTrace,SQLTrace> list;
     //Maximum size of the cache.
-    private int numTopQueriesToReport = 10;
-    private long timeToKeepQueries = 60 * 1000;
+    protected int numTopQueriesToReport = 10;
+    protected long timeToKeepQueries = 60000;
+    protected final String poolName;
+    protected ConcurrentSkipListMap<String, SQLTrace> cache;
+    
     private SQLTraceTimerTask sqlTraceTimerTask;
-    private final String poolName;
-    private final String appName;
-    private final String moduleName;
-    private final static Logger _logger = LogDomains.getLogger(SQLTraceCache.class,
+    protected final static Logger _logger = LogDomains.getLogger(SQLTraceCache.class,
             LogDomains.RSR_LOGGER);
-    private static final String LINE_BREAK = "%%%EOL%%%";
+    protected static final String LINE_BREAK = "%%%EOL%%%";
 
-    public SQLTraceCache(String poolName, String appName, String moduleName, int maxSize, long timeToKeepQueries) {
+    public SQLTraceCache(String poolName, int maxSize, long timeToKeepQueries) {
+        this.cache = new ConcurrentSkipListMap<>();
         this.poolName = poolName;
-        this.appName = appName;
-        this.moduleName = moduleName;
         this.numTopQueriesToReport = maxSize;
-        list = new ConcurrentSkipListMap<>();
         this.timeToKeepQueries = timeToKeepQueries * 60 * 1000;
     }
 
-    public Collection<SQLTrace> getSqlTraceList() {
-        return list.keySet();
+    public Collection<String> getSqlTraceList() {
+        return cache.keySet();
     }
 
     public String getPoolName() {
@@ -94,7 +92,6 @@ public class SQLTraceCache {
      * @param timer
      */
     public void scheduleTimerTask(Timer timer) {
-
         if(sqlTraceTimerTask != null) {
             sqlTraceTimerTask.cancel();
             sqlTraceTimerTask = null;
@@ -115,7 +112,6 @@ public class SQLTraceCache {
      * Cancel the timer task used to perform a purgeEntries on the cache.
      */
     public synchronized void cancelTimerTask() {
-
         if(_logger.isLoggable(Level.FINEST)) {
             _logger.finest("Cancelling Sql Trace Caching timer task");
         }
@@ -147,20 +143,7 @@ public class SQLTraceCache {
      * @param cacheObj
      * @return
      */
-    public void checkAndUpdateCache(SQLTrace cacheObj) {
-            if (cacheObj != null) {
-                SQLTrace cache = list.get(cacheObj);
-                if (cache != null) {
-                    //If already found in the cache
-                    //equals is invoked here and hence comparison based on query name is done
-                    //Get the object at the index to update the numExecutions
-                    cache.setNumExecutions(cache.getNumExecutions() + 1);
-                    cache.setLastUsageTime(System.currentTimeMillis());
-                } else {
-                    list.put(cacheObj,cacheObj);
-                }
-            }
-    }
+    public abstract void checkAndUpdateCache(SQLTrace cacheObj);
 
     /**
      * Entries are removed from the list after sorting
@@ -168,34 +151,26 @@ public class SQLTraceCache {
      * entries are maintained in the list after the purgeEntries.
      */
     public void purgeEntries() {
-            Iterator i = list.keySet().descendingIterator();
-            int elementCount = list.size(); // avoid using size in the loop as expensive in time
-            while (i.hasNext() && elementCount > numTopQueriesToReport) {
-                SQLTrace cacheObj = (SQLTrace) i.next();
-                if(_logger.isLoggable(Level.FINEST)) {
-                    _logger.finest("removing sql=" + cacheObj.getQueryName());
-                }
-                i.remove();
-                elementCount--;
-            }
-    }
-
-    /**
-     * Returns the String representation of the list of traced sql queries
-     * ordered by the number most frequently used, followed by the usage
-     * timestamp. Only the top 'n' queries represented by the numTopQueriesToReport are
-     * chosen for display.
-     *
-     * @return string representation of the list of sql queries sorted
-     */
-    public String getTopQueries() {
-        purgeEntries();
-        StringBuilder sb = new StringBuilder();
-        for(SQLTrace cache : list.keySet()) {
-            sb.append(LINE_BREAK);
-            sb.append(cache.getQueryName());
-            sb.append(" executions: ").append(cache.getNumExecutions());
+        List<SQLTrace> sqlTraceList = new ArrayList(cache.values());
+        Collections.sort(sqlTraceList, SQLTrace.SQLTraceFrequencyComparator);
+        
+        int elementCount = sqlTraceList.size();        
+        while (elementCount > numTopQueriesToReport) {
+            SQLTrace sqlTrace = sqlTraceList.get(elementCount - 1);
+            cache.remove(sqlTrace.getQueryName());
+            sqlTraceList.remove(sqlTrace);
+            elementCount --;
         }
-        return sb.toString();
+
+//        Iterator i = cache..keySet().descendingIterator();
+//        int elementCount = cache.size(); // avoid using size in the loop as expensive in time
+//        while (i.hasNext() && elementCount > numTopQueriesToReport) {
+//            SQLTrace cacheObj = (SQLTrace) i.next();
+//            if(_logger.isLoggable(Level.FINEST)) {
+//                _logger.finest("removing sql=" + cacheObj.getQueryName());
+//            }
+//            i.remove();
+//            elementCount--;
+//        }
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceDelegator.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/util/SQLTraceDelegator.java
@@ -170,7 +170,7 @@ public class SQLTraceDelegator implements SQLTraceListener {
                         break;
                     }
                     if (sqlQuery != null) {
-                        probeProvider.traceSQLEvent(poolName, appName, moduleName, sqlQuery);
+                        probeProvider.traceSQLEvent(poolName, appName, moduleName, sqlQuery, record.getExecutionTime());
                     }
                 }
             }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SilentSqlTraceListener.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SilentSqlTraceListener.java
@@ -1,7 +1,41 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.jdbc;
 
@@ -9,7 +43,7 @@ import org.glassfish.api.jdbc.SQLTraceListener;
 import org.glassfish.api.jdbc.SQLTraceRecord;
 
 /**
- *
+ * An SQL Trace Listener that simply does nothing to act as a default.
  * @author Andrew Pielage
  */
 public class SilentSqlTraceListener implements SQLTraceListener {

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SilentSqlTraceListener.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/SilentSqlTraceListener.java
@@ -1,0 +1,21 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.jdbc;
+
+import org.glassfish.api.jdbc.SQLTraceListener;
+import org.glassfish.api.jdbc.SQLTraceRecord;
+
+/**
+ *
+ * @author Andrew Pielage
+ */
+public class SilentSqlTraceListener implements SQLTraceListener {
+    
+    @Override
+    public void sqlTrace(SQLTraceRecord record) {
+        // Do nothing, we want to be silent
+    }
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTrace.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTrace.java
@@ -1,0 +1,106 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.jdbc.stats;
+
+import com.sun.gjc.util.SQLTrace;
+import java.util.Comparator;
+
+/**
+ *
+ * @author Andrew Pielage
+ */
+public class SlowSqlTrace extends SQLTrace {
+    
+    private long slowestExecutionTime;
+    
+    public SlowSqlTrace(String query, int numExecutions, long time, long executionTime) {
+        super(query, numExecutions, time);
+        this.slowestExecutionTime = executionTime;
+    }
+    
+    public long getSlowestExecutionTime() {
+        return slowestExecutionTime;
+    }
+    
+    public void setSlowestExecutionTime(long slowestExecutionTime) {
+        this.slowestExecutionTime = slowestExecutionTime;
+    }
+    
+    @Override
+    public int compareTo(Object o) {
+        if (!(o instanceof SlowSqlTrace)) {
+            throw new ClassCastException("SqlTraceCache object is expected");
+        }
+        
+        long lastUsageTime = ((SlowSqlTrace) o).getLastUsageTime();
+        long execTime = ((SlowSqlTrace) o).getSlowestExecutionTime();
+        
+        int compare = 0;
+        
+        // Compare the execution times
+        if (execTime == this.getSlowestExecutionTime()) {
+            compare = 0;
+        } else if (execTime < this.getSlowestExecutionTime()) {
+            compare = -1;
+        } else {
+            compare = 1;
+        }
+        
+        // If the slowestExecutionTime is the same, compare against last used
+        if (compare == 0) {
+            if(lastUsageTime == this.getLastUsageTime()) {
+                compare = 0;
+            } else if(lastUsageTime < this.getLastUsageTime()) {
+                compare = -1;
+            } else {
+                compare = 1;
+            }
+        }
+
+        return compare;
+    }
+    
+    public static Comparator<SlowSqlTrace> SlowSqlTraceSlowestExecutionComparator = new Comparator<SlowSqlTrace>() {
+        
+        @Override
+        public int compare(SlowSqlTrace sqlTrace1, SlowSqlTrace sqlTrace2) {
+            final long sqlTrace1SlowestExecution = sqlTrace1.getSlowestExecutionTime();
+            final long sqlTrace2SlowestExecution = sqlTrace2.getSlowestExecutionTime();
+            
+            
+            int compare = 0;
+            if (sqlTrace1SlowestExecution < sqlTrace2SlowestExecution) {
+                compare = 1;
+            } else if (sqlTrace1SlowestExecution > sqlTrace2SlowestExecution) {
+                compare = -1;
+            }
+            
+            if (compare == 0) {
+                final int sqlTrace1Frequency = sqlTrace1.getNumExecutions();
+                final int sqlTrace2Frequency = sqlTrace2.getNumExecutions();
+                
+                if (sqlTrace1Frequency < sqlTrace2Frequency) {
+                    compare = 1;
+                } else if (sqlTrace1Frequency > sqlTrace2Frequency) {
+                    compare = -1;
+                }
+                
+                if (compare == 0) {
+                    final long sqlTrace1LastUsageTime = sqlTrace1.getLastUsageTime();
+                    final long sqlTrace2LastUsageTime = sqlTrace2.getLastUsageTime();
+                    
+                    if (sqlTrace1LastUsageTime < sqlTrace2LastUsageTime) {
+                        compare = 1;
+                    } else if (sqlTrace1LastUsageTime > sqlTrace2LastUsageTime) {
+                        compare = -1;
+                    }
+                }
+            }
+            
+            return compare;
+        }
+    };
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTrace.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTrace.java
@@ -1,7 +1,41 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.jdbc.stats;
 
@@ -9,7 +43,7 @@ import com.sun.gjc.util.SQLTrace;
 import java.util.Comparator;
 
 /**
- *
+ * Extends the SQLTrace class to also store the slowest SQL execution times.
  * @author Andrew Pielage
  */
 public class SlowSqlTrace extends SQLTrace {
@@ -21,48 +55,23 @@ public class SlowSqlTrace extends SQLTrace {
         this.slowestExecutionTime = executionTime;
     }
     
+    /**
+     * Gets the slowest execution time for this SQL Trace
+     * @return The slowest execution time
+     */
     public long getSlowestExecutionTime() {
         return slowestExecutionTime;
     }
     
+    /**
+     * Sets the slowest execution time for this SQL trace
+     * @param slowestExecutionTime The execution time to set
+     */
     public void setSlowestExecutionTime(long slowestExecutionTime) {
         this.slowestExecutionTime = slowestExecutionTime;
     }
     
-    @Override
-    public int compareTo(Object o) {
-        if (!(o instanceof SlowSqlTrace)) {
-            throw new ClassCastException("SqlTraceCache object is expected");
-        }
-        
-        long lastUsageTime = ((SlowSqlTrace) o).getLastUsageTime();
-        long execTime = ((SlowSqlTrace) o).getSlowestExecutionTime();
-        
-        int compare = 0;
-        
-        // Compare the execution times
-        if (execTime == this.getSlowestExecutionTime()) {
-            compare = 0;
-        } else if (execTime < this.getSlowestExecutionTime()) {
-            compare = -1;
-        } else {
-            compare = 1;
-        }
-        
-        // If the slowestExecutionTime is the same, compare against last used
-        if (compare == 0) {
-            if(lastUsageTime == this.getLastUsageTime()) {
-                compare = 0;
-            } else if(lastUsageTime < this.getLastUsageTime()) {
-                compare = -1;
-            } else {
-                compare = 1;
-            }
-        }
-
-        return compare;
-    }
-    
+    // Comparator that orders based on the slowest execution time, the number of executions, and the last usage time.
     public static Comparator<SlowSqlTrace> SlowSqlTraceSlowestExecutionComparator = new Comparator<SlowSqlTrace>() {
         
         @Override
@@ -70,14 +79,17 @@ public class SlowSqlTrace extends SQLTrace {
             final long sqlTrace1SlowestExecution = sqlTrace1.getSlowestExecutionTime();
             final long sqlTrace2SlowestExecution = sqlTrace2.getSlowestExecutionTime();
             
-            
+            // Initialise the comparison variable to be equal
             int compare = 0;
+            
+            // Compare the execution times
             if (sqlTrace1SlowestExecution < sqlTrace2SlowestExecution) {
                 compare = 1;
             } else if (sqlTrace1SlowestExecution > sqlTrace2SlowestExecution) {
                 compare = -1;
             }
             
+            // If the execution times are equal, compare against the number of executions
             if (compare == 0) {
                 final int sqlTrace1Frequency = sqlTrace1.getNumExecutions();
                 final int sqlTrace2Frequency = sqlTrace2.getNumExecutions();
@@ -88,6 +100,7 @@ public class SlowSqlTrace extends SQLTrace {
                     compare = -1;
                 }
                 
+                // If the number of executions is also the same, compare the last usage times
                 if (compare == 0) {
                     final long sqlTrace1LastUsageTime = sqlTrace1.getLastUsageTime();
                     final long sqlTrace2LastUsageTime = sqlTrace2.getLastUsageTime();

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTraceCache.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTraceCache.java
@@ -1,0 +1,84 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.jdbc.stats;
+
+import com.sun.gjc.util.SQLTrace;
+import com.sun.gjc.util.SQLTraceCache;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ * @author Andrew Pielage
+ */
+public class SlowSqlTraceCache extends SQLTraceCache {
+    
+    public SlowSqlTraceCache(String poolName, int maxNumberOfQueries, long timeToKeepQueries) {
+        super(poolName, maxNumberOfQueries, timeToKeepQueries);
+    }
+    
+    /**
+     * Request for adding a sql query in the form of SQLTrace to this cache.
+     * If the query is already found
+     * in the list, the number of times it is executed is incremented by one
+     * along with the timestamp.
+     * If the query is a new one, it is added to the list.
+     * 
+     * @param sqlTrace
+     * @return
+     */
+    @Override
+    public void checkAndUpdateCache(SQLTrace sqlTrace) {    
+        if (sqlTrace != null) {
+            SlowSqlTrace slowSqlTrace = (SlowSqlTrace) sqlTrace;
+            SlowSqlTrace storedSlowSqlTrace = (SlowSqlTrace) cache.get(slowSqlTrace.getQueryName());
+
+            if (storedSlowSqlTrace != null) {
+                //If already found in the cache
+                //equals is invoked here and hence comparison based on query name is done
+                //Get the object at the index to update the numExecutions
+                storedSlowSqlTrace.setNumExecutions(storedSlowSqlTrace.getNumExecutions() + 1);
+                storedSlowSqlTrace.setLastUsageTime(System.currentTimeMillis());
+                
+                long newExecutionTime = slowSqlTrace.getSlowestExecutionTime();
+                if (storedSlowSqlTrace.getSlowestExecutionTime() < newExecutionTime) {
+                    storedSlowSqlTrace.setSlowestExecutionTime(newExecutionTime);
+                }
+            } else {
+                cache.put(slowSqlTrace.getQueryName(), slowSqlTrace);
+            }
+        }
+    }
+    
+    @Override
+    public void purgeEntries() {
+        List<SlowSqlTrace> slowSqlTraceList = new ArrayList(cache.values());
+        Collections.sort(slowSqlTraceList, SlowSqlTrace.SlowSqlTraceSlowestExecutionComparator);
+        
+        int elementCount = slowSqlTraceList.size();        
+        while (elementCount > numTopQueriesToReport) {
+            SlowSqlTrace slowSqlTrace = slowSqlTraceList.get(elementCount - 1);
+            cache.remove(slowSqlTrace.getQueryName());
+            slowSqlTraceList.remove(slowSqlTrace);
+            elementCount --;
+        }
+    }
+    
+    public String getSlowestSqlQueries() {
+        purgeEntries();
+        
+        List<SlowSqlTrace> slowSqlTraceList = new ArrayList(cache.values());
+        Collections.sort(slowSqlTraceList, SlowSqlTrace.SlowSqlTraceSlowestExecutionComparator);
+
+        String slowestSqlQueries = "";
+        for (SlowSqlTrace slowSqlTrace : slowSqlTraceList) {
+            slowestSqlQueries += LINE_BREAK + slowSqlTrace.getQueryName() + ": " + slowSqlTrace.getSlowestExecutionTime();
+        }
+        
+        return slowestSqlQueries;
+    }
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTraceCache.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/fish/payara/jdbc/stats/SlowSqlTraceCache.java
@@ -1,7 +1,41 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.jdbc.stats;
 
@@ -12,7 +46,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- *
+ * 
  * @author Andrew Pielage
  */
 public class SlowSqlTraceCache extends SQLTraceCache {
@@ -22,25 +56,22 @@ public class SlowSqlTraceCache extends SQLTraceCache {
     }
     
     /**
-     * Request for adding a sql query in the form of SQLTrace to this cache.
-     * If the query is already found
-     * in the list, the number of times it is executed is incremented by one
-     * along with the timestamp.
+     * Request for adding a sql query in the form of SlowSqlTrace to this cache.
+     * If the query is already found in the list, the number of times it is executed is incremented by one
+     * along with the timestamp. If its slowest execution time has also increased, this is updated.
      * If the query is a new one, it is added to the list.
      * 
      * @param sqlTrace
-     * @return
      */
     @Override
     public void checkAndUpdateCache(SQLTrace sqlTrace) {    
         if (sqlTrace != null) {
+            // Cast to a slowSqlTrace object
             SlowSqlTrace slowSqlTrace = (SlowSqlTrace) sqlTrace;
             SlowSqlTrace storedSlowSqlTrace = (SlowSqlTrace) cache.get(slowSqlTrace.getQueryName());
 
             if (storedSlowSqlTrace != null) {
                 //If already found in the cache
-                //equals is invoked here and hence comparison based on query name is done
-                //Get the object at the index to update the numExecutions
                 storedSlowSqlTrace.setNumExecutions(storedSlowSqlTrace.getNumExecutions() + 1);
                 storedSlowSqlTrace.setLastUsageTime(System.currentTimeMillis());
                 
@@ -54,6 +85,9 @@ public class SlowSqlTraceCache extends SQLTraceCache {
         }
     }
     
+    /**
+     * Overrides the purgeEntries method to purge the quickest running SQL Traces
+     */
     @Override
     public void purgeEntries() {
         List<SlowSqlTrace> slowSqlTraceList = new ArrayList(cache.values());
@@ -68,6 +102,10 @@ public class SlowSqlTraceCache extends SQLTraceCache {
         }
     }
     
+    /**
+     * Returns the slowest SQL traces.
+     * @return A String representation of the slowest SQL Traces
+     */
     public String getSlowestSqlQueries() {
         purgeEntries();
         
@@ -76,7 +114,8 @@ public class SlowSqlTraceCache extends SQLTraceCache {
 
         String slowestSqlQueries = "";
         for (SlowSqlTrace slowSqlTrace : slowSqlTraceList) {
-            slowestSqlQueries += LINE_BREAK + slowSqlTrace.getQueryName() + ": " + slowSqlTrace.getSlowestExecutionTime();
+            slowestSqlQueries += LINE_BREAK + slowSqlTrace.getQueryName() + " - Slowest Execution Time: " 
+                    + slowSqlTrace.getSlowestExecutionTime() + "ms";
         }
         
         return slowestSqlQueries;

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -1133,6 +1133,26 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public void setSlowQueryThresholdInSeconds(String value) throws PropertyVetoException {
         }
+        
+        @Override
+        public String getSlowQueryFrequencyMonitoringRange() {
+            return getPropertyValue("fish.payara.slow-query-frequency-monitoring-range", "0");
+        }
+        
+        @Override
+        public void setSlowQueryFrequencyMonitoringRange(String value) throws PropertyVetoException {
+            // Do nothing
+        }
+        
+        @Override
+        public String getSlowQueryTimeMonitoringRange() {
+            return getPropertyValue("fish.payara.slow-query-time-monitoring-range", "0");
+        }
+        
+        @Override
+        public void setSlowQueryTimeMonitoringRange(String value) throws PropertyVetoException {
+            // Do nothing
+        }
 
         @Override
         public String getLogJdbcCalls() {

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -1133,26 +1133,6 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public void setSlowQueryThresholdInSeconds(String value) throws PropertyVetoException {
         }
-        
-        @Override
-        public String getSlowQueryFrequencyMonitoringRange() {
-            return getPropertyValue("fish.payara.slow-query-frequency-monitoring-range", "0");
-        }
-        
-        @Override
-        public void setSlowQueryFrequencyMonitoringRange(String value) throws PropertyVetoException {
-            // Do nothing
-        }
-        
-        @Override
-        public String getSlowQueryTimeMonitoringRange() {
-            return getPropertyValue("fish.payara.slow-query-time-monitoring-range", "0");
-        }
-        
-        @Override
-        public void setSlowQueryTimeMonitoringRange(String value) throws PropertyVetoException {
-            // Do nothing
-        }
 
         @Override
         public String getLogJdbcCalls() {


### PR DESCRIPTION
Adds the capability to monitor the slowest SQL traces executed against a connection pool.

To enable this, turn on monitoring of the JDBC Connection pools in a config, for example:
`asadmin set server.monitoring-service.module-monitoring-levels.jdbc-connection-pool=HIGH`

It is configured in the same way as the frequent SQL tracing, using the _number-of-top-queries-to-report_ and _time-to-keep-queries-in-minutes_ properties:

```
asadmin set server.resources.jdbc-connection-pool.<POOL_NAME>.property.number-of-top-queries-to-report=15                    
asadmin set server.resources.jdbc-connection-pool.<POOL_NAME>.property.time-to-keep-queries-in-minutes=10  
```

The monitoring figures can be viewed via the admin console (under Resources > _Resource_ > JDBC Connection Pool Statistics), or using `asadmin get -m server.resources.<POOL_NAME>.slowSqlQueries-current`

For ease of use, I've also created a default SQL Trace listener that simply does nothing, as the monitoring of the slowest SQL traces requires an SQL Trace listener. This can be replaced with any other valid SQL Trace listener without affecting the monitoring (as far as I've tested anyway). The new default SQL Trace listener **is now the default value of the _sqlTraceListeners_ option for the _create-jdbc-connection-pool_ command**.

This PR also fixes monitoring of the most Frequent SQL Traces, though this still retains all of its previous shortcomings.