### PR TITLE
 PAYARA-1078 Make JDBC connection validation use the configured statement timeout

### DIFF
--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DefaultConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DefaultConnectionValidation.java
@@ -61,13 +61,16 @@ public class DefaultConnectionValidation implements ConnectionValidation {
      * Check for validity of <code>java.sql.Connection</code>
      *
      * @param con       <code>java.sql.Connection</code>to be validated
-     * @throws SQLException if the connection is not valid
+     * @param statementTimeout The time in seconds to wait for the query to complete
+     * @return True if connection is valid
      */
-    public boolean isConnectionValid(Connection con) {
+    @Override
+    public boolean isConnectionValid(Connection con, int statementTimeout) {
         boolean isValid = false;
         Statement stmt = null;
         try {
             stmt = con.createStatement();
+            stmt.setQueryTimeout(statementTimeout);
             isValid = stmt.execute(SQL);
         } catch (SQLException sqle) {
             isValid = false;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DefaultConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DefaultConnectionValidation.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.api.jdbc.validation;
 
 import com.sun.logging.LogDomains;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DerbyConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DerbyConnectionValidation.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.api.jdbc.validation;
 
 import org.glassfish.api.jdbc.ConnectionValidation;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DerbyConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/DerbyConnectionValidation.java
@@ -61,13 +61,16 @@ public class DerbyConnectionValidation implements ConnectionValidation {
      * Check for validity of <code>java.sql.Connection</code>
      *
      * @param con       <code>java.sql.Connection</code>to be validated
-     * @throws SQLException if the connection is not valid
+     * @param statementTimeout The time in seconds to wait for the query to complete
+     * @return True if connection is valid
      */
-    public boolean isConnectionValid(Connection con) {
+    @Override
+    public boolean isConnectionValid(Connection con, int statementTimeout) {
         boolean isValid = false;
         Statement stmt = null;
         try {
             stmt = con.createStatement();
+            stmt.setQueryTimeout(statementTimeout);
             isValid = stmt.execute(SQL);
         } catch (SQLException sqle) {
             isValid = false;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/JDBC40ConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/JDBC40ConnectionValidation.java
@@ -54,18 +54,19 @@ import java.sql.SQLException;
  * @author Shalini M
  */
 public class JDBC40ConnectionValidation implements ConnectionValidation {
-
     
     /**
      * Check for validity of <code>java.sql.Connection</code>
      *
      * @param con       <code>java.sql.Connection</code>to be validated
-     * @throws SQLException if the connection is not valid
+     * @param statementTimeout The time in seconds to wait for the query to complete
+     * @return True if connection is valid
      */
-    public boolean isConnectionValid(Connection con) {
+    @Override
+    public boolean isConnectionValid(Connection con, int statementTimeout) {
         boolean isValid = false;
         try {
-            isValid = con.isValid(0);
+            isValid = con.isValid(statementTimeout);
         } catch (SQLException sqle) {
             isValid = false;
         } 

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/JDBC40ConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/JDBC40ConnectionValidation.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.api.jdbc.validation;
 
 import org.glassfish.api.jdbc.ConnectionValidation;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/OracleConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/OracleConnectionValidation.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.api.jdbc.validation;
 
 import org.glassfish.api.jdbc.ConnectionValidation;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/OracleConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/OracleConnectionValidation.java
@@ -62,13 +62,16 @@ public class OracleConnectionValidation implements ConnectionValidation {
      * Check for validity of <code>java.sql.Connection</code>
      *
      * @param con       <code>java.sql.Connection</code>to be validated
-     * @throws SQLException if the connection is not valid
+     * @param statementTimeout The time in seconds to wait for the query to complete
+     * @return True if connection is valid
      */
-    public boolean isConnectionValid(Connection con) {
+    @Override
+    public boolean isConnectionValid(Connection con, int statementTimeout) {
         boolean isValid = false;
         Statement stmt = null;
         try {
             stmt = con.createStatement();
+            stmt.setQueryTimeout(statementTimeout);
             isValid = stmt.execute(SQL);
         } catch (SQLException sqle) {
             isValid = false;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/PostgresConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/PostgresConnectionValidation.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.api.jdbc.validation;
 
 import org.glassfish.api.jdbc.ConnectionValidation;

--- a/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/PostgresConnectionValidation.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/org/glassfish/api/jdbc/validation/PostgresConnectionValidation.java
@@ -62,13 +62,16 @@ public class PostgresConnectionValidation implements ConnectionValidation {
      * Check for validity of <code>java.sql.Connection</code>
      *
      * @param con       <code>java.sql.Connection</code>to be validated
-     * @throws SQLException if the connection is not valid
+     * @param statementTimeout The time in seconds to wait for the query to complete
+     * @return True if connection is valid
      */
-    public boolean isConnectionValid(Connection con) {
+    @Override
+    public boolean isConnectionValid(Connection con, int statementTimeout) {
         boolean isValid = false;
         Statement stmt = null;
         try {
             stmt = con.createStatement();
+            stmt.setQueryTimeout(statementTimeout);
             isValid = stmt.execute(SQL);
         } catch (SQLException sqle) {
             isValid = false;

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/jdbc/ConnectionValidation.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/jdbc/ConnectionValidation.java
@@ -50,12 +50,14 @@ import java.sql.SQLException;
  * @author Shalini M
  */
 public interface ConnectionValidation {
-  /**
-   * Check for validity of <code>java.sql.Connection</code>
-   *
-   * @param con       <code>java.sql.Connection</code>to be validated
-   * @throws SQLException if the connection is not valid
-   */
-   boolean isConnectionValid(Connection con) throws SQLException;
-
+    
+    /**
+     * Check for validity of <code>java.sql.Connection</code>
+     *
+     * @param con       <code>java.sql.Connection</code>to be validated
+     * @param statementTimeout The statement timeout value
+     * @throws SQLException if the connection is not valid
+     */
+   boolean isConnectionValid(Connection con, int statementTimeout) throws SQLException;
+   
 }

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/jdbc/ConnectionValidation.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/jdbc/ConnectionValidation.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.api.jdbc;
 
 import java.sql.Connection;


### PR DESCRIPTION
This PR changes the GlassFish API slightly; the `isConnectionValid(Connection con)` method of the `ConnectionValidation` class is now `isConnectionValid(Connection con, int statementTimeout)`.

The timeout only applies to the `table` and the applicable `custom-validation` connection validation types.

