### PR TITLE
Rework global serializer setting, do not override user settings

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -227,12 +227,16 @@ public class HazelcastCore implements EventListener {
                     Logger.getLogger(HazelcastCore.class.getName()).log(Level.WARNING, "Hazelcast Application Object Serialization Not Available");
                 }
                 SerializationConfig serConfig = config.getSerializationConfig();
-                if (serConfig == null || serConfig.getGlobalSerializerConfig() == null) {
+                if (serConfig == null) {
                     SerializationConfig serializationConfig = new SerializationConfig()
                             .setGlobalSerializerConfig(new GlobalSerializerConfig().setImplementation(
                                     new PayaraHazelcastSerializer(ctxUtil, null))
                                     .setOverrideJavaSerialization(true));
                     config.setSerializationConfig(serializationConfig);
+                } else if (serConfig.getGlobalSerializerConfig() == null) {
+                    serConfig.setGlobalSerializerConfig(new GlobalSerializerConfig().setImplementation(
+                            new PayaraHazelcastSerializer(ctxUtil, null))
+                            .setOverrideJavaSerialization(true));
                 }
                 Serializer ser = config.getSerializationConfig().getGlobalSerializerConfig().getImplementation();
                 if(ctxUtil != null && ser instanceof StreamSerializer) {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -233,7 +233,7 @@ public class HazelcastCore implements EventListener {
                                     new PayaraHazelcastSerializer(ctxUtil, null))
                                     .setOverrideJavaSerialization(true));
                     config.setSerializationConfig(serializationConfig);
-                } else if (serConfig.getGlobalSerializerConfig() == null) {
+                } else {
                     serConfig.setGlobalSerializerConfig(new GlobalSerializerConfig().setImplementation(
                             new PayaraHazelcastSerializer(ctxUtil, null))
                             .setOverrideJavaSerialization(true));


### PR DESCRIPTION
Fixes issue #1872
This no longer overrides user settings if the global serializer is null. Instead will only set the global serializer if there are user serialization settings. Same behaviour if all serialization settings are null.
Tested with example provided in issue.