### PR TITLE
Payara 1434 cdi bus outbount instance names as array

### DIFF
--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/Outbound.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/Outbound.java
@@ -74,12 +74,12 @@ public @interface Outbound {
     boolean loopBack() default false;
     
     /**
-     * Property to restrict the outbound event to specific named server or micro instances
-     * default is to fire on all server and micro instances.
-     * Set a comma separated list of instance names to restruct the event to firing only
+     * Property to restrict the outbound event to specific named server or micro instances.
+     * Default behavior is to fire on all server and micro instances.
+     * Set one or more instance names to restrict the event to firing only
      * on the specified instances.
      * @return 
      */
     @Nonbinding
-    String instanceName() default "";
+    String[] instanceName() default "";
 }

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/Outbound.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/Outbound.java
@@ -49,8 +49,7 @@ import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
 
 /**
- * Annotation to be applied to a Cache @Inject point to define the cache configuration
- * for the Producer to configure the cache
+ * Annotation to be applied to a CDI event @Inject point to send it remotely via CDI event bus. Such events can be observed using the {@link Inbound} qualifier.
  * @author steve
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Changed instanceName from type String to array.
A single instance name can still be defined in the same way (due to how arrays work in annotations):

```
@Inject
@Outbound(instanceName = "Instance-1")
Event<String> event;
```

However, instead of using comma to separate more instances, multiple instance names are specified as an array:

```
    @Inject
    @Outbound(instanceName = {"inst1", "inst2"})
    Event<String> event;
```

Internaly, three commas (instead of a single comma) are used as a separator in the flattened string value, so that it doesn't clash if comma is used also inside an instance name.