### PR TITLE
PAYARA-1964

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -41,8 +41,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../nucleus/pom.xml</relativePath>
     </parent>

--- a/appserver/admin/pom.xml
+++ b/appserver/admin/pom.xml
@@ -46,8 +46,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/admingui/community-theme-l10n/pom.xml
+++ b/appserver/admingui/community-theme-l10n/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.admingui</groupId>
         <artifactId>admingui</artifactId>
-        <version>4.1</version>
+        <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <artifactId>console-community-branding-plugin-l10n</artifactId>
     

--- a/appserver/admingui/community-theme/pom.xml
+++ b/appserver/admingui/community-theme/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.admingui</groupId>
         <artifactId>admingui</artifactId>
-        <version>4.1</version>
+        <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-community-branding-plugin</artifactId>

--- a/appserver/admingui/dataprovider/pom.xml
+++ b/appserver/admingui/dataprovider/pom.xml
@@ -43,8 +43,8 @@
 <!--"Portions Copyright [2016] [Payara Foundation]" -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/appserver/admingui/devtests/pom.xml
+++ b/appserver/admingui/devtests/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>fish.payara.admingui</groupId>
         <artifactId>admingui</artifactId>
-        <version>4.1</version>
+        <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/appserver/admingui/gf-admingui-connector/pom.xml
+++ b/appserver/admingui/gf-admingui-connector/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/appserver/admingui/jsftemplating/pom.xml
+++ b/appserver/admingui/jsftemplating/pom.xml
@@ -44,9 +44,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
-        <version>4.1</version>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
+        <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/appserver/admingui/plugin-service/pom.xml
+++ b/appserver/admingui/plugin-service/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/appserver/admingui/pom.xml
+++ b/appserver/admingui/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/appserver/ant-tasks/pom.xml
+++ b/appserver/ant-tasks/pom.xml
@@ -44,11 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>  
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>ant-tasks</artifactId>
     <name>Ant tasks</name>
 

--- a/appserver/appclient/pom.xml
+++ b/appserver/appclient/pom.xml
@@ -44,10 +44,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>appclient</artifactId>
     <packaging>pom</packaging>
     <name>App Client Modules</name>  

--- a/appserver/batch/pom.xml
+++ b/appserver/batch/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/common/pom.xml
+++ b/appserver/common/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/concurrent/pom.xml
+++ b/appserver/concurrent/pom.xml
@@ -44,8 +44,8 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 

--- a/appserver/connectors/pom.xml
+++ b/appserver/connectors/pom.xml
@@ -43,8 +43,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.connectors</groupId>

--- a/appserver/core/pom.xml
+++ b/appserver/core/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>

--- a/appserver/deployment/jsr88-jar/pom.xml
+++ b/appserver/deployment/jsr88-jar/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/appserver/deployment/pom.xml
+++ b/appserver/deployment/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>

--- a/appserver/ejb/pom.xml
+++ b/appserver/ejb/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.ejb</groupId>

--- a/appserver/extras/appserv-rt/pom.xml
+++ b/appserver/extras/appserv-rt/pom.xml
@@ -44,12 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>appserv-rt-pom</artifactId>
     <packaging>pom</packaging>
     <name>GlassFish appserv-rt Manifest pom</name>  

--- a/appserver/extras/embedded-shell/pom.xml
+++ b/appserver/extras/embedded-shell/pom.xml
@@ -45,11 +45,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>glassfish-embedded-shell</artifactId>
     <version>4.1-SNAPSHOT</version>
     <name>Embedded GlassFish Shell</name>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -45,7 +45,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
@@ -55,13 +55,6 @@
     <name>Embedded Payara All-In-One</name>
 
     <packaging>jar</packaging>
-    
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
   <build>
     <defaultGoal>install</defaultGoal>
@@ -391,30 +384,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>DeploySnapshot</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>DeploySnapshot</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/extras/embedded/glassfish-uber/pom.xml
+++ b/appserver/extras/embedded/glassfish-uber/pom.xml
@@ -46,8 +46,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>

--- a/appserver/extras/embedded/pom.xml
+++ b/appserver/extras/embedded/pom.xml
@@ -44,10 +44,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
+    
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>embedded</artifactId>
     <packaging>pom</packaging>
     <name>GlassFish Embedded modules</name>  

--- a/appserver/extras/embedded/shell/glassfish-embedded-shell-frag/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-shell-frag/pom.xml
@@ -44,12 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>glassfish-embedded-shell-frag</artifactId>
     <name>Embedded GlassFish Shell dist. fragment</name>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/extras/embedded/shell/glassfish-embedded-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-shell/pom.xml
