### PR TITLE
Payara 1524 Payara Web throws JMS error

### DIFF
--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -1,45 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2013-2015 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2013-2015 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.main.admin</groupId>
+        <artifactId>admin</artifactId>
+        <version>4.1.1.172-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>appserver-domain-web</artifactId>
+    <name>Web Appserver template</name>
+    <description>Web Appserver template</description>
+	
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.admin</groupId>
+                                    <artifactId>nucleus-domain</artifactId>
+                                    <version>${project.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <excludes>config/domain.xml, template-info.xml, stringsubs.xml, META-INF/**</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>merge-copyright-headers</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/classes/config/logging.properties</outputFile>
+                            <inputFiles>
+                                <inputFile>${project.build.directory}/dependency/config/logging.properties</inputFile>
+                                <inputFile>../../logging/logging.properties</inputFile>
+                            </inputFiles>  
+                        </configuration>
+                    </execution>
+                </executions>						 
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <finalName>classes</finalName>
+                            <attach>false</attach>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <useProjectArtifact>false</useProjectArtifact>
+                        </configuration>                        
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/admin/gf_template_web/src/main/assembly/appserver-domain-web.xml
+++ b/appserver/admin/gf_template_web/src/main/assembly/appserver-domain-web.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="iso-8859-1"?>
 <!--
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 1997-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -41,29 +41,29 @@
 
 -->
 
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>template</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
-        <version>4.1.1.172-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-    <groupId>org.glassfish.main.admin</groupId>
-    <artifactId>admin</artifactId>
-    <packaging>pom</packaging>
-    <name>Admin Modules</name>
-    <modules>
-        <module>backup</module>
-        <module>cli</module>
-        <module>cli-optional</module>
-        <module>admin-core</module>
-        <module>backup-l10n</module>
-        <module>cli-optional-l10n</module>
-        <module>gf_template</module>
-        <module>gf_template_web</module>
-        <module>payara_template</module>
-    </modules>
-</project>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/config</directory>
+			 <excludes>
+			   <exclude>logging.properties</exclude>
+			 </excludes>
+			<outputDirectory>./config</outputDirectory>
+         </fileSet>
+		 <fileSet>
+            <directory>${project.build.directory}/dependency</directory>
+			 <excludes>
+			   <exclude>config/**</exclude>
+			 </excludes>
+            <outputDirectory>./</outputDirectory>
+         </fileSet>
+    </fileSets>
+</assembly>

--- a/appserver/admin/gf_template_web/src/main/assembly/appserver-domain-web.xml
+++ b/appserver/admin/gf_template_web/src/main/assembly/appserver-domain-web.xml
@@ -1,44 +1,42 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"

--- a/appserver/admin/gf_template_web/src/main/resources/config/default-web.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/default-web.xml
@@ -1,0 +1,1198 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2006-2013 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!-- Portions Copyright [2016] [Payara Foundation] -->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <!-- ======================== Introduction ============================== -->
+
+
+  <!-- The default deployment descriptor.                                   -->
+  <!--                                                                      -->
+  <!-- The default deployment descriptor specifies default deployment       -->
+  <!-- descriptor values inherited by any web applications deployed to      -->
+  <!-- the application server.                                              -->
+
+
+  <!-- ============ Built In Context Init Parameter Definitions =========== -->
+
+
+  <!-- Init parameter to force the XML validation of JSF configuration  --> 
+  <!-- ressources.                                                      -->
+
+  <context-param>
+      <param-name>com.sun.faces.validateXml</param-name>
+      <param-value>true</param-value>
+  </context-param>
+
+  <!-- Init parameter will cause the JSF implementation to bypass      -->
+  <!-- processing the web.xml to determine if we should continue       --> 
+  <!-- bootstrapping JSF for the web application.                      -->
+
+  <context-param>
+      <param-name>com.sun.faces.forceLoadConfiguration</param-name>
+      <param-value>true</param-value>
+  </context-param> 
+      
+
+  <!-- ================== Built In Servlet Definitions ==================== -->
+
+
+  <!-- The DefaultDervlet, which is responsible for serving static          -->
+  <!-- resources.                                                           -->
+  <!-- This servlet processes any requests that are not mapped to other     -->
+  <!-- servlets with servlet mappings (defined either here or in your own   -->
+  <!-- web.xml file.  This servlet supports the following initialization    -->
+  <!-- parameters (default values have been placed in square brackets):     -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   fileEncoding        Encoding to be used to read static resources   -->
+  <!--                       [platform default]                             -->
+  <!--                                                                      -->
+  <!--   input               Input buffer size (in bytes) when reading      -->
+  <!--                       resources to be served.  [2048]                -->
+  <!--                                                                      -->
+  <!--   listings            Should directory listings be produced if there -->
+  <!--                       is no welcome file in this directory?  [false] -->
+  <!--                       WARNING: Listings for directories with many    -->
+  <!--                       entries can be slow and may consume            -->
+  <!--                       significant proportions of server resources.   -->
+  <!--                                                                      -->
+  <!--   sortedBy            Specifies the criteria that will be used for   -->
+  <!--                       sorting directory entries. Legal values are    -->
+  <!--                       NAME, SIZE, and LAST_MODIFIED.  [NAME]         -->
+  <!--                                                                      -->
+  <!--   output              Output buffer size (in bytes) when writing     -->
+  <!--                       resources to be served.  [2048]                -->
+  <!--                                                                      -->
+  <!--   readonly            Is this context "read only", so HTTP           -->
+  <!--                       commands like PUT and DELETE are               -->
+  <!--                       rejected?  [true]                              -->
+  <!--                                                                      -->
+  <!--   readmeFile          File name to display with the directory        -->
+  <!--                       contents. [null]                               -->
+  <!--                                                                      -->
+  <!--   sendfileSize        If the connector used supports sendfile, this  -->
+  <!--                       represents the minimal file size in KB for     -->
+  <!--                       which sendfile will be used. Use a negative    -->
+  <!--                       value to always disable sendfile.  [48]        -->
+  <!--                                                                      -->
+  <!--   useAcceptRanges     Should the Accept-Ranges header be included    -->
+  <!--                       in responses where appropriate? [true]         -->
+  <!--                                                                      -->
+  <!--   maxHeaderRangeItems The max number of items in Range header.       -->
+  <!--                       -1 means unbounded.  [10]                      -->
+  <!--                                                                      -->
+  <!--  For directory listing customization. Checks localXsltFile, then     -->
+  <!--  globalXsltFile, then defaults to original behavior.                 -->
+  <!--                                                                      -->
+  <!--   localXsltFile       Make directory listings an XML doc and         -->
+  <!--                       pass the result to this style sheet residing   -->
+  <!--                       in that directory. This overrides              -->
+  <!--                        globalXsltFile[null]                          -->
+  <!--                                                                      -->
+  <!--   globalXsltFile      Site wide configuration version of             -->
+  <!--                       localXsltFile This argument is expected        -->
+  <!--                       to be a physical file. [null]                  -->
+
+  <servlet>
+    <servlet-name>default</servlet-name>
+    <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>listings</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+
+  <!-- The JSP page compiler and execution servlet, which is the mechanism  -->
+  <!-- used by the application server to support JSP pages.  Traditionally, -->
+  <!-- this servlet is mapped to the URL pattern "*.jsp".                   -->
+  <!-- This servlet supports the following initialization parameters        -->
+  <!-- (default values have been placed in square brackets):                -->
+  <!--                                                                      -->
+  <!--   checkInterval       If development is false and checkInterval is   -->
+  <!--                       greater than zero, background compilations are -->
+  <!--                       enabled. checkInterval is the time in seconds  -->
+  <!--                       between checks to see if a JSP page needs to   -->
+  <!--                       be recompiled. [0]                             -->
+  <!--                                                                      -->
+  <!--   modificationTestInterval                                           -->
+  <!--                       Causes a JSP (and its dependent files) to not  -->
+  <!--                       be checked for modification during the         -->
+  <!--                       specified time interval (in seconds) from the  -->
+  <!--                       last time the JSP was checked for              -->
+  <!--                       modification. A value of 0 will cause the JSP  -->
+  <!--                       to be checked on every access.                 -->
+  <!--                       Used in development mode only. [0]             -->
+  <!--                                                                      -->
+  <!--   compiler            Which compiler Ant should use to compile JSP   -->
+  <!--                       pages.  See the Ant documentation for more     -->
+  <!--                       information. [javac]                           -->
+  <!--                                                                      -->
+  <!--   classdebuginfo      Should the class file be compiled with         -->
+  <!--                       debugging information?  [true]                 -->
+  <!--                                                                      -->
+  <!--   classpath           What class path should I use while compiling   -->
+  <!--                       generated servlets?  [Created dynamically      -->
+  <!--                       based on the current web application]          -->
+  <!--                       [Ignored in Glassfish]                         -->
+  <!--                                                                      -->
+  <!--   development         Is Jasper used in development mode? If true,   -->
+  <!--                       the frequency at which JSPs are checked for    -->
+  <!--                       modification may be specified via the          -->
+  <!--                       modificationTestInterval parameter. [true]     -->
+  <!--                                                                      -->
+  <!--   enablePooling       Determines whether tag handler pooling is      -->
+  <!--                       enabled  [true]                                -->
+  <!--                                                                      -->
+  <!--   fork                Tell Ant to fork compiles of JSP pages so that -->
+  <!--                       JSP pages are compiled in their own JVM        -->
+  <!--                       (separate from the JVM that the application    -->
+  <!--                       server is running in). [true]                  -->
+  <!--                                                                      -->
+  <!--   ieClassId           The class-id value to be sent to Internet      -->
+  <!--                       Explorer when using <jsp:plugin> tags.         -->
+  <!--                       [clsid:8AD9C840-044E-11D1-B3E9-00805F499D93]   -->
+  <!--                                                                      -->
+  <!--   javaEncoding        Java file encoding to use for generating java  -->
+  <!--                       source files. [UTF8]                           -->
+  <!--                                                                      -->
+  <!--   keepgenerated       Should we keep the generated Java source code  -->
+  <!--                       for each page instead of deleting it?          -->
+  <!--                       [true with JDK 5 and before, or for jspc]      -->
+  <!--                       [false otherwise]                              -->
+  <!--                                                                      -->
+  <!--   saveBytecode        Should the generated byte code be saved to     -->
+  <!--                       .class files?  This option is meaningful only  -->
+  <!--                       when Java compiler API, JSR199 (available with -->
+  <!--                       JDK 6) is used for javac compilations.         -->
+  <!--                       [false] [true for jspc]                        -->
+  <!--                                                                      -->
+  <!--   mappedfile          Should we generate static content with one     -->
+  <!--                       print statement per input line, to ease        -->
+  <!--                       debugging?  [true]                             -->
+  <!--                                                                      -->
+  <!--   trimSpaces          Should white spaces in template text between   -->
+  <!--                       actions or directives be trimmed?  [false]     -->
+  <!--                                                                      -->
+  <!--   suppressSmap        Should the generation of SMAP info for JSR45   -->
+  <!--                       debugging be suppressed?  [false]              -->
+  <!--                                                                      -->
+  <!--   dumpSmap            Should the SMAP info for JSR45 debugging be    -->
+  <!--                       dumped to a file? [false]                      -->
+  <!--                       False if suppressSmap is true                  -->
+  <!--                                                                      -->
+  <!--   genStrAsCharArray   Should text strings be generated as char       -->
+  <!--                       arrays, to improve performance in some cases?  -->
+  <!--                       [false]                                        -->
+  <!--                                                                      -->
+  <!--   genStrAsByteArray   Should text strings be generated as bytes      -->
+  <!--                       (encoded with the page encoding), if the page  -->
+  <!--                       is not buffered?                               -->
+  <!--                       [true]                                         -->
+  <!--                                                                      -->
+  <!--   defaultBufferNone   Should the default for the buffer attribute of -->
+  <!--                       the page directive be "none"?  [false]         -->
+  <!--                                                                      -->
+  <!--   errorOnUseBeanInvalidClassAttribute                                -->
+  <!--                       Should Jasper issue an error when the value of -->
+  <!--                       the class attribute in an useBean action is    -->
+  <!--                       not a valid bean class?  [false]               -->
+  <!--                                                                      -->
+  <!--   scratchdir          What scratch directory should we use when      -->
+  <!--                       compiling JSP pages?  [default work directory  -->
+  <!--                       for the current web application]               -->
+  <!--                                                                      -->
+  <!--   xpoweredBy          Determines whether X-Powered-By response       -->
+  <!--                       header is added by generated servlet  [true]   -->
+  <!--                                                                      -->
+  <!--   usePrecompiled      If true, it is assumed that JSPs have been     -->
+  <!--                       precompiled, and their corresponding servlet   -->
+  <!--                       classes have been bundled in the web           -->
+  <!--                       application's WEB-INF/lib or WEB-INF/classes,  -->
+  <!--                       so that when a JSP is accessed, it is not      -->
+  <!--                       compiled, and instead, its precompiled servlet -->
+  <!--                       class is used. [false]                         -->
+  <!--                                                                      -->
+  <!--   use-precompiled     Same as usePrecompiled. If both are specified, -->
+  <!--                       usePrecompiled takes precedence                -->
+  <!--                                                                      -->
+  <!--   initialCapacity     Initial capacity of HashMap mapping JSPs to    -->
+  <!--                       their corresponding servlets [32]              -->
+  <!--                                                                      -->
+  <!--   initial-capacity    Same as initialCapacity. If both are specified,-->
+  <!--                       initialCapacity takes precedence               -->
+  <!--                                                                      -->
+  <!--   httpMethods         Comma separated list of HTTP methods supported -->
+  <!--                       by the JspServlet. Wildcard ("*") denotes      -->
+  <!--                       "ALL METHODS". [ALL METHODS]                   -->
+  <!--                                                                      -->
+  <!--   reload-interval     Specifies the frequency (in seconds) at which  -->
+  <!--                       JSP files are checked for modifications.       -->
+  <!--                       Setting this value to 0 checks JSPs for        -->
+  <!--                       modifications on every request. Setting this   -->
+  <!--                       value to -1 disables checks for JSP            -->
+  <!--                       modifications and JSP recompilation.           -->
+  <!--                                                                      -->
+  <!--   compilerSourceVM    Provides source compatibility with the         -->
+  <!--                       specified JDK release (same as -source         -->
+  <!--                       javac command-line switch)                     -->
+  <!--                                                                      -->
+  <!--   compilerTargetVM    Generates class files for specified VM version -->
+  <!--                       (same as -target javac command-line switch)    -->
+  <!--                                                                      -->
+  <!--   system-jar-includes Specify a list (of jars, or fragments of jar   -->
+  <!--                       paths) that is used to determine if a system   -->
+  <!--                       jar (obtained from the system classloader)     -->
+  <!--                       should be included in the javac classpath      -->
+  <!--                       [Include all system jars]                      -->
+  <!--                                                                      -->
+  <!-- If you wish to use Jikes to compile JSP pages:                       -->
+  <!-- * Set the "classpath" initialization parameter appropriately         -->
+  <!--   for this web application.                                          -->
+  <!-- * Set the "jspCompilerPlugin" initialization parameter to            -->
+  <!--   "org.apache.jasper.compiler.JikesJavaCompiler".                    -->
+
+  <servlet>
+    <servlet-name>jsp</servlet-name>
+    <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
+    <init-param>
+      <param-name>xpoweredBy</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <init-param>
+      <param-name>httpMethods</param-name>
+      <param-value>GET,POST,HEAD</param-value>
+    </init-param>
+    <init-param>
+      <param-name>system-jar-includes</param-name>
+      <param-value>
+        /lib/
+        \lib\
+        javax.el.jar
+        javax.servlet-api.jar
+        javax.servlet.jsp-api.jar
+        javax.servlet.jsp.jstl-api.jar
+        javax.servlet.jsp.jstl.jar
+        javax.jms-api.jar
+        javax.faces.jar
+        javax.servlet.jsp.jar
+        jspcaching-connector.jar
+        web-glue.jar
+        bean-validator.jar
+        javax.ejb.jar
+        javax.enterprise.deploy-api.jar
+        javax.jms-api.jar
+        javax.mail.jar
+        javax.management.j2ee-api.jar
+        javax.persistence.jar
+        javax.resource-api.jar
+        javax.security.auth.message.jar
+        javax.security.jacc.jar
+        javax.transaction-api.jar
+        javax.xml.rpc-api.jar
+        webservices-osgi.jar
+        weld-osgi-bundle-glassfish4.jar
+        jersey-mvc-jsp.jar
+      </param-value>
+    </init-param>
+    <load-on-startup>3</load-on-startup>
+  </servlet>
+  
+
+  <!-- NOTE: An SSI Filter is also available as an alternative SSI          -->
+  <!-- implementation. Use either the Servlet or the Filter but NOT both.   -->
+  <!--                                                                      -->
+  <!-- Server Side Includes processing servlet, which processes SSI         -->
+  <!-- directives in HTML pages consistent with similar support in web      -->
+  <!-- servers like Apache.  Traditionally, this servlet is mapped to the   -->
+  <!-- URL pattern "*.shtml".  This servlet supports the following          -->
+  <!-- initialization parameters (default values are in square brackets):   -->
+  <!--                                                                      -->
+  <!--   buffered            Should output from this servlet be buffered?   -->
+  <!--                       (0=false, 1=true)  [0]                         -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   expires             The number of seconds before a page with SSI   -->
+  <!--                       directives will expire.  [No default]          -->
+  <!--                                                                      -->
+  <!--   isVirtualWebappRelative                                            -->
+  <!--                       Should "virtual" paths be interpreted as       -->
+  <!--                       relative to the context root, instead of       -->
+  <!--                       the server root?  (0=false, 1=true) [0]        -->
+  <!--                                                                      -->
+  <!--   inputEncoding       The encoding to assume for SSI resources if    -->
+  <!--                       one is not available from the resource.        -->
+  <!--                       [Platform default]                             -->
+  <!--                                                                      -->
+  <!--   outputEncoding      The encoding to use for the page that results  -->
+  <!--                       from the SSI processing. [UTF-8]               -->
+
+<!--
+  <servlet>
+    <servlet-name>ssi</servlet-name>
+    <servlet-class>org.apache.catalina.ssi.SSIServlet</servlet-class>
+    <init-param>
+      <param-name>buffered</param-name>
+      <param-value>1</param-value>
+    </init-param>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>expires</param-name>
+      <param-value>666</param-value>
+    </init-param>
+    <init-param>
+      <param-name>isVirtualWebappRelative</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <load-on-startup>4</load-on-startup>
+  </servlet>
+-->
+
+
+  <!-- Common Gateway Includes (CGI) processing servlet, which supports     -->
+  <!-- execution of external applications that conform to the CGI spec      -->
+  <!-- requirements.  Typically, this servlet is mapped to the URL pattern  -->
+  <!-- "/cgi-bin/*", which means that any CGI applications that are         -->
+  <!-- executed must be present within the web application.  This servlet   -->
+  <!-- supports the following initialization parameters (default values     -->
+  <!-- are in square brackets):                                             -->
+  <!--                                                                      -->
+  <!--   cgiPathPrefix        The CGI search path will start at             -->
+  <!--                        webAppRootDir + File.separator + this prefix. -->
+  <!--                        [WEB-INF/cgi]                                 -->
+  <!--                                                                      -->
+  <!--   debug                Debugging detail level for messages logged    -->
+  <!--                        by this servlet.  [0]                         -->
+  <!--                                                                      -->
+  <!--   executable           Name of the executable used to run the        -->
+  <!--                        script. [perl]                                -->
+  <!--                                                                      -->
+  <!--   parameterEncoding    Name of parameter encoding to be used with    -->
+  <!--                        CGI servlet.                                  -->
+  <!--                        [System.getProperty("file.encoding","UTF-8")] -->
+  <!--                                                                      -->
+  <!--   passShellEnvironment Should the shell environment variables (if    -->
+  <!--                        any) be passed to the CGI script? [false]     -->
+  <!--                                                                      -->
+  <!--   stderrTimeout        The time (in milliseconds) to wait for the    -->
+  <!--                        reading of stderr to complete before          -->
+  <!--                        terminating the CGI process. [2000]           -->
+
+
+<!--
+  <servlet>
+    <servlet-name>cgi</servlet-name>
+    <servlet-class>org.apache.catalina.servlets.CGIServlet</servlet-class>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>cgiPathPrefix</param-name>
+      <param-value>WEB-INF/cgi</param-value>
+    </init-param>
+    <load-on-startup>5</load-on-startup>
+  </servlet>
+-->
+
+
+  <!-- ================ Built In Servlet Mappings ========================= -->
+
+  <!-- The mapping for the default servlet -->
+  <servlet-mapping>
+    <servlet-name>default</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <!-- The mapping for the JSP servlet -->
+  <servlet-mapping>
+    <servlet-name>jsp</servlet-name>
+    <url-pattern>*.jsp</url-pattern>
+    <url-pattern>*.jspx</url-pattern>
+  </servlet-mapping>
+
+  <!-- The mapping for the SSI servlet -->
+<!--
+  <servlet-mapping>
+    <servlet-name>ssi</servlet-name>
+    <url-pattern>*.shtml</url-pattern>
+  </servlet-mapping>
+-->
+
+  <!-- The mapping for the CGI Gateway servlet -->
+<!--
+  <servlet-mapping>
+    <servlet-name>cgi</servlet-name>
+    <url-pattern>/cgi-bin/*</url-pattern>
+  </servlet-mapping>
+-->
+
+
+  <!-- ================== Built In Filter Definitions ===================== -->
+
+  <!-- NOTE: An SSI Servlet is also available as an alternative SSI         -->
+  <!-- implementation. Use either the Servlet or the Filter but NOT both.   -->
+  <!--                                                                      -->
+  <!-- Server Side Includes processing filter, which processes SSI          -->
+  <!-- directives in HTML pages consistent with similar support in web      -->
+  <!-- servers like Apache.  Traditionally, this filter is mapped to the    -->
+  <!-- URL pattern "*.shtml", though it can be mapped to "*" as it will     -->
+  <!-- selectively enable/disable SSI processing based on mime types. For   -->
+  <!-- this to work you will need to uncomment the .shtml mime type         -->
+  <!-- definition towards the bottom of this file.                          -->
+  <!-- The contentType init param allows you to apply SSI processing to JSP -->
+  <!-- pages, javascript, or any other content you wish.  This filter       -->
+  <!-- supports the following initialization parameters (default values are -->
+  <!-- in square brackets):                                                 -->
+  <!--                                                                      -->
+  <!--   contentType         A regex pattern that must be matched before    -->
+  <!--                       SSI processing is applied.                     -->
+  <!--                       [text/x-server-parsed-html(;.*)?]              -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   expires             The number of seconds before a page with SSI   -->
+  <!--                       directives will expire.  [No default]          -->
+  <!--                                                                      -->
+  <!--   isVirtualWebappRelative                                            -->
+  <!--                       Should "virtual" paths be interpreted as       -->
+  <!--                       relative to the context root, instead of       -->
+  <!--                       the server root?  (0=false, 1=true) [0]        -->
+
+<!--
+  <filter>
+    <filter-name>ssi</filter-name>
+    <filter-class>
+      org.apache.catalina.ssi.SSIFilter
+    </filter-class>
+    <init-param>
+      <param-name>contentType</param-name>
+      <param-value>text/x-server-parsed-html(;.*)?</param-value>
+    </init-param>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>expires</param-name>
+      <param-value>666</param-value>
+    </init-param>
+    <init-param>
+      <param-name>isVirtualWebappRelative</param-name>
+      <param-value>0</param-value>
+    </init-param>
+  </filter>
+-->
+
+
+  <!-- ==================== Built In Filter Mappings ====================== -->
+
+  <!-- The mapping for the SSI Filter -->
+<!--
+  <filter-mapping>
+    <filter-name>ssi</filter-name>
+    <url-pattern>*.shtml</url-pattern>
+  </filter-mapping>
+-->
+
+
+  <!-- ==================== Default Session Configuration ================= -->
+
+  <!-- You can set the default session timeout (in minutes) for all newly   -->
+  <!-- created sessions by modifying the value below.                       -->
+
+  <session-config>
+    <session-timeout>30</session-timeout>
+  </session-config>
+
+
+  <!-- ===================== Default MIME Type Mappings =================== -->
+
+  <!-- When serving static resources, the application server will           -->
+  <!-- automatically generate a "Content-Type" response header from the     -->
+  <!-- filename extension of the resource, based on these mappings.         -->
+  <!-- Additional mappings may be specified here (to be shared by all       -->
+  <!-- web applications) or in a web application's web.xml deployment       -->
+  <!-- descriptor (for that web application's individual use).              -->
+
+  <mime-mapping>
+    <extension>abs</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ai</extension>
+    <mime-type>application/postscript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aif</extension>
+    <mime-type>audio/x-aiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aifc</extension>
+    <mime-type>audio/x-aiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aiff</extension>
+    <mime-type>audio/x-aiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aim</extension>
+    <mime-type>application/x-aim</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>art</extension>
+    <mime-type>image/x-jg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>asf</extension>
+    <mime-type>video/x-ms-asf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>asx</extension>
+    <mime-type>video/x-ms-asf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>au</extension>
+    <mime-type>audio/basic</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>avi</extension>
+    <mime-type>video/x-msvideo</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>avx</extension>
+    <mime-type>video/x-rad-screenplay</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>bcpio</extension>
+    <mime-type>application/x-bcpio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>bin</extension>
+    <mime-type>application/octet-stream</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>bmp</extension>
+    <mime-type>image/bmp</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>body</extension>
+    <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>cdf</extension>
+    <mime-type>application/x-cdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>cer</extension>
+    <mime-type>application/x-x509-ca-cert</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>class</extension>
+    <mime-type>application/java</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>cpio</extension>
+    <mime-type>application/x-cpio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>csh</extension>
+    <mime-type>application/x-csh</mime-type>
+  </mime-mapping>
+   <mime-mapping>
+    <extension>css</extension>
+    <mime-type>text/css</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dib</extension>
+    <mime-type>image/bmp</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>doc</extension>
+    <mime-type>application/msword</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dtd</extension>
+    <mime-type>application/xml-dtd</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dv</extension>
+    <mime-type>video/x-dv</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dvi</extension>
+    <mime-type>application/x-dvi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>eps</extension>
+    <mime-type>application/postscript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>etx</extension>
+    <mime-type>text/x-setext</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>exe</extension>
+    <mime-type>application/octet-stream</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gif</extension>
+    <mime-type>image/gif</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gk</extension>
+    <mime-type>application/octet-stream</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gtar</extension>
+    <mime-type>application/x-gtar</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gz</extension>
+    <mime-type>application/x-gzip</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>hdf</extension>
+    <mime-type>application/x-hdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>hqx</extension>
+    <mime-type>application/mac-binhex40</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>htc</extension>
+    <mime-type>text/x-component</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>htm</extension>
+    <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>html</extension>
+    <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>hqx</extension>
+    <mime-type>application/mac-binhex40</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ico</extension>
+    <mime-type>image/x-icon</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ief</extension>
+    <mime-type>image/ief</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jad</extension>
+    <mime-type>text/vnd.sun.j2me.app-descriptor</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jar</extension>
+    <mime-type>application/java-archive</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>java</extension>
+    <mime-type>text/plain</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jnlp</extension>
+    <mime-type>application/x-java-jnlp-file</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jpe</extension>
+    <mime-type>image/jpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jpeg</extension>
+    <mime-type>image/jpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jpg</extension>
+    <mime-type>image/jpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>js</extension>
+    <mime-type>text/javascript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>kar</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>latex</extension>
+    <mime-type>application/x-latex</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>m3u</extension>
+    <mime-type>audio/x-mpegurl</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mac</extension>
+    <mime-type>image/x-macpaint</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>man</extension>
+    <mime-type>application/x-troff-man</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mathml</extension>
+    <mime-type>application/mathml+xml</mime-type> 
+  </mime-mapping>
+  <mime-mapping>
+    <extension>me</extension>
+    <mime-type>application/x-troff-me</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mid</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>midi</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mif</extension>
+    <mime-type>application/x-mif</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mov</extension>
+    <mime-type>video/quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>movie</extension>
+    <mime-type>video/x-sgi-movie</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mp1</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mp2</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mp3</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpa</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpe</extension>
+    <mime-type>video/mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpeg</extension>
+    <mime-type>video/mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpega</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpg</extension>
+    <mime-type>video/mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpv2</extension>
+    <mime-type>video/mpeg2</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ms</extension>
+    <mime-type>application/x-wais-source</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>nc</extension>
+    <mime-type>application/x-netcdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>oda</extension>
+    <mime-type>application/oda</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>odg</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.graphics</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>odp</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.presentation</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ods</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.spreadsheet</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>odt</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.text</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ogg</extension>
+    <mime-type>application/ogg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pbm</extension>
+    <mime-type>image/x-portable-bitmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pct</extension>
+    <mime-type>image/pict</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pdf</extension>
+    <mime-type>application/pdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pgm</extension>
+    <mime-type>image/x-portable-graymap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pic</extension>
+    <mime-type>image/pict</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pict</extension>
+    <mime-type>image/pict</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pls</extension>
+    <mime-type>audio/x-scpls</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>png</extension>
+    <mime-type>image/png</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pnm</extension>
+    <mime-type>image/x-portable-anymap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pnt</extension>
+    <mime-type>image/x-macpaint</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ppm</extension>
+    <mime-type>image/x-portable-pixmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ppt</extension>
+    <mime-type>application/powerpoint</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ps</extension>
+    <mime-type>application/postscript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>psd</extension>
+    <mime-type>image/x-photoshop</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>qt</extension>
+    <mime-type>video/quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>qti</extension>
+    <mime-type>image/x-quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>qtif</extension>
+    <mime-type>image/x-quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ras</extension>
+    <mime-type>image/x-cmu-raster</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rdf</extension>
+    <mime-type>application/rdf+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rgb</extension>
+    <mime-type>image/x-rgb</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rm</extension>
+    <mime-type>application/vnd.rn-realmedia</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>roff</extension>
+    <mime-type>application/x-troff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rtf</extension>
+    <mime-type>application/rtf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rtx</extension>
+    <mime-type>text/richtext</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>sh</extension>
+    <mime-type>application/x-sh</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>shar</extension>
+    <mime-type>application/x-shar</mime-type>
+  </mime-mapping>
+<!--
+  <mime-mapping>
+    <extension>shtml</extension>
+    <mime-type>text/x-server-parsed-html</mime-type>
+  </mime-mapping>
+-->
+  <mime-mapping>
+    <extension>sit</extension>
+    <mime-type>application/x-stuffit</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>smf</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>snd</extension>
+    <mime-type>audio/basic</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>src</extension>
+    <mime-type>application/x-wais-source</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>sv4cpio</extension>
+    <mime-type>application/x-sv4cpio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>sv4crc</extension>
+    <mime-type>application/x-sv4crc</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>svg</extension>
+    <mime-type>image/svg+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>svgz</extension>
+    <mime-type>image/svg+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>swf</extension>
+    <mime-type>application/x-shockwave-flash</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>t</extension>
+    <mime-type>application/x-troff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tar</extension>
+    <mime-type>application/x-tar</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tcl</extension>
+    <mime-type>application/x-tcl</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tex</extension>
+    <mime-type>application/x-tex</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>texi</extension>
+    <mime-type>application/x-texinfo</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>texinfo</extension>
+    <mime-type>application/x-texinfo</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tif</extension>
+    <mime-type>image/tiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tiff</extension>
+    <mime-type>image/tiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tr</extension>
+    <mime-type>application/x-troff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tsv</extension>
+    <mime-type>text/tab-separated-values</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>txt</extension>
+    <mime-type>text/plain</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ulw</extension>
+    <mime-type>audio/basic</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ustar</extension>
+    <mime-type>application/x-ustar</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xbm</extension>
+    <mime-type>image/x-xbitmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xml</extension>
+    <mime-type>application/xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xpm</extension>
+    <mime-type>image/x-xpixmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xsl</extension>
+    <mime-type>application/xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xslt</extension>
+    <mime-type>application/xslt+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xwd</extension>
+    <mime-type>image/x-xwindowdump</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>vsd</extension>
+    <mime-type>application/x-visio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>vxml</extension>
+    <mime-type>application/voicexml+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>wav</extension>
+    <mime-type>audio/x-wav</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- Wireless Bitmap -->
+    <extension>wbmp</extension>
+    <mime-type>image/vnd.wap.wbmp</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- WML Source -->
+    <extension>wml</extension>
+    <mime-type>text/vnd.wap.wml</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- Compiled WML -->
+    <extension>wmlc</extension>
+    <mime-type>application/vnd.wap.wmlc</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- WML Script Source -->
+    <extension>wmls</extension>
+    <mime-type>text/vnd.wap.wmls</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- Compiled WML Script -->
+    <extension>wmlscriptc</extension>
+    <mime-type>application/vnd.wap.wmlscriptc</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>wrl</extension>
+    <mime-type>x-world/x-vrml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xht</extension>
+    <mime-type>application/xhtml+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xhtml</extension>
+    <mime-type>application/xhtml+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xls</extension>
+    <mime-type>application/vnd.ms-excel</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xul</extension>
+    <mime-type>application/vnd.mozilla.xul+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>z</extension>
+    <mime-type>application/x-compress</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>zip</extension>
+    <mime-type>application/zip</mime-type>
+  </mime-mapping>
+
+
+  <!-- ==================== Default Welcome File List ===================== -->
+
+  <!-- When a request URI refers to a directory, the default servlet looks  -->
+  <!-- for a "welcome file" within that directory and, if present,          -->
+  <!-- to the corresponding resource URI for display.  If no welcome file   -->
+  <!-- is present, the default servlet either serves a directory listing,   -->
+  <!-- or returns a 404 status, depending on how it is configured.          -->
+  <!--                                                                      -->
+  <!-- If you define welcome files in your own application's web.xml        -->
+  <!-- deployment descriptor, that list *replaces* the list configured      -->
+  <!-- here, so be sure that you include any of the default values that     -->
+  <!-- you wish to include.                                                 -->
+
+
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+    <welcome-file>index.htm</welcome-file>
+    <welcome-file>index.jsp</welcome-file>
+  </welcome-file-list>
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+  </login-config>
+
+</web-app>
+

--- a/appserver/admin/gf_template_web/src/main/resources/config/default-web.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/default-web.xml
@@ -1,46 +1,43 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2006-2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
 
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -1,0 +1,512 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<!-- Portions Copyright [2017] [Payara Foundation and/or its affiliates] -->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+<security-configurations>
+    <authentication-service default="true" name="adminAuth" use-password-credential="true">
+      <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+        <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+      <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+        <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+    </authentication-service>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.ClientDataSource" res-type="javax.sql.DataSource">
+      <property value="1527" name="PortNumber" />
+      <property value="APP" name="Password" />
+      <property value="APP" name="User" />
+      <property value="localhost" name="serverName" />
+      <property value="sun-appserv-samples" name="DatabaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+    </server>
+  </servers>
+  <nodes>
+    <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
+  </nodes>
+ <configs>
+   <config name="%%%CONFIG_MODEL_NAME%%%">
+      <!--%%%TOKENS_HERE%%%-->
+      <!--%%%PORT_BASE%%%-->
+      <http-service>
+        <access-log/>
+        <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
+        <virtual-server id="__asadmin" network-listeners="admin-listener"/>
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
+	  <ssl ssl3-enabled="false" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" />
+       <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
+       <asadmin-recorder-configuration></asadmin-recorder-configuration>
+       <request-tracing-service-configuration>
+         <log-notifier></log-notifier>
+       </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
+       <diagnostic-service />
+      <security-service>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <message-security-config auth-layer="HttpServlet">
+            <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                <request-policy auth-source="sender"></request-policy>
+                <response-policy></response-policy>
+                <property name="loginPage" value="/login.jsf"></property>
+                <property name="loginErrorPage" value="/loginError.jsf"></property>
+            </provider-config>
+        </message-security-config>
+	<property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+        <jvm-options>-XX:MaxPermSize=192m</jvm-options>
+        <jvm-options>-client</jvm-options>
+        <jvm-options>-Djava.awt.headless=true</jvm-options>
+        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+        <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+        <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+        <jvm-options>-Xmx512m</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+		<jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
+        <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.shell.remote,org.apache.felix.fileinstall</jvm-options>
+        <!-- Configuration of various third-party OSGi bundles like
+             Felix Remote Shell, FileInstall, etc. -->
+        <!-- Port on which remote shell listens for connections.-->
+        <jvm-options>-Dosgi.shell.telnet.port=%%%OSGI_SHELL_TELNET_PORT%%%</jvm-options>
+        <!-- How many concurrent users can connect to this remote shell -->
+        <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+        <!-- From which hosts users can connect -->
+        <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+        <!-- Gogo shell configuration -->
+        <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+        <!-- Directory being watched by fileinstall. -->
+        <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+        <!-- Time period fileinstaller thread in ms. -->
+        <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+        <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+        <jvm-options>-Dfelix.fileinstall.log.level=2</jvm-options>
+        <!-- should new bundles be started or installed only? 
+             true => start, false => only install 
+        -->
+        <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+        <!-- should watched bundles be started transiently or persistently -->
+        <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+        <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+             If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+        -->
+        <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+        <!-- End of OSGi bundle configurations -->
+        <jvm-options>-XX:NewRatio=2</jvm-options>
+        <!-- Woodstox property needed to pass StAX TCK -->
+        <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
+        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+      </java-config>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener-1">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+	    <ssl ssl3-enabled="false" />
+          </protocol>
+          <protocol security-enabled="true" name="http-listener-2">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+          <protocol name="admin-listener">
+            <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+          <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+      </thread-pools>
+    </config>
+     <config name="default-config" dynamic-reconfiguration-enabled="true" >
+         <http-service>
+             <access-log/>
+             <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
+                 <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
+             </virtual-server>
+             <virtual-server id="__asadmin" network-listeners="admin-listener" />
+         </http-service>
+         <iiop-service>
+             <orb use-thread-pool-ids="thread-pool-1" />
+             <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
+	         <ssl ssl3-enabled="false" />
+             <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+             </iiop-listener>
+             <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+             </iiop-listener>
+         </iiop-service>
+         <admin-service system-jmx-connector-name="system" type="server">
+             <!-- JSR 160  "system-jmx-connector" -->
+             <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
+             <!-- JSR 160  "system-jmx-connector" -->
+             <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+         </admin-service>
+         <web-container>
+             <session-config>
+                 <session-manager>
+                     <manager-properties/>
+                     <store-properties />
+                 </session-manager>
+                 <session-properties />
+             </session-config>
+         </web-container>
+         <ejb-container session-store="${com.sun.aas.instanceRoot}/session-store">
+             <ejb-timer-service />
+         </ejb-container>
+         <mdb-container />
+         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+             <module-log-levels />
+         </log-service>
+         <security-service>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+             <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
+                 <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
+             </jacc-provider>
+             <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
+             <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                 <property value="false" name="auditOn" />
+             </audit-module>
+             <message-security-config auth-layer="SOAP">
+                 <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+             </message-security-config>
+         </security-service>
+         <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
+         <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
+         <request-tracing-service-configuration>
+             <log-notifier></log-notifier>
+         </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
+         <diagnostic-service />
+         <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+             <jvm-options>-XX:MaxPermSize=192m</jvm-options>
+             <jvm-options>-server</jvm-options>
+             <jvm-options>-Djava.awt.headless=true</jvm-options>
+             <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+             <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+             <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+             <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+             <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+             <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+             <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+             <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+             <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+             <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+             <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+             <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+             <jvm-options>-XX:NewRatio=2</jvm-options>
+             <jvm-options>-Xmx512m</jvm-options>
+             <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names.
+                  The remote shell bundle has been disabled for cluster and remote instances. -->
+             <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.fileinstall</jvm-options>
+             <!-- Port on which remote shell listens for connections.-->
+             <jvm-options>-Dosgi.shell.telnet.port=${OSGI_SHELL_TELNET_PORT}</jvm-options>
+             <!-- How many concurrent users can connect to this remote shell -->
+             <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+             <!-- From which hosts users can connect -->
+             <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+             <!-- Gogo shell configuration -->
+             <!--PAYARA-495-->
+             <!--<jvm-options>-Dgosh.args=nointeractive</jvm-options>-->
+             <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+             <!-- Directory being watched by fileinstall. -->
+             <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+             <!-- Time period fileinstaller thread in ms. -->
+             <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+             <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+             <jvm-options>-Dfelix.fileinstall.log.level=3</jvm-options>
+             <!-- should new bundles be started or installed only?
+                 true => start, false => only install
+             -->
+             <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+             <!-- should watched bundles be started transiently or persistently -->
+             <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+             <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+                  If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+             -->
+             <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+             <!-- End of OSGi bundle configurations -->
+             <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+             <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+             <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
+             <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+             
+        </java-config>
+         <availability-service>
+             <web-container-availability/>
+             <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+         </availability-service>
+         <network-config>
+             <protocols>
+                 <protocol name="http-listener-1">
+                     <http default-virtual-server="server">
+                         <file-cache />
+                     </http>
+		     <ssl ssl3-enabled="false" />
+                 </protocol>
+                 <protocol security-enabled="true" name="http-listener-2">
+                     <http default-virtual-server="server">
+                         <file-cache />
+                     </http>
+                     <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
+                 </protocol>
+                 <protocol name="admin-listener">
+                     <http default-virtual-server="__asadmin" max-connections="250">
+                         <file-cache enabled="false" />
+                     </http>
+                 </protocol>
+                 <protocol security-enabled="true" name="sec-admin-listener">
+                   <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                     <file-cache></file-cache>
+                   </http>
+                   <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                 </protocol>
+                 <protocol name="admin-http-redirect">
+                   <http-redirect secure="true"></http-redirect>
+                 </protocol>
+                 <protocol name="pu-protocol">
+                   <port-unification>
+                     <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                     <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                   </port-unification>
+                 </protocol>
+
+             </protocols>
+             <network-listeners>
+                 <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                 <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                 <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+             </network-listeners>
+             <transports>
+                 <transport name="tcp" />
+             </transports>
+         </network-config>
+         <thread-pools>
+             <thread-pool name="http-thread-pool" />
+             <thread-pool min-thread-pool-size="2" max-thread-pool-size="200" idle-thread-timeout-in-seconds="120" name="thread-pool-1" />
+	     <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+         </thread-pools>
+         <group-management-service/>
+         <!--%%%DEFAULT_TOKENS_HERE%%%-->
+         <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
+         <system-property name="HTTP_LISTENER_PORT" value="28080"/>
+         <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
+         <system-property name="IIOP_LISTENER_PORT" value="23700"/>
+         <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
+         <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
+         <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
+         <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
+         <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
+     </config>
+  </configs>
+  <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
+  <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
+      <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
+      <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
+  </secure-admin>
+</domain>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -1,46 +1,42 @@
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
-
-<!-- Portions Copyright [2017] [Payara Foundation and/or its affiliates] -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
 <security-configurations>

--- a/appserver/admin/gf_template_web/src/main/resources/config/glassfish-acc.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/glassfish-acc.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 1997-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -41,29 +41,36 @@
 
 -->
 
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!--
+   Please remember to customize this file for your environment. The defaults for 
+   following fields may not be appropriate.  
+   - target-server name, address and port
+   - Property security.config in message-security-config
+-->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
-        <version>4.1.1.172-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-    <groupId>org.glassfish.main.admin</groupId>
-    <artifactId>admin</artifactId>
-    <packaging>pom</packaging>
-    <name>Admin Modules</name>
-    <modules>
-        <module>backup</module>
-        <module>cli</module>
-        <module>cli-optional</module>
-        <module>admin-core</module>
-        <module>backup-l10n</module>
-        <module>cli-optional-l10n</module>
-        <module>gf_template</module>
-        <module>gf_template_web</module>
-        <module>payara_template</module>
-    </modules>
-</project>
+<!DOCTYPE client-container PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Application Client Container//EN" "http://glassfish.org/dtds/glassfish-application-client-container_1_3.dtd">
+
+<client-container>
+  <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>
+  <log-service file="" level="WARNING"/>
+  <message-security-config auth-layer="SOAP">
+    <!-- turned off by default -->
+    <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-id="XWS_ClientProvider" provider-type="client"> 
+      <request-policy auth-source="content"/>
+      <response-policy auth-source="content"/>
+      <property name="encryption.key.alias" value="s1as"/>
+      <property name="signature.key.alias" value="s1as"/>
+      <property name="dynamic.username.password" value="false"/>
+      <property name="debug" value="false"/>
+    </provider-config>
+    <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-id="ClientProvider" provider-type="client"> 
+      <request-policy auth-source="content"/>
+      <response-policy auth-source="content"/>
+      <property name="encryption.key.alias" value="s1as"/>
+      <property name="signature.key.alias" value="s1as"/>
+      <property name="dynamic.username.password" value="false"/>
+      <property name="debug" value="false"/>
+      <property name="security.config" value="${com.sun.aas.installRoot}/lib/appclient/wss-client-config-1.0.xml"/>
+    </provider-config>
+  </message-security-config>
+</client-container>

--- a/appserver/admin/gf_template_web/src/main/resources/config/glassfish-acc.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/glassfish-acc.xml
@@ -1,44 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 
 <!--

--- a/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-1.0.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-1.0.xml
@@ -1,0 +1,124 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<!--
+ This server side config file pairs with wss-client-config-1.0.xml on the client
+ and supports the following UseCases:
+ Usecase 1: Authentication using Protected UsernameToken
+ Usecase 3: Encrypted UsernameToken and MessageBody
+ Usecase 4: Response Encryption Key Learnt from Incoming Message
+
+ Certificate Alias Information :
+ 1. A certificateAlias under the <xwss:Encrypt> element signifies the certificate
+    of the recipient of the message.
+ 2. A certificateAlias under the <xwss:Sign> element signifies the certificate of the
+    sender.
+                                                                                                                                               
+ NOTE:
+                                                                                                                                               
+   1. the certificateAlias has the above meaning for all the Sign and Encrypt elements below
+   2. there are several Sign and Encrypt elements below and similarly several RequireSignature and
+      RequireEncryption elements. Which of them would be actually used at runtime will depend on
+      the AuthPolicy passed to the module.
+                                                                                                                                               
+      For Example : if Auth-Source=Sender then only the <xwss:UsernameToken> elements will be used
+      and none of the <xwss:Sign> elements will be used.
+      If Auth-Source=Content then the <xwss:Sign> element will be used
+                                                                                                                                               
+   3.  The different variations of <xwss:Encrypt> elements in this configuration file are to accomodate
+       default encryption of the UsernameToken.
+                                                                                                                                               
+   4.  The actual certificate alias to be used for any Signature operation can be modified during AuthModule
+       initialization by setting the alias as the value of "signature.key.alias" property in the Module Options Map.
+   5.  The actual certificate alias to be used for any Encrypt operation can be modified during AuthModule
+       initialization by setting the alias as the value of "encryption.key.alias" property in the Module Options Map.
+                                                                                                                                               
+   6. Debug Dumping of Messages can be enabled by setting the "debug" property in the Module Options Map to "true" during
+      AuthModule initialization.
+   7. The Actual configuration file to be used by an Authmodule can be changed by setting the property "security.config" in
+      the Module Options Map to point to the configuration file location.
+   8. When the "security.config" property is not set during module initialization then a client auth module will use wss-client-config-2.0.xml
+      by default.
+   9. When the "security.config" property is not set during module initialization then a server auth module will use wss-server-config-2.0.xml
+      by default.
+
+-->
+
+<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config" 
+                            dumpMessages="false">
+    <xwss:Timestamp/>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireSignature>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireSignature>     
+    <xwss:RequireUsernameToken nonceRequired="false" passwordDigestRequired="false"/>      
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+    </xwss:Encrypt>    
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Sign>
+        <xwss:X509Token certificateAlias="s1as"/>
+    </xwss:Sign>
+    <xwss:UsernameToken digestPassword="false" useNonce="false"/>
+</xwss:SecurityConfiguration>

--- a/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-1.0.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-1.0.xml
@@ -1,43 +1,41 @@
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 
 <!--

--- a/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-2.0.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-2.0.xml
@@ -1,0 +1,132 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<!--
+ This server side config file pairs with wss-client-config-2.0.xml on the client 
+ and supports the following UseCases:
+ Usecase 2: Encrypted UsernameToken
+ Usecase 3: Encrypted UsernameToken and MessageBody 
+ Usecase 4: Response Encryption Key Learnt from Incoming Message
+
+ Certificate Alias Information :
+ 1. A certificateAlias under the <xwss:Encrypt> element signifies the certificate
+    of the recipient of the message.
+ 2. A certificateAlias under the <xwss:Sign> element signifies the certificate of the
+    sender.
+                                                                                                                                               
+ NOTE:
+                                                                                                                                               
+   1. the certificateAlias has the above meaning for all the Sign and Encrypt elements below
+   2. there are several Sign and Encrypt elements below and similarly several RequireSignature and
+      RequireEncryption elements. Which of them would be actually used at runtime will depend on
+      the AuthPolicy passed to the module.
+                                                                                                                                               
+      For Example : if Auth-Source=Sender then only the <xwss:UsernameToken> elements will be used
+      and none of the <xwss:Sign> elements will be used.
+      If Auth-Source=Content then the <xwss:Sign> element will be used
+                                                                                                                                               
+   3.  The different variations of <xwss:Encrypt> elements in this configuration file are to accomodate
+       default encryption of the UsernameToken.
+                                                                                                                                               
+   4.  The actual certificate alias to be used for any Signature operation can be modified during AuthModule
+       initialization by setting the alias as the value of "signature.key.alias" property in the Module Options Map.
+   5.  The actual certificate alias to be used for any Encrypt operation can be modified during AuthModule
+       initialization by setting the alias as the value of "encryption.key.alias" property in the Module Options Map.
+                                                                                                                                               
+   6. Debug Dumping of Messages can be enabled by setting the "debug" property in the Module Options Map to "true" during
+      AuthModule initialization.
+   7. The Actual configuration file to be used by an Authmodule can be changed by setting the property "security.config" in
+      the Module Options Map to point to the configuration file location.
+   8. When the "security.config" property is not set during module initialization then a client auth module will use wss-client-config-2.0.xml
+      by default.
+   9. When the "security.config" property is not set during module initialization then a server auth module will use wss-server-config-2.0.xml
+      by default.
+
+-->
+<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config" 
+                            dumpMessages="false">
+    <xwss:Timestamp/>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+    </xwss:Encrypt>    
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Sign>
+        <xwss:X509Token certificateAlias="s1as"/>
+    </xwss:Sign>
+    <xwss:UsernameToken digestPassword="false" useNonce="true"/>
+
+    <xwss:RequireUsernameToken nonceRequired="true" passwordDigestRequired="false"/>      
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireSignature>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireSignature>     
+</xwss:SecurityConfiguration>

--- a/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-2.0.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/wss-server-config-2.0.xml
@@ -1,43 +1,41 @@
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 
 <!--

--- a/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
+    <component id="GlassFish Core">
+        <group-ref name="glassfish-core-sub"/>
+    </component>
+    <group id="glassfish-core-sub" mode="forward">
+    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+        <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
+        <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
+        <change-pair-ref name="VERSION"/>
+        <change-pair-ref name="INSTALL_ROOT"/>
+        <change-pair-ref name="SERVER_ID"/>
+        <change-pair-ref name="SERVER_ROOT"/>
+        <change-pair-ref name="SERVER_NAME"/>
+        <change-pair-ref name="ORB_LISTENER1_PORT"/>
+        <change-pair-ref name="CONFIG_MODEL_NAME"/>
+        <change-pair-ref name="DOMAIN_NAME"/>
+        <change-pair-ref name="JMS_PROVIDER_PORT"/>
+        <change-pair-ref name="ORB_LISTENER_PORT"/>
+        <change-pair-ref name="ORB_SSL_PORT"/>
+        <change-pair-ref name="ORB_MUTUALAUTH_PORT"/>
+        <change-pair-ref name="JMX_SYSTEM_CONNECTOR_PORT"/>
+        <change-pair-ref name="JAVA_DEBUGGER_PORT"/>
+        <change-pair-ref name="OSGI_SHELL_TELNET_PORT"/>
+        <change-pair-ref name="HTTP_PORT"/>
+        <change-pair-ref name="HTTP_SSL_PORT"/>
+        <change-pair-ref name="ADMIN_PORT"/>
+        <change-pair-ref name="SECURE_ADMIN_IDENTIFIER"/>
+        <change-pair-ref name="ADMIN_CERT_DN"/>
+        <change-pair-ref name="INSTANCE_CERT_DN"/>
+        <change-pair-ref name="HOST_NAME"/>
+        <change-pair-ref name="TOKENS_HERE"/>
+        <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
+        <change-pair-ref name="PORT_BASE"/>
+    </group>
+    <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
+    <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
+    <change-pair id="SERVER_ID" before="%%%SERVER_ID%%%" after="$SERVER_ID$"/>
+    <change-pair id="SERVER_ROOT" before="%%%SERVER_ROOT%%%" after="$SERVER_ROOT$"/>
+    <change-pair id="SERVER_NAME" before="%%%SERVER_NAME%%%" after="$SERVER_NAME$"/>
+    <change-pair id="ORB_LISTENER1_PORT" before="%%%ORB_LISTENER1_PORT%%%" after="$ORB_LISTENER_PORT$"/>
+    <change-pair id="CONFIG_MODEL_NAME" before="%%%CONFIG_MODEL_NAME%%%" after="$CONFIG_MODEL_NAME$"/>
+    <change-pair id="DOMAIN_NAME" before="%%%DOMAIN_NAME%%%" after="$DOMAIN_NAME$"/>
+    <change-pair id="JMS_PROVIDER_PORT" before="%%%JMS_PROVIDER_PORT%%%" after="$JMS_PROVIDER_PORT$"/>
+    <change-pair id="ORB_LISTENER_PORT" before="%%%ORB_LISTENER_PORT%%%" after="$ORB_LISTENER_PORT$"/>
+    <change-pair id="ORB_SSL_PORT" before="%%%ORB_SSL_PORT%%%" after="$ORB_SSL_PORT$"/>
+    <change-pair id="ORB_MUTUALAUTH_PORT" before="%%%ORB_MUTUALAUTH_PORT%%%" after="$ORB_MUTUALAUTH_PORT$"/>
+    <change-pair id="JMX_SYSTEM_CONNECTOR_PORT" before="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" after="$JMX_SYSTEM_CONNECTOR_PORT$"/>
+    <change-pair id="JAVA_DEBUGGER_PORT" before="%%%JAVA_DEBUGGER_PORT%%%" after="$JAVA_DEBUGGER_PORT$"/>
+    <change-pair id="OSGI_SHELL_TELNET_PORT" before="%%%OSGI_SHELL_TELNET_PORT%%%" after="$OSGI_SHELL_TELNET_PORT$"/>
+    <change-pair id="HTTP_PORT" before="%%%HTTP_PORT%%%" after="$HTTP_PORT$"/>
+    <change-pair id="HTTP_SSL_PORT" before="%%%HTTP_SSL_PORT%%%" after="$HTTP_SSL_PORT$"/>
+    <change-pair id="ADMIN_PORT" before="%%%ADMIN_PORT%%%" after="$ADMIN_PORT$"/>
+    <change-pair id="SECURE_ADMIN_IDENTIFIER" before="%%%SECURE_ADMIN_IDENTIFIER%%%" after="$SECURE_ADMIN_IDENTIFIER$"/>
+    <change-pair id="ADMIN_CERT_DN" before="%%%ADMIN_CERT_DN%%%" after="$ADMIN_CERT_DN$"/>
+    <change-pair id="INSTANCE_CERT_DN" before="%%%INSTANCE_CERT_DN%%%" after="$INSTANCE_CERT_DN$"/>
+    <change-pair id="HOST_NAME" before="%%%HOST_NAME%%%" after="$HOST_NAME$"/>
+    <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
+    <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
+    <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <defaults>
+        <property key="ADMIN_PORT" value="4848" type="port"/>
+        <property key="HTTP_SSL_PORT" value="8181" type="port"/>
+        <property key="ORB_SSL_PORT" value="3820" type="port"/>
+        <property key="ORB_MUTUALAUTH_PORT" value="3920" type="port"/>
+        <property key="HTTP_PORT" value="8080" type="port"/>
+        <property key="JMS_PROVIDER_PORT" value="7676" type="port"/>
+        <property key="ORB_LISTENER_PORT" value="3700" type="port"/>
+        <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
+        <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
+        <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+    </defaults>
+</stringsubs-definition>

--- a/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
@@ -1,44 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
     <component id="GlassFish Core">

--- a/appserver/admin/gf_template_web/src/main/resources/template-info.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/template-info.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 1997-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -40,30 +40,10 @@
     holder.
 
 -->
-
-<!-- Portions Copyright [2016] [Payara Foundation] -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
-        <version>4.1.1.172-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-    <groupId>org.glassfish.main.admin</groupId>
-    <artifactId>admin</artifactId>
-    <packaging>pom</packaging>
-    <name>Admin Modules</name>
-    <modules>
-        <module>backup</module>
-        <module>cli</module>
-        <module>cli-optional</module>
-        <module>admin-core</module>
-        <module>backup-l10n</module>
-        <module>cli-optional-l10n</module>
-        <module>gf_template</module>
-        <module>gf_template_web</module>
-        <module>payara_template</module>
-    </modules>
-</project>
+<domain-template-info xmlns="http://xmlns.oracle.com/cie/glassfish/domain-template"
+    version="4.0.0.0"
+    type="Domain Template"
+    name="Basic GlassFish Server Domain"
+    author="Oracle Corporation"
+    description="Create a basic GlassFish Server domain."
+></domain-template-info>

--- a/appserver/admin/gf_template_web/src/main/resources/template-info.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/template-info.xml
@@ -1,44 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-    Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 <domain-template-info xmlns="http://xmlns.oracle.com/cie/glassfish/domain-template"
     version="4.0.0.0"

--- a/appserver/admin/payara_template_web/pom.xml
+++ b/appserver/admin/payara_template_web/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.main.admin</groupId>
+        <artifactId>admin</artifactId>
+        <version>4.1.1.172-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>payara-domain-web</artifactId>
+    <name>Web Payara template</name>
+    <description>Web Payara template</description>
+	
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.admin</groupId>
+                                    <artifactId>nucleus-domain</artifactId>
+                                    <version>${project.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <excludes>config/domain.xml, template-info.xml, stringsubs.xml, META-INF/**</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>merge-copyright-headers</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/classes/config/logging.properties</outputFile>
+                            <inputFiles>
+                                <inputFile>${project.build.directory}/dependency/config/logging.properties</inputFile>
+                                <inputFile>../../logging/logging.properties</inputFile>
+                            </inputFiles>  
+                        </configuration>
+                    </execution>
+                </executions>						 
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <finalName>classes</finalName>
+                            <attach>false</attach>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <useProjectArtifact>false</useProjectArtifact>
+                        </configuration>                        
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/admin/payara_template_web/pom.xml
+++ b/appserver/admin/payara_template_web/pom.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/admin/payara_template_web/src/main/assembly/payara-domain-web.xml
+++ b/appserver/admin/payara_template_web/src/main/assembly/payara-domain-web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>template</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/config</directory>
+			 <excludes>
+			   <exclude>logging.properties</exclude>
+			 </excludes>
+			<outputDirectory>./config</outputDirectory>
+         </fileSet>
+		 <fileSet>
+            <directory>${project.build.directory}/dependency</directory>
+			 <excludes>
+			   <exclude>config/**</exclude>
+			 </excludes>
+            <outputDirectory>./</outputDirectory>
+         </fileSet>
+    </fileSets>
+</assembly>

--- a/appserver/admin/payara_template_web/src/main/assembly/payara-domain-web.xml
+++ b/appserver/admin/payara_template_web/src/main/assembly/payara-domain-web.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/appserver/admin/payara_template_web/src/main/resources/config/default-web.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/default-web.xml
@@ -1,0 +1,1180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+<!-- Portions Copyright [2016] [Payara Foundation] -->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <!-- ======================== Introduction ============================== -->
+
+
+  <!-- The default deployment descriptor.                                   -->
+  <!--                                                                      -->
+  <!-- The default deployment descriptor specifies default deployment       -->
+  <!-- descriptor values inherited by any web applications deployed to      -->
+  <!-- the application server.                                              -->
+
+
+  <!-- ============ Built In Context Init Parameter Definitions =========== -->
+
+
+  <!-- Init parameter to force the XML validation of JSF configuration  --> 
+  <!-- ressources.                                                      -->
+
+  <context-param>
+      <param-name>com.sun.faces.validateXml</param-name>
+      <param-value>true</param-value>
+  </context-param>
+
+  <!-- Init parameter will cause the JSF implementation to bypass      -->
+  <!-- processing the web.xml to determine if we should continue       --> 
+  <!-- bootstrapping JSF for the web application.                      -->
+
+  <context-param>
+      <param-name>com.sun.faces.forceLoadConfiguration</param-name>
+      <param-value>true</param-value>
+  </context-param> 
+      
+
+  <!-- ================== Built In Servlet Definitions ==================== -->
+
+
+  <!-- The DefaultDervlet, which is responsible for serving static          -->
+  <!-- resources.                                                           -->
+  <!-- This servlet processes any requests that are not mapped to other     -->
+  <!-- servlets with servlet mappings (defined either here or in your own   -->
+  <!-- web.xml file.  This servlet supports the following initialization    -->
+  <!-- parameters (default values have been placed in square brackets):     -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   fileEncoding        Encoding to be used to read static resources   -->
+  <!--                       [platform default]                             -->
+  <!--                                                                      -->
+  <!--   input               Input buffer size (in bytes) when reading      -->
+  <!--                       resources to be served.  [2048]                -->
+  <!--                                                                      -->
+  <!--   listings            Should directory listings be produced if there -->
+  <!--                       is no welcome file in this directory?  [false] -->
+  <!--                       WARNING: Listings for directories with many    -->
+  <!--                       entries can be slow and may consume            -->
+  <!--                       significant proportions of server resources.   -->
+  <!--                                                                      -->
+  <!--   sortedBy            Specifies the criteria that will be used for   -->
+  <!--                       sorting directory entries. Legal values are    -->
+  <!--                       NAME, SIZE, and LAST_MODIFIED.  [NAME]         -->
+  <!--                                                                      -->
+  <!--   output              Output buffer size (in bytes) when writing     -->
+  <!--                       resources to be served.  [2048]                -->
+  <!--                                                                      -->
+  <!--   readonly            Is this context "read only", so HTTP           -->
+  <!--                       commands like PUT and DELETE are               -->
+  <!--                       rejected?  [true]                              -->
+  <!--                                                                      -->
+  <!--   readmeFile          File name to display with the directory        -->
+  <!--                       contents. [null]                               -->
+  <!--                                                                      -->
+  <!--   sendfileSize        If the connector used supports sendfile, this  -->
+  <!--                       represents the minimal file size in KB for     -->
+  <!--                       which sendfile will be used. Use a negative    -->
+  <!--                       value to always disable sendfile.  [48]        -->
+  <!--                                                                      -->
+  <!--   useAcceptRanges     Should the Accept-Ranges header be included    -->
+  <!--                       in responses where appropriate? [true]         -->
+  <!--                                                                      -->
+  <!--   maxHeaderRangeItems The max number of items in Range header.       -->
+  <!--                       -1 means unbounded.  [10]                      -->
+  <!--                                                                      -->
+  <!--  For directory listing customization. Checks localXsltFile, then     -->
+  <!--  globalXsltFile, then defaults to original behavior.                 -->
+  <!--                                                                      -->
+  <!--   localXsltFile       Make directory listings an XML doc and         -->
+  <!--                       pass the result to this style sheet residing   -->
+  <!--                       in that directory. This overrides              -->
+  <!--                        globalXsltFile[null]                          -->
+  <!--                                                                      -->
+  <!--   globalXsltFile      Site wide configuration version of             -->
+  <!--                       localXsltFile This argument is expected        -->
+  <!--                       to be a physical file. [null]                  -->
+
+  <servlet>
+    <servlet-name>default</servlet-name>
+    <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>listings</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+
+  <!-- The JSP page compiler and execution servlet, which is the mechanism  -->
+  <!-- used by the application server to support JSP pages.  Traditionally, -->
+  <!-- this servlet is mapped to the URL pattern "*.jsp".                   -->
+  <!-- This servlet supports the following initialization parameters        -->
+  <!-- (default values have been placed in square brackets):                -->
+  <!--                                                                      -->
+  <!--   checkInterval       If development is false and checkInterval is   -->
+  <!--                       greater than zero, background compilations are -->
+  <!--                       enabled. checkInterval is the time in seconds  -->
+  <!--                       between checks to see if a JSP page needs to   -->
+  <!--                       be recompiled. [0]                             -->
+  <!--                                                                      -->
+  <!--   modificationTestInterval                                           -->
+  <!--                       Causes a JSP (and its dependent files) to not  -->
+  <!--                       be checked for modification during the         -->
+  <!--                       specified time interval (in seconds) from the  -->
+  <!--                       last time the JSP was checked for              -->
+  <!--                       modification. A value of 0 will cause the JSP  -->
+  <!--                       to be checked on every access.                 -->
+  <!--                       Used in development mode only. [0]             -->
+  <!--                                                                      -->
+  <!--   compiler            Which compiler Ant should use to compile JSP   -->
+  <!--                       pages.  See the Ant documentation for more     -->
+  <!--                       information. [javac]                           -->
+  <!--                                                                      -->
+  <!--   classdebuginfo      Should the class file be compiled with         -->
+  <!--                       debugging information?  [true]                 -->
+  <!--                                                                      -->
+  <!--   classpath           What class path should I use while compiling   -->
+  <!--                       generated servlets?  [Created dynamically      -->
+  <!--                       based on the current web application]          -->
+  <!--                       [Ignored in Glassfish]                         -->
+  <!--                                                                      -->
+  <!--   development         Is Jasper used in development mode? If true,   -->
+  <!--                       the frequency at which JSPs are checked for    -->
+  <!--                       modification may be specified via the          -->
+  <!--                       modificationTestInterval parameter. [true]     -->
+  <!--                                                                      -->
+  <!--   enablePooling       Determines whether tag handler pooling is      -->
+  <!--                       enabled  [true]                                -->
+  <!--                                                                      -->
+  <!--   fork                Tell Ant to fork compiles of JSP pages so that -->
+  <!--                       JSP pages are compiled in their own JVM        -->
+  <!--                       (separate from the JVM that the application    -->
+  <!--                       server is running in). [true]                  -->
+  <!--                                                                      -->
+  <!--   ieClassId           The class-id value to be sent to Internet      -->
+  <!--                       Explorer when using <jsp:plugin> tags.         -->
+  <!--                       [clsid:8AD9C840-044E-11D1-B3E9-00805F499D93]   -->
+  <!--                                                                      -->
+  <!--   javaEncoding        Java file encoding to use for generating java  -->
+  <!--                       source files. [UTF8]                           -->
+  <!--                                                                      -->
+  <!--   keepgenerated       Should we keep the generated Java source code  -->
+  <!--                       for each page instead of deleting it?          -->
+  <!--                       [true with JDK 5 and before, or for jspc]      -->
+  <!--                       [false otherwise]                              -->
+  <!--                                                                      -->
+  <!--   saveBytecode        Should the generated byte code be saved to     -->
+  <!--                       .class files?  This option is meaningful only  -->
+  <!--                       when Java compiler API, JSR199 (available with -->
+  <!--                       JDK 6) is used for javac compilations.         -->
+  <!--                       [false] [true for jspc]                        -->
+  <!--                                                                      -->
+  <!--   mappedfile          Should we generate static content with one     -->
+  <!--                       print statement per input line, to ease        -->
+  <!--                       debugging?  [true]                             -->
+  <!--                                                                      -->
+  <!--   trimSpaces          Should white spaces in template text between   -->
+  <!--                       actions or directives be trimmed?  [false]     -->
+  <!--                                                                      -->
+  <!--   suppressSmap        Should the generation of SMAP info for JSR45   -->
+  <!--                       debugging be suppressed?  [false]              -->
+  <!--                                                                      -->
+  <!--   dumpSmap            Should the SMAP info for JSR45 debugging be    -->
+  <!--                       dumped to a file? [false]                      -->
+  <!--                       False if suppressSmap is true                  -->
+  <!--                                                                      -->
+  <!--   genStrAsCharArray   Should text strings be generated as char       -->
+  <!--                       arrays, to improve performance in some cases?  -->
+  <!--                       [false]                                        -->
+  <!--                                                                      -->
+  <!--   genStrAsByteArray   Should text strings be generated as bytes      -->
+  <!--                       (encoded with the page encoding), if the page  -->
+  <!--                       is not buffered?                               -->
+  <!--                       [true]                                         -->
+  <!--                                                                      -->
+  <!--   defaultBufferNone   Should the default for the buffer attribute of -->
+  <!--                       the page directive be "none"?  [false]         -->
+  <!--                                                                      -->
+  <!--   errorOnUseBeanInvalidClassAttribute                                -->
+  <!--                       Should Jasper issue an error when the value of -->
+  <!--                       the class attribute in an useBean action is    -->
+  <!--                       not a valid bean class?  [false]               -->
+  <!--                                                                      -->
+  <!--   scratchdir          What scratch directory should we use when      -->
+  <!--                       compiling JSP pages?  [default work directory  -->
+  <!--                       for the current web application]               -->
+  <!--                                                                      -->
+  <!--   xpoweredBy          Determines whether X-Powered-By response       -->
+  <!--                       header is added by generated servlet  [true]   -->
+  <!--                                                                      -->
+  <!--   usePrecompiled      If true, it is assumed that JSPs have been     -->
+  <!--                       precompiled, and their corresponding servlet   -->
+  <!--                       classes have been bundled in the web           -->
+  <!--                       application's WEB-INF/lib or WEB-INF/classes,  -->
+  <!--                       so that when a JSP is accessed, it is not      -->
+  <!--                       compiled, and instead, its precompiled servlet -->
+  <!--                       class is used. [false]                         -->
+  <!--                                                                      -->
+  <!--   use-precompiled     Same as usePrecompiled. If both are specified, -->
+  <!--                       usePrecompiled takes precedence                -->
+  <!--                                                                      -->
+  <!--   initialCapacity     Initial capacity of HashMap mapping JSPs to    -->
+  <!--                       their corresponding servlets [32]              -->
+  <!--                                                                      -->
+  <!--   initial-capacity    Same as initialCapacity. If both are specified,-->
+  <!--                       initialCapacity takes precedence               -->
+  <!--                                                                      -->
+  <!--   httpMethods         Comma separated list of HTTP methods supported -->
+  <!--                       by the JspServlet. Wildcard ("*") denotes      -->
+  <!--                       "ALL METHODS". [ALL METHODS]                   -->
+  <!--                                                                      -->
+  <!--   reload-interval     Specifies the frequency (in seconds) at which  -->
+  <!--                       JSP files are checked for modifications.       -->
+  <!--                       Setting this value to 0 checks JSPs for        -->
+  <!--                       modifications on every request. Setting this   -->
+  <!--                       value to -1 disables checks for JSP            -->
+  <!--                       modifications and JSP recompilation.           -->
+  <!--                                                                      -->
+  <!--   compilerSourceVM    Provides source compatibility with the         -->
+  <!--                       specified JDK release (same as -source         -->
+  <!--                       javac command-line switch)                     -->
+  <!--                                                                      -->
+  <!--   compilerTargetVM    Generates class files for specified VM version -->
+  <!--                       (same as -target javac command-line switch)    -->
+  <!--                                                                      -->
+  <!--   system-jar-includes Specify a list (of jars, or fragments of jar   -->
+  <!--                       paths) that is used to determine if a system   -->
+  <!--                       jar (obtained from the system classloader)     -->
+  <!--                       should be included in the javac classpath      -->
+  <!--                       [Include all system jars]                      -->
+  <!--                                                                      -->
+  <!-- If you wish to use Jikes to compile JSP pages:                       -->
+  <!-- * Set the "classpath" initialization parameter appropriately         -->
+  <!--   for this web application.                                          -->
+  <!-- * Set the "jspCompilerPlugin" initialization parameter to            -->
+  <!--   "org.apache.jasper.compiler.JikesJavaCompiler".                    -->
+
+  <servlet>
+    <servlet-name>jsp</servlet-name>
+    <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
+    <init-param>
+      <param-name>xpoweredBy</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <init-param>
+        <param-name>reload-interval</param-name>
+        <param-value>-1</param-value>
+    </init-param>
+    <init-param>
+        <param-name>development</param-name>
+        <param-value>false</param-value>
+    </init-param>
+    <init-param>
+      <param-name>httpMethods</param-name>
+      <param-value>GET,POST,HEAD</param-value>
+    </init-param>
+    <init-param>
+      <param-name>system-jar-includes</param-name>
+      <param-value>
+        /lib/
+        \lib\
+        javax.el.jar
+        javax.servlet-api.jar
+        javax.servlet.jsp-api.jar
+        javax.servlet.jsp.jstl-api.jar
+        javax.servlet.jsp.jstl.jar
+        javax.jms-api.jar
+        javax.faces.jar
+        javax.servlet.jsp.jar
+        jspcaching-connector.jar
+        web-glue.jar
+        bean-validator.jar
+        javax.ejb.jar
+        javax.enterprise.deploy-api.jar
+        javax.jms-api.jar
+        javax.mail.jar
+        javax.management.j2ee-api.jar
+        javax.persistence.jar
+        javax.resource-api.jar
+        javax.security.auth.message.jar
+        javax.security.jacc.jar
+        javax.transaction-api.jar
+        javax.xml.rpc-api.jar
+        webservices-osgi.jar
+        weld-osgi-bundle-glassfish4.jar
+        jersey-mvc-jsp.jar
+      </param-value>
+    </init-param>
+    <load-on-startup>3</load-on-startup>
+  </servlet>
+  
+
+  <!-- NOTE: An SSI Filter is also available as an alternative SSI          -->
+  <!-- implementation. Use either the Servlet or the Filter but NOT both.   -->
+  <!--                                                                      -->
+  <!-- Server Side Includes processing servlet, which processes SSI         -->
+  <!-- directives in HTML pages consistent with similar support in web      -->
+  <!-- servers like Apache.  Traditionally, this servlet is mapped to the   -->
+  <!-- URL pattern "*.shtml".  This servlet supports the following          -->
+  <!-- initialization parameters (default values are in square brackets):   -->
+  <!--                                                                      -->
+  <!--   buffered            Should output from this servlet be buffered?   -->
+  <!--                       (0=false, 1=true)  [0]                         -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   expires             The number of seconds before a page with SSI   -->
+  <!--                       directives will expire.  [No default]          -->
+  <!--                                                                      -->
+  <!--   isVirtualWebappRelative                                            -->
+  <!--                       Should "virtual" paths be interpreted as       -->
+  <!--                       relative to the context root, instead of       -->
+  <!--                       the server root?  (0=false, 1=true) [0]        -->
+  <!--                                                                      -->
+  <!--   inputEncoding       The encoding to assume for SSI resources if    -->
+  <!--                       one is not available from the resource.        -->
+  <!--                       [Platform default]                             -->
+  <!--                                                                      -->
+  <!--   outputEncoding      The encoding to use for the page that results  -->
+  <!--                       from the SSI processing. [UTF-8]               -->
+
+<!--
+  <servlet>
+    <servlet-name>ssi</servlet-name>
+    <servlet-class>org.apache.catalina.ssi.SSIServlet</servlet-class>
+    <init-param>
+      <param-name>buffered</param-name>
+      <param-value>1</param-value>
+    </init-param>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>expires</param-name>
+      <param-value>666</param-value>
+    </init-param>
+    <init-param>
+      <param-name>isVirtualWebappRelative</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <load-on-startup>4</load-on-startup>
+  </servlet>
+-->
+
+
+  <!-- Common Gateway Includes (CGI) processing servlet, which supports     -->
+  <!-- execution of external applications that conform to the CGI spec      -->
+  <!-- requirements.  Typically, this servlet is mapped to the URL pattern  -->
+  <!-- "/cgi-bin/*", which means that any CGI applications that are         -->
+  <!-- executed must be present within the web application.  This servlet   -->
+  <!-- supports the following initialization parameters (default values     -->
+  <!-- are in square brackets):                                             -->
+  <!--                                                                      -->
+  <!--   cgiPathPrefix        The CGI search path will start at             -->
+  <!--                        webAppRootDir + File.separator + this prefix. -->
+  <!--                        [WEB-INF/cgi]                                 -->
+  <!--                                                                      -->
+  <!--   debug                Debugging detail level for messages logged    -->
+  <!--                        by this servlet.  [0]                         -->
+  <!--                                                                      -->
+  <!--   executable           Name of the executable used to run the        -->
+  <!--                        script. [perl]                                -->
+  <!--                                                                      -->
+  <!--   parameterEncoding    Name of parameter encoding to be used with    -->
+  <!--                        CGI servlet.                                  -->
+  <!--                        [System.getProperty("file.encoding","UTF-8")] -->
+  <!--                                                                      -->
+  <!--   passShellEnvironment Should the shell environment variables (if    -->
+  <!--                        any) be passed to the CGI script? [false]     -->
+  <!--                                                                      -->
+  <!--   stderrTimeout        The time (in milliseconds) to wait for the    -->
+  <!--                        reading of stderr to complete before          -->
+  <!--                        terminating the CGI process. [2000]           -->
+
+
+<!--
+  <servlet>
+    <servlet-name>cgi</servlet-name>
+    <servlet-class>org.apache.catalina.servlets.CGIServlet</servlet-class>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>cgiPathPrefix</param-name>
+      <param-value>WEB-INF/cgi</param-value>
+    </init-param>
+    <load-on-startup>5</load-on-startup>
+  </servlet>
+-->
+
+
+  <!-- ================ Built In Servlet Mappings ========================= -->
+
+  <!-- The mapping for the default servlet -->
+  <servlet-mapping>
+    <servlet-name>default</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <!-- The mapping for the JSP servlet -->
+  <servlet-mapping>
+    <servlet-name>jsp</servlet-name>
+    <url-pattern>*.jsp</url-pattern>
+    <url-pattern>*.jspx</url-pattern>
+  </servlet-mapping>
+
+  <!-- The mapping for the SSI servlet -->
+<!--
+  <servlet-mapping>
+    <servlet-name>ssi</servlet-name>
+    <url-pattern>*.shtml</url-pattern>
+  </servlet-mapping>
+-->
+
+  <!-- The mapping for the CGI Gateway servlet -->
+<!--
+  <servlet-mapping>
+    <servlet-name>cgi</servlet-name>
+    <url-pattern>/cgi-bin/*</url-pattern>
+  </servlet-mapping>
+-->
+
+
+  <!-- ================== Built In Filter Definitions ===================== -->
+
+  <!-- NOTE: An SSI Servlet is also available as an alternative SSI         -->
+  <!-- implementation. Use either the Servlet or the Filter but NOT both.   -->
+  <!--                                                                      -->
+  <!-- Server Side Includes processing filter, which processes SSI          -->
+  <!-- directives in HTML pages consistent with similar support in web      -->
+  <!-- servers like Apache.  Traditionally, this filter is mapped to the    -->
+  <!-- URL pattern "*.shtml", though it can be mapped to "*" as it will     -->
+  <!-- selectively enable/disable SSI processing based on mime types. For   -->
+  <!-- this to work you will need to uncomment the .shtml mime type         -->
+  <!-- definition towards the bottom of this file.                          -->
+  <!-- The contentType init param allows you to apply SSI processing to JSP -->
+  <!-- pages, javascript, or any other content you wish.  This filter       -->
+  <!-- supports the following initialization parameters (default values are -->
+  <!-- in square brackets):                                                 -->
+  <!--                                                                      -->
+  <!--   contentType         A regex pattern that must be matched before    -->
+  <!--                       SSI processing is applied.                     -->
+  <!--                       [text/x-server-parsed-html(;.*)?]              -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   expires             The number of seconds before a page with SSI   -->
+  <!--                       directives will expire.  [No default]          -->
+  <!--                                                                      -->
+  <!--   isVirtualWebappRelative                                            -->
+  <!--                       Should "virtual" paths be interpreted as       -->
+  <!--                       relative to the context root, instead of       -->
+  <!--                       the server root?  (0=false, 1=true) [0]        -->
+
+<!--
+  <filter>
+    <filter-name>ssi</filter-name>
+    <filter-class>
+      org.apache.catalina.ssi.SSIFilter
+    </filter-class>
+    <init-param>
+      <param-name>contentType</param-name>
+      <param-value>text/x-server-parsed-html(;.*)?</param-value>
+    </init-param>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>expires</param-name>
+      <param-value>666</param-value>
+    </init-param>
+    <init-param>
+      <param-name>isVirtualWebappRelative</param-name>
+      <param-value>0</param-value>
+    </init-param>
+  </filter>
+-->
+
+
+  <!-- ==================== Built In Filter Mappings ====================== -->
+
+  <!-- The mapping for the SSI Filter -->
+<!--
+  <filter-mapping>
+    <filter-name>ssi</filter-name>
+    <url-pattern>*.shtml</url-pattern>
+  </filter-mapping>
+-->
+
+
+  <!-- ==================== Default Session Configuration ================= -->
+
+  <!-- You can set the default session timeout (in minutes) for all newly   -->
+  <!-- created sessions by modifying the value below.                       -->
+
+  <session-config>
+    <session-timeout>30</session-timeout>
+  </session-config>
+
+
+  <!-- ===================== Default MIME Type Mappings =================== -->
+
+  <!-- When serving static resources, the application server will           -->
+  <!-- automatically generate a "Content-Type" response header from the     -->
+  <!-- filename extension of the resource, based on these mappings.         -->
+  <!-- Additional mappings may be specified here (to be shared by all       -->
+  <!-- web applications) or in a web application's web.xml deployment       -->
+  <!-- descriptor (for that web application's individual use).              -->
+
+  <mime-mapping>
+    <extension>abs</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ai</extension>
+    <mime-type>application/postscript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aif</extension>
+    <mime-type>audio/x-aiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aifc</extension>
+    <mime-type>audio/x-aiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aiff</extension>
+    <mime-type>audio/x-aiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>aim</extension>
+    <mime-type>application/x-aim</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>art</extension>
+    <mime-type>image/x-jg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>asf</extension>
+    <mime-type>video/x-ms-asf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>asx</extension>
+    <mime-type>video/x-ms-asf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>au</extension>
+    <mime-type>audio/basic</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>avi</extension>
+    <mime-type>video/x-msvideo</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>avx</extension>
+    <mime-type>video/x-rad-screenplay</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>bcpio</extension>
+    <mime-type>application/x-bcpio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>bin</extension>
+    <mime-type>application/octet-stream</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>bmp</extension>
+    <mime-type>image/bmp</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>body</extension>
+    <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>cdf</extension>
+    <mime-type>application/x-cdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>cer</extension>
+    <mime-type>application/x-x509-ca-cert</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>class</extension>
+    <mime-type>application/java</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>cpio</extension>
+    <mime-type>application/x-cpio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>csh</extension>
+    <mime-type>application/x-csh</mime-type>
+  </mime-mapping>
+   <mime-mapping>
+    <extension>css</extension>
+    <mime-type>text/css</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dib</extension>
+    <mime-type>image/bmp</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>doc</extension>
+    <mime-type>application/msword</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dtd</extension>
+    <mime-type>application/xml-dtd</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dv</extension>
+    <mime-type>video/x-dv</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>dvi</extension>
+    <mime-type>application/x-dvi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>eps</extension>
+    <mime-type>application/postscript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>etx</extension>
+    <mime-type>text/x-setext</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>exe</extension>
+    <mime-type>application/octet-stream</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gif</extension>
+    <mime-type>image/gif</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gk</extension>
+    <mime-type>application/octet-stream</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gtar</extension>
+    <mime-type>application/x-gtar</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>gz</extension>
+    <mime-type>application/x-gzip</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>hdf</extension>
+    <mime-type>application/x-hdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>hqx</extension>
+    <mime-type>application/mac-binhex40</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>htc</extension>
+    <mime-type>text/x-component</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>htm</extension>
+    <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>html</extension>
+    <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>hqx</extension>
+    <mime-type>application/mac-binhex40</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ico</extension>
+    <mime-type>image/x-icon</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ief</extension>
+    <mime-type>image/ief</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jad</extension>
+    <mime-type>text/vnd.sun.j2me.app-descriptor</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jar</extension>
+    <mime-type>application/java-archive</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>java</extension>
+    <mime-type>text/plain</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jnlp</extension>
+    <mime-type>application/x-java-jnlp-file</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jpe</extension>
+    <mime-type>image/jpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jpeg</extension>
+    <mime-type>image/jpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>jpg</extension>
+    <mime-type>image/jpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>js</extension>
+    <mime-type>text/javascript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>kar</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>latex</extension>
+    <mime-type>application/x-latex</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>m3u</extension>
+    <mime-type>audio/x-mpegurl</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mac</extension>
+    <mime-type>image/x-macpaint</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>man</extension>
+    <mime-type>application/x-troff-man</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mathml</extension>
+    <mime-type>application/mathml+xml</mime-type> 
+  </mime-mapping>
+  <mime-mapping>
+    <extension>me</extension>
+    <mime-type>application/x-troff-me</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mid</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>midi</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mif</extension>
+    <mime-type>application/x-mif</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mov</extension>
+    <mime-type>video/quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>movie</extension>
+    <mime-type>video/x-sgi-movie</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mp1</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mp2</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mp3</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpa</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpe</extension>
+    <mime-type>video/mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpeg</extension>
+    <mime-type>video/mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpega</extension>
+    <mime-type>audio/x-mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpg</extension>
+    <mime-type>video/mpeg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>mpv2</extension>
+    <mime-type>video/mpeg2</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ms</extension>
+    <mime-type>application/x-wais-source</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>nc</extension>
+    <mime-type>application/x-netcdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>oda</extension>
+    <mime-type>application/oda</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>odg</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.graphics</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>odp</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.presentation</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ods</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.spreadsheet</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>odt</extension>
+    <mime-type>application/x-vnd.oasis.opendocument.text</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ogg</extension>
+    <mime-type>application/ogg</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pbm</extension>
+    <mime-type>image/x-portable-bitmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pct</extension>
+    <mime-type>image/pict</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pdf</extension>
+    <mime-type>application/pdf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pgm</extension>
+    <mime-type>image/x-portable-graymap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pic</extension>
+    <mime-type>image/pict</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pict</extension>
+    <mime-type>image/pict</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pls</extension>
+    <mime-type>audio/x-scpls</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>png</extension>
+    <mime-type>image/png</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pnm</extension>
+    <mime-type>image/x-portable-anymap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>pnt</extension>
+    <mime-type>image/x-macpaint</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ppm</extension>
+    <mime-type>image/x-portable-pixmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ppt</extension>
+    <mime-type>application/powerpoint</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ps</extension>
+    <mime-type>application/postscript</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>psd</extension>
+    <mime-type>image/x-photoshop</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>qt</extension>
+    <mime-type>video/quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>qti</extension>
+    <mime-type>image/x-quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>qtif</extension>
+    <mime-type>image/x-quicktime</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ras</extension>
+    <mime-type>image/x-cmu-raster</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rdf</extension>
+    <mime-type>application/rdf+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rgb</extension>
+    <mime-type>image/x-rgb</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rm</extension>
+    <mime-type>application/vnd.rn-realmedia</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>roff</extension>
+    <mime-type>application/x-troff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rtf</extension>
+    <mime-type>application/rtf</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>rtx</extension>
+    <mime-type>text/richtext</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>sh</extension>
+    <mime-type>application/x-sh</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>shar</extension>
+    <mime-type>application/x-shar</mime-type>
+  </mime-mapping>
+<!--
+  <mime-mapping>
+    <extension>shtml</extension>
+    <mime-type>text/x-server-parsed-html</mime-type>
+  </mime-mapping>
+-->
+  <mime-mapping>
+    <extension>sit</extension>
+    <mime-type>application/x-stuffit</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>smf</extension>
+    <mime-type>audio/x-midi</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>snd</extension>
+    <mime-type>audio/basic</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>src</extension>
+    <mime-type>application/x-wais-source</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>sv4cpio</extension>
+    <mime-type>application/x-sv4cpio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>sv4crc</extension>
+    <mime-type>application/x-sv4crc</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>svg</extension>
+    <mime-type>image/svg+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>svgz</extension>
+    <mime-type>image/svg+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>swf</extension>
+    <mime-type>application/x-shockwave-flash</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>t</extension>
+    <mime-type>application/x-troff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tar</extension>
+    <mime-type>application/x-tar</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tcl</extension>
+    <mime-type>application/x-tcl</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tex</extension>
+    <mime-type>application/x-tex</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>texi</extension>
+    <mime-type>application/x-texinfo</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>texinfo</extension>
+    <mime-type>application/x-texinfo</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tif</extension>
+    <mime-type>image/tiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tiff</extension>
+    <mime-type>image/tiff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tr</extension>
+    <mime-type>application/x-troff</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>tsv</extension>
+    <mime-type>text/tab-separated-values</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>txt</extension>
+    <mime-type>text/plain</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ulw</extension>
+    <mime-type>audio/basic</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>ustar</extension>
+    <mime-type>application/x-ustar</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xbm</extension>
+    <mime-type>image/x-xbitmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xml</extension>
+    <mime-type>application/xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xpm</extension>
+    <mime-type>image/x-xpixmap</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xsl</extension>
+    <mime-type>application/xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xslt</extension>
+    <mime-type>application/xslt+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xwd</extension>
+    <mime-type>image/x-xwindowdump</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>vsd</extension>
+    <mime-type>application/x-visio</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>vxml</extension>
+    <mime-type>application/voicexml+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>wav</extension>
+    <mime-type>audio/x-wav</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- Wireless Bitmap -->
+    <extension>wbmp</extension>
+    <mime-type>image/vnd.wap.wbmp</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- WML Source -->
+    <extension>wml</extension>
+    <mime-type>text/vnd.wap.wml</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- Compiled WML -->
+    <extension>wmlc</extension>
+    <mime-type>application/vnd.wap.wmlc</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- WML Script Source -->
+    <extension>wmls</extension>
+    <mime-type>text/vnd.wap.wmls</mime-type>
+  </mime-mapping>
+  <mime-mapping> <!-- Compiled WML Script -->
+    <extension>wmlscriptc</extension>
+    <mime-type>application/vnd.wap.wmlscriptc</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>wrl</extension>
+    <mime-type>x-world/x-vrml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xht</extension>
+    <mime-type>application/xhtml+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xhtml</extension>
+    <mime-type>application/xhtml+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xls</extension>
+    <mime-type>application/vnd.ms-excel</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>xul</extension>
+    <mime-type>application/vnd.mozilla.xul+xml</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>z</extension>
+    <mime-type>application/x-compress</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+    <extension>zip</extension>
+    <mime-type>application/zip</mime-type>
+  </mime-mapping>
+
+
+  <!-- ==================== Default Welcome File List ===================== -->
+
+  <!-- When a request URI refers to a directory, the default servlet looks  -->
+  <!-- for a "welcome file" within that directory and, if present,          -->
+  <!-- to the corresponding resource URI for display.  If no welcome file   -->
+  <!-- is present, the default servlet either serves a directory listing,   -->
+  <!-- or returns a 404 status, depending on how it is configured.          -->
+  <!--                                                                      -->
+  <!-- If you define welcome files in your own application's web.xml        -->
+  <!-- deployment descriptor, that list *replaces* the list configured      -->
+  <!-- here, so be sure that you include any of the default values that     -->
+  <!-- you wish to include.                                                 -->
+
+
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+    <welcome-file>index.htm</welcome-file>
+    <welcome-file>index.jsp</welcome-file>
+  </welcome-file-list>
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+  </login-config>
+
+</web-app>
+

--- a/appserver/admin/payara_template_web/src/main/resources/config/default-web.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/default-web.xml
@@ -1,20 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 

--- a/appserver/admin/payara_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/domain.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
 <security-configurations>

--- a/appserver/admin/payara_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/domain.xml
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+<security-configurations>
+    <authentication-service default="true" name="adminAuth" use-password-credential="true">
+      <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+        <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+      <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+        <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+    </authentication-service>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/embedded_default" />
+      <property name="connectionAttributes" value=";create=true" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+    </server>
+  </servers>
+  <nodes>
+    <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
+  </nodes>
+ <configs>
+   <config name="%%%CONFIG_MODEL_NAME%%%">
+      <!--%%%TOKENS_HERE%%%-->
+      <!--%%%PORT_BASE%%%-->
+      <http-service>
+        <access-log/>
+        <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
+        <virtual-server id="__asadmin" network-listeners="admin-listener"/>
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
+	  <ssl ssl3-enabled="false" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+        <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" timeout-in-seconds="300">
+         <property name="xaresource-txn-timeout" value="300"/>
+       </transaction-service>
+       <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
+       <ejb-container max-pool-size="128">
+         <ejb-timer-service />
+       </ejb-container>
+       <asadmin-recorder-configuration></asadmin-recorder-configuration>
+       <request-tracing-service-configuration>
+         <log-notifier></log-notifier>
+       </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+       <batch-runtime-configuration data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
+       <monitoring-service-configuration></monitoring-service-configuration>
+       <diagnostic-service />
+      <security-service activate-default-principal-to-role-mapping="true">
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <message-security-config auth-layer="HttpServlet">
+            <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                <request-policy auth-source="sender"></request-policy>
+                <response-policy></response-policy>
+                <property name="loginPage" value="/login.jsf"></property>
+                <property name="loginErrorPage" value="/loginError.jsf"></property>
+            </provider-config>
+        </message-security-config>
+	<property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+        <jvm-options>-server</jvm-options>
+        <jvm-options>-XX:+UseG1GC</jvm-options>
+        <jvm-options>-XX:+UseStringDeduplication</jvm-options>
+        <jvm-options>-Djava.awt.headless=true</jvm-options>
+        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+        <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+        <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <jvm-options>-XX:NewRatio=2</jvm-options>
+        <jvm-options>-Xmx2g</jvm-options>
+        <jvm-options>-Xms2g</jvm-options>
+        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+      </java-config>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener-1">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="true"></file-cache>
+            </http>
+	    <ssl ssl3-enabled="false" />
+          </protocol>
+          <protocol security-enabled="true" name="http-listener-2">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="true"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+          <protocol name="admin-listener">
+            <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+        <thread-pool max-thread-pool-size="50" name="http-thread-pool"></thread-pool>
+        <thread-pool max-thread-pool-size="250" name="thread-pool-1"></thread-pool>
+        <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+      </thread-pools>
+      <system-property name="fish.payara.classloading.delegate" value="false"/>
+      <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
+    </config>
+     <config name="default-config" dynamic-reconfiguration-enabled="true" >
+         <http-service>
+             <access-log/>
+             <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
+                 <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
+             </virtual-server>
+             <virtual-server id="__asadmin" network-listeners="admin-listener" />
+         </http-service>
+         <iiop-service>
+             <orb use-thread-pool-ids="thread-pool-1" />
+             <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
+	         <ssl ssl3-enabled="false" />
+             <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+             </iiop-listener>
+             <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+             </iiop-listener>
+         </iiop-service>
+         <admin-service system-jmx-connector-name="system" type="server">
+             <!-- JSR 160  "system-jmx-connector" -->
+             <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
+             <!-- JSR 160  "system-jmx-connector" -->
+             <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+             <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
+         </admin-service>
+         <web-container>
+             <session-config>
+                 <session-manager>
+                     <manager-properties/>
+                     <store-properties />
+                 </session-manager>
+                 <session-properties />
+             </session-config>
+         </web-container>
+         <ejb-container max-pool-size="128" session-store="${com.sun.aas.instanceRoot}/session-store">
+             <ejb-timer-service />
+         </ejb-container>
+         <mdb-container />
+         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+             <module-log-levels />
+         </log-service>
+         <security-service activate-default-principal-to-role-mapping="true">
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+             <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
+                 <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
+             </jacc-provider>
+             <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
+             <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                 <property value="false" name="auditOn" />
+             </audit-module>
+             <message-security-config auth-layer="SOAP">
+                 <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+             </message-security-config>
+         </security-service>
+         <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" timeout-in-seconds="300">
+           <property name="xaresource-txn-timeout" value="300"/>
+         </transaction-service>
+         <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
+         <request-tracing-service-configuration>
+             <log-notifier></log-notifier>
+         </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
+         <diagnostic-service />
+      <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+        <jvm-options>-server</jvm-options>
+        <jvm-options>-XX:+UseG1GC</jvm-options>
+        <jvm-options>-XX:+UseStringDeduplication</jvm-options>
+        <jvm-options>-Djava.awt.headless=true</jvm-options>
+        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+        <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <jvm-options>-XX:NewRatio=2</jvm-options>
+        <jvm-options>-Xmx2g</jvm-options>
+        <jvm-options>-Xms2g</jvm-options>
+        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>        
+      </java-config>
+         <availability-service>
+             <web-container-availability/>
+             <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+         </availability-service>
+         <network-config>
+             <protocols>
+                 <protocol name="http-listener-1">
+                     <http default-virtual-server="server">
+                         <file-cache enabled="true" />
+                     </http>
+		     <ssl ssl3-enabled="false" />
+                 </protocol>
+                 <protocol security-enabled="true" name="http-listener-2">
+                     <http default-virtual-server="server">
+                         <file-cache enabled="true" />
+                     </http>
+                     <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
+                 </protocol>
+                 <protocol name="admin-listener">
+                     <http default-virtual-server="__asadmin" max-connections="250">
+                         <file-cache enabled="false" />
+                     </http>
+                 </protocol>
+                 <protocol security-enabled="true" name="sec-admin-listener">
+                   <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                     <file-cache></file-cache>
+                   </http>
+                   <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                 </protocol>
+                 <protocol name="admin-http-redirect">
+                   <http-redirect secure="true"></http-redirect>
+                 </protocol>
+                 <protocol name="pu-protocol">
+                   <port-unification>
+                     <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                     <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                   </port-unification>
+                 </protocol>
+
+             </protocols>
+             <network-listeners>
+                 <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                 <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                 <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+             </network-listeners>
+             <transports>
+                 <transport name="tcp" />
+             </transports>
+         </network-config>
+         <thread-pools>
+             <thread-pool name="http-thread-pool" />
+             <thread-pool max-thread-pool-size="250" idle-thread-timeout-in-seconds="120" name="thread-pool-1" min-thread-pool-size="2"/>
+	     <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+         </thread-pools>
+         <group-management-service/>
+         <!--%%%DEFAULT_TOKENS_HERE%%%-->
+         <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
+         <system-property name="HTTP_LISTENER_PORT" value="28080"/>
+         <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
+         <system-property name="IIOP_LISTENER_PORT" value="23700"/>
+         <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
+         <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
+         <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
+         <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
+         <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
+         <system-property name="fish.payara.classloading.delegate" value="false"/>
+         <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
+     </config>
+  </configs>
+  <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
+  <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
+      <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
+      <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
+  </secure-admin>
+</domain>

--- a/appserver/admin/payara_template_web/src/main/resources/config/glassfish-acc.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/glassfish-acc.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+<!--
+   Please remember to customize this file for your environment. The defaults for 
+   following fields may not be appropriate.  
+   - target-server name, address and port
+   - Property security.config in message-security-config
+-->
+
+<!DOCTYPE client-container PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Application Client Container//EN" "http://glassfish.org/dtds/glassfish-application-client-container_1_3.dtd">
+
+<client-container>
+  <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>
+  <log-service file="" level="WARNING"/>
+  <message-security-config auth-layer="SOAP">
+    <!-- turned off by default -->
+    <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-id="XWS_ClientProvider" provider-type="client"> 
+      <request-policy auth-source="content"/>
+      <response-policy auth-source="content"/>
+      <property name="encryption.key.alias" value="s1as"/>
+      <property name="signature.key.alias" value="s1as"/>
+      <property name="dynamic.username.password" value="false"/>
+      <property name="debug" value="false"/>
+    </provider-config>
+    <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-id="ClientProvider" provider-type="client"> 
+      <request-policy auth-source="content"/>
+      <response-policy auth-source="content"/>
+      <property name="encryption.key.alias" value="s1as"/>
+      <property name="signature.key.alias" value="s1as"/>
+      <property name="dynamic.username.password" value="false"/>
+      <property name="debug" value="false"/>
+      <property name="security.config" value="${com.sun.aas.installRoot}/lib/appclient/wss-client-config-1.0.xml"/>
+    </provider-config>
+  </message-security-config>
+</client-container>

--- a/appserver/admin/payara_template_web/src/main/resources/config/glassfish-acc.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/glassfish-acc.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <!--
    Please remember to customize this file for your environment. The defaults for 

--- a/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-1.0.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-1.0.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+
+<!--
+ This server side config file pairs with wss-client-config-1.0.xml on the client
+ and supports the following UseCases:
+ Usecase 1: Authentication using Protected UsernameToken
+ Usecase 3: Encrypted UsernameToken and MessageBody
+ Usecase 4: Response Encryption Key Learnt from Incoming Message
+
+ Certificate Alias Information :
+ 1. A certificateAlias under the <xwss:Encrypt> element signifies the certificate
+    of the recipient of the message.
+ 2. A certificateAlias under the <xwss:Sign> element signifies the certificate of the
+    sender.
+                                                                                                                                               
+ NOTE:
+                                                                                                                                               
+   1. the certificateAlias has the above meaning for all the Sign and Encrypt elements below
+   2. there are several Sign and Encrypt elements below and similarly several RequireSignature and
+      RequireEncryption elements. Which of them would be actually used at runtime will depend on
+      the AuthPolicy passed to the module.
+                                                                                                                                               
+      For Example : if Auth-Source=Sender then only the <xwss:UsernameToken> elements will be used
+      and none of the <xwss:Sign> elements will be used.
+      If Auth-Source=Content then the <xwss:Sign> element will be used
+                                                                                                                                               
+   3.  The different variations of <xwss:Encrypt> elements in this configuration file are to accomodate
+       default encryption of the UsernameToken.
+                                                                                                                                               
+   4.  The actual certificate alias to be used for any Signature operation can be modified during AuthModule
+       initialization by setting the alias as the value of "signature.key.alias" property in the Module Options Map.
+   5.  The actual certificate alias to be used for any Encrypt operation can be modified during AuthModule
+       initialization by setting the alias as the value of "encryption.key.alias" property in the Module Options Map.
+                                                                                                                                               
+   6. Debug Dumping of Messages can be enabled by setting the "debug" property in the Module Options Map to "true" during
+      AuthModule initialization.
+   7. The Actual configuration file to be used by an Authmodule can be changed by setting the property "security.config" in
+      the Module Options Map to point to the configuration file location.
+   8. When the "security.config" property is not set during module initialization then a client auth module will use wss-client-config-2.0.xml
+      by default.
+   9. When the "security.config" property is not set during module initialization then a server auth module will use wss-server-config-2.0.xml
+      by default.
+
+-->
+
+<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config" 
+                            dumpMessages="false">
+    <xwss:Timestamp/>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireSignature>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireSignature>     
+    <xwss:RequireUsernameToken nonceRequired="false" passwordDigestRequired="false"/>      
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+    </xwss:Encrypt>    
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Sign>
+        <xwss:X509Token certificateAlias="s1as"/>
+    </xwss:Sign>
+    <xwss:UsernameToken digestPassword="false" useNonce="false"/>
+</xwss:SecurityConfiguration>

--- a/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-1.0.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-1.0.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 
 <!--

--- a/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-2.0.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-2.0.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+
+-->
+
+
+<!--
+ This server side config file pairs with wss-client-config-2.0.xml on the client 
+ and supports the following UseCases:
+ Usecase 2: Encrypted UsernameToken
+ Usecase 3: Encrypted UsernameToken and MessageBody 
+ Usecase 4: Response Encryption Key Learnt from Incoming Message
+
+ Certificate Alias Information :
+ 1. A certificateAlias under the <xwss:Encrypt> element signifies the certificate
+    of the recipient of the message.
+ 2. A certificateAlias under the <xwss:Sign> element signifies the certificate of the
+    sender.
+                                                                                                                                               
+ NOTE:
+                                                                                                                                               
+   1. the certificateAlias has the above meaning for all the Sign and Encrypt elements below
+   2. there are several Sign and Encrypt elements below and similarly several RequireSignature and
+      RequireEncryption elements. Which of them would be actually used at runtime will depend on
+      the AuthPolicy passed to the module.
+                                                                                                                                               
+      For Example : if Auth-Source=Sender then only the <xwss:UsernameToken> elements will be used
+      and none of the <xwss:Sign> elements will be used.
+      If Auth-Source=Content then the <xwss:Sign> element will be used
+                                                                                                                                               
+   3.  The different variations of <xwss:Encrypt> elements in this configuration file are to accomodate
+       default encryption of the UsernameToken.
+                                                                                                                                               
+   4.  The actual certificate alias to be used for any Signature operation can be modified during AuthModule
+       initialization by setting the alias as the value of "signature.key.alias" property in the Module Options Map.
+   5.  The actual certificate alias to be used for any Encrypt operation can be modified during AuthModule
+       initialization by setting the alias as the value of "encryption.key.alias" property in the Module Options Map.
+                                                                                                                                               
+   6. Debug Dumping of Messages can be enabled by setting the "debug" property in the Module Options Map to "true" during
+      AuthModule initialization.
+   7. The Actual configuration file to be used by an Authmodule can be changed by setting the property "security.config" in
+      the Module Options Map to point to the configuration file location.
+   8. When the "security.config" property is not set during module initialization then a client auth module will use wss-client-config-2.0.xml
+      by default.
+   9. When the "security.config" property is not set during module initialization then a server auth module will use wss-server-config-2.0.xml
+      by default.
+
+-->
+<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config" 
+                            dumpMessages="false">
+    <xwss:Timestamp/>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+    </xwss:Encrypt>    
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Encrypt>
+        <xwss:X509Token certificateAlias="s1as"/>
+        <xwss:KeyEncryptionMethod algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:Encrypt>
+    <xwss:Sign>
+        <xwss:X509Token certificateAlias="s1as"/>
+    </xwss:Sign>
+    <xwss:UsernameToken digestPassword="false" useNonce="true"/>
+
+    <xwss:RequireUsernameToken nonceRequired="true" passwordDigestRequired="false"/>      
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireEncryption>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+        <xwss:Target type="qname">{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}UsernameToken</xwss:Target>
+    </xwss:RequireEncryption>
+    <xwss:RequireSignature>
+        <xwss:Target type="qname">SOAP-BODY</xwss:Target>
+    </xwss:RequireSignature>     
+</xwss:SecurityConfiguration>

--- a/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-2.0.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/config/wss-server-config-2.0.xml
@@ -1,19 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 
 

--- a/appserver/admin/payara_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/stringsubs.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+<stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
+    <component id="GlassFish Core">
+        <group-ref name="glassfish-core-sub"/>
+    </component>
+    <group id="glassfish-core-sub" mode="forward">
+    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+        <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
+        <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
+        <change-pair-ref name="VERSION"/>
+        <change-pair-ref name="INSTALL_ROOT"/>
+        <change-pair-ref name="SERVER_ID"/>
+        <change-pair-ref name="SERVER_ROOT"/>
+        <change-pair-ref name="SERVER_NAME"/>
+        <change-pair-ref name="ORB_LISTENER1_PORT"/>
+        <change-pair-ref name="CONFIG_MODEL_NAME"/>
+        <change-pair-ref name="DOMAIN_NAME"/>
+        <change-pair-ref name="JMS_PROVIDER_PORT"/>
+        <change-pair-ref name="ORB_LISTENER_PORT"/>
+        <change-pair-ref name="ORB_SSL_PORT"/>
+        <change-pair-ref name="ORB_MUTUALAUTH_PORT"/>
+        <change-pair-ref name="JMX_SYSTEM_CONNECTOR_PORT"/>
+        <change-pair-ref name="JAVA_DEBUGGER_PORT"/>
+        <change-pair-ref name="OSGI_SHELL_TELNET_PORT"/>
+        <change-pair-ref name="HTTP_PORT"/>
+        <change-pair-ref name="HTTP_SSL_PORT"/>
+        <change-pair-ref name="ADMIN_PORT"/>
+        <change-pair-ref name="SECURE_ADMIN_IDENTIFIER"/>
+        <change-pair-ref name="ADMIN_CERT_DN"/>
+        <change-pair-ref name="INSTANCE_CERT_DN"/>
+        <change-pair-ref name="HOST_NAME"/>
+        <change-pair-ref name="TOKENS_HERE"/>
+        <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
+        <change-pair-ref name="PORT_BASE"/>
+    </group>
+    <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
+    <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
+    <change-pair id="SERVER_ID" before="%%%SERVER_ID%%%" after="$SERVER_ID$"/>
+    <change-pair id="SERVER_ROOT" before="%%%SERVER_ROOT%%%" after="$SERVER_ROOT$"/>
+    <change-pair id="SERVER_NAME" before="%%%SERVER_NAME%%%" after="$SERVER_NAME$"/>
+    <change-pair id="ORB_LISTENER1_PORT" before="%%%ORB_LISTENER1_PORT%%%" after="$ORB_LISTENER_PORT$"/>
+    <change-pair id="CONFIG_MODEL_NAME" before="%%%CONFIG_MODEL_NAME%%%" after="$CONFIG_MODEL_NAME$"/>
+    <change-pair id="DOMAIN_NAME" before="%%%DOMAIN_NAME%%%" after="$DOMAIN_NAME$"/>
+    <change-pair id="JMS_PROVIDER_PORT" before="%%%JMS_PROVIDER_PORT%%%" after="$JMS_PROVIDER_PORT$"/>
+    <change-pair id="ORB_LISTENER_PORT" before="%%%ORB_LISTENER_PORT%%%" after="$ORB_LISTENER_PORT$"/>
+    <change-pair id="ORB_SSL_PORT" before="%%%ORB_SSL_PORT%%%" after="$ORB_SSL_PORT$"/>
+    <change-pair id="ORB_MUTUALAUTH_PORT" before="%%%ORB_MUTUALAUTH_PORT%%%" after="$ORB_MUTUALAUTH_PORT$"/>
+    <change-pair id="JMX_SYSTEM_CONNECTOR_PORT" before="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" after="$JMX_SYSTEM_CONNECTOR_PORT$"/>
+    <change-pair id="JAVA_DEBUGGER_PORT" before="%%%JAVA_DEBUGGER_PORT%%%" after="$JAVA_DEBUGGER_PORT$"/>
+    <change-pair id="OSGI_SHELL_TELNET_PORT" before="%%%OSGI_SHELL_TELNET_PORT%%%" after="$OSGI_SHELL_TELNET_PORT$"/>
+    <change-pair id="HTTP_PORT" before="%%%HTTP_PORT%%%" after="$HTTP_PORT$"/>
+    <change-pair id="HTTP_SSL_PORT" before="%%%HTTP_SSL_PORT%%%" after="$HTTP_SSL_PORT$"/>
+    <change-pair id="ADMIN_PORT" before="%%%ADMIN_PORT%%%" after="$ADMIN_PORT$"/>
+    <change-pair id="SECURE_ADMIN_IDENTIFIER" before="%%%SECURE_ADMIN_IDENTIFIER%%%" after="$SECURE_ADMIN_IDENTIFIER$"/>
+    <change-pair id="ADMIN_CERT_DN" before="%%%ADMIN_CERT_DN%%%" after="$ADMIN_CERT_DN$"/>
+    <change-pair id="INSTANCE_CERT_DN" before="%%%INSTANCE_CERT_DN%%%" after="$INSTANCE_CERT_DN$"/>
+    <change-pair id="HOST_NAME" before="%%%HOST_NAME%%%" after="$HOST_NAME$"/>
+    <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
+    <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
+    <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <defaults>
+        <property key="ADMIN_PORT" value="4848" type="port"/>
+        <property key="HTTP_SSL_PORT" value="8181" type="port"/>
+        <property key="ORB_SSL_PORT" value="3820" type="port"/>
+        <property key="ORB_MUTUALAUTH_PORT" value="3920" type="port"/>
+        <property key="HTTP_PORT" value="8080" type="port"/>
+        <property key="JMS_PROVIDER_PORT" value="7676" type="port"/>
+        <property key="ORB_LISTENER_PORT" value="3700" type="port"/>
+        <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
+        <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
+        <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+    </defaults>
+</stringsubs-definition>

--- a/appserver/admin/payara_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/stringsubs.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
     <component id="GlassFish Core">

--- a/appserver/admin/payara_template_web/src/main/resources/template-info.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/template-info.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ -->
+
+<domain-template-info xmlns="http://xmlns.oracle.com/cie/glassfish/domain-template"
+    version="4.0.0.0"
+    type="Domain Template"
+    name="Basic Payara Server Domain"
+    author="Payara Foundation"
+    description="Create a basic Payara Server domain."
+></domain-template-info>

--- a/appserver/admin/payara_template_web/src/main/resources/template-info.xml
+++ b/appserver/admin/payara_template_web/src/main/resources/template-info.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
 
 <domain-template-info xmlns="http://xmlns.oracle.com/cie/glassfish/domain-template"
     version="4.0.0.0"

--- a/appserver/admin/pom.xml
+++ b/appserver/admin/pom.xml
@@ -65,5 +65,6 @@
         <module>gf_template</module>
         <module>gf_template_web</module>
         <module>payara_template</module>
+        <module>payara_template_web</module>
     </modules>
 </project>

--- a/appserver/admin/pom.xml
+++ b/appserver/admin/pom.xml
@@ -41,7 +41,7 @@
 
 -->
 
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/distributions/payara-ml/src/main/assembly/payara-ml.xml
+++ b/appserver/distributions/payara-ml/src/main/assembly/payara-ml.xml
@@ -58,6 +58,10 @@
                 <exclude>bin/*</exclude>
                 <exclude>glassfish/bin/*</exclude>
                 <exclude>glassfish/lib/nadmin*</exclude>
+                <!-- Exclude appserver-domain files except for original -->
+                <exclude>glassfish/common/templates/gf/*appserver-domain-*.jar</exclude>
+                <!-- Exclude payara-domain files except for original -->
+                <exclude>glassfish/common/templates/gf/*payara-domain-*.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>

--- a/appserver/distributions/payara-ml/src/main/assembly/payara-ml.xml
+++ b/appserver/distributions/payara-ml/src/main/assembly/payara-ml.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 

--- a/appserver/distributions/payara-web-ml/src/main/assembly/payara-web-ml.xml
+++ b/appserver/distributions/payara-web-ml/src/main/assembly/payara-web-ml.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2017] [Payara Foundation] -->
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">

--- a/appserver/distributions/payara-web-ml/src/main/assembly/payara-web-ml.xml
+++ b/appserver/distributions/payara-web-ml/src/main/assembly/payara-web-ml.xml
@@ -58,6 +58,10 @@
                 <exclude>bin/*</exclude>
                 <exclude>glassfish/bin/*</exclude>
                 <exclude>glassfish/lib/nadmin*</exclude>
+                <!-- Exclude appserver-domain files -->
+                <exclude>glassfish/common/templates/gf/*appserver-domain*.jar</exclude>
+                <!-- Exclude payara-domain files -->
+                <exclude>glassfish/common/templates/gf/*payara-domain*.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>
@@ -79,4 +83,18 @@
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>
     </fileSets>
+    
+    <!-- Name of appserver-domain and payara-domain replacements -->
+    <files>
+        <file>
+            <source>${temp.dir}/${install.dir.name}/glassfish/common/templates/gf/appserver-domain-web.jar</source>
+            <destName>appserver-domain.jar</destName>
+            <outputDirectory>${install.dir.name}/glassfish/common/templates/gf/</outputDirectory>
+        </file>
+        <file>
+            <source>${temp.dir}/${install.dir.name}/glassfish/common/templates/gf/payara-domain-web.jar</source>
+            <destName>payara-domain.jar</destName>
+            <outputDirectory>${install.dir.name}/glassfish/common/templates/gf/</outputDirectory>
+        </file>
+    </files>
 </assembly>

--- a/appserver/distributions/payara-web/src/main/assembly/payara-web.xml
+++ b/appserver/distributions/payara-web/src/main/assembly/payara-web.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2017] [Payara Foundation] -->
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">

--- a/appserver/distributions/payara-web/src/main/assembly/payara-web.xml
+++ b/appserver/distributions/payara-web/src/main/assembly/payara-web.xml
@@ -58,6 +58,8 @@
                 <exclude>bin/*</exclude>
                 <exclude>glassfish/bin/*</exclude>
                 <exclude>glassfish/lib/nadmin*</exclude>
+                <!-- Exclude appserver-domain files -->
+                <exclude>glassfish/common/templates/gf/*appserver-domain*.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>
@@ -79,4 +81,13 @@
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>
     </fileSets>
+    
+    <!-- Name of appserver-domain replacement -->
+    <files>
+        <file>
+            <source>${temp.dir}/${install.dir.name}/glassfish/common/templates/gf/appserver-domain-web.jar</source>
+            <destName>appserver-domain.jar</destName>
+            <outputDirectory>${install.dir.name}/glassfish/common/templates/gf/</outputDirectory>
+        </file>
+    </files>
 </assembly>

--- a/appserver/distributions/payara-web/src/main/assembly/payara-web.xml
+++ b/appserver/distributions/payara-web/src/main/assembly/payara-web.xml
@@ -60,6 +60,8 @@
                 <exclude>glassfish/lib/nadmin*</exclude>
                 <!-- Exclude appserver-domain files -->
                 <exclude>glassfish/common/templates/gf/*appserver-domain*.jar</exclude>
+                <!-- Exclude payara-domain files -->
+                <exclude>glassfish/common/templates/gf/*payara-domain*.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>
@@ -82,11 +84,16 @@
         </fileSet>
     </fileSets>
     
-    <!-- Name of appserver-domain replacement -->
+    <!-- Name of appserver-domain and payara-domain replacements -->
     <files>
         <file>
             <source>${temp.dir}/${install.dir.name}/glassfish/common/templates/gf/appserver-domain-web.jar</source>
             <destName>appserver-domain.jar</destName>
+            <outputDirectory>${install.dir.name}/glassfish/common/templates/gf/</outputDirectory>
+        </file>
+        <file>
+            <source>${temp.dir}/${install.dir.name}/glassfish/common/templates/gf/payara-domain-web.jar</source>
+            <destName>payara-domain.jar</destName>
             <outputDirectory>${install.dir.name}/glassfish/common/templates/gf/</outputDirectory>
         </file>
     </files>

--- a/appserver/distributions/payara/src/main/assembly/payara.xml
+++ b/appserver/distributions/payara/src/main/assembly/payara.xml
@@ -58,6 +58,10 @@
                 <exclude>bin/*</exclude>
                 <exclude>glassfish/bin/*</exclude>
                 <exclude>glassfish/lib/nadmin*</exclude>
+                <!-- Exclude appserver-domain files except for original -->
+                <exclude>glassfish/common/templates/gf/*appserver-domain-*.jar</exclude>
+                <!-- Exclude payara-domain files except for original -->
+                <exclude>glassfish/common/templates/gf/*payara-domain-*.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}</outputDirectory>
         </fileSet>

--- a/appserver/distributions/payara/src/main/assembly/payara.xml
+++ b/appserver/distributions/payara/src/main/assembly/payara.xml
@@ -40,7 +40,8 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 

--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
 
 <project name="glassfish-embedded-all" default="create.distribution" basedir=".">
     <property name="rootdir" value="target"/>

--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -109,9 +109,9 @@
 	  <fileset dir="${modulesdir}" includes="console-**-help.jar"/>
 	  <fileset dir="${modulesdir}" includes="console-**-plugin.jar"/>
 	  <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
-	  <fileset dir="${gfdir}" includes="**/appserver-domain.jar"/>
+	  <fileset dir="${gfdir}" includes="**/appserver-domain*.jar"/>
 	  <fileset dir="${gfdir}" includes="**/nucleus-domain.jar"/>
-      <fileset dir="${gfdir}" includes="**/payara-domain.jar"/>
+          <fileset dir="${gfdir}" includes="**/payara-domain*.jar"/>
 	  <fileset dir="${gfdir}" includes="**/weld-se-core.jar"/>
 	  <fileset dir="${gfdir}" includes="**/weld-environment-common.jar"/>
 	</delete>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -117,8 +117,8 @@
 	  <fileset dir="${runtimedir}" includes="console-**-help.jar"/>
 	  <fileset dir="${runtimedir}" includes="console-**-plugin.jar"/>
 	  <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
-	  <fileset dir="${runtimedir}" includes="**/appserver-domain.jar"/>
-	  <fileset dir="${runtimedir}" includes="**/payara-domain.jar"/>
+	  <fileset dir="${runtimedir}" includes="**/appserver-domain*.jar"/>
+	  <fileset dir="${runtimedir}" includes="**/payara-domain*.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/nucleus-domain.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/weld-se-core.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/weld-environment-common.jar"/>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
 
 <project name="payara-micro" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>

--- a/appserver/extras/payara-micro/payara-micro-microprofile-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-microprofile-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
 
 <project name="payara-microprofile" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>

--- a/appserver/extras/payara-micro/payara-micro-microprofile-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-microprofile-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016] [Payara Foundation] -->
+<!-- Portions Copyright [2017] [Payara Foundation] -->
 
 <project name="payara-microprofile" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>

