### PR TITLE
Payara 1739 Pre and post boot command files a little too thorough

### DIFF
--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -243,7 +243,8 @@ public class GlassFishMain {
             if(line == null) {
                 return null;
             }
-            line = line.replaceAll("#.*", ""); // Removes comments
+            line = line.replaceAll("^\\s*#.*", ""); // Removes comments at the start of lines
+            line = line.replaceAll("\\s#.*", ""); // Removes comments with whitespace before them. This allows for hashtags used in commands to be ignored.
             if (line.isEmpty() || line.replaceAll("\\s", "").isEmpty()) {
                 return null;
             }


### PR DESCRIPTION
Previous fix also removed the end of commands with hashtags in them as comments. 
E.g. 
`set configs.config.server-config.http-service.virtual-server.test.default-web-module=ear-test#ear-test-web-1.0-SNAPSHOT.war`
Now only removes comments if they have whitespace before them.