### PR TITLE
Update grizzly to 2.3.29 and handle gzip/lzma content-encoding of requests PAYARA-1288 PAYARA-1441

### DIFF
--- a/appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/SpdyAddOnProvider.java
+++ b/appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/SpdyAddOnProvider.java
@@ -109,11 +109,11 @@ public class SpdyAddOnProvider implements AddOn, ConfigAwareElement<Spdy> {
             }
         }
 
-        if (spdyVersions == null || spdyVersions.length == 0) {
-            spdyVersions = GlassFishSpdyAddOn.getAllVersions();
+        if(spdyVersions != null && spdyVersions.length > 0) {
+            spdyAddOn = new GlassFishSpdyAddOn(spdyMode, spdyVersions);
+        } else {
+            spdyAddOn = new GlassFishSpdyAddOn(spdyMode);
         }
-        
-        spdyAddOn = new GlassFishSpdyAddOn(spdyMode, spdyVersions);
         
         spdyAddOn.setInitialWindowSize(Integer.getInteger(spdy.getInitialWindowSizeInBytes()));
         spdyAddOn.setMaxConcurrentStreams(Integer.getInteger(spdy.getMaxConcurrentStreams()));
@@ -130,6 +130,10 @@ public class SpdyAddOnProvider implements AddOn, ConfigAwareElement<Spdy> {
     private static class GlassFishSpdyAddOn extends SpdyAddOn {
         private FilterChainBuilder filterChainBuilder;
 
+        public GlassFishSpdyAddOn(final SpdyMode mode) {
+            super(mode);
+        }
+        
         public GlassFishSpdyAddOn(final SpdyMode mode,
                 final SpdyVersion... supportedSpdyVersions) {
             super(mode, supportedSpdyVersions);
@@ -149,9 +153,6 @@ public class SpdyAddOnProvider implements AddOn, ConfigAwareElement<Spdy> {
             return new SpdyNpnConfigProbe(filterChainBuilder);
         }
 
-        private static SpdyVersion[] getAllVersions() {
-            return ALL_SPDY_VERSIONS;
-        }
         // ---------------------------------------------------------- Nested Classes
 
         private final class SpdyNpnConfigProbe extends TransportProbe.Adapter {

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -689,6 +689,7 @@ public class GenericGrizzlyListener implements GrizzlyListener {
                getTimeoutSeconds(http), TimeUnit.SECONDS));
         final org.glassfish.grizzly.http.HttpServerFilter httpServerFilter =
             createHttpServerCodecFilter(http);
+        httpServerFilter.setRemoveHandledContentEncodingHeaders(true);
         final Set<ContentEncoding> contentEncodings =
             configureContentEncodings(http);
         for (ContentEncoding contentEncoding : contentEncodings) {
@@ -1102,11 +1103,15 @@ public class GenericGrizzlyListener implements GrizzlyListener {
             new CompressionEncodingFilter(compressionLevel, compressionMinSize,
                 compressableMimeTypes,
                 noCompressionUserAgents,
-                GZipContentEncoding.getGzipAliases()));
+                GZipContentEncoding.getGzipAliases(),
+                compressionLevel != CompressionLevel.OFF
+            ));
         final ContentEncoding lzmaEncoding = new LZMAContentEncoding(new CompressionEncodingFilter(compressionLevel, compressionMinSize,
                 compressableMimeTypes,
                 noCompressionUserAgents,
-                LZMAContentEncoding.getLzmaAliases()));
+                LZMAContentEncoding.getLzmaAliases(),
+                compressionLevel != CompressionLevel.OFF
+        ));
         final Set<ContentEncoding> set = new HashSet<ContentEncoding>(2);
         set.add(gzipContentEncoding);
         set.add(lzmaEncoding);

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -192,7 +192,7 @@
         <stax-api.version>1.0-2</stax-api.version>
         <management-api.version>1.1-rev-1</management-api.version>
         <servlet-api.version>3.1.0</servlet-api.version>
-        <grizzly.version>2.3.27</grizzly.version>
+        <grizzly.version>2.3.29</grizzly.version>
         <saaj-api.version>1.3.4</saaj-api.version>
         <hk2.version>2.4.0</hk2.version>
         <hk2.plugin.version>2.4.0</hk2.plugin.version>


### PR DESCRIPTION
This change updates the grizzly dependency to the 2.3.29. This enables
handling of content-encodings for incoming requests by the server.
The ability to compress responses has already been part of glassfish,
but response handling did not include the ability to handle gzip/lzma
compressed requests.

This was requested in #1038 [2] and also requested for glassfish [0].

Grizzly 2.3.28 gained decompression support[1], but introduced a
regression. In this version the incoming datastream was decompressed,
but the Content-Encoding header was left in place. This in turn lead
to servlet filters/applications to asume the stream was still
compressed and triggered a second decompression step [3].

With grizzly 2.3.29 defaults were changed to match 2.3.27 (making
request decompression opt-in) and add the ability to remove the
problematic header line (opt-in too).

The changes are:

- nucleus/pom.xml:
  - Update grizzly dependecy

- nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java:
  - Enable removal of content-encodings from the header field,
    that were handled by the decompression filters
  - Enable decompression of requests, if compression is enabled

- appserver/grizzly/glassfish-spdy/src/main/java/org/glassfish/grizzly/extras/spdy/SpdyAddOnProvider.java
  - ALL_SPDY_VERSIONS is not visible anymore and needs a work-around

This is a followup to the support request 229, CLA was send in parallel.

[0] https://java.net/jira/browse/GLASSFISH-5258
[1] https://java.net/jira/browse/GRIZZLY-1669
[2] https://github.com/payara/Payara/issues/1038
[3] https://github.com/payara/Payara/issues/1186
[4] https://java.net/jira/browse/GRIZZLY-1875?focusedCommentId=393843&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-393843