### PR TITLE
PAYARA-1290 various application-scoped deployment fixes

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorConnectionPoolAdminServiceImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorConnectionPoolAdminServiceImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.connectors.service;
 
@@ -188,7 +188,7 @@ public class ConnectorConnectionPoolAdminServiceImpl extends ConnectorService {
         try {
 
             _runtime.getResourceNamingService().publishObject(poolInfo, jndiNameForPool, connectorPoolObj, true);
-            ManagedConnectionFactory mcf = obtainManagedConnectionFactory(poolInfo);
+            ManagedConnectionFactory mcf = createManagedConnectionFactory(connectorPoolObj);
             if (mcf == null) {
                 _runtime.getResourceNamingService().unpublishObject(poolInfo, jndiNameForPool);
                 String i18nMsg = localStrings.getString("ccp_adm.failed_to_create_mcf", poolInfo);
@@ -909,6 +909,13 @@ public class ConnectorConnectionPoolAdminServiceImpl extends ConnectorService {
 
     public ManagedConnectionFactory obtainManagedConnectionFactory(PoolInfo poolInfo) throws ConnectorRuntimeException{
         return obtainManagedConnectionFactory(poolInfo, null);
+    }
+
+    private ManagedConnectionFactory createManagedConnectionFactory(ConnectorConnectionPool connectorPoolObj) throws ConnectorRuntimeException {
+        if(_registry.isMCFCreated(connectorPoolObj.getPoolInfo())) {
+            recreateConnectorConnectionPool(connectorPoolObj);
+        }
+        return obtainManagedConnectionFactory(connectorPoolObj.getPoolInfo());
     }
 
     /**

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
@@ -91,6 +91,7 @@ public class ApplicationValidator extends ComponentValidator
     final String JNDI_COMP = "java:comp";
     final String JNDI_MODULE = "java:module";
     final String JNDI_APP = "java:app";
+    private final String EJB_LEVEL = "EJBLevel:";
 
     private boolean allUniqueResource = true;
 
@@ -589,14 +590,15 @@ public class ApplicationValidator extends ComponentValidator
                     }
                 }
 
-                Vector vectorScope = commonResourceValidator.getScope();
+                @SuppressWarnings("unchecked")
+                Vector<String> vectorScope = commonResourceValidator.getScope();
                 if (vectorScope != null) {
                     vectorScope.add(scope);
                 }
                 commonResourceValidator.setScope(vectorScope);
                 allResourceDescriptors.put(name, commonResourceValidator);
             } else {
-                Vector<String> vectorScope = new Vector<String>();
+                Vector<String> vectorScope = new Vector<>();
                 vectorScope.add(scope);
                 allResourceDescriptors.put(name, new CommonResourceValidator(descriptor, name, vectorScope));
             }
@@ -709,9 +711,13 @@ public class ApplicationValidator extends ComponentValidator
                     otherElements = otherElements.substring(0, otherElements.indexOf("#"));
                 }
                 if (firstElement.equals(otherElements)) {
+                    boolean fail = !firstElement.startsWith(EJB_LEVEL);
                     inValidJndiName = jndiName;
-                    DOLUtils.getDefaultLogger().log(Level.SEVERE, "DEP0004:Deployment failed due to the conflict occur for jndi-name: {0} for application: {1}",
+                    DOLUtils.getDefaultLogger().log(fail? Level.SEVERE : Level.FINE, "DEP0004:Deployment failed due to the conflict occur for jndi-name: {0} for application: {1}",
                         new Object[] { jndiName, application.getAppName() });
+                    if(fail) {
+                        return false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Application-scoped DB connection resources work correctly with redeployment
- No severer errors that don't mean anything (duplicate jndi-name)
Fixes #907 