### PR TITLE
Improvement for high number of JAR scanning threads.

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.deployment.annotation.impl;
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
@@ -348,9 +348,8 @@ public abstract class ModuleScanner<T> extends JavaEEScanner implements Scanner<
         if (executorService != null) {
             return executorService;
         }
-        Runtime runtime = Runtime.getRuntime();
-       int nrOfProcessors = runtime.availableProcessors();
-        executorService = Executors.newFixedThreadPool(nrOfProcessors, new ThreadFactory() {
+
+        executorService = Executors.newCachedThreadPool(new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
                 Thread t = new Thread(r);

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
@@ -349,16 +349,23 @@ public abstract class ModuleScanner<T> extends JavaEEScanner implements Scanner<
             return executorService;
         }
 
-        executorService = Executors.newCachedThreadPool(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("dol-jar-scanner");
-                t.setDaemon(true);
-                t.setContextClassLoader(getClass().getClassLoader());
-                return t;
-            }
-        });
+        Runtime runtime = Runtime.getRuntime();
+        int nrOfProcessors = runtime.availableProcessors();
+
+        executorService = new ThreadPoolExecutor(0, nrOfProcessors,
+                30L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>(),
+                new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r);
+                        t.setName("dol-jar-scanner");
+                        t.setDaemon(true);
+                        t.setContextClassLoader(getClass().getClassLoader());
+                        return t;
+                    }
+                });
+
         return executorService;
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -2255,9 +2255,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     }
 
     private ExecutorService createExecutorService() {
-        Runtime runtime = Runtime.getRuntime();
-        int nrOfProcessors = runtime.availableProcessors();
-        return Executors.newFixedThreadPool(nrOfProcessors, new ThreadFactory() {
+        return Executors.newCachedThreadPool(new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
                 Thread t = new Thread(r);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -2255,16 +2255,22 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     }
 
     private ExecutorService createExecutorService() {
-        return Executors.newCachedThreadPool(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("deployment-jar-scanner");
-                t.setContextClassLoader(getClass().getClassLoader());
-                t.setDaemon(true);
-                return t;
-            }
-        });
+        Runtime runtime = Runtime.getRuntime();
+        int nrOfProcessors = runtime.availableProcessors();
+
+        return new ThreadPoolExecutor(0, nrOfProcessors,
+                30L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>(),
+                new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r);
+                        t.setName("deployment-jar-scanner");
+                        t.setContextClassLoader(getClass().getClassLoader());
+                        t.setDaemon(true);
+                        return t;
+                    }
+                });
     }
 
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.v3.server;
 


### PR DESCRIPTION
This fixes and improves #2150. It uses `Executors.newCachedThreadPool(..)` instead of a fixed thread pool with the number of available processors as size instead.