### PR TITLE
PAYARA-1072 PAYARA-1740 Refactor context util and bug fixes

### DIFF
--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
@@ -161,8 +161,7 @@ public class ClusteredCDIEventBusImpl implements CDIEventListener, ClusteredCDIE
                 return;
         }
 
-        Context ctx = ctxUtil.pushContext();
-        try {
+        try(Context ctx = ctxUtil.pushContext()) {
             managedExecutorService.submit(new Runnable() {
                 @Override
                 public void run() {
@@ -204,8 +203,6 @@ public class ClusteredCDIEventBusImpl implements CDIEventListener, ClusteredCDIE
                     }
                 }
             });
-        } finally {
-            ctxUtil.popContext(ctx);
         }
     }
 

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
@@ -126,8 +126,8 @@ public class ClusteredCDIEventBusImpl implements CDIEventListener, ClusteredCDIE
         
         // try again
 
-        if (ctxUtil.getApplicationName() == null) {
-            ctxUtil = Globals.getDefaultHabitat().getService(JavaEEContextUtil.class);
+        if (ctxUtil.getInvocationComponentId() == null) {
+            ctxUtil.setInstanceContext();
         }
         
         if (managedExecutorService == null) {

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/context/JavaEEContextUtilImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/context/JavaEEContextUtilImpl.java
@@ -44,19 +44,20 @@ import com.sun.enterprise.deployment.BundleDescriptor;
 import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.deployment.JndiNameEnvironment;
 import com.sun.enterprise.util.Utility;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
 import org.glassfish.internal.api.JavaEEContextUtil;
 import java.util.HashMap;
 import javax.annotation.PostConstruct;
 import javax.enterprise.inject.spi.CDI;
-import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.api.ServerContext;
-import org.glassfish.internal.data.ApplicationInfo;
-import org.glassfish.internal.data.ApplicationRegistry;
 import org.jboss.weld.context.bound.BoundRequestContext;
 import org.jvnet.hk2.annotations.Service;
 
@@ -67,13 +68,18 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service
 @PerLookup
-public class JavaEEContextUtilImpl implements JavaEEContextUtil {
+public class JavaEEContextUtilImpl implements JavaEEContextUtil, Serializable {
     @PostConstruct
     void init() {
-        capturedInvocation = serverContext.getInvocationManager().getCurrentInvocation();
-        if(capturedInvocation != null) {
-            capturedInvocation = capturedInvocation.clone();
-        }
+        serverContext = Globals.getDefaultHabitat().getService(ServerContext.class);
+        compEnvMgr = Globals.getDefaultHabitat().getService(ComponentEnvManager.class);
+
+        doSetInstanceContext();
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        init();
     }
 
     /**
@@ -141,48 +147,62 @@ public class JavaEEContextUtilImpl implements JavaEEContextUtil {
     }
 
     /**
-     * @return application name or null if there is no invocation context
+     * set context class loader by component ID
      */
     @Override
-    public String getApplicationName() {
-        ComponentInvocation ci = serverContext.getInvocationManager().getCurrentInvocation();
-        return ci != null? ci.getModuleName() : null;
-    }
-
-    /**
-     * set context class loader by appName
-     *
-     * @param appName
-     */
-    @Override
-    public void setApplicationContext(String appName) {
-        if(appName == null) {
-            return;
+    public void setApplicationClassLoader() {
+        ClassLoader cl = null;
+        if(capturedInvocation != null && capturedInvocation.getJNDIEnvironment() != null) {
+            cl = getClassLoaderForEnvironment((JndiNameEnvironment)capturedInvocation.getJNDIEnvironment());
         }
-        ApplicationInfo appInfo = appRegistry.get(appName);
-
-        // try plain non-versioned app first
-        if(appInfo == null) {
-            appName = stripVersionSuffix(appName);
-            appInfo = appRegistry.get(appName);
+        else if(componentId != null) {
+            cl = getClassLoaderForEnvironment(compEnvMgr.getJndiNameEnvironment(componentId));
         }
-        // for versioned applications, search app registry and strip out the version number
-        if(appInfo == null) {
-            for(String regAppName : appRegistry.getAllApplicationNames()) {
-                if(stripVersionSuffix(regAppName).equals(appName)) {
-                    appInfo = appRegistry.get(regAppName);
-                    break;
-                }
-            }
-        }
-        if(appInfo != null) {
-            Utility.setContextClassLoader(appInfo.getAppClassLoader());
+        if(cl != null) {
+            Utility.setContextClassLoader(cl);
         }
     }
 
     @Override
     public ClassLoader getInvocationClassLoader() {
         JndiNameEnvironment componentEnv = compEnvMgr.getCurrentJndiNameEnvironment();
+        return getClassLoaderForEnvironment(componentEnv);
+    }
+
+    @Override
+    public void setInstanceContext() {
+        componentId = null;
+        doSetInstanceContext();
+    }
+
+    @Override
+    public String getInvocationComponentId() {
+        ComponentInvocation inv = serverContext.getInvocationManager().getCurrentInvocation();
+        return inv != null? inv.getComponentId() : null;
+    }
+
+    @Override
+    public JavaEEContextUtil setInstanceComponentId(String componentId) {
+        this.componentId = componentId;
+        if(componentId != null) {
+            createInvocationContext();
+        }
+        return this;
+    }
+
+    private void doSetInstanceContext() {
+        capturedInvocation = serverContext.getInvocationManager().getCurrentInvocation();
+        if(capturedInvocation != null) {
+            capturedInvocation = capturedInvocation.clone();
+            componentId = capturedInvocation.getComponentId();
+        }
+        else if(componentId != null) {
+            // deserialized version
+            createInvocationContext();
+        }
+    }
+
+    private ClassLoader getClassLoaderForEnvironment(JndiNameEnvironment componentEnv) {
         if(componentEnv instanceof BundleDescriptor) {
             BundleDescriptor bd = (BundleDescriptor)componentEnv;
             return bd.getClassLoader();
@@ -193,14 +213,16 @@ public class JavaEEContextUtilImpl implements JavaEEContextUtil {
         return null;
     }
 
-    private static String stripVersionSuffix(String name) {
-        int delimiterIndex = name.lastIndexOf(':');
-        return delimiterIndex != -1? name.substring(0, delimiterIndex) : name;
+    private void createInvocationContext() {
+        capturedInvocation = new ComponentInvocation();
+        capturedInvocation.componentId = componentId;
+        capturedInvocation.setJNDIEnvironment(compEnvMgr.getJndiNameEnvironment(componentId));
     }
 
 
-    private @Inject @Getter(AccessLevel.PACKAGE) ServerContext serverContext;
-    private ComponentInvocation capturedInvocation;
-    private @Inject ComponentEnvManager compEnvMgr;
-    private @Inject ApplicationRegistry appRegistry;
+    private transient @Getter(AccessLevel.PACKAGE) ServerContext serverContext;
+    private transient ComponentEnvManager compEnvMgr;
+    private transient ComponentInvocation capturedInvocation;
+    private String componentId;
+    private static final long serialVersionUID = 1L;
 }

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/context/JavaEEContextUtilImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/context/JavaEEContextUtilImpl.java
@@ -217,6 +217,7 @@ public class JavaEEContextUtilImpl implements JavaEEContextUtil, Serializable {
         capturedInvocation = new ComponentInvocation();
         capturedInvocation.componentId = componentId;
         capturedInvocation.setJNDIEnvironment(compEnvMgr.getJndiNameEnvironment(componentId));
+        capturedInvocation.setComponentInvocationType(ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION);
     }
 
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -828,6 +828,14 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         return sb.toString();
     }
 
+    static String stripApplicationVersion(String appName) {
+        int idx = appName.lastIndexOf(':');
+        if (idx < 0) {
+            return appName;
+        }
+        return appName.substring(0, idx);
+    }
+
     static String stripMavenVersion(String name) {
         int suffixIdx = name.lastIndexOf('-');
         if(suffixIdx > 0) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -477,7 +477,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             archiveName = BeanDeploymentArchiveImpl.stripMavenVersion(archiveName);
         }
         if(!context.getArchiveHandler().getArchiveType().isEmpty()) {
-            archiveName = String.format("%s.%s", archiveName, context.getArchiveHandler().getArchiveType());
+            archiveName = String.format("%s.%s", BeanDeploymentArchiveImpl.stripApplicationVersion(archiveName), context.getArchiveHandler().getArchiveType());
         }
         
         DeploymentImpl deploymentImpl = context.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/JavaEEContextUtil.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/JavaEEContextUtil.java
@@ -49,32 +49,21 @@ import org.jvnet.hk2.annotations.Contract;
 @Contract
 public interface JavaEEContextUtil {
     /**
-     * pushes Java EE invocation context
+     * pushes Java EE invocation context onto the invocation stack
+     * use Lombok @Cleanup or try-with-resources to pop the context
      *
-     * @return old ClassLoader, or null if no invocation has been created
+     * @return the new context that was created
      */
     Context pushContext();
 
     /**
      * pushes invocation context onto the stack
      * Also creates Request scope
+     * use Lombok @Cleanup or try-with-resources to pop the context
      *
      * @return new context that was created
      */
-    RequestContext pushRequestContext();
-
-    /**
-     * context to pop from the stack
-     *
-     * @param ctx to be popped
-     */
-    void popContext(Context ctx);
-    /**
-     * context to pop from the stack
-     *
-     * @param context to be popped
-     */
-    void popRequestContext(RequestContext context);
+    Context pushRequestContext();
 
     /**
      * set context class loader by internal state of this instance
@@ -100,10 +89,13 @@ public interface JavaEEContextUtil {
      */
     ClassLoader getInvocationClassLoader();
     /**
-     * @return component ID for this instance
+     * @return component ID for the current invocation (not this instance), not null
      */
     String getInvocationComponentId();
 
-    interface Context {};
-    interface RequestContext {};
+    interface Context extends Closeable {};
+    interface Closeable extends AutoCloseable {
+        @Override
+        public void close();
+    }
 }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/JavaEEContextUtil.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/JavaEEContextUtil.java
@@ -77,22 +77,32 @@ public interface JavaEEContextUtil {
     void popRequestContext(RequestContext context);
 
     /**
-     * @return application name or null if there is no invocation context
+     * set context class loader by internal state of this instance
      */
-    String getApplicationName();
+    void setApplicationClassLoader();
 
     /**
-     * set context class loader by appName
-     *
-     * @param appName
+     * Sets the state of this instance from current invocation context
      */
-    void setApplicationContext(String appName);
+    void setInstanceContext();
+
+    /**
+     * sets component ID for this instance and re-generates the invocation based on it
+     *
+     * @param componentId
+     * @return self for fluent API
+     */
+    JavaEEContextUtil setInstanceComponentId(String componentId);
 
     /**
      * @return Class Loader that's associated with current invocation
      *         or null if there is no current invocation
      */
     ClassLoader getInvocationClassLoader();
+    /**
+     * @return component ID for this instance
+     */
+    String getInvocationComponentId();
 
     interface Context {};
     interface RequestContext {};

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastSerializer.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastSerializer.java
@@ -60,14 +60,15 @@ public class PayaraHazelcastSerializer implements StreamSerializer<Object> {
 
     @Override
     public void write(ObjectDataOutput out, Object object) throws IOException {
-        delegate.write(out, ctxUtil.getApplicationName());
+        delegate.write(out, ctxUtil.getInvocationComponentId());
         delegate.write(out, object);
     }
 
     @Override
     public Object read(ObjectDataInput in) throws IOException {
-        String appName = (String)delegate.read(in);
-        ctxUtil.setApplicationContext(appName);
+        String componentId = (String)delegate.read(in);
+        ctxUtil.setInstanceComponentId(componentId);
+        ctxUtil.setApplicationClassLoader();
         return delegate.read(in);
     }
 

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/CacheManagerProxy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/CacheManagerProxy.java
@@ -70,8 +70,25 @@ public class CacheManagerProxy implements CacheManager {
         return ctxUtil != null? new CacheProxy<>(cache, ctxUtil) : cache;
     }
 
+    @Override
+    public <K, V> Cache<K, V> getCache(String cacheName) {
+        JavaEEContextUtil ctxUtil = serverContext.getDefaultServices().getService(JavaEEContextUtil.class);
+        Cache<K, V> cache = delegate.getCache(cacheName);
+        return cache != null? new CacheProxy<>(cache, ctxUtil) : null;
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getCache(String cacheName, Class<K> keyType, Class<V> valueType) {
+        JavaEEContextUtil ctxUtil = serverContext.getDefaultServices().getService(JavaEEContextUtil.class);
+        Cache<K, V> cache = delegate.getCache(cacheName, keyType, valueType);
+        return cache != null? new CacheProxy<>(cache, ctxUtil) : null;
+    }
+
+
     private interface Exclusions {
         public <K, V, C extends Configuration<K, V>> Cache<K, V> createCache(String string, C config) throws IllegalArgumentException;
+        public <K, V> Cache<K, V> getCache(String cacheName);
+        public <K, V> Cache<K, V> getCache(String cacheName, Class<K> keyType, Class<V> valueType);
     }
 
 

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/CompleteConfigurationProxy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/CompleteConfigurationProxy.java
@@ -41,7 +41,6 @@ package fish.payara.nucleus.hazelcast.contextproxy;
 
 import org.glassfish.internal.api.JavaEEContextUtil;
 import org.glassfish.internal.api.JavaEEContextUtil.Context;
-import org.glassfish.internal.api.JavaEEContextUtil.RequestContext;
 import java.util.Collection;
 import java.util.Map;
 import javax.cache.Cache;
@@ -52,6 +51,7 @@ import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
 import javax.cache.integration.CacheWriter;
 import javax.cache.integration.CacheWriterException;
+import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -80,15 +80,9 @@ class CompleteConfigurationProxy<K, V> extends MutableConfiguration<K, V> {
         return new Factory<CacheLoader<K, V>>() {
             @Override
             public CacheLoader<K, V> create() {
-                Context ctx = null;
-                try {
-                    ctx = ctxUtil.pushContext();
-                    final CacheLoader<K, V> loader = fact.create();
-                    return new CacheLoaderImpl(loader);
-                }
-                finally {
-                    ctxUtil.popContext(ctx);
-                }
+                @Cleanup Context ctx = ctxUtil.pushContext();
+                final CacheLoader<K, V> loader = fact.create();
+                return new CacheLoaderImpl(loader);
             }
             
             class CacheLoaderImpl implements CacheLoader<K, V> {
@@ -98,26 +92,14 @@ class CompleteConfigurationProxy<K, V> extends MutableConfiguration<K, V> {
 
                 @Override
                 public V load(K k) throws CacheLoaderException {
-                    RequestContext context = null;
-                    try {
-                        context = ctxUtil.pushRequestContext();
-                        return loader.load(k);
-                    }
-                    finally {
-                        ctxUtil.popRequestContext(context);
-                    }
+                    @Cleanup Context context = ctxUtil.pushRequestContext();
+                    return loader.load(k);
                 }
 
                 @Override
                 public Map<K, V> loadAll(Iterable<? extends K> itrbl) throws CacheLoaderException {
-                    RequestContext context = null;
-                    try {
-                        context = ctxUtil.pushRequestContext();
-                        return loader.loadAll(itrbl);
-                    }
-                    finally {
-                        ctxUtil.popRequestContext(context);
-                    }
+                    @Cleanup Context context = ctxUtil.pushRequestContext();
+                    return loader.loadAll(itrbl);
                 }
 
                 private final CacheLoader<K, V> loader;
@@ -131,66 +113,36 @@ class CompleteConfigurationProxy<K, V> extends MutableConfiguration<K, V> {
         return new Factory<CacheWriter<? super K, ? super V>>() {
             @Override
             public CacheWriter<K, V> create() {
-                Context ctx = null;
-                try {
-                    ctx = ctxUtil.pushContext();
-                    @SuppressWarnings("unchecked")
-                    final CacheWriter<K, V> delegate = (CacheWriter<K, V>) fact.create();
-                    return new CacheWriterImpl(delegate);
-                }
-                finally {
-                    ctxUtil.popContext(ctx);
-                }
+                @Cleanup Context ctx = ctxUtil.pushContext();
+                @SuppressWarnings("unchecked")
+                final CacheWriter<K, V> delegate = (CacheWriter<K, V>) fact.create();
+                return new CacheWriterImpl(delegate);
             }
 
             @RequiredArgsConstructor
             class CacheWriterImpl implements CacheWriter<K, V> {
                 @Override
                 public void write(Cache.Entry<? extends K, ? extends V> entry) throws CacheWriterException {
-                    RequestContext context = null;
-                    try {
-                        context = ctxUtil.pushRequestContext();
-                        delegate.write(entry);
-                    }
-                    finally {
-                        ctxUtil.popRequestContext(context);
-                    }
+                    @Cleanup Context context = ctxUtil.pushRequestContext();
+                    delegate.write(entry);
                 }
 
                 @Override
                 public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> clctn) throws CacheWriterException {
-                    RequestContext context = null;
-                    try {
-                        context = ctxUtil.pushRequestContext();
-                        delegate.writeAll(clctn);
-                    }
-                    finally {
-                        ctxUtil.popRequestContext(context);
-                    }
+                    @Cleanup Context context = ctxUtil.pushRequestContext();
+                    delegate.writeAll(clctn);
                 }
 
                 @Override
                 public void delete(Object o) throws CacheWriterException {
-                    RequestContext context = null;
-                    try {
-                        context = ctxUtil.pushRequestContext();
-                        delegate.delete(o);
-                    }
-                    finally {
-                        ctxUtil.popRequestContext(context);
-                    }
+                    @Cleanup Context context = ctxUtil.pushRequestContext();
+                    delegate.delete(o);
                 }
 
                 @Override
                 public void deleteAll(Collection<?> clctn) throws CacheWriterException {
-                    RequestContext context = null;
-                    try {
-                        context = ctxUtil.pushRequestContext();
-                        delegate.deleteAll(clctn);
-                    }
-                    finally {
-                        ctxUtil.popRequestContext(context);
-                    }
+                    @Cleanup Context context = ctxUtil.pushRequestContext();
+                    delegate.deleteAll(clctn);
                 }
 
                 private final CacheWriter<K, V> delegate;

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/CompleteConfigurationProxy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/CompleteConfigurationProxy.java
@@ -39,7 +39,6 @@
  */
 package fish.payara.nucleus.hazelcast.contextproxy;
 
-import java.io.IOException;
 import org.glassfish.internal.api.JavaEEContextUtil;
 import org.glassfish.internal.api.JavaEEContextUtil.Context;
 import org.glassfish.internal.api.JavaEEContextUtil.RequestContext;
@@ -54,7 +53,6 @@ import javax.cache.integration.CacheLoaderException;
 import javax.cache.integration.CacheWriter;
 import javax.cache.integration.CacheWriterException;
 import lombok.RequiredArgsConstructor;
-import org.glassfish.internal.api.Globals;
 
 /**
  * Proxy all applicable factory calls
@@ -67,11 +65,6 @@ class CompleteConfigurationProxy<K, V> extends MutableConfiguration<K, V> {
         super(config);
         this.ctxUtil = ctxUtil;
         init();
-    }
-
-    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-        ctxUtil = Globals.getDefaultHabitat().getService(JavaEEContextUtil.class);
     }
 
     private void init() {
@@ -207,6 +200,6 @@ class CompleteConfigurationProxy<K, V> extends MutableConfiguration<K, V> {
         };
     }
 
-    private transient /* final */ JavaEEContextUtil ctxUtil;
+    private final JavaEEContextUtil ctxUtil;
     private static final long serialVersionUID = 1L;
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/EntryProcessorProxy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/EntryProcessorProxy.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.nucleus.hazelcast.contextproxy;
 
+import java.io.Serializable;
 import org.glassfish.internal.api.JavaEEContextUtil;
 import org.glassfish.internal.api.JavaEEContextUtil.Context;
 import javax.cache.processor.EntryProcessor;
@@ -55,7 +56,7 @@ import lombok.RequiredArgsConstructor;
  * @param <T>
  */
 @RequiredArgsConstructor
-public class EntryProcessorProxy<K, V, T> implements EntryProcessor<K, V, T>{
+public class EntryProcessorProxy<K, V, T> implements EntryProcessor<K, V, T>, Serializable {
     @Override
     public T process(MutableEntry<K, V> me, Object... os) throws EntryProcessorException {
         Context ctx = null;
@@ -70,4 +71,5 @@ public class EntryProcessorProxy<K, V, T> implements EntryProcessor<K, V, T>{
 
     private final EntryProcessor<K, V, T> delegate;
     private final JavaEEContextUtil ctxUtil;
+    private static final long serialVersionUID = 1L;
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/EntryProcessorProxy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/contextproxy/EntryProcessorProxy.java
@@ -45,6 +45,7 @@ import org.glassfish.internal.api.JavaEEContextUtil.Context;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
+import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -59,14 +60,8 @@ import lombok.RequiredArgsConstructor;
 public class EntryProcessorProxy<K, V, T> implements EntryProcessor<K, V, T>, Serializable {
     @Override
     public T process(MutableEntry<K, V> me, Object... os) throws EntryProcessorException {
-        Context ctx = null;
-        try {
-            ctx = ctxUtil.pushContext();
-            return delegate.process(me, os);
-        }
-        finally {
-            ctxUtil.popContext(ctx);
-        }
+        @Cleanup Context ctx = ctxUtil.pushContext();
+        return delegate.process(me, os);
     }
 
     private final EntryProcessor<K, V, T> delegate;

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -204,7 +204,7 @@
         <logging-annotation-processor.version>1.7</logging-annotation-processor.version>
         <command-security-plugin.version>1.0.7</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
-        <hazelcast.version>3.8.2</hazelcast.version>
+        <hazelcast.version>3.8</hazelcast.version>
         <mail.version>1.5.6</mail.version>
         <javax.annotation-api.version>1.2</javax.annotation-api.version>
         <smack.version>4.1.9</smack.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -204,7 +204,7 @@
         <logging-annotation-processor.version>1.7</logging-annotation-processor.version>
         <command-security-plugin.version>1.0.7</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
-        <hazelcast.version>3.8</hazelcast.version>
+        <hazelcast.version>3.8.2</hazelcast.version>
         <mail.version>1.5.6</mail.version>
         <javax.annotation-api.version>1.2</javax.annotation-api.version>
         <smack.version>4.1.9</smack.version>


### PR DESCRIPTION
- Refactor JavaEEContextUtil APIs to greatly simplify and modernize it's usage
- Use try-with-resources for automatic context cleanup
- No more postInvoke, use automatic cleanup instead
- Bug fixes for JCache (add createCaache() support)

- fixed versioned BDA IDs for compatibility between versioned and non-versioned applications, especially the case with Payara Micro