### PR TITLE
PAYARA-1437 removed defaults for healthcheck service commands

### DIFF
--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckConfigurer.java
@@ -88,10 +88,10 @@ public class HealthCheckConfigurer implements AdminCommand {
     @Param(name = "enabled", optional = false)
     private Boolean enabled;
 
-    @Param(name = "historicalTraceEnabled", optional = true, defaultValue = "false")
+    @Param(name = "historicalTraceEnabled", optional = true)
     private Boolean historicalTraceEnabled;
 
-    @Param(name = "historicalTraceStoreSize", optional = true, defaultValue = "20")
+    @Param(name = "historicalTraceStoreSize", optional = true)
     private Integer historicalTraceStoreSize;
 
     @Override

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceConfigureCheckerWithThresholdsCommand.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceConfigureCheckerWithThresholdsCommand.java
@@ -90,7 +90,7 @@ public class HealthCheckServiceConfigureCheckerWithThresholdsCommand implements 
     @Min(value = 1, message = "Time period must be 1 or more")
     private String time;
 
-    @Param(name = "unit", optional = true, defaultValue = "MINUTES", 
+    @Param(name = "unit", optional = true,
             acceptableValues = "DAYS,HOURS,MICROSECONDS,MILLISECONDS,MINUTES,NANOSECONDS,SECONDS")
     private String unit;
     

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceThresholdConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HealthCheckServiceThresholdConfigurer.java
@@ -84,13 +84,13 @@ public class HealthCheckServiceThresholdConfigurer implements AdminCommand {
     @Param(name = "serviceName", optional = false)
     private String serviceName;
 
-    @Param(name = "thresholdCritical", optional = true, defaultValue = HealthCheckConstants.THRESHOLD_DEFAULTVAL_CRITICAL)
+    @Param(name = "thresholdCritical", optional = true)
     private String thresholdCritical;
 
-    @Param(name = "thresholdWarning", optional = true, defaultValue = HealthCheckConstants.THRESHOLD_DEFAULTVAL_WARNING)
+    @Param(name = "thresholdWarning", optional = true)
     private String thresholdWarning;
 
-    @Param(name = "thresholdGood", optional = true, defaultValue = HealthCheckConstants.THRESHOLD_DEFAULTVAL_GOOD)
+    @Param(name = "thresholdGood", optional = true)
     private String thresholdGood;
 
     @Param(name = "dynamic", optional = true, defaultValue = "false")

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HoggingThreadsConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HoggingThreadsConfigurer.java
@@ -91,19 +91,19 @@ public class HoggingThreadsConfigurer implements AdminCommand {
     @Min(value = 1, message = "Time period must be 1 or more")
     private String time;
 
-    @Param(name = "unit", optional = true, defaultValue = "SECONDS", acceptableValues = "DAYS,HOURS,MICROSECONDS,MILLISECONDS,MINUTES,NANOSECONDS,SECONDS")
+    @Param(name = "unit", optional = true, acceptableValues = "DAYS,HOURS,MICROSECONDS,MILLISECONDS,MINUTES,NANOSECONDS,SECONDS")
     private String unit;
     
     @Param(name = "name", optional = true)
     private String name;
     
-    @Param(name = "threshold-percentage", defaultValue = "95")
+    @Param(name = "threshold-percentage")
     @Min(value = 0, message = "Threshold is a percentage so must be greater than zero")
     @Max(value = 100, message ="Threshold is a percentage so must be less than 100")
     private String threshold;
 
     @Min(value = 1, message = "Retry count must be 1 or more")
-    @Param(name = "retry-count", defaultValue = "3")
+    @Param(name = "retry-count")
     private String retryCount;
 
     @Param(name = "dynamic", optional = true, defaultValue = "false")


### PR DESCRIPTION
I believe null checks already exist for healthcheck-configure-service-thresholds, certainly if done dynamically.