### PR TITLE
PAYARA-1383 Deprecate name parameter and fix pages

### DIFF
--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceConfigureCheckerWithThresholdsCommand.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceConfigureCheckerWithThresholdsCommand.java
@@ -138,7 +138,7 @@ public class HealthCheckServiceConfigureCheckerWithThresholdsCommand implements 
         checkerConfigureParameters.add("dynamic", dynamic.toString());
         checkerConfigureParameters.add("time", time);
         checkerConfigureParameters.add("unit", unit);
-        checkerConfigureParameters.add("name", checkerName);
+        checkerConfigureParameters.add("checkerName", checkerName);
         checkerConfigureParameters.add("serviceName", serviceName);
         checkerConfigureParameters.add("target", target);
         

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceConfigurer.java
@@ -95,8 +95,12 @@ public class HealthCheckServiceConfigurer implements AdminCommand {
     private String serviceName;
 
     @Param(name = "name", optional = true)
+    @Deprecated
     private String name;
 
+    @Param(name = "checkerName", optional = true)
+    private String checkerName;
+    
     @Param(name = "dynamic", optional = true, defaultValue = "false")
     protected Boolean dynamic;
 
@@ -125,6 +129,11 @@ public class HealthCheckServiceConfigurer implements AdminCommand {
             return;
         }
 
+        // Warn about deprecated option
+        if (name != null) {
+            actionReport.appendMessage("\n--name parameter is decremented, please begin using the --checkerName option\n");
+        }
+        
         HealthCheckServiceConfiguration healthCheckServiceConfiguration = config.getExtensionByType(HealthCheckServiceConfiguration.class);
         final Checker checker = healthCheckServiceConfiguration.getCheckerByType(service.getCheckerType());
 
@@ -194,6 +203,11 @@ public class HealthCheckServiceConfigurer implements AdminCommand {
         }
         if (name != null) {
             checkerProxy.setName(name);
+        }
+        
+        // Take priority over deprecated parameter
+        if (checkerName != null) {
+            checkerProxy.setName(checkerName);
         }
     }
 }

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HoggingThreadsConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HoggingThreadsConfigurer.java
@@ -19,7 +19,6 @@
 package fish.payara.nucleus.healthcheck.admin;
 
 import com.sun.enterprise.config.serverbeans.Config;
-import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import fish.payara.nucleus.healthcheck.HealthCheckService;
 import fish.payara.nucleus.healthcheck.configuration.HealthCheckServiceConfiguration;
@@ -95,7 +94,11 @@ public class HoggingThreadsConfigurer implements AdminCommand {
     private String unit;
     
     @Param(name = "name", optional = true)
+    @Deprecated
     private String name;
+
+    @Param(name = "checkerName", optional = true)
+    private String checkerName;
     
     @Param(name = "threshold-percentage")
     @Min(value = 0, message = "Threshold is a percentage so must be greater than zero")
@@ -127,7 +130,12 @@ public class HoggingThreadsConfigurer implements AdminCommand {
             actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
             return;
         }
-
+        
+        // Warn about deprecated option
+        if (name != null) {
+            actionReport.appendMessage("\n--name parameter is decremented, please begin using the --checkerName option\n");
+        }
+        
         try {
             HealthCheckServiceConfiguration healthCheckServiceConfiguration = config.getExtensionByType(HealthCheckServiceConfiguration.class);
             HoggingThreadsChecker hoggingThreadConfiguration = healthCheckServiceConfiguration.getCheckerByType(HoggingThreadsChecker.class);
@@ -188,6 +196,11 @@ public class HoggingThreadsConfigurer implements AdminCommand {
         
         if (name != null) {
             checkerProxy.setName(name);
+        }
+        
+        // Take priority over deprecated parameter
+        if (checkerName != null) {
+            checkerProxy.setName(checkerName);
         }
         
         if (time != null) {


### PR DESCRIPTION
The name parameter is a reserved word, and so can't be used from the admin console or rest interface.