### PR TITLE
PAYARA-769 Make resetAssociation() more robust (#1148)

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManagerImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManagerImpl.java
@@ -212,14 +212,13 @@ public class PoolManagerImpl extends AbstractPoolManager implements ComponentInv
             }
         } catch (Exception e) {
             //In the rare cases where enlistResource throws exception, we
-            //should return the resource to the pool
-            putbackDirectToPool(handle, spec.getPoolInfo());
+            //should throw the resource away
+            putbackBadResourceToPool(handle);
             _logger.log(Level.WARNING, "poolmgr.err_enlisting_res_in_getconn",
                     spec.getPoolInfo());
-            logFine("rm.enlistResource threw Exception. Returning resource to pool");
+            logFine("rm.enlistResource threw Exception. Evicting resource from pool");
             //and rethrow the exception
             throw new PoolingException(e);
-
         }
 
         return handle.getUserConnection();

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/rm/LazyEnlistableResourceManagerImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/rm/LazyEnlistableResourceManagerImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.resource.rm;
 
@@ -149,14 +150,14 @@ public class LazyEnlistableResourceManagerImpl extends ResourceManagerImpl {
                     h.setEnlistmentSuspended(true);
             } catch( Exception e ) {
                 //In the rare cases where enlistResource throws exception, we
-    	        //should return the resource to the pool
+    	        //should report the resource to the pool as bad
                     PoolManager mgr = ConnectorRuntime.getRuntime().getPoolManager();
-    	            mgr.putbackDirectToPool( h, h.getResourceSpec().getPoolInfo());
+    	            mgr.putbackBadResourceToPool(h);
                     _logger.log(Level.WARNING,
                                 "poolmgr.err_enlisting_res_in_getconn", h
                                 .getResourceSpec().getPoolInfo());
     	        if (_logger.isLoggable(Level.FINE) ) {
-    	            _logger.fine("rm.enlistResource threw Exception. Returning resource to pool");
+    	            _logger.fine("rm.enlistResource threw Exception. Evicting resource from pool");
     	        }
     	        //and rethrow the exception
     	        throw new ResourceException( e );

--- a/appserver/connectors/connectors-runtime/src/main/resources/com/sun/enterprise/LogStrings.properties
+++ b/appserver/connectors/connectors-runtime/src/main/resources/com/sun/enterprise/LogStrings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016] [Payara Foundation]
+# Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 datasource.xadatasource_error=RAR5005:Error in accessing XA resource with JNDI name [{0}] for recovery
 RAR5005.diag.cause.1=The XA resource has been deleted before attempting recovery
@@ -223,7 +223,7 @@ resource_pool.failed_creating_resource=RAR7127: Unable to create a new resource 
 connection_sharing_start=ConnectorXAResource.start() - associating connection : {0}
 connection_sharing_end=ConnectorXAResource.end() called
 connection_sharing_reset_association=ConnectorXAResource.resetAssociation() - dissociating connection : {0}
-poolmgr.err_enlisting_res_in_getconn=RAR7132: Unable to enlist the resource in transaction. Returned resource to pool. Pool name: [ {0} ]
+poolmgr.err_enlisting_res_in_getconn=RAR7132: Unable to enlist the resource in transaction. Evicting resource from pool. Pool name: [ {0} ]
 rardeployment.connectorresource_removal_from_jndi_error=RAR7133: Unable to remove resource [ {0} ] from jndi
 rardeployment.no_module_deployed=RAR7134: RAR [ {0} ] is not deployed
 rardeployment.connector_descriptor_jndi_removal_failure=RAR7135: Unable to remove connector-descriptor of resource-adapter [{0}] from jndi


### PR DESCRIPTION
Committed by @retoo
* Payara-769: Make resetAssociation() more robust by avoiding begin()ing tx in error handling/finally

Otherwise we will crash right again in our finally/resetAssociation block which will
cause the connection pool entry to have avery inconsistent state from which the
server does not recover.

* Payara-769: When errors occur during TXStart we should evict the connection from the pool

* Payara copyright

* Payara Copyright

* Payara Copyright