### PR TITLE
Replicate original set command key instead of processed one. Fixes #1280

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.admin;
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
@@ -370,7 +370,7 @@ public class SetCommand extends V2DottedNameSupport implements AdminCommand, Pos
                     ConfigSupport.createAndSet((ConfigBean) parentNode, Property.class, attributes);
                     success(context, targetName, value);
                     runLegacyChecks(context);
-                    if (targetService.isThisDAS() && !replicateSetCommand(context, targetName, value))
+                    if (targetService.isThisDAS() && !replicateSetCommand(context, target, value))
                         return false;
                     return true;
                 } catch (TransactionFailure transactionFailure) {
@@ -495,7 +495,7 @@ public class SetCommand extends V2DottedNameSupport implements AdminCommand, Pos
             fail(context, localStrings.getLocalString("admin.set.configuration.notfound", "No configuration found for {0}", targetName));
             return false;
         }
-        if (targetService.isThisDAS() && !replicateSetCommand(context, targetName, value))
+        if (targetService.isThisDAS() && !replicateSetCommand(context, target, value))
             return false;
         return true;
     }


### PR DESCRIPTION
As discussed in the issue,  the patch is correct unless there exists a situation, where instance would give different result to ` getAliasedParent(domain, pattern)` than the DAS.