### PR TITLE
PAYARA-1284 JMX monitoring set-monitoring-configuration fix

### DIFF
--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
@@ -73,7 +73,7 @@ public class SetMonitoringConfiguration implements AdminCommand {
     @Inject
     MonitoringService monitoringService;
 
-    @Param(name = "enabled", optional = false)
+    @Param(name = "enabled", optional = true)
     private Boolean enabled;
 
     @Param(name = "amx", optional = true)


### PR DESCRIPTION
PAYARA-1284 JMX monitoring set-monitoring-configuration no longer requires --enabled to keep its current state