### PR TITLE
PAYARA-1681 Add default JVM options check

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -59,6 +59,7 @@ import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
 import com.sun.enterprise.universal.xml.MiniXmlParser;
 import static com.sun.enterprise.util.SystemPropertyConstants.*;
 import static com.sun.enterprise.admin.launcher.GFLauncherConstants.*;
+import fish.payara.admin.launcher.PayaraJvmOptionDefaults;
 
 /**
  * This is the main Launcher class designed for external and internal usage.
@@ -818,13 +819,28 @@ public abstract class GFLauncher {
                 parser.getProfilerSystemProperties());
 
         List<String> rawJvmOptions = parser.getJvmOptions();
-        rawJvmOptions.addAll(getSpecialSystemProperties());
+        rawJvmOptions.addAll(getSpecialSystemProperties()); 
         if (profiler.isEnabled()) {
             rawJvmOptions.addAll(profiler.getJvmOptions());
         }
         jvmOptions = new JvmOptions(rawJvmOptions);
         if (info.isDropInterruptedCommands()) {
             jvmOptions.sysProps.put(SystemPropertyConstants.DROP_INTERRUPTED_COMMANDS, Boolean.TRUE.toString());
+        }
+        
+        // PAYARA-1681 - Add any missing required JVM Options
+        addDefaultJvmOptions();
+    }
+    
+    private void addDefaultJvmOptions() {
+        if (!jvmOptions.getCombinedMap().containsKey(PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY)) {
+            jvmOptions.sysProps.put(PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY, 
+                    PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE);
+            
+            // Log that we've made the change
+            GFLauncherLogger.fine(GFLauncherLogger.DEFAULT_JVM_OPTION, 
+                    PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY,
+                    PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE);
         }
     }
 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -59,7 +59,7 @@ import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
 import com.sun.enterprise.universal.xml.MiniXmlParser;
 import static com.sun.enterprise.util.SystemPropertyConstants.*;
 import static com.sun.enterprise.admin.launcher.GFLauncherConstants.*;
-import fish.payara.admin.launcher.PayaraJvmOptionDefaults;
+import fish.payara.admin.launcher.PayaraDefaultJvmOptions;
 
 /**
  * This is the main Launcher class designed for external and internal usage.
@@ -828,19 +828,19 @@ public abstract class GFLauncher {
             jvmOptions.sysProps.put(SystemPropertyConstants.DROP_INTERRUPTED_COMMANDS, Boolean.TRUE.toString());
         }
         
-        // PAYARA-1681 - Add any missing required JVM Options
+        // PAYARA-1681 - Add default Payara JVM options if an override isn't in place
         addDefaultJvmOptions();
     }
     
     private void addDefaultJvmOptions() {
-        if (!jvmOptions.getCombinedMap().containsKey(PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY)) {
-            jvmOptions.sysProps.put(PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY, 
-                    PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE);
+        if (!jvmOptions.getCombinedMap().containsKey(PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY)) {
+            jvmOptions.sysProps.put(PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY, 
+                    PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE);
             
             // Log that we've made the change
             GFLauncherLogger.fine(GFLauncherLogger.DEFAULT_JVM_OPTION, 
-                    PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY,
-                    PayaraJvmOptionDefaults.GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE);
+                    PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY,
+                    PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE);
         }
     }
 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -819,7 +819,7 @@ public abstract class GFLauncher {
                 parser.getProfilerSystemProperties());
 
         List<String> rawJvmOptions = parser.getJvmOptions();
-        rawJvmOptions.addAll(getSpecialSystemProperties()); 
+        rawJvmOptions.addAll(getSpecialSystemProperties());
         if (profiler.isEnabled()) {
             rawJvmOptions.addAll(profiler.getJvmOptions());
         }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
@@ -37,6 +37,9 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+
+// Portions Copyright [2017] [Payara Foundation and/or its affiliates.]
+
 package com.sun.enterprise.admin.launcher;
 
 import com.sun.enterprise.server.logging.ODLLogFormatter;

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
@@ -193,7 +193,7 @@ public class GFLauncherLogger {
             message =
     "Using Payara default value \"{1}\" for JVM option: {0}",
     comment = "JVM Info",
-    cause = "JVM Option not present in domain.xml",
+    cause = "JVM option not present in domain.xml",
     action = "Override the Payara default by adding the JVM option to your config",
     level = "FINE")
     public static final String DEFAULT_JVM_OPTION = "PAYARA-GFLAUNCHER-00001";

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
@@ -185,4 +185,13 @@ public class GFLauncherLogger {
     action = "NA",
     level = "INFO")
     public static final String COMMAND_LINE = "NCLS-GFLAUNCHER-00005";
+    
+    @LogMessageInfo(
+            message =
+    "Using Payara default value \"{1}\" for JVM option: {0}",
+    comment = "JVM Info",
+    cause = "JVM Option not present in domain.xml",
+    action = "Override the Payara default by adding the JVM option to your config",
+    level = "FINE")
+    public static final String DEFAULT_JVM_OPTION = "PAYARA-GFLAUNCHER-00001";
 }

--- a/nucleus/admin/launcher/src/main/java/fish/payara/admin/launcher/PayaraDefaultJvmOptions.java
+++ b/nucleus/admin/launcher/src/main/java/fish/payara/admin/launcher/PayaraDefaultJvmOptions.java
@@ -43,7 +43,7 @@ package fish.payara.admin.launcher;
  *
  * @author Andrew Pielage
  */
-public class PayaraJvmOptionDefaults {
+public class PayaraDefaultJvmOptions {
     public static final String GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY="org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER";
     public static final String GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE="org.glassfish.grizzly.memory.HeapMemoryManager";
 }

--- a/nucleus/admin/launcher/src/main/java/fish/payara/admin/launcher/PayaraJvmOptionDefaults.java
+++ b/nucleus/admin/launcher/src/main/java/fish/payara/admin/launcher/PayaraJvmOptionDefaults.java
@@ -1,0 +1,49 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2016-2017] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.admin.launcher;
+
+/**
+ *
+ * @author Andrew Pielage
+ */
+public class PayaraJvmOptionDefaults {
+    public static final String GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY="org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER";
+    public static final String GRIZZLY_DEFAULT_MEMORY_MANAGER_VALUE="org.glassfish.grizzly.memory.HeapMemoryManager";
+}


### PR DESCRIPTION
If the JVM option _org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER_ is not present in the server/instance config, we will override the Grizzly default and use the _HeapMemoryManager_.
To override this behaviour (so to use a different memory manager), you must specify this JVM option in the server/instance config with your desired setting.

This is to help with people upgrading from an older version of Payara where this JVM option has not been added to the default domain.xml.

When this override happens, a message is logged at a level of FINE.

When this override happens, the JVM option is **NOT** added to the domain.xml.
