### PR TITLE
PAYARA-1283 Edit logging of set-monitoring-configuration error to mak…

### DIFF
--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
@@ -126,7 +126,8 @@ public class SetMonitoringConfiguration implements AdminCommand {
             }
 
         } catch (TransactionFailure ex) {
-            Logger.getLogger(SetMonitoringConfiguration.class.getName()).log(Level.WARNING, "Exception during command ", ex);
+            Logger.getLogger(SetMonitoringConfiguration.class.getName()).log(Level.WARNING, "Exception during command "
+                    + "set-monitoring-configuration: " + ex.getCause().getMessage());
             actionReport.setMessage(ex.getCause().getMessage());
             actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
         }


### PR DESCRIPTION
…e it less verbose and easier to read.

The command will now log something along the lines of this:

`Exception during command set-monitoring-configuration: A Property with the same key "HeapMemoryUsage" already exists in MonitoringServiceConfiguration null|#]`