### PR TITLE
PAYARA-1898 Disabled findbugs plugin

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -162,7 +162,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- on Hudson and RE, this gets replaced by real build ID -->
         <build.id>${build.number}</build.id>
-        <findbugs.skip>false</findbugs.skip>
+        <findbugs.skip>true</findbugs.skip>
         <findbugs.threshold>High</findbugs.threshold>
         <findbugs.common>exclude-common.xml</findbugs.common>
         <findbugs.exclude />


### PR DESCRIPTION
The plugin will no longer run as part of the site lifecycle by default, it already has its own profile.