### PR TITLE
PAYARA-1486 Changed the roomName attribute to be roomID

### DIFF
--- a/appserver/admingui/xmpp-notifier-console-plugin/src/main/resources/fish/payara/admingui/notifier/xmpp/Strings.properties
+++ b/appserver/admingui/xmpp-notifier-console-plugin/src/main/resources/fish/payara/admingui/notifier/xmpp/Strings.properties
@@ -19,7 +19,7 @@
 notifier.xmpp.tabs.tabText=XMPP
 notifier.xmpp.tabs.tabToolTip=XMPP Notification Configuration
 notifier.xmpp.configuration.pageTitle=XMPP Notifier Configuration
-notifier.xmpp.configuration.pageHelpText=Enable and configure a XMPP notifier.
+notifier.xmpp.configuration.pageHelpText=Enable and configure an XMPP notifier.
 notifier.xmpp.configuration.enabledLabel=Enabled
 notifier.xmpp.configuration.enabledLabelHelpText=Enables/Disables the XMPP notifier.
 notifier.xmpp.configuration.hostNameLabel=Host
@@ -34,5 +34,5 @@ notifier.xmpp.configuration.passwordLabel=Password
 notifier.xmpp.configuration.passwordLabelHelpText=Password to use.
 notifier.xmpp.configuration.securityDisabledLabel=Security Disabled
 notifier.xmpp.configuration.securityDisabledLabelHelpText=Check if you wish to disable security.
-notifier.xmpp.configuration.roomNameLabel=Room Name
-notifier.xmpp.configuration.roomNameLabelHelpText=Name of the room to use.
+notifier.xmpp.configuration.roomIDLabel=Room ID
+notifier.xmpp.configuration.roomIDLabelHelpText=The ID of the room to send notifications to.

--- a/appserver/admingui/xmpp-notifier-console-plugin/src/main/resources/xmpp/xmppNotifierConfiguration.jsf
+++ b/appserver/admingui/xmpp-notifier-console-plugin/src/main/resources/xmpp/xmppNotifierConfiguration.jsf
@@ -121,11 +121,11 @@
                 <sun:checkbox id="securityDisabledBox" selected="#{pageSession.securityDisabledSelected}" 
                               selectedValue="true" />
             </sun:property>
-            <sun:property id="roomNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
-                          label="$resource{i18nxn.notifier.xmpp.configuration.roomNameLabel}"  
-                          helpText="$resource{i18nxn.notifier.xmpp.configuration.roomNameLabelHelpText}">
-                <sun:textField id="roomName" columns="$int{75}" maxLength="255" 
-                               text="#{pageSession.valueMap['roomName']}" styleClass="required"  
+            <sun:property id="roomIDProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                          label="$resource{i18nxn.notifier.xmpp.configuration.roomIDLabel}"  
+                          helpText="$resource{i18nxn.notifier.xmpp.configuration.roomIDLabelHelpText}">
+                <sun:textField id="roomID" columns="$int{75}" maxLength="255" 
+                               text="#{pageSession.valueMap['roomID']}" styleClass="required"  
                                required="#{true}"/>
             </sun:property>
         </sun:propertySheetSection>

--- a/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotificationConfigurer.java
@@ -84,7 +84,7 @@ public class XmppNotificationConfigurer extends BaseNotificationConfigurer<XmppN
     @Param(name = "securityDisabled", defaultValue = "false", optional = true)
     private Boolean securityDisabled;
 
-    @Param(name = "roomName")
+    @Param(name = "roomID")
     private String roomName;
 
     protected void applyValues(XmppNotifierConfiguration configuration) throws PropertyVetoException {


### PR DESCRIPTION
I changed the Admin Console label, asadmin command and the attribute that the admin console uses for the REST API.

I did a simple test to make sure it worked...
1. ran asadmin help notification-xmpp-configure
2. enabled asadmin command recorder

both times the roomID was correctly used.