### PR TITLE
PAYARA-1423 notification svc preview

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
+++ b/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
@@ -77,8 +77,7 @@ notification.serverTabs.titleHelp=Click <a href="#{request.contextPath}/payaraEx
 button.notificationLogViewer=   View Notification Log
 
 notification.configurationTitle=Notification Configuration
-notification.configurationTitleHelp=Enable and configure the settings for the Notification.<br/>\
-<br/><b>WARNING!</b>: Notification Service is a tech preview. We strongly recommend not to use it on a production system.
+notification.configurationTitleHelp=Enable and configure the settings for the Notification Service.
 notification.configuration.enabled=Notification Service Enabled
 notification.configuration.enabledHelp=Determines whether the Notification Service is enabled.
 notification.configuration.dynamic=Dynamic

--- a/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
+++ b/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
@@ -95,8 +95,7 @@ notification.configuration.notifier.name=Notifier Service Name
 notification.configuration.notifier.nameHelp=Name of the Notifier Service
 
 requestTracing.configurationTitle=Request Tracing Configuration
-requestTracing.configurationTitleHelp=Enable and configure the settings for the Request Tracing.<br/>\
-<br/><b>WARNING!</b>: Request Tracing Service is a tech preview. We strongly recommend not to use it on a production system.
+requestTracing.configurationTitleHelp=Enable and configure the settings for the Request Tracing Service.
 requestTracing.configuration.enabled=Request Tracing
 requestTracing.configuration.enabledHelp=Determines whether the Request Tracing Service is enabled.
 requestTracing.configuration.dynamic=Request Tracing


### PR DESCRIPTION
I'm not sure, but I think that the Notification service shouldn't be in technical preview since 164, or at least since 171. In that case, there should be no warning message in admin console.

If it is still in technical preview, **don't merge this PR yet**.