### PR TITLE
Changed Healthcheck to HealthCheck in Admin Console PAYARA-1859

### DIFF
--- a/appserver/admingui/healthcheck-service-console-plugin/src/main/resources/fish/payara/admingui/healthcheck/Strings.properties
+++ b/appserver/admingui/healthcheck-service-console-plugin/src/main/resources/fish/payara/admingui/healthcheck/Strings.properties
@@ -36,41 +36,41 @@
 #     only if the new code is made subject to such option by the copyright
 #     holder.
 
-tree.healthcheck=Healthcheck
-healthcheck.configuration.pageTitle=Healthcheck
-healthcheck.configuration.pageTitleHelpText=General configuration for the Healthcheck Service.
+tree.healthcheck=Health Check
+healthcheck.configuration.pageTitle=Health Check Configuration
+healthcheck.configuration.pageTitleHelpText=General configuration for the Health Check Service.
 healthcheck.configuration.enabledLabel=Enabled
-healthcheck.configuration.enabledLabelHelpText=Enables or disables the Healthcheck service.
+healthcheck.configuration.enabledLabelHelpText=Enables or disables the Health Check service.
 healthcheck.configuration.logNotifierEnabled=Log Notifier Enabled
 healthcheck.configuration.logNotifierEnabledHelp=Determines whether the Log Notifier is enabled.
 healthcheck.configuration.dynamicLabel=Dynamic
-healthcheck.configuration.dynamicLabelHelpText=If checked the Healthcheck Service will be restarted dynamically.
+healthcheck.configuration.dynamicLabelHelpText=If checked, the Health Check Service will be restarted dynamically.
 healthcheck.configuration.historicalTraceEnabledLabel=Historical Tracing Enabled
 healthcheck.configuration.historicalTraceEnabledLabelHelpText=Enables or disables the storage of historical traces.
 healthcheck.configuration.historicalTraceStoreSizeLabel=Historical Trace Store Size
 healthcheck.configuration.historicalTraceStoreSizeLabelHelpText=The number of historical traces to store.
 
-healthcheck.configuration.tabSetTitle=Healthcheck
-healthcheck.configuration.tabSetTitleToolTip=Configures the Healthcheck Service.
+healthcheck.configuration.tabSetTitle=Health Check Configuration
+healthcheck.configuration.tabSetTitleToolTip=Configures the Health Check Service.
 healthcheck.configuration.generalTabTitle=General
-healthcheck.configuration.generalTabTitleToolTip=Configures the Healthcheck Service.
+healthcheck.configuration.generalTabTitleToolTip=Configures the Health Check Service.
 healthcheck.configuration.cpuUsageCheckerTabTitle=CPU Usage
-healthcheck.configuration.cpuUsageCheckerTabTitleToolTip=Configures the CPU Usage Healthcheck.
+healthcheck.configuration.cpuUsageCheckerTabTitleToolTip=Configures the CPU Usage Health Check.
 healthcheck.configuration.connectionPoolCheckerTabTitle=Connection Pool
-healthcheck.configuration.connectionPoolCheckerTabTitleToolTip=Configures the Connection Pool Healthcheck.
+healthcheck.configuration.connectionPoolCheckerTabTitleToolTip=Configures the Connection Pool Health Check.
 healthcheck.configuration.heapMemoryUsageCheckerTabTitle=Heap Memory Usage
-healthcheck.configuration.heapMemoryUsageCheckerTabTitleToolTip=Configures the Heap Memory Usage Healthcheck.
+healthcheck.configuration.heapMemoryUsageCheckerTabTitleToolTip=Configures the Heap Memory Usage Health Check.
 healthcheck.configuration.machineMemoryUsageCheckerTabTitle=Machine Memory Usage
-healthcheck.configuration.machineMemoryUsageCheckerTabTitleToolTip=Configures the Machine Memory Usage Healthcheck.
+healthcheck.configuration.machineMemoryUsageCheckerTabTitleToolTip=Configures the Machine Memory Usage Health Check.
 healthcheck.configuration.hoggingThreadsCheckerTabTitle=Hogging Threads
-healthcheck.configuration.hoggingThreadsCheckerTabTitleToolTip=Configures the Hogging Threads Healthcheck.
+healthcheck.configuration.hoggingThreadsCheckerTabTitleToolTip=Configures the Hogging Threads Health Check.
 healthcheck.configuration.garbageCollectorCheckerTabTitle=Garbage Collector
