### PR TITLE
PAYARA-1792 Environment variable replacement does not work in glassfish-resources.xml

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/AdministeredObjectDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/AdministeredObjectDefinitionDeployer.java
@@ -66,6 +66,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.config.support.TranslatedConfigView;
 
 /**
  * @author Dapeng Hu
@@ -221,7 +222,7 @@ public class AdministeredObjectDefinitionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return value;
+            return (String) TranslatedConfigView.getTranslatedValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/ConnectionFactoryDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/ConnectionFactoryDefinitionDeployer.java
@@ -67,6 +67,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.config.support.TranslatedConfigView;
 
 import static org.glassfish.deployment.common.JavaEEResourceType.*;
 
@@ -236,7 +237,7 @@ public class ConnectionFactoryDefinitionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return value;
+            return (String) TranslatedConfigView.getTranslatedValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSConnectionFactoryDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSConnectionFactoryDefinitionDeployer.java
@@ -72,6 +72,7 @@ import java.util.logging.Logger;
 import static com.sun.appserv.connectors.internal.api.ConnectorConstants.LOCAL_TRANSACTION_TX_SUPPORT_STRING;
 import static com.sun.appserv.connectors.internal.api.ConnectorConstants.NO_TRANSACTION_TX_SUPPORT_STRING;
 import static com.sun.appserv.connectors.internal.api.ConnectorConstants.XA_TRANSACTION_TX_SUPPORT_STRING;
+import org.glassfish.config.support.TranslatedConfigView;
 import static org.glassfish.deployment.common.JavaEEResourceType.*;
 
 @Service
@@ -242,7 +243,7 @@ public class JMSConnectionFactoryDefinitionDeployer implements ResourceDeployer 
         }
 
         public String getValue() {
-            return value;
+            return (String) TranslatedConfigView.getTranslatedValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSDestinationDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSDestinationDefinitionDeployer.java
@@ -66,6 +66,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.config.support.TranslatedConfigView;
 
 @Service
 @ResourceDeployerInfo(JMSDestinationDefinitionDescriptor.class)
@@ -218,7 +219,7 @@ public class JMSDestinationDefinitionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return value;
+            return (String) TranslatedConfigView.getTranslatedValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/MailSessionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/MailSessionDeployer.java
@@ -72,6 +72,7 @@ import java.beans.PropertyVetoException;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.config.support.TranslatedConfigView;
 
 /**
  * Handle deployment of resources defined by @MailSessionDefinition
@@ -363,7 +364,7 @@ public class MailSessionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return value;
+            return (String) TranslatedConfigView.getTranslatedValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {
@@ -441,7 +442,7 @@ public class MailSessionDeployer implements ResourceDeployer {
 
         @Override
         public String getHost() {
-            return desc.getHost();
+            return (String) TranslatedConfigView.getTranslatedValue(desc.getHost());
         }
 
         @Override
@@ -451,7 +452,7 @@ public class MailSessionDeployer implements ResourceDeployer {
 
         @Override
         public String getUser() {
-            return desc.getUser();
+            return (String) TranslatedConfigView.getTranslatedValue(desc.getUser());
         }
 
         @Override
@@ -461,7 +462,7 @@ public class MailSessionDeployer implements ResourceDeployer {
 
         @Override
         public String getPassword(){
-            return desc.getPassword();
+            return (String) TranslatedConfigView.getTranslatedValue(desc.getPassword());
         }
         
         @Override
@@ -483,7 +484,7 @@ public class MailSessionDeployer implements ResourceDeployer {
         
         @Override
         public String getFrom() {
-            return desc.getFrom();
+            return (String) TranslatedConfigView.getTranslatedValue(desc.getFrom());
         }
 
         @Override

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
@@ -93,6 +93,7 @@ import com.sun.enterprise.deployment.ConnectorDescriptor;
 import com.sun.enterprise.resource.pool.ResourcePool;
 import com.sun.enterprise.resource.pool.waitqueue.PoolWaitQueue;
 import com.sun.enterprise.util.i18n.StringManager;
+import org.glassfish.config.support.TranslatedConfigView;
 
 /**
  * Handles Jdbc connection pool events in the server instance. When user adds a
@@ -510,13 +511,12 @@ public class JdbcConnectionPoolDeployer implements ResourceDeployer {
                 } else if ("USERNAME".equals(name.toUpperCase(Locale.getDefault()))
                         || "USER".equals(name.toUpperCase(locale))) {
 
-                    propList.add(new ConnectorConfigProperty("User",
-                            rp.getValue(), "user name", "java.lang.String"));
+                    propList.add(new ConnectorConfigProperty("User", (String) TranslatedConfigView.getTranslatedValue(rp.getValue()), "user name", "java.lang.String"));
 
                 } else if ("PASSWORD".equals(name.toUpperCase(locale))) {
 
                     propList.add(new ConnectorConfigProperty("Password",
-                            rp.getValue(), "Password", "java.lang.String"));
+                            (String) TranslatedConfigView.getTranslatedValue(rp.getValue()), "Password", "java.lang.String"));
 
                 } else if ("JDBC30DATASOURCE".equals(name.toUpperCase(locale))) {
 
@@ -549,12 +549,12 @@ public class JdbcConnectionPoolDeployer implements ResourceDeployer {
 
                     propList.add(new ConnectorConfigProperty(
                             (String) mcfConPropKeys.get(name.toUpperCase(Locale.getDefault())),
-                            rp.getValue() == null ? "" : rp.getValue(),
+                            rp.getValue() == null ? "" : (String) TranslatedConfigView.getTranslatedValue(rp.getValue()),
                             "Some property",
                             "java.lang.String"));
                 } else {
                     driverProperties = driverProperties + "set" + escape(name)
-                            + "#" + escape(rp.getValue()) + "##";
+                            + "#" + escape((String) TranslatedConfigView.getTranslatedValue(rp.getValue())) + "##";
                 }
             }
 

--- a/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/deployer/MailResourceDeployer.java
+++ b/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/deployer/MailResourceDeployer.java
@@ -71,6 +71,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.config.support.TranslatedConfigView;
 
 /**
  * Handles mail resource events in the server instance.
@@ -279,11 +280,11 @@ public class MailResourceDeployer extends GlobalResourceDeployer
         mailResource.setStoreProtocolClass(mailResourceConfig.getStoreProtocolClass());
         mailResource.setTransportProtocol(mailResourceConfig.getTransportProtocol());
         mailResource.setTransportProtocolClass(mailResourceConfig.getTransportProtocolClass());
-        mailResource.setMailHost(mailResourceConfig.getHost());
-        mailResource.setUsername(mailResourceConfig.getUser());
-        mailResource.setPassword(mailResourceConfig.getPassword());
+        mailResource.setMailHost((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getHost()));
+        mailResource.setUsername((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getUser()));
+        mailResource.setPassword((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getPassword()));
         mailResource.setAuth(Boolean.valueOf(mailResourceConfig.getAuth()));
-        mailResource.setMailFrom(mailResourceConfig.getFrom());
+        mailResource.setMailFrom((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getFrom()));
         mailResource.setDebug(Boolean.valueOf(mailResourceConfig.getDebug()));
 
         // sets the properties

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
 package org.glassfish.resources.admin.cli;
 
 import com.sun.enterprise.util.SystemPropertyConstants;


### PR DESCRIPTION
ensure environment variable, password alias and system property replacement is possible when using glassfish-resources.xml