### PR TITLE
PAYARA-2240 JMX monitoring values with spaces now recognised

### DIFF
--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
@@ -232,9 +232,11 @@ public class SetMonitoringConfiguration implements AdminCommand {
         }
 
         if (null != addproperty) {
-            String[] addpropertytokens = addproperty.split(" ");
+            // Negative lookbehind - find space characters not preceeded by \
+            String[] addpropertytokens = addproperty.split("(?<!\\\\) ");
             String name = null, value = null, description = null;
             for (String token : addpropertytokens) {
+                token = token.replaceAll("\\\\", "");
                 String[] param = token.split("=",2);
                 switch (param[0]) {
                     case "name":


### PR DESCRIPTION
JMX Monitoring values which have spaces as part of their name, path, or type can now be entered by escaping the space:
`name=PS\ Scavenge`