### PR TITLE
PAYARA-1555 PAYARA-1794 added an option to prepend the   passwordfile option to the commands recorded by the asadmin recorder

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/asadminRecorder/asadminRecorderServer.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/asadminRecorder/asadminRecorderServer.jsf
@@ -108,7 +108,7 @@
         <sun:textField id="filteredCommands" columns="$int{75}" maxLength="255" text="#{pageSession.valueMap['filteredCommands']}" />
     </sun:property>
     <sun:property id="passwordFileProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nar.asadminRecorder.configuration.passwordFile}"  helpText="$resource{i18nar.asadminRecorder.configuration.passwordFileHelp}">
-        <sun:textField id="passwordFile" columns="$int{75}" maxLength="255" text="#{pageSession.valueMap['passwordFile']}" />
+        <sun:textField id="passwordFile" columns="$int{75}" maxLength="255" text="#{pageSession.valueMap['prependedPasswordFile']}" />
     </sun:property>
 </sun:propertySheetSection>
 

--- a/appserver/admingui/payara-console-extras/src/main/resources/asadminRecorder/asadminRecorderServer.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/asadminRecorder/asadminRecorderServer.jsf
@@ -86,6 +86,9 @@
     <sun:property id="filteredCommandsProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nar.asadminRecorder.configuration.filteredCommands}"  helpText="$resource{i18nar.asadminRecorder.configuration.filteredCommandsHelp}">
         <sun:textField id="filteredCommands" columns="$int{75}" maxLength="255" text="#{pageSession.valueMap['filteredCommands']}" />
     </sun:property>
+    <sun:property id="passwordFileProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nar.asadminRecorder.configuration.passwordFile}"  helpText="$resource{i18nar.asadminRecorder.configuration.passwordFileHelp}">
+        <sun:textField id="passwordFile" columns="$int{75}" maxLength="255" text="#{pageSession.valueMap['passwordFile']}" />
+    </sun:property>
 </sun:propertySheetSection>
 
 </sun:form>

--- a/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
+++ b/appserver/admingui/payara-console-extras/src/main/resources/fish/payara/admingui/extras/Strings.properties
@@ -109,6 +109,8 @@ asadminRecorder.configuration.outputLocation=Output Location
 asadminRecorder.configuration.outputLocationHelp=The absolute file to write the recorded asadmin commands to.
 asadminRecorder.configuration.filteredCommands=Filtered Commands
 asadminRecorder.configuration.filteredCommandsHelp=A comma separated list of asadmin commands to not write to file. Accepts regular expressions.
+asadminRecorder.configuration.passwordFile=Password File
+asadminRecorder.configuration.passwordFileHelp=The location of the password file to use with recorded asadmin commands.
 asadminRecorder.asadminRecorderTabs=Asadmin Recorder
 
 notification.serverTabs=Notification

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
@@ -68,4 +68,8 @@ public interface AsadminRecorderConfiguration extends ConfigBeanProxy, ConfigExt
             + "set-asadmin-recorder-configuration,asadmin-recorder-enabled")
     public String getFilteredCommands();
     public void setFilteredCommands(String filteredCommands);
+    
+    @Attribute(defaultValue = "")
+    public String getPasswordFile();
+    public void setPasswordFile(String passwordFile);
 }

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
@@ -70,6 +70,6 @@ public interface AsadminRecorderConfiguration extends ConfigBeanProxy, ConfigExt
     public void setFilteredCommands(String filteredCommands);
     
     @Attribute()