-healthcheck.configuration.garbageCollectorCheckerTabTitleToolTip=Configures the Garbage Collector Healthcheck.
+healthcheck.configuration.garbageCollectorCheckerTabTitleToolTip=Configures the Garbage Collector Health Check.
 
 healthcheck.checker.configuration.enabledLabel=Enabled
 healthcheck.checker.configuration.enabledLabelHelpText=Enables or Disables the checker.
 healthcheck.checker.configuration.dynamicLabel=Dynamic
-healthcheck.checker.configuration.dynamicLabelHelpText=If checked the Healthcheck Service will be restarted dynamically.
+healthcheck.checker.configuration.dynamicLabelHelpText=If checked, the Health Check Service will be restarted dynamically.
 healthcheck.checker.configuration.nameLabel=Name
 healthcheck.checker.configuration.nameLabelHelpText=The name of the checker.
 healthcheck.checker.configuration.timeLabel=Time
@@ -84,32 +84,32 @@ healthcheck.checker.configuration.thresholdWarningLabelHelpText=The threshold fo
 healthcheck.checker.configuration.thresholdCriticalLabel=Threshold Critical
 healthcheck.checker.configuration.thresholdCriticalLabelHelpText=The threshold for a metric to be classified as Critical.
 
-healthcheck.historic.table.name=Historic Healthchecks
-healthcheck.historic.table.empty=No Historic Healthchecks
+healthcheck.historic.table.name=Historic Health Checks
+healthcheck.historic.table.empty=No Historic Health Checks
 healthcheck.historic.table.headings.dateTime=Time
 healthcheck.historic.table.headings.message=Message
 
 healthcheck.checker.configuration.cpuUsage.pageTitle=CPU Usage
-healthcheck.checker.configuration.cpuUsage.pageTitleHelpText=Configuration options for the CPU Usage Healthcheck.
+healthcheck.checker.configuration.cpuUsage.pageTitleHelpText=Configuration options for the CPU Usage Health Check.
 
 healthcheck.checker.configuration.connectionPool.pageTitle=Connection Pool
-healthcheck.checker.configuration.connectionPool.pageTitleHelpText=Configuration options for the Connection Pool Healthcheck.
+healthcheck.checker.configuration.connectionPool.pageTitleHelpText=Configuration options for the Connection Pool Health Check.
 
 healthcheck.checker.configuration.heapMemoryUsage.pageTitle=Heap Memory Usage
-healthcheck.checker.configuration.heapMemoryUsage.pageTitleHelpText=Configuration options for the Heap Memory Usage Healthcheck.
+healthcheck.checker.configuration.heapMemoryUsage.pageTitleHelpText=Configuration options for the Heap Memory Usage Health Check.
 
 healthcheck.checker.configuration.machineMemoryUsage.pageTitle=Machine Memory Usage
-healthcheck.checker.configuration.machineMemoryUsage.pageTitleHelpText=Configuration options for the Machine Memory Usage Healthcheck.
+healthcheck.checker.configuration.machineMemoryUsage.pageTitleHelpText=Configuration options for the Machine Memory Usage Health Check.
 
 healthcheck.checker.configuration.hoggingThreads.pageTitle=Hogging Threads
-healthcheck.checker.configuration.hoggingThreads.pageTitleHelpText=Configuration options for the Hogging Threads Healthcheck.
+healthcheck.checker.configuration.hoggingThreads.pageTitleHelpText=Configuration options for the Hogging Threads Health Check.
 healthcheck.checker.configuration.hoggingThreads.thresholdPercentageLabel=Threshold Percentage
 healthcheck.checker.configuration.hoggingThreads.thresholdPercentageLabelHelpText=Percentage before a thread is marked as hogging.
 healthcheck.checker.configuration.hoggingThreads.retryCountLabel=Retry Count
 healthcheck.checker.configuration.hoggingThreads.retryCountLabelHelpText=Number of times to retry a thread before marking it as hogging.
 
 healthcheck.checker.configuration.garbageCollector.pageTitle=Garbage Collector
-healthcheck.checker.configuration.garbageCollector.pageTitleHelpText=Configuration options for the Garbage Collector Healthcheck.
+healthcheck.checker.configuration.garbageCollector.pageTitleHelpText=Configuration options for the Garbage Collector Health Check.
 
 healthcheck.configuration.availableNotifiers=Avaliable Notifiers
 healthcheck.configuration.selectedNotifiers=Selected Notifiers

