### PR TITLE
PAYARA 1739 Pre and Post boot command parsing problem

### DIFF
--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -243,7 +243,10 @@ public class GlassFishMain {
                 CommandRunner cmdRunner = gf.getCommandRunner();
                 
                 while (line != null) {
-                    if (!(line.isEmpty() || line.contains("#"))) {
+                    if (!line.isEmpty()) {
+                        if(line.contains("#")) {
+                            line = line.split("#")[0];
+                        }
                         runCommand(cmdRunner, line);
                     }
                     line = reader.readLine();

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -174,13 +174,7 @@ public class GlassFishMain {
                             continue;
                         }
                         CommandRunner cmdRunner = gf.getCommandRunner();
-                        String[] tokens = command.split("\\s");
-                        CommandResult result = cmdRunner.run(tokens[0], Arrays.copyOfRange(tokens, 1, tokens.length));
-                        System.out.println(result.getExitStatus());
-                        System.out.println(result.getOutput());
-                        if (result.getFailureCause() != null) {
-                            result.getFailureCause().printStackTrace();
-                        }
+                        runCommand(cmdRunner, command);
                     }
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -218,6 +212,21 @@ public class GlassFishMain {
             });
 
         }
+        /**
+         * Runs a command read from a string
+         * @param cmdRunner
+         * @param line
+         * @throws GlassFishException 
+         */
+        private void runCommand(CommandRunner cmdRunner, String line) throws GlassFishException, IOException {
+            System.out.println("Running command: " + line);
+            String[] tokens = line.split("\\s");
+            CommandResult result = cmdRunner.run(tokens[0], Arrays.copyOfRange(tokens, 1, tokens.length));
+            System.out.println(result.getOutput());
+            if(result.getFailureCause() != null) {
+                result.getFailureCause().printStackTrace();
+            }
+        }
  
         /**
          * Runs a series of commands from a file
@@ -230,25 +239,13 @@ public class GlassFishMain {
             try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
                 
                 System.out.println("Reading in commandments from " + file);
-                String line = reader.readLine();;
+                String line = reader.readLine();
+                CommandRunner cmdRunner = gf.getCommandRunner();
+                
                 while (line != null) {
-                    
-                        String[] commmandParts = cleanCommand(line);
-                        CommandRunner runner = gf.getCommandRunner();
-                        CommandResult result;
-                        if (!(commmandParts[0].isEmpty() || commmandParts[0].equals(" "))){
-                            
-                            if (commmandParts.length == 1){
-                                result = runner.run(commmandParts[0]);
-                            } else {
-                                String[] argv = commmandParts[1].split(" ");
-                                result = runner.run(commmandParts[0], argv);
-                            }
-                            System.out.println(result.getOutput());
-                            if (result.getFailureCause() != null){
-                                throw result.getFailureCause();
-                            }
-                        }
+                    if (!(line.isEmpty() || line.contains("#"))) {
+                        runCommand(cmdRunner, line);
+                    }
                     line = reader.readLine();
                 }
             } catch (IOException ex) {
@@ -256,22 +253,6 @@ public class GlassFishMain {
             } catch (Throwable ex) {
                 Logger.getLogger(GlassFishMain.class.getName()).log(Level.SEVERE, null, ex);
             }
-        }
-        
-        /**
-         * Cleans up a single line command to be space-seperated, comments removed etc.
-         * @param command
-         * @return 
-         */
-        private String[] cleanCommand(String command){
-            String line = command.split("#")[0];
-            line = line.trim();
-            if (!line.startsWith("set ")){
-                line = line.replaceAll("=", " ");
-            }            
-            line = line.replaceAll("(\\s+)", " ");
-            String[] split = line.split(" ", 2);
-            return split;
         }
         
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -212,6 +212,7 @@ public class GlassFishMain {
             });
 
         }
+        
         /**
          * Runs a command read from a string
          * @param cmdRunner
@@ -219,13 +220,34 @@ public class GlassFishMain {
          * @throws GlassFishException 
          */
         private void runCommand(CommandRunner cmdRunner, String line) throws GlassFishException, IOException {
+            
+            line = cleanCommand(line);
+            if(line == null) {
+                return;
+            }
+            
             System.out.println("Running command: " + line);
-            String[] tokens = line.split("\\s");
+            String[] tokens = line.split("\\s+");
             CommandResult result = cmdRunner.run(tokens[0], Arrays.copyOfRange(tokens, 1, tokens.length));
             System.out.println(result.getOutput());
             if(result.getFailureCause() != null) {
                 result.getFailureCause().printStackTrace();
             }
+        }
+        
+        /**
+         * Cleans a command read from a string
+         * @param line
+         */
+        private String cleanCommand(String line) {
+            if(line == null) {
+                return null;
+            }
+            line = line.replaceAll("#.*", ""); // Removes comments
+            if (line.isEmpty() || line.replaceAll("\\s", "").isEmpty()) {
+                return null;
+            }
+            return line;
         }
  
         /**
@@ -243,12 +265,7 @@ public class GlassFishMain {
                 CommandRunner cmdRunner = gf.getCommandRunner();
                 
                 while (line != null) {
-                    if (!line.isEmpty()) {
-                        if(line.contains("#")) {
-                            line = line.split("#")[0];
-                        }
-                        runCommand(cmdRunner, line);
-                    }
+                    runCommand(cmdRunner, line);
                     line = reader.readLine();
                 }
             } catch (IOException ex) {


### PR DESCRIPTION
Previous parsing method was replacing equals characters with spaces which causes problems with passing properties to commands.

e.g. command = "create-jdbc-connection-pool --datasourceclassname com.mysql.jdbc.jdbc2.optional.MysqlDataSource --restype javax.sql.DataSource --property user=root:password=password:serverName=localhost:portNumber=3306:databaseName=test test-connection-pool --user admin --passwordFile /opt/pwdfile"