@@ -45,11 +45,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
+    
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>glassfish-embedded-shell</artifactId>
     <name>Embedded GlassFish Shell</name>
 

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell-frag/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell-frag/pom.xml
@@ -44,12 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>glassfish-embedded-static-shell-frag</artifactId>
     <name>Embedded GlassFish Static Shell dist. fragment</name>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -45,12 +45,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>glassfish-embedded-static-shell</artifactId>
     <name>Embedded GlassFish Static Shell</name>
     <packaging>jar</packaging>

--- a/appserver/extras/embedded/shell/pom.xml
+++ b/appserver/extras/embedded/shell/pom.xml
@@ -46,12 +46,13 @@
 
 
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>glassfish-embedded-shell-jar</artifactId>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -57,12 +57,7 @@
     <version>4.1.2.174-SNAPSHOT</version>
     <name>Embedded Payara Web</name>
     <packaging>jar</packaging>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
+
     <build>
         <defaultGoal>install</defaultGoal>
         <plugins>
@@ -338,30 +333,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>DeploySnapshot</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>DeploySnapshot</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -46,7 +46,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/appserver/extras/javaee/pom.xml
+++ b/appserver/extras/javaee/pom.xml
@@ -44,12 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     
+    <groupId>org.glassfish.main.extras</groupId>
     <artifactId>javaee-pom</artifactId>
     <packaging>pom</packaging>
     <name>GlassFish JavaEE Manifest pom</name>  

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -54,13 +54,6 @@
     <name>Payara Micro Distribution</name>
     <packaging>jar</packaging>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <build>
         <defaultGoal>install</defaultGoal>
         <plugins>
@@ -458,30 +451,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>DeploySnapshot</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>DeploySnapshot</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/extras/payara-micro/pom.xml
+++ b/appserver/extras/payara-micro/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main.extras</groupId>
+        <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -45,12 +45,12 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.glassfish.main.extras</groupId>
+    <groupId>fish.payara.extras</groupId>
     <artifactId>extras</artifactId>
     <packaging>pom</packaging>
     

--- a/appserver/featuresets/pom.xml
+++ b/appserver/featuresets/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>

--- a/appserver/flashlight/pom.xml
+++ b/appserver/flashlight/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/grizzly/pom.xml
+++ b/appserver/grizzly/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/ha/pom.xml
+++ b/appserver/ha/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/installer/pom.xml
+++ b/appserver/installer/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     

--- a/appserver/javaee-api/pom.xml
+++ b/appserver/javaee-api/pom.xml
@@ -45,10 +45,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>javaee-api-parent</artifactId>
     <packaging>pom</packaging>
     <name>JavaEE API</name>

--- a/appserver/jdbc/jdbc-ra/pom.xml
+++ b/appserver/jdbc/jdbc-ra/pom.xml
@@ -44,8 +44,8 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-      <groupId>org.glassfish.main</groupId>
-      <artifactId>glassfish-parent</artifactId>
+      <groupId>fish.payara</groupId>
+      <artifactId>payara-parent</artifactId>
       <version>4.1.2.174-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
   </parent>

--- a/appserver/jdbc/pom.xml
+++ b/appserver/jdbc/pom.xml
@@ -43,8 +43,8 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 

--- a/appserver/jms/pom.xml
+++ b/appserver/jms/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/load-balancer/pom.xml
+++ b/appserver/load-balancer/pom.xml
@@ -43,8 +43,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/orb/pom.xml
+++ b/appserver/orb/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/osgi-platforms/pom.xml
+++ b/appserver/osgi-platforms/pom.xml
@@ -45,8 +45,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.glassfish.main</groupId>
-      <artifactId>glassfish-parent</artifactId>
+      <groupId>fish.payara</groupId>
+      <artifactId>payara-parent</artifactId>
       <version>4.1.2.174-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/packager/external/pom.xml
+++ b/appserver/packager/external/pom.xml
@@ -49,8 +49,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.glassfish.main</groupId>
-      <artifactId>glassfish-parent</artifactId>
+      <groupId>fish.payara</groupId>
+      <artifactId>payara-parent</artifactId>
       <version>4.1.2.174-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/appserver/packager/pom.xml
+++ b/appserver/packager/pom.xml
@@ -45,8 +45,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 

--- a/appserver/payara-appserver-modules/pom.xml
+++ b/appserver/payara-appserver-modules/pom.xml
@@ -41,10 +41,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
+    <groupId>org.glassfish.main</groupId>
     <artifactId>payara-appserver-modules</artifactId>
     <name>Payara Appserver Modules</name>
     <description>Payara Appserver modules</description>

--- a/appserver/persistence/pom.xml
+++ b/appserver/persistence/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.persistence</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -45,12 +45,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../nucleus/pom.xml</relativePath>
     </parent>    
-    <artifactId>glassfish-parent</artifactId>
+    <artifactId>payara-parent</artifactId>
     <packaging>pom</packaging>
     <name>Payara Appserver Parent Project</name>
     
