### PR TITLE
Payara 1056 global thread pool statistics redux

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/GrizzlyMonitoring.java
@@ -54,8 +54,6 @@ import com.sun.enterprise.v3.services.impl.monitor.stats.KeepAliveStatsProvider;
 import com.sun.enterprise.v3.services.impl.monitor.stats.KeepAliveStatsProviderGlobal;
 import com.sun.enterprise.v3.services.impl.monitor.stats.ThreadPoolStatsProvider;
 import com.sun.enterprise.v3.services.impl.monitor.stats.ThreadPoolStatsProviderGlobal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.glassfish.external.probe.provider.PluginPoint;
@@ -152,7 +150,6 @@ public class GrizzlyMonitoring {
         
         StatsProviderManager.register(CONFIG_ELEMENT, PluginPoint.SERVER,
                 subtreePrefix(name) + "/thread-pool", threadPoolStatsProvider);
-        updateGlobalThreadPoolStatsProvider();
     }
 
     /**
@@ -164,6 +161,9 @@ public class GrizzlyMonitoring {
         final ThreadPoolStatsProvider threadPoolStatsProvider =
                 threadPoolStatsProvidersMap.remove(name);
         if (threadPoolStatsProvider != null) {
+            // Unregister it from the global thread pool stats provider
+            threadPoolStatsProvider.unregisterThreadPool(name);
+
             StatsProviderManager.unregister(threadPoolStatsProvider);
             updateGlobalThreadPoolStatsProvider();
         }
@@ -173,7 +173,7 @@ public class GrizzlyMonitoring {
      * Updates the global thread pool stats provider with the most current
      * total values.
      */