--- a/appserver/admingui/healthcheck-service-console-plugin/src/main/resources/fish/payara/admingui/healthcheck/Strings.properties
+++ b/appserver/admingui/healthcheck-service-console-plugin/src/main/resources/fish/payara/admingui/healthcheck/Strings.properties
@@ -36,41 +36,41 @@
 #     only if the new code is made subject to such option by the copyright
 #     holder.
 
-tree.healthcheck=Health Check
-healthcheck.configuration.pageTitle=Health Check Configuration
-healthcheck.configuration.pageTitleHelpText=General configuration for the Health Check Service.
+tree.healthcheck=HealthCheck
+healthcheck.configuration.pageTitle=HealthCheck Configuration
+healthcheck.configuration.pageTitleHelpText=General configuration for the HealthCheck Service.
 healthcheck.configuration.enabledLabel=Enabled
-healthcheck.configuration.enabledLabelHelpText=Enables or disables the Health Check service.
+healthcheck.configuration.enabledLabelHelpText=Enables or disables the HealthCheck service.
 healthcheck.configuration.logNotifierEnabled=Log Notifier Enabled
 healthcheck.configuration.logNotifierEnabledHelp=Determines whether the Log Notifier is enabled.
 healthcheck.configuration.dynamicLabel=Dynamic
-healthcheck.configuration.dynamicLabelHelpText=If checked, the Health Check Service will be restarted dynamically.
+healthcheck.configuration.dynamicLabelHelpText=If checked, the HealthCheck Service will be restarted dynamically.
 healthcheck.configuration.historicalTraceEnabledLabel=Historical Tracing Enabled
 healthcheck.configuration.historicalTraceEnabledLabelHelpText=Enables or disables the storage of historical traces.
 healthcheck.configuration.historicalTraceStoreSizeLabel=Historical Trace Store Size
 healthcheck.configuration.historicalTraceStoreSizeLabelHelpText=The number of historical traces to store.
 
-healthcheck.configuration.tabSetTitle=Health Check Configuration
-healthcheck.configuration.tabSetTitleToolTip=Configures the Health Check Service.
+healthcheck.configuration.tabSetTitle=HealthCheck Configuration
+healthcheck.configuration.tabSetTitleToolTip=Configures the HealthCheck Service.
 healthcheck.configuration.generalTabTitle=General
-healthcheck.configuration.generalTabTitleToolTip=Configures the Health Check Service.
+healthcheck.configuration.generalTabTitleToolTip=Configures the HealthCheck Service.
 healthcheck.configuration.cpuUsageCheckerTabTitle=CPU Usage
-healthcheck.configuration.cpuUsageCheckerTabTitleToolTip=Configures the CPU Usage Health Check.
+healthcheck.configuration.cpuUsageCheckerTabTitleToolTip=Configures the CPU Usage HealthCheck.
 healthcheck.configuration.connectionPoolCheckerTabTitle=Connection Pool
-healthcheck.configuration.connectionPoolCheckerTabTitleToolTip=Configures the Connection Pool Health Check.
+healthcheck.configuration.connectionPoolCheckerTabTitleToolTip=Configures the Connection Pool HealthCheck.
 healthcheck.configuration.heapMemoryUsageCheckerTabTitle=Heap Memory Usage
-healthcheck.configuration.heapMemoryUsageCheckerTabTitleToolTip=Configures the Heap Memory Usage Health Check.
+healthcheck.configuration.heapMemoryUsageCheckerTabTitleToolTip=Configures the Heap Memory Usage HealthCheck.
 healthcheck.configuration.machineMemoryUsageCheckerTabTitle=Machine Memory Usage
-healthcheck.configuration.machineMemoryUsageCheckerTabTitleToolTip=Configures the Machine Memory Usage Health Check.
+healthcheck.configuration.machineMemoryUsageCheckerTabTitleToolTip=Configures the Machine Memory Usage HealthCheck.
 healthcheck.configuration.hoggingThreadsCheckerTabTitle=Hogging Threads
-healthcheck.configuration.hoggingThreadsCheckerTabTitleToolTip=Configures the Hogging Threads Health Check.
+healthcheck.configuration.hoggingThreadsCheckerTabTitleToolTip=Configures the Hogging Threads HealthCheck.
 healthcheck.configuration.garbageCollectorCheckerTabTitle=Garbage Collector
