### PR TITLE
PAYARA-2054 Updated Mojarra with patched version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -81,7 +81,7 @@
         <!-- JSF -->
         <javax.faces-spec.version>2.3</javax.faces-spec.version>
         <javax.faces-api.version>2.3</javax.faces-api.version>
-        <mojarra.version>2.3.2</mojarra.version>
+        <mojarra.version>2.3.2-payara-p1</mojarra.version>
         
         <!-- WebSocket -->
         <websocket-api.version>1.1</websocket-api.version>


### PR DESCRIPTION
PAYARA-2054 This resolves the needless necessity of having a 2.3 faces-config.xml
file.

See https://github.com/payara/Payara_PatchedProjects/pull/81