-    private void updateGlobalThreadPoolStatsProvider() {
+    public void updateGlobalThreadPoolStatsProvider() {
         final ThreadPoolStatsProvider globalThreadPoolStatsProvider = 
                 threadPoolStatsProvidersMap.get("");
         
@@ -185,44 +185,27 @@ public class GrizzlyMonitoring {
         int coreThreadTotal = 0;
         int maxThreadTotal = 0;    
         
-        // If multiple listeners use the same thread pool, we don't want to
-        // count the threads twice, so we'll store the names of those we've
-        // already counted in here
-        List<String> countedThreadPoolNames = new ArrayList<>();
-        
         // Calculate the totals for each of the metrics
         for (Map.Entry<String, ThreadPoolStatsProvider> threadPoolStatsProvider
                 : threadPoolStatsProvidersMap.entrySet()) {
-            if (!threadPoolStatsProvider.getKey().equals("")) {  
+            if (!threadPoolStatsProvider.getKey().equals("")) {
                 // Get the pool config so we can check the thread pool name
                 ThreadPoolConfig threadPoolConfig = (ThreadPoolConfig) 
                         threadPoolStatsProvider.getValue().getStatsObject();
                 if (threadPoolConfig != null) {
-                    String threadPoolName = threadPoolConfig.getPoolName();
-                    
-                    // Check we haven't already counted the threads in this 
-                    // thread pool
-                    if (!countedThreadPoolNames.contains(threadPoolName)) {
-                        // Safe to cast from long to int, as the values cannot 
-                        // actually be higher than max int.
-                        coreThreadTotal += (int) (long) threadPoolStatsProvider
-                                .getValue().getCoreThreadsCount().getCount();
-                        maxThreadTotal += (int) (long) threadPoolStatsProvider
-                                .getValue().getMaxThreadsCount().getCount();
-
-                        // Add to the list of counted thread pools so we don't
-                        // count the threads twice
-                        countedThreadPoolNames.add(threadPoolName);
-                    }
+                    // Safe to cast from long to int, as the values cannot 
+                    // actually be higher than max int.
+                    coreThreadTotal += (int) (long) threadPoolStatsProvider
+                            .getValue().getCoreThreadsCount().getCount();
+                    maxThreadTotal += (int) (long) threadPoolStatsProvider
+                            .getValue().getMaxThreadsCount().getCount();
                 }
             }
         }
         
         // Now that we've calculated the global core and max values, set them
-        globalThreadPoolStatsProvider.setCoreThreadsEvent("", "", 
-                coreThreadTotal);
-        globalThreadPoolStatsProvider.setMaxThreadsEvent("", "", 
-                maxThreadTotal);
+        globalThreadPoolStatsProvider.setCoreThreadsEvent("", coreThreadTotal);
+        globalThreadPoolStatsProvider.setMaxThreadsEvent("", maxThreadTotal);
     }
 
     /**

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/ThreadPoolMonitor.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/ThreadPoolMonitor.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor;
 
 import com.sun.enterprise.v3.services.impl.monitor.stats.ConnectionQueueStatsProvider;
@@ -98,39 +100,33 @@ public class ThreadPoolMonitor implements ThreadPoolProbe {
 
     @Override
     public void onThreadAllocateEvent(AbstractThreadPool threadPool, Thread thread) {
-        grizzlyMonitoring.getThreadPoolProbeProvider().threadAllocatedEvent(
-                monitoringId, threadPool,
-                thread.getId());
+        grizzlyMonitoring.getThreadPoolProbeProvider().threadAllocatedEvent(monitoringId, threadPool, thread.getId());
     }
 
     @Override
     public void onThreadReleaseEvent(AbstractThreadPool threadPool, Thread thread) {
-        grizzlyMonitoring.getThreadPoolProbeProvider().threadReleasedEvent(
-                monitoringId, threadPool,
-                thread.getId());
+        grizzlyMonitoring.getThreadPoolProbeProvider().threadReleasedEvent(monitoringId, threadPool, thread.getId());
     }
 
     @Override
     public void onMaxNumberOfThreadsEvent(AbstractThreadPool threadPool, int maxNumberOfThreads) {
-        grizzlyMonitoring.getThreadPoolProbeProvider().maxNumberOfThreadsReachedEvent(
-                monitoringId, threadPool,
+        grizzlyMonitoring.getThreadPoolProbeProvider().maxNumberOfThreadsReachedEvent(monitoringId, threadPool, 
                 maxNumberOfThreads);
     }
 
     @Override
     public void onTaskDequeueEvent(AbstractThreadPool threadPool, Runnable task) {
-        grizzlyMonitoring.getThreadPoolProbeProvider().threadDispatchedFromPoolEvent(
-                monitoringId, Thread.currentThread().getId());
-        grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskDequeuedEvent(
-                monitoringId, task.getClass().getName());
+        grizzlyMonitoring.getThreadPoolProbeProvider().threadDispatchedFromPoolEvent(monitoringId, 
+                Thread.currentThread().getId());
+        grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskDequeuedEvent(monitoringId, task.getClass().getName());
     }
 
     @Override
     public void onTaskCancelEvent(AbstractThreadPool threadPool, Runnable task) {
         // when dequeued task is cancelled - we have to "return" the thread, that
         // we marked as dispatched from the pool
-        grizzlyMonitoring.getThreadPoolProbeProvider().threadReturnedToPoolEvent(
-                monitoringId, Thread.currentThread().getId());
+        grizzlyMonitoring.getThreadPoolProbeProvider().threadReturnedToPoolEvent(monitoringId, 
+                Thread.currentThread().getId());
     }
     
     @Override
@@ -141,13 +137,11 @@ public class ThreadPoolMonitor implements ThreadPoolProbe {
 
     @Override
     public void onTaskQueueEvent(AbstractThreadPool threadPool, Runnable task) {
-        grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskQueuedEvent(
-                monitoringId, task.getClass().getName());
+        grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskQueuedEvent(monitoringId, task.getClass().getName());
     }
 
     @Override
     public void onTaskQueueOverflowEvent(AbstractThreadPool threadPool) {
-        grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskQueueOverflowEvent(
-                monitoringId);
+        grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskQueueOverflowEvent(monitoringId);
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/probes/ThreadPoolProbeProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/probes/ThreadPoolProbeProvider.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.v3.services.impl.monitor.probes;
 
 import org.glassfish.external.probe.provider.annotations.Probe;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/probes/ThreadPoolProbeProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/probes/ThreadPoolProbeProvider.java
@@ -43,6 +43,7 @@ package com.sun.enterprise.v3.services.impl.monitor.probes;
 import org.glassfish.external.probe.provider.annotations.Probe;
 import org.glassfish.external.probe.provider.annotations.ProbeParam;
 import org.glassfish.external.probe.provider.annotations.ProbeProvider;
+import org.glassfish.grizzly.threadpool.AbstractThreadPool;
 
 /**
  * Probe provider interface for thread pool related events.
@@ -53,14 +54,12 @@ public class ThreadPoolProbeProvider {
     @Probe(name="setMaxThreadsEvent")
     public void setMaxThreadsEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
         @ProbeParam("maxNumberOfThreads") int maxNumberOfThreads) {}
     
 
     @Probe(name="setCoreThreadsEvent")
     public void setCoreThreadsEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
         @ProbeParam("coreNumberOfThreads") int coreNumberOfThreads) {}
 
     /**
@@ -70,34 +69,32 @@ public class ThreadPoolProbeProvider {
     @Probe(name="threadAllocatedEvent")
     public void threadAllocatedEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
+        @ProbeParam("threadPool") AbstractThreadPool threadPool,
         @ProbeParam("threadId") long threadId) {}
 
 
     @Probe(name="threadReleasedEvent")
     public void threadReleasedEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
+        @ProbeParam("threadPool") AbstractThreadPool threadPool,
         @ProbeParam("threadId") long threadId) {}
 
 
     @Probe(name="maxNumberOfThreadsReachedEvent")
     public void maxNumberOfThreadsReachedEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
+        @ProbeParam("threadPool") AbstractThreadPool threadPool,
         @ProbeParam("maxNumberOfThreads") int maxNumberOfThreads) {}
 
 
     @Probe(name="threadDispatchedFromPoolEvent")
     public void threadDispatchedFromPoolEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
         @ProbeParam("threadId") long threadId) {}
 
 
     @Probe(name="threadReturnedToPoolEvent")
     public void threadReturnedToPoolEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPoolName") String threadPoolName,
         @ProbeParam("threadId") long threadId) {}
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -51,7 +51,6 @@ import org.glassfish.gmbal.AMXMetadata;
 import org.glassfish.gmbal.Description;
 import org.glassfish.gmbal.ManagedAttribute;
 import org.glassfish.gmbal.ManagedObject;
-import org.glassfish.grizzly.threadpool.AbstractThreadPool;
 
 /**
  * Server wide Thread Pool statistics

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/stats/ThreadPoolStatsProviderGlobal.java
@@ -42,16 +42,16 @@
 
 package com.sun.enterprise.v3.services.impl.monitor.stats;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import org.glassfish.external.probe.provider.annotations.ProbeListener;
 import org.glassfish.external.probe.provider.annotations.ProbeParam;
 import org.glassfish.external.statistics.CountStatistic;
+import org.glassfish.external.statistics.annotations.Reset;
 import org.glassfish.gmbal.AMXMetadata;
 import org.glassfish.gmbal.Description;
 import org.glassfish.gmbal.ManagedAttribute;
 import org.glassfish.gmbal.ManagedObject;
+import org.glassfish.grizzly.threadpool.AbstractThreadPool;
 
 /**
  * Server wide Thread Pool statistics
@@ -74,20 +74,11 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
         countThreadsInThreadPools();
         return currentThreadCount;
     }
-
-    @ManagedAttribute(id = "currentthreadsbusy")
-    @Description("Provides the number of request processing threads currently in use in the listener thread pool serving requests.")
-    @Override
-    public CountStatistic getCurrentThreadsBusy() {
-        countThreadsInThreadPools();
-        return currentThreadsBusy;
-    }
     
     @ProbeListener("glassfish:kernel:thread-pool:setMaxThreadsEvent")
     @Override
     public void setMaxThreadsEvent(
             @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("maxNumberOfThreads") int maxNumberOfThreads) {
 
         maxThreadsCount.setCount(maxNumberOfThreads);
@@ -97,20 +88,31 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     @Override
     public void setCoreThreadsEvent(
             @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("coreNumberOfThreads") int coreNumberOfThreads) {
 
         coreThreadsCount.setCount(coreNumberOfThreads);
     }
-
+    
+    @ProbeListener("glassfish:kernel:thread-pool:threadDispatchedFromPoolEvent")
+    @Override
+    public void threadDispatchedFromPoolEvent(
+            @ProbeParam("monitoringId") String monitoringId,
+            @ProbeParam("threadId") long threadId) {
+        currentThreadsBusy.increment();
+    }
+    
     @ProbeListener("glassfish:kernel:thread-pool:threadReturnedToPoolEvent")
     @Override
     public void threadReturnedToPoolEvent(
             @ProbeParam("monitoringId") String monitoringId,
-            @ProbeParam("threadPoolName") String threadPoolName,
             @ProbeParam("threadId") long threadId) {
 
         totalExecutedTasksCount.increment();
+        
+        // Stop it from decrementing to negative values
+        if (currentThreadsBusy.getCount() > 0) {
+            currentThreadsBusy.decrement();
+        }
     }
     
     /**
@@ -120,28 +122,33 @@ public class ThreadPoolStatsProviderGlobal extends ThreadPoolStatsProvider {
     private void countThreadsInThreadPools() {     
         // Set to 0 as we want to reset them
         currentThreadCount.setCount(0);
-        currentThreadsBusy.setCount(0);
         
         // Get all the threads currently in the JVM
         Set<Thread> threads = Thread.getAllStackTraces().keySet();
         
-        // If multiple listeners use the same thread pool, you will get 
-        // duplicate named threads, so we want to filter these out
-        List<String> alreadyCounted = new ArrayList<>();
         for (Thread thread : threads) {
             String threadName = thread.getName();
             for (String threadPoolName : threadPoolNames) {
-                if (thread.isAlive() && threadName.contains(threadPoolName 
-                        + "(") && !alreadyCounted.contains(threadName)) {
-                    alreadyCounted.add(threadName);
-                    currentThreadCount.increment();
-                    if (thread.getState() == Thread.State.RUNNABLE) {
-                        currentThreadsBusy.increment();
-                    }
-                    
+                if (thread.isAlive() && threadName.contains(threadPoolName + "(")) {
+                    currentThreadCount.increment();                   
                     break;
                 }
             }
         }
+    }
+    
+    public void subtractBusyThreads(long busyThreads) {
+        long busyThreadsCount = currentThreadsBusy.getCount() - busyThreads;
+        if (busyThreadsCount > 0) {
+            currentThreadsBusy.setCount(currentThreadsBusy.getCount() - busyThreads);
+        } else {
+            currentThreadsBusy.setCount(0);
+        }
+    }
+    
+    @Reset
+    @Override
+    public void reset() {
+        // Do nothing
     }
 }


### PR DESCRIPTION
Re-implements original busy thread count impl, and reworks the global and individual thread counts for current, core, and max threads to be more accurate.

Also cleans up the probe provider methods a little.