### PR TITLE
PAYARA-1324 session replication resilience and improvements

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/ManagerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/ManagerBase.java
@@ -55,6 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 package org.apache.catalina.session;
 
@@ -73,10 +74,15 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.*;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -1328,5 +1334,35 @@ public abstract class ManagerBase implements Manager {
      */
     public void release() {
         clearSessions();
+    }
+
+    /**
+     * create appropriate object input stream with appropriate class loading
+     * @param is
+     * @return stream
+     * @throws IOException
+     */
+    ObjectInputStream createObjectInputStream(InputStream is) throws IOException {
+        if (container != null) {
+            return ((StandardContext) container).createObjectInputStream(is);
+        } else {
+            return new ObjectInputStream(is);
+        }
+    }
+
+    /**
+     * create appropriate object output stream with appropriate class loading
+     * @param os
+     * @return stream
+     * @throws IOException
+     */
+    ObjectOutputStream createObjectOutputStream(OutputStream os) throws IOException {
+
+        if (container != null) {
+            return ((StandardContext) container).createObjectOutputStream(
+                    new BufferedOutputStream(os));
+        } else {
+            return new ObjectOutputStream(new BufferedOutputStream(os));
+        }
     }
 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/PersistentManagerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/PersistentManagerBase.java
@@ -1221,12 +1221,8 @@ public abstract class PersistentManagerBase
         } catch (ClassNotFoundException | ClassCastException e) {
             String msg = MessageFormat.format(rb.getString(DESERILIZING_SESSION_EXCEPTION),
                                               new Object[] {id, e});
-            if(e instanceof ClassCastException) {
-                log.warning(msg);
-                return null;
-            }
-            log.log(Level.SEVERE, msg);
-            throw new IllegalStateException(msg);
+            log.log(Level.WARNING, msg);
+            return null;
         }
 
         if (session == null)

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/PersistentManagerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/PersistentManagerBase.java
@@ -1218,9 +1218,13 @@ public abstract class PersistentManagerBase
                      session = store.load(id);
                 }
             }   
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | ClassCastException e) {
             String msg = MessageFormat.format(rb.getString(DESERILIZING_SESSION_EXCEPTION),
                                               new Object[] {id, e});
+            if(e instanceof ClassCastException) {
+                log.warning(msg);
+                return null;
+            }
             log.log(Level.SEVERE, msg);
             throw new IllegalStateException(msg);
         }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardManager.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardManager.java
@@ -549,7 +549,6 @@ public class StandardManager
                 int n = count.intValue();
                 if (log.isLoggable(Level.FINE))
                     log.log(Level.FINE, "Loading " + n + " persisted sessions");
