### PR TITLE
PAYARA-1842 race condition in admin gui when modifying logging attributes

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/SetLogAttributes.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/SetLogAttributes.java
@@ -48,8 +48,11 @@ import com.sun.enterprise.config.serverbeans.Servers;
 import com.sun.enterprise.server.logging.GFFileHandler;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.SystemPropertyConstants;
+import java.beans.PropertyChangeEvent;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.inject.Inject;
@@ -66,7 +69,10 @@ import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.config.support.CommandTarget;
 import org.glassfish.config.support.TargetType;
 import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.internal.config.UnprocessedConfigListener;
 import org.jvnet.hk2.annotations.Service;
+import org.jvnet.hk2.config.UnprocessedChangeEvent;
+import org.jvnet.hk2.config.UnprocessedChangeEvents;
 
 
 /**
@@ -125,6 +131,8 @@ public class SetLogAttributes implements AdminCommand {
     @Inject
     Clusters clusters;
 
+    @Inject
+    UnprocessedConfigListener ucl;
 
     String[] validAttributes = {"handlers", "handlerServices",
             "java.util.logging.ConsoleHandler.formatter",
@@ -220,6 +228,25 @@ public class SetLogAttributes implements AdminCommand {
             } 
 
             if (success) {
+                // do not record duplicate logging attribute restart events
+                boolean triggerRestart = true;
+                unprocessedLoop:
+                for(UnprocessedChangeEvents evts : ucl.getUnprocessedChangeEvents()) {
+                    for(UnprocessedChangeEvent evt : evts.getUnprocessed()) {
+                        if(evt.getEvent().getSource().getClass().getName().equals(this.getClass().getName())) {
+                            triggerRestart = false;
+                            break unprocessedLoop;
+                        }
+                    }
+                }
+                if (triggerRestart) {
+                    List<UnprocessedChangeEvents> logAttrChanges = new ArrayList<>();
+                    logAttrChanges.add(new UnprocessedChangeEvents(new UnprocessedChangeEvent(
+                            new PropertyChangeEvent(this, "Logging Attribute", null, null),
+                            "logging attribute(s) modified")));
+                    ucl.unprocessedTransactedEvents(logAttrChanges);
+                }
+
                 String effectiveTarget = (isDas ? SystemPropertyConstants.DAS_SERVER_NAME : targetConfigName);
                 sbfSuccessMsg.append(localStrings.getLocalString(
                         "set.log.attribute.success", 


### PR DESCRIPTION
trigger server restart here because the GUI cannot wait for the log file to be re-read and
thus triggering restart message too late, as it won't show up in the GUI when logging attribtues are changed