### PR TITLE
PAYARA-1282 jmx monitoring service is not dynamic until first restart

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -125,6 +125,7 @@
       <notification-service-configuration enabled="true">
         <log-notifier-configuration enabled="true"></log-notifier-configuration>
       </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
        <diagnostic-service />
       <security-service>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
@@ -381,6 +382,7 @@
       <notification-service-configuration enabled="true">
         <log-notifier-configuration enabled="true"></log-notifier-configuration>
       </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
          <diagnostic-service />
          <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
              <jvm-options>-XX:MaxPermSize=192m</jvm-options>

--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -40,6 +40,8 @@
 
 -->
 
+<!-- Portions Copyright [2017] [Payara Foundation and/or its affiliates] -->
+
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
 <security-configurations>
     <authentication-service default="true" name="adminAuth" use-password-credential="true">

--- a/appserver/admin/payara_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/payara_template/src/main/resources/config/domain.xml
@@ -103,6 +103,7 @@
         <log-notifier-configuration enabled="true"></log-notifier-configuration>
       </notification-service-configuration>
        <batch-runtime-configuration data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
+       <monitoring-service-configuration></monitoring-service-configuration>
        <diagnostic-service />
       <security-service activate-default-principal-to-role-mapping="true">
         <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
@@ -335,6 +336,7 @@
       <notification-service-configuration enabled="true">
         <log-notifier-configuration enabled="true"></log-notifier-configuration>
       </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
          <diagnostic-service />
       <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
         <jvm-options>-server</jvm-options>


### PR DESCRIPTION
This fix is implemented by adding the default configuration tags for this service to the default domain.xml files, so will not take affect for those migrating from previous versions (if they have not already made a configuration change to the _monitoring-service-configuration_ service)