-                StandardSession.threadContextManager.set(this);
                 for (int i = 0; i < n; i++) {
                     StandardSession session =
                         StandardSession.deserialize(ois, this);
@@ -584,7 +583,6 @@ public class StandardManager
                 }
                 throw e;
             } finally {
-                StandardSession.threadContextManager.remove();
                 // Close the input stream
                 try {
                     if (ois != null) {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardManager.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardManager.java
@@ -598,36 +598,6 @@ public class StandardManager
     }
 
     /**
-     * create appropriate object input stream with appropriate class loading
-     * @param is
-     * @return stream
-     * @throws IOException
-     */
-    ObjectInputStream createObjectInputStream(InputStream is) throws IOException {
-        if (container != null) {
-            return ((StandardContext) container).createObjectInputStream(is);
-        } else {
-            return new ObjectInputStream(is);
-        }
-    }
-
-    /**
-     * create appropriate object output stream with appropriate class loading
-     * @param os
-     * @return stream
-     * @throws IOException
-     */
-    ObjectOutputStream createObjectOutputStream(OutputStream os) throws IOException {
-
-        if (container != null) {
-            return ((StandardContext) container).createObjectOutputStream(
-                    new BufferedOutputStream(os));
-        } else {
-            return new ObjectOutputStream(new BufferedOutputStream(os));
-        }
-    }
-
-    /**
      * Save any currently active sessions in the appropriate persistence
      * mechanism, if any.  If persistence is not supported, this method
      * returns without doing anything.

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -2220,9 +2220,9 @@ public class StandardSession
             try {
                 Object val = saveValues.get(i);
                 if(checkedSerializableObjects.getIfPresent(val) == null) {
-                    StandardManager sm = (StandardManager)getManager();
+                    ManagerBase manager = (ManagerBase)getManager();
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    try (ObjectOutputStream oos = sm.createObjectOutputStream(baos)) {
+                    try (ObjectOutputStream oos = manager.createObjectOutputStream(baos)) {
                         // need to write the object to temporary buffer,
                         // so main stream doesn't get corrupted in case of partial
                         // object write and NotSerializedException

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -318,7 +318,7 @@ public class StandardSession
      * The Manager with which this Session is associated.
      */
     protected transient Manager manager = null;
-    static final transient ThreadLocal<Manager> threadContextManager
+    static final transient ThreadLocal<ManagerBase> threadContextManager
             = new ThreadLocal<>();
     private transient Cache<Object, Object> checkedSerializableObjects = buildSerializableCache();
 
@@ -2095,11 +2095,11 @@ public class StandardSession
                     case SEPARATE_BUFFER_SERIALIZATION:
                     {
                         value = stream.readObject();
-                        StandardManager sm = (StandardManager) getManager();
-                        if (sm == null) {
-                            sm = (StandardManager) threadContextManager.get();
+                        ManagerBase mgr = (ManagerBase) getManager();
+                        if (mgr == null) {
+                            mgr = threadContextManager.get();
                         }
-                        value = sm.createObjectInputStream(new ByteArrayInputStream((byte[]) value)).readObject();
+                        value = mgr.createObjectInputStream(new ByteArrayInputStream((byte[]) value)).readObject();
                         break;
                     }
                 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -2254,7 +2254,7 @@ public class StandardSession
                         "' with value '" + saveValues.get(i) + "'");
             } catch (IOException e) {
                 if((e instanceof NotSerializableException || e.getCause() instanceof NotSerializableException)
-                        && serSuccess != true) {
+                        && (serSuccess == null || serSuccess == false)) {
                 String msg = MessageFormat.format(rb.getString(CANNOT_SERIALIZE_SESSION_EXCEPTION),
                                                   new Object[] {saveNames.get(i), id});
                 log(msg, Level.WARNING);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -2253,8 +2253,8 @@ public class StandardSession
                     log("  storing attribute '" + saveNames.get(i) +
                         "' with value '" + saveValues.get(i) + "'");
             } catch (IOException e) {
-                if((e instanceof NotSerializableException) || (e.getCause() instanceof NotSerializableException)
-                        && (serSuccess != true)) {
+                if((e instanceof NotSerializableException || e.getCause() instanceof NotSerializableException)
+                        && serSuccess != true) {
                 String msg = MessageFormat.format(rb.getString(CANNOT_SERIALIZE_SESSION_EXCEPTION),
                                                   new Object[] {saveNames.get(i), id});
                 log(msg, Level.WARNING);

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ModifiedAttributeHASession.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ModifiedAttributeHASession.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 /*
  * ModifiedAttributeHASession.java
@@ -50,6 +51,7 @@ import org.apache.catalina.Manager;
 import org.apache.catalina.util.Enumerator;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -63,7 +65,7 @@ public class ModifiedAttributeHASession extends BaseHASession {
     
     private static final Logger _logger = HAStoreBase._logger;
 
-    private transient Map<String, SessionAttributeState> _attributeStates = new HashMap<String, SessionAttributeState>();
+    private transient Map<String, SessionAttributeState> _attributeStates = new ConcurrentHashMap<>();
     private transient boolean _dirtyFlag = false;
     
     
@@ -145,7 +147,7 @@ public class ModifiedAttributeHASession extends BaseHASession {
      */     
     void clearAttributeStates() {
         if(_attributeStates == null) {
-            _attributeStates = new HashMap<String, SessionAttributeState>();
+            _attributeStates = new ConcurrentHashMap<>();
         }
         _attributeStates.clear();
     }

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationAttributeStore.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationAttributeStore.java
@@ -405,14 +405,16 @@ public class ReplicationAttributeStore extends ReplicationStore {
         }
     }
     
-    private CompositeMetadata createCompositeMetadata(ModifiedAttributeHASession modAttrSession) {
+    private CompositeMetadata createCompositeMetadata(ModifiedAttributeHASession modAttrSession) throws IOException {
         
         byte[] trunkState = null;
         if (!modAttrSession.isNew()) {
             try {
                 trunkState = this.getByteArray(modAttrSession);
             } catch(IOException ex) {
-                //no op
+                if(ex instanceof NotSerializableException) {
+                    throw ex;
+                }
             }
         }
         if(_logger.isLoggable(Level.FINE)) {

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationAttributeStore.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationAttributeStore.java
@@ -37,11 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.web.ha.session.management;
 
 import com.sun.enterprise.container.common.spi.util.JavaEEIOUtils;
-import com.sun.enterprise.web.ServerConfigLookup;
 import org.glassfish.ha.store.api.BackingStore;
 import org.glassfish.ha.store.api.BackingStoreException;
 import org.apache.catalina.*;
@@ -408,7 +408,7 @@ public class ReplicationAttributeStore extends ReplicationStore {
     private CompositeMetadata createCompositeMetadata(ModifiedAttributeHASession modAttrSession) {
         
         byte[] trunkState = null;
-        if (modAttrSession.isNew()) {
+        if (!modAttrSession.isNew()) {
             try {
                 trunkState = this.getByteArray(modAttrSession);
             } catch(IOException ex) {


### PR DESCRIPTION
more resilience of session serialization in presence of errors, such as:
- ignore non-serializable fields with a warning, even if they are inside a serializable object