@@ -59,8 +59,8 @@
         <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</developerConnection>
         <url>https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</url>
       <tag>payara-server-4.1.2.174-SNAPSHOT</tag>
-  </scm>
-    
+    </scm>
+  
     <properties>
         <jms-api.version>2.0.1</jms-api.version>
         <jsp-api.version>2.3.2-b01</jsp-api.version>
@@ -1136,5 +1136,30 @@
                 <module>javaee-api</module>
             </modules>
         </profile>   
-      </profiles>
+        
+        <profile>
+            <id>DeploySnapshot</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>DeploySnapshot</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>payara-nexus</serverId>
+                            <nexusUrl>https://nexus.payara.fish/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/registration/pom.xml
+++ b/appserver/registration/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/resources/pom.xml
+++ b/appserver/resources/pom.xml
@@ -43,8 +43,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/security/pom.xml
+++ b/appserver/security/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>

--- a/appserver/tests/embedded/inplanted/pom.xml
+++ b/appserver/tests/embedded/inplanted/pom.xml
@@ -45,13 +45,15 @@
 
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
+        <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glassfish.main</groupId>
     <artifactId>inplanted</artifactId>
+    <version>4.1-SNAPSHOT</version>
     <name>Inplanted mode embedded testing</name>
 
   <build>

--- a/appserver/tests/embedded/static/web/pom.xml
+++ b/appserver/tests/embedded/static/web/pom.xml
@@ -45,13 +45,15 @@
 
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish</groupId>
-        <artifactId>glassfish-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
+        <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glassfish</groupId>
     <artifactId>static</artifactId>
+    <version>4.1-SNAPSHOT</version>
     <name>Static embedded testing</name>
 
   <build>

--- a/appserver/tests/embedded/web/web-all/pom.xml
+++ b/appserver/tests/embedded/web/web-all/pom.xml
@@ -50,9 +50,9 @@
         investigates this issue further.                                                                                maven-buildglassfish-extension
     -->
     <!--<parent>-->
-    <!--<groupId>org.glassfish</groupId>-->
-    <!--<artifactId>glassfish-parent</artifactId>-->
-    <!--<version>4.1-SNAPSHOT</version>-->
+    <!--<groupId>fish.payara</groupId>-->
+    <!--<artifactId>payara-parent</artifactId>-->
+    <!--<version>4.1.2.174-SNAPSHOT</version>-->
     <!--</parent>-->
 
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/transaction/pom.xml
+++ b/appserver/transaction/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/verifier/verifier-impl-l10n/pom.xml
+++ b/appserver/verifier/verifier-impl-l10n/pom.xml
@@ -44,11 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>verifier-l10n</artifactId>
     
     <name>Verifier implementation module l10n</name>

--- a/appserver/verifier/verifier-impl/pom.xml
+++ b/appserver/verifier/verifier-impl/pom.xml
@@ -44,11 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>verifier</artifactId>
     <packaging>glassfish-jar</packaging>
 

--- a/appserver/verifier/verifier-jdk-extension-bundle/pom.xml
+++ b/appserver/verifier/verifier-jdk-extension-bundle/pom.xml
@@ -44,11 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>        
     </parent>
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>verifier-jdk-extension-bundle</artifactId>
     <packaging>jar</packaging>
     <name>GlassFish Verifier Extension Bundle</name>

--- a/appserver/verifier/verifier-scripts/pom.xml
+++ b/appserver/verifier/verifier-scripts/pom.xml
@@ -44,12 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>        
     </parent>
 
+    <groupId>org.glassfish.main</groupId>
     <artifactId>verifier-scripts</artifactId>
     <name>Verifier scripts</name>
 

--- a/appserver/web/pom.xml
+++ b/appserver/web/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/appserver/webservices/pom.xml
+++ b/appserver/webservices/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/admin/pom.xml
+++ b/nucleus/admin/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/cluster/pom.xml
+++ b/nucleus/cluster/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -45,8 +45,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>  

--- a/nucleus/common/pom.xml
+++ b/nucleus/common/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/common/scattered-archive-api/pom.xml
+++ b/nucleus/common/scattered-archive-api/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>  

--- a/nucleus/core/pom.xml
+++ b/nucleus/core/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>

--- a/nucleus/deployment/pom.xml
+++ b/nucleus/deployment/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/diagnostics/pom.xml
+++ b/nucleus/diagnostics/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.diagnostics</groupId>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -47,8 +47,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>

--- a/nucleus/flashlight/pom.xml
+++ b/nucleus/flashlight/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/grizzly/pom.xml
+++ b/nucleus/grizzly/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>        
     </parent>

