### PR TITLE
PAYARA-1694 Healthcheck still prints out error in log

### DIFF
--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HistoricHealthCheckEventRetriever.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/HistoricHealthCheckEventRetriever.java
@@ -102,7 +102,6 @@ public class HistoricHealthCheckEventRetriever implements AdminCommand {
 
         if (!service.isEnabled()){
             actionReport.setMessage("Health Check service is not enabled");
-            actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
             return;
         }      
         else {


### PR DESCRIPTION
Don't mark command as failed when not enabled