--- a/appserver/extras/payara-micro/payara-micro-microprofile-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-microprofile-distribution/build.xml
@@ -116,9 +116,9 @@
 	  <fileset dir="${runtimedir}" includes="**console-plugin.jar"/>
 	  <fileset dir="${runtimedir}" includes="console-**-plugin.jar"/>
 	  <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
-	  <fileset dir="${runtimedir}" includes="**/appserver-domain.jar"/>
+	  <fileset dir="${runtimedir}" includes="**/appserver-domain*.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/payara-domain*.jar"/>
-	  <fileset dir="${runtimedir}" includes="**/nucleus-domain.jar"/>
+	  <fileset dir="${runtimedir}" includes="**/nucleus-domain*.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/weld-se-core.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/weld-environment-common.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/derbyLocale*.jar"/>

--- a/appserver/packager/glassfish-nucleus/pom.xml
+++ b/appserver/packager/glassfish-nucleus/pom.xml
@@ -143,9 +143,14 @@
            <artifactId>payara-domain</artifactId>
            <version>${project.version}</version>
        </dependency>
-        <dependency>
+       <dependency>
            <groupId>org.glassfish.main.admin</groupId>
            <artifactId>appserver-domain-web</artifactId>
+           <version>${project.version}</version>
+       </dependency>
+       <dependency>
+           <groupId>org.glassfish.main.admin</groupId>
+           <artifactId>payara-domain-web</artifactId>
            <version>${project.version}</version>
        </dependency>
     </dependencies>

--- a/appserver/packager/glassfish-nucleus/pom.xml
+++ b/appserver/packager/glassfish-nucleus/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2017] [Payara Foundation] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/packager/glassfish-nucleus/pom.xml
+++ b/appserver/packager/glassfish-nucleus/pom.xml
@@ -143,6 +143,11 @@
            <artifactId>payara-domain</artifactId>
            <version>${project.version}</version>
        </dependency>
+        <dependency>
+           <groupId>org.glassfish.main.admin</groupId>
+           <artifactId>appserver-domain-web</artifactId>
+           <version>${project.version}</version>
+       </dependency>
     </dependencies>
 </project>
 


### PR DESCRIPTION
Caused by JMS declaration lines in domain.xml.
- Added new modules to generate modified domain templates for Web Profile
- New domain templates have had the JMS lines removed.
- New domain templates are packaged into glassfish-nucleus packager as gf_template_web and payara_template_web.
- Payara Web and Web-ML replace the default domain templates with the correct one.
- All other distributions now discard any new domain templates to keep the originals.