### PR TITLE
PAYARA-1423 Removed the warning of Request Tracing in preview from admin console

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
+++ b/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
@@ -95,8 +95,7 @@ notification.configuration.notifier.name=Notifier Service Name
 notification.configuration.notifier.nameHelp=Name of the Notifier Service
 
 requestTracing.configurationTitle=Request Tracing Configuration
-requestTracing.configurationTitleHelp=Enable and configure the settings for the Request Tracing.<br/>\
-<br/><b>WARNING!</b>: Request Tracing Service is a tech preview. We strongly recommend not to use it on a production system.
+requestTracing.configurationTitleHelp=Enable and configure the settings for the Request Tracing Service.
 requestTracing.configuration.enabled=Request Tracing
 requestTracing.configuration.enabledHelp=Determines whether the Request Tracing Service is enabled.
 requestTracing.configuration.dynamic=Request Tracing


### PR DESCRIPTION
Request tracing is officially production-ready since 164, therefore there should be no warning anymore.