-    public String getPrependPasswordFile();
-    public void setPrependPasswordFile(String passwordFile);
+    public String getPrependedPasswordFile();
+    public void setPrependedPasswordFile(String passwordFile);
 }

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
@@ -1,19 +1,40 @@
-/**
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- * Copyright (c) 2016 Payara Foundation and/or its affiliates.
- * All rights reserved.
+/*
  *
- * The contents of this file are subject to the terms of the Common Development
+ * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
  * and Distribution License("CDDL") (collectively, the "License").  You
  * may not use this file except in compliance with the License.  You can
  * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
  * language governing permissions and limitations under the License.
  *
  * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.asadmin.recorder;
 

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderConfiguration.java
@@ -70,6 +70,6 @@ public interface AsadminRecorderConfiguration extends ConfigBeanProxy, ConfigExt
     public void setFilteredCommands(String filteredCommands);
     
     @Attribute(defaultValue = "")
-    public String getPasswordFile();
-    public void setPasswordFile(String passwordFile);
+    public String getPrependPasswordFile();
+    public void setPrependPasswordFile(String passwordFile);
 }

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
@@ -100,6 +100,12 @@ public class AsadminRecorderService implements EventListener {
         
         String asadminCommand = commandName;
         String mandatoryOption = "";
+        
+        // prepend passwordfile option if present
+        if (!asadminRecorderConfiguration.getPasswordFile().equals("")) {
+            asadminCommand = " --passwordfile=" + asadminRecorderConfiguration.getPasswordFile() + " " + asadminCommand;
+        }
+        
         for (Map.Entry<String, List<String>> parameter : parameters.entrySet()) {
             // Check for broken parameters
             if (!FILTERED_PARAMETERS.contains(parameter.getKey())) {

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
@@ -1,23 +1,43 @@
-/**
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- * Copyright (c) 2016 Payara Foundation and/or its affiliates.
- * All rights reserved.
+/*
  *
- * The contents of this file are subject to the terms of the Common Development
+ * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
  * and Distribution License("CDDL") (collectively, the "License").  You
  * may not use this file except in compliance with the License.  You can
  * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
  * language governing permissions and limitations under the License.
  *
  * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.asadmin.recorder;
 
-import java.beans.PropertyVetoException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -41,9 +61,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Optional;
 import org.jvnet.hk2.annotations.Service;
-import org.jvnet.hk2.config.ConfigSupport;
-import org.jvnet.hk2.config.SingleConfigCode;
-import org.jvnet.hk2.config.TransactionFailure;
 
 /**
  *

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
@@ -102,8 +102,9 @@ public class AsadminRecorderService implements EventListener {
         String mandatoryOption = "";
         
         // prepend passwordfile option if present
-        if (!asadminRecorderConfiguration.getPasswordFile().equals("")) {
-            asadminCommand = " --passwordfile=" + asadminRecorderConfiguration.getPasswordFile() + " " + asadminCommand;
+        if (!asadminRecorderConfiguration.getPrependPasswordFile().equals("")) {
+            asadminCommand = " --passwordfile=" + asadminRecorderConfiguration.getPrependPasswordFile() + " " 
+                    + asadminCommand;
         }
         
         for (Map.Entry<String, List<String>> parameter : parameters.entrySet()) {

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
@@ -104,8 +104,9 @@ public class AsadminRecorderService implements EventListener {
         String mandatoryOption = "";
         
         // prepend passwordfile option if present
-        if (asadminRecorderConfiguration.getPrependPasswordFile() != null && !asadminRecorderConfiguration.getPrependPasswordFile().equals("")) {
-            asadminCommand = " --passwordfile=" + asadminRecorderConfiguration.getPrependPasswordFile() + " " 
+        if (asadminRecorderConfiguration.getPrependedPasswordFile() != null 
+                && !asadminRecorderConfiguration.getPrependedPasswordFile().equals("")) {
+            asadminCommand = " --passwordfile=" + asadminRecorderConfiguration.getPrependedPasswordFile() + " " 
                     + asadminCommand;
         }
         

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/AsadminRecorderService.java
@@ -52,9 +52,11 @@ import org.jvnet.hk2.config.TransactionFailure;
 @Service (name = "asadmin-recorder")
 @RunLevel(StartupRunLevel.VAL)
 public class AsadminRecorderService implements EventListener {
+    private static final List<String> FILTERED_PARAMETERS = Arrays.asList("userpassword");
+    
     private List<String> filteredCommands;
     private String filteredCommandsString;
-    
+       
     @Inject
     @Named(ServerEnvironment.DEFAULT_INSTANCE_NAME)
     @Optional
@@ -81,20 +83,22 @@ public class AsadminRecorderService implements EventListener {
         
         String asadminCommand = commandName;
         String mandatoryOption = "";
-        for (Map.Entry<String, List<String>> parameter : 
-                parameters.entrySet()) {
-            if (parameter.getKey().equals("DEFAULT")) {
-                // This can have sub-parameters, so loop through and add spaces
-                // between the sub-parameters.
-                for (int i = 0; i < parameter.getValue().size(); i++) {
-                    mandatoryOption += parameter.getValue().get(i);
-                    if (i != (parameter.getValue().size() - 1)) {
-                        mandatoryOption += " ";
-                    }
-                }    
-            } else {
-                asadminCommand += " --" + parameter.getKey() + "="
-                    + parameter.getValue().get(0); 
+        for (Map.Entry<String, List<String>> parameter : parameters.entrySet()) {
+            // Check for broken parameters
+            if (!FILTERED_PARAMETERS.contains(parameter.getKey())) {
+                if (parameter.getKey().equals("DEFAULT")) {
+                    // This can have sub-parameters, so loop through and add spaces
+                    // between the sub-parameters.
+                    for (int i = 0; i < parameter.getValue().size(); i++) {
+                        mandatoryOption += parameter.getValue().get(i);
+                        if (i != (parameter.getValue().size() - 1)) {
+                            mandatoryOption += " ";
+                        }
+                    }    
+                } else {
+                    asadminCommand += " --" + parameter.getKey() + "="
+                        + parameter.getValue().get(0); 
+                }
             }
         }
 

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/GetAsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/GetAsadminRecorderConfiguration.java
@@ -87,7 +87,7 @@ public class GetAsadminRecorderConfiguration implements AdminCommand
     
     private final String target = "server";
     private final String[] headers = {"Enabled", "Filter Commands", 
-            "Output Location", "Filtered Commands", "Password File"};
+            "Output Location", "Filtered Commands", "Prepended Password File"};
             
     @Override
     public void execute(AdminCommandContext context)
@@ -111,7 +111,8 @@ public class GetAsadminRecorderConfiguration implements AdminCommand
                 asadminRecorderConfiguration.filterCommands(), 
                 asadminRecorderConfiguration.getOutputLocation(),
                 asadminRecorderConfiguration.getFilteredCommands(),
-                asadminRecorderConfiguration.getPrependPasswordFile()};
+                (asadminRecorderConfiguration.getPrependedPasswordFile().equals("") 
+                    ? asadminRecorderConfiguration.getPrependedPasswordFile() : "N/A")};
         
         columnFormatter.addRow(values);
         
@@ -121,7 +122,7 @@ public class GetAsadminRecorderConfiguration implements AdminCommand
         map.put("filterCommands", values[1]);
         map.put("outputLocation", values[2]);
         map.put("filteredCommands", values[3]);
-        map.put("prependPasswordFile", values[4]);
+        map.put("prependedPasswordFile", values[4]);
         extraProps.put("getAsadminRecorderConfiguration",map);
         
         actionReport.setExtraProperties(extraProps);

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/GetAsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/GetAsadminRecorderConfiguration.java
@@ -87,7 +87,8 @@ public class GetAsadminRecorderConfiguration implements AdminCommand
         Object values[] = {asadminRecorderConfiguration.isEnabled(), 
                 asadminRecorderConfiguration.filterCommands(), 
                 asadminRecorderConfiguration.getOutputLocation(),
-                asadminRecorderConfiguration.getFilteredCommands()};
+                asadminRecorderConfiguration.getFilteredCommands(),
+                asadminRecorderConfiguration.getPrependPasswordFile()};
         
         columnFormatter.addRow(values);
         
@@ -97,6 +98,7 @@ public class GetAsadminRecorderConfiguration implements AdminCommand
         map.put("filterCommands", values[1]);
         map.put("outputLocation", values[2]);
         map.put("filteredCommands", values[3]);
+        map.put("prependPasswordFile", values[4]);
         extraProps.put("getAsadminRecorderConfiguration",map);
         
         actionReport.setExtraProperties(extraProps);

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/GetAsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/GetAsadminRecorderConfiguration.java
@@ -64,7 +64,7 @@ public class GetAsadminRecorderConfiguration implements AdminCommand
     
     private final String target = "server";
     private final String[] headers = {"Enabled", "Filter Commands", 
-            "Output Location", "Filtered Commands"};
+            "Output Location", "Filtered Commands", "Password File"};
             
     @Override
     public void execute(AdminCommandContext context)

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/SetAsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/SetAsadminRecorderConfiguration.java
@@ -96,7 +96,7 @@ public class SetAsadminRecorderConfiguration implements AdminCommand {
     @Param(name = "filteredCommands", optional = true)
     private String filteredCommands;
     
-    @Param(name = "prependpasswordfile", optional = true)
+    @Param(name = "prependedPasswordFile", optional = true)
     private String passwordFile;
     
     @Override
@@ -135,7 +135,7 @@ public class SetAsadminRecorderConfiguration implements AdminCommand {
                     }
                     
                     if (passwordFile != null) {
-                        asadminRecorderConfigurationProxy.setPrependPasswordFile(passwordFile);
+                        asadminRecorderConfigurationProxy.setPrependedPasswordFile(passwordFile);
                     }
                     
                     return null;

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/SetAsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/SetAsadminRecorderConfiguration.java
@@ -73,7 +73,7 @@ public class SetAsadminRecorderConfiguration implements AdminCommand {
     @Param(name = "filteredCommands", optional = true)
     private String filteredCommands;
     
-    @Param(name = "passwordfile", optional = true)
+    @Param(name = "prependpasswordfile", optional = true)
     private String passwordFile;
     
     @Override
@@ -112,7 +112,7 @@ public class SetAsadminRecorderConfiguration implements AdminCommand {
                     }
                     
                     if (passwordFile != null) {
-                        asadminRecorderConfigurationProxy.setPasswordFile(passwordFile);
+                        asadminRecorderConfigurationProxy.setPrependPasswordFile(passwordFile);
                     }
                     
                     return null;

--- a/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/SetAsadminRecorderConfiguration.java
+++ b/nucleus/payara-modules/asadmin-recorder/src/main/java/fish/payara/asadmin/recorder/admin/SetAsadminRecorderConfiguration.java
@@ -73,6 +73,9 @@ public class SetAsadminRecorderConfiguration implements AdminCommand {
     @Param(name = "filteredCommands", optional = true)
     private String filteredCommands;
     
+    @Param(name = "passwordfile", optional = true)
+    private String passwordFile;
+    
     @Override
     public void execute(AdminCommandContext context) {
         try {
@@ -106,6 +109,10 @@ public class SetAsadminRecorderConfiguration implements AdminCommand {
                     if (filteredCommands != null) {
                         asadminRecorderConfigurationProxy.
                                 setFilteredCommands(filteredCommands);
+                    }
+                    
+                    if (passwordFile != null) {
+                        asadminRecorderConfigurationProxy.setPasswordFile(passwordFile);
                     }
                     
                     return null;


### PR DESCRIPTION
2 for the price of 1. Asadmin recorder now gracefully handles "--passwordfile", with an optional setting to prepend recorded commands with a password file of your choosing.

set-asadmin-recorder-configuration now accepts --prependpasswordfile, which can also be set from the admin console