### PR TITLE
Use logging instead of System.out.println PAYARA-1878

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
@@ -342,7 +342,7 @@ public class TransactionalInterceptorBase implements Serializable {
         if (currentInvocation == null) {
             //there should always be a currentInvocation and so this would seem a bug
             // but not a fatal one as app should not be relying on this, so log warning only
-            System.out.println("TransactionalInterceptorBase.markThreadAsTransactional currentInvocation==null");
+            _logger.log(java.util.logging.Level.WARNING, "TransactionalInterceptorBase.markThreadAsTransactional currentInvocation==null");
             return;
         }
         currentInvocation.setTransactionOperationsManager(preexistingTransactionOperationsManager);


### PR DESCRIPTION
Whilst the scenario causing to this println is not supposed to happen, it's currently happening a very large number of times a second on one of my servers, and being unable to turn off the message to get at more pertinent logging is making it hard to fix.