### PR TITLE
PAYARA-1402 OSGi classloading failure improvements

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.server;
 
@@ -246,7 +247,16 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
                         Module m = mr.getProvidingModule(name);
                         if (m != null) {
                             if(select(m)) {
-                                return m.getClassLoader().loadClass(name); // abort search if we fail to load.
+                                try {
+                                    return m.getClassLoader().loadClass(name); // abort search if we fail to load.
+                                }
+                                catch(ClassNotFoundException e) {
+                                    Throwable thr = e.getException();
+                                    if(thr != null) {
+                                        logger.log(Level.WARNING, "APIClassLoader.loadClass() caused exception", thr);
+                                    }
+                                    throw e;
+                                }
                             } else {
                                 logger.logp(Level.FINE, "APIClassLoaderServiceImpl$APIClassLoader", "loadClass",
                                         "Skipping loading {0} from module {1} as this module is not yet resolved.",


### PR DESCRIPTION
log a warning when OSGi exception results from an API load, instead of swallowing the error