--- a/nucleus/osgi-platforms/pom.xml
+++ b/nucleus/osgi-platforms/pom.xml
@@ -49,8 +49,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.glassfish.main</groupId>
-      <artifactId>glassfish-nucleus-parent</artifactId>
+      <groupId>fish.payara</groupId>
+      <artifactId>payara-nucleus-parent</artifactId>
       <version>4.1.2.174-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/packager/external/pom.xml
+++ b/nucleus/packager/external/pom.xml
@@ -49,8 +49,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.glassfish.main</groupId>
-      <artifactId>glassfish-nucleus-parent</artifactId>
+      <groupId>fish.payara</groupId>
+      <artifactId>payara-nucleus-parent</artifactId>
       <version>4.1.2.174-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/nucleus/packager/pom.xml
+++ b/nucleus/packager/pom.xml
@@ -48,8 +48,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
 

--- a/nucleus/payara-modules/pom.xml
+++ b/nucleus/payara-modules/pom.xml
@@ -42,7 +42,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
+        <groupId>fish.payara</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/nucleus/payara-modules/pom.xml
+++ b/nucleus/payara-modules/pom.xml
@@ -43,7 +43,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -63,18 +63,6 @@
         <developerConnection>scm:git:git@github.com:payara/payara.git</developerConnection>
         <tag>payara-server-4.1.2.174-SNAPSHOT</tag>
     </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>payara-nexus</id>
-            <url>https://nexus.payara.fish/content/repositories/payara-snapshots</url>
-        </snapshotRepository>
-        
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
     
     <issueManagement>
         <system>Github</system>
@@ -1255,6 +1243,14 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>payara-nexus</id>
+                    <url>https://nexus.payara.fish/content/repositories/payara-snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+            
             <build>
                 <plugins>
                     <plugin>
@@ -1263,7 +1259,7 @@
                         <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
+                            <serverId>payara-nexus</serverId>
                             <nexusUrl>https://nexus.payara.fish/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
@@ -1277,6 +1273,14 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+            
             <build>
                 <plugins>
                     <plugin>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -51,8 +51,8 @@
         <relativePath />
     </parent>
 
-    <groupId>org.glassfish.main</groupId>
-    <artifactId>glassfish-nucleus-parent</artifactId>
+    <groupId>fish.payara</groupId>
+    <artifactId>payara-nucleus-parent</artifactId>
     <version>4.1.2.174-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>GlassFish Nucleus Parent Project</name>
@@ -64,6 +64,18 @@
         <tag>payara-server-4.1.2.174-SNAPSHOT</tag>
     </scm>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>payara-nexus</id>
+            <url>https://nexus.payara.fish/content/repositories/payara-snapshots</url>
+        </snapshotRepository>
+        
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+    
     <issueManagement>
         <system>Github</system>
         <url>https://github.com/payara/Payara/issues</url>
@@ -1236,6 +1248,56 @@
             <properties>
                 <javadoc.options>-Xdoclint:none</javadoc.options>
             </properties>
+        </profile>
+        
+        <profile>
+            <id>DeploySnapshot-Internal</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>DeploySnapshot</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://nexus.payara.fish/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
+        <profile>
+            <id>DeploySnapshot-Sonatype</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>DeploySnapshot</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -1254,9 +1254,6 @@
             <id>DeploySnapshot-Internal</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>DeploySnapshot</name>
-                </property>
             </activation>
             <build>
                 <plugins>
@@ -1279,9 +1276,6 @@
             <id>DeploySnapshot-Sonatype</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>DeploySnapshot</name>
-                </property>
             </activation>
             <build>
                 <plugins>

--- a/nucleus/resources-l10n/pom.xml
+++ b/nucleus/resources-l10n/pom.xml
@@ -42,12 +42,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glassfish.main</groupId>
     <artifactId>nucleus-resources-l10n</artifactId>
     
     <name>nucleus.resources l10n</name>

--- a/nucleus/resources/pom.xml
+++ b/nucleus/resources/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.resourcebase.resources</groupId>

--- a/nucleus/security/pom.xml
+++ b/nucleus/security/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.main.security</groupId>

--- a/nucleus/test-utils/pom.xml
+++ b/nucleus/test-utils/pom.xml
@@ -44,11 +44,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1.2.174-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    
+    <groupId>org.glassfish.main</groupId>
     <artifactId>test-utils</artifactId>
     <packaging>pom</packaging>
     <name>Test Utilities Modules</name>  

--- a/nucleus/tests/pom.xml
+++ b/nucleus/tests/pom.xml
@@ -44,8 +44,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>4.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
Changes the groupId and artifactId of the parent poms (and edits their children appropriately) so that we can deploy them to Maven snapshots to fix the "parent pom not found" errors when downloading the embedded/micro snapshots.

Also adds in a profile so that we can test uploading snapshots before pushing them to Sonatype.