### PR TITLE
PAYARA-2247 disable jmx log monitoring service by default.

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -97,7 +97,7 @@ Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
             <log-service file="${com.sun.aas.instanceRoot}/logs/server.log" log-rotation-limit-in-bytes="2000000">
                 <module-log-levels />
             </log-service>
-            <monitoring-service-configuration amx="true" enabled="true" log-frequency="30">
+            <monitoring-service-configuration amx="false" enabled="false" log-frequency="30">
         	<log-notifier></log-notifier>
         	<eventbus-notifier></eventbus-notifier>
             </monitoring-service-configuration>


### PR DESCRIPTION
Disables JMX Log Monitoring by default in Payara Micro