### PR TITLE
Javadoc Plugin Fix

### DIFF
--- a/appserver/admingui/email-notifier-console-plugin/src/main/java/fish/payara/admingui/notifier/email/EmailNotifierPlugin.java
+++ b/appserver/admingui/email-notifier-console-plugin/src/main/java/fish/payara/admingui/notifier/email/EmailNotifierPlugin.java
@@ -16,7 +16,7 @@
  file and include the License file at packager/legal/LICENSE.txt.
  */
 
-package fish.payara.admingui.notifier.eventbus;
+package fish.payara.admingui.notifier.email;
 
 import java.net.URL;
 import org.glassfish.api.admingui.ConsoleProvider;

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -241,6 +241,7 @@
         <jdk.version>1.7.0-09</jdk.version>
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
         <javadoc.skip>false</javadoc.skip>
+        <javadoc.version>2.10.3</javadoc.version>
         <deploy.skip>false</deploy.skip>
     </properties>
 
@@ -338,7 +339,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>${javadoc.version}</version>
+                    <configuration>
+                        <additionalparam>${javadoc.options}</additionalparam>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1090,11 +1094,6 @@
                 <version>2.14.2</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
-            </dependency>
-            <dependency>
                 <groupId>org.fusesource.hawtjni</groupId>
                 <artifactId>hawtjni-runtime</artifactId>
                 <version>1.13</version>
@@ -1245,6 +1244,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.options>-Xdoclint:none</javadoc.options>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Made a new profile to disable doclint on JDK 1.8 and above, which was causing errors when running the javadoc goal.