-healthcheck.configuration.garbageCollectorCheckerTabTitleToolTip=Configures the Garbage Collector Health Check.
+healthcheck.configuration.garbageCollectorCheckerTabTitleToolTip=Configures the Garbage Collector HealthCheck.
 
 healthcheck.checker.configuration.enabledLabel=Enabled
 healthcheck.checker.configuration.enabledLabelHelpText=Enables or Disables the checker.
 healthcheck.checker.configuration.dynamicLabel=Dynamic
-healthcheck.checker.configuration.dynamicLabelHelpText=If checked, the Health Check Service will be restarted dynamically.
+healthcheck.checker.configuration.dynamicLabelHelpText=If checked, the HealthCheck Service will be restarted dynamically.
 healthcheck.checker.configuration.nameLabel=Name
 healthcheck.checker.configuration.nameLabelHelpText=The name of the checker.
 healthcheck.checker.configuration.timeLabel=Time
@@ -84,32 +84,32 @@ healthcheck.checker.configuration.thresholdWarningLabelHelpText=The threshold fo
 healthcheck.checker.configuration.thresholdCriticalLabel=Threshold Critical
 healthcheck.checker.configuration.thresholdCriticalLabelHelpText=The threshold for a metric to be classified as Critical.
 
-healthcheck.historic.table.name=Historic Health Checks
-healthcheck.historic.table.empty=No Historic Health Checks
+healthcheck.historic.table.name=Historic HealthChecks
+healthcheck.historic.table.empty=No Historic HealthChecks
 healthcheck.historic.table.headings.dateTime=Time
 healthcheck.historic.table.headings.message=Message
 
 healthcheck.checker.configuration.cpuUsage.pageTitle=CPU Usage
-healthcheck.checker.configuration.cpuUsage.pageTitleHelpText=Configuration options for the CPU Usage Health Check.
+healthcheck.checker.configuration.cpuUsage.pageTitleHelpText=Configuration options for the CPU Usage HealthCheck.
 
 healthcheck.checker.configuration.connectionPool.pageTitle=Connection Pool
-healthcheck.checker.configuration.connectionPool.pageTitleHelpText=Configuration options for the Connection Pool Health Check.
+healthcheck.checker.configuration.connectionPool.pageTitleHelpText=Configuration options for the Connection Pool HealthCheck.
 
 healthcheck.checker.configuration.heapMemoryUsage.pageTitle=Heap Memory Usage
-healthcheck.checker.configuration.heapMemoryUsage.pageTitleHelpText=Configuration options for the Heap Memory Usage Health Check.
+healthcheck.checker.configuration.heapMemoryUsage.pageTitleHelpText=Configuration options for the Heap Memory Usage HealthCheck.
 
 healthcheck.checker.configuration.machineMemoryUsage.pageTitle=Machine Memory Usage
-healthcheck.checker.configuration.machineMemoryUsage.pageTitleHelpText=Configuration options for the Machine Memory Usage Health Check.
+healthcheck.checker.configuration.machineMemoryUsage.pageTitleHelpText=Configuration options for the Machine Memory Usage HealthCheck.
 
 healthcheck.checker.configuration.hoggingThreads.pageTitle=Hogging Threads
-healthcheck.checker.configuration.hoggingThreads.pageTitleHelpText=Configuration options for the Hogging Threads Health Check.
+healthcheck.checker.configuration.hoggingThreads.pageTitleHelpText=Configuration options for the Hogging Threads HealthCheck.
 healthcheck.checker.configuration.hoggingThreads.thresholdPercentageLabel=Threshold Percentage
 healthcheck.checker.configuration.hoggingThreads.thresholdPercentageLabelHelpText=Percentage before a thread is marked as hogging.
 healthcheck.checker.configuration.hoggingThreads.retryCountLabel=Retry Count
 healthcheck.checker.configuration.hoggingThreads.retryCountLabelHelpText=Number of times to retry a thread before marking it as hogging.
 
 healthcheck.checker.configuration.garbageCollector.pageTitle=Garbage Collector
-healthcheck.checker.configuration.garbageCollector.pageTitleHelpText=Configuration options for the Garbage Collector Health Check.
+healthcheck.checker.configuration.garbageCollector.pageTitleHelpText=Configuration options for the Garbage Collector HealthCheck.
 
 healthcheck.configuration.availableNotifiers=Avaliable Notifiers
 healthcheck.configuration.selectedNotifiers=Selected Notifiers


### PR DESCRIPTION
To align with the documentation and blogs.
Documentation should also be fixed from Health Check to HealthCheck.