### PR TITLE
PAYARA-2285 Jmx Monitoring Same Attribute Different Beans Merge

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
@@ -204,7 +204,11 @@ public class RestUtil {
                 restResponse = post(endpoint, attrs);
             }
         } else if ("put".equals(method)) {
-            restResponse = put(endpoint, attrs);
+            if (useData) {
+                restResponse = put(endpoint, data, (String) handlerCtx.getInputValue("contentType"));
+            } else {
+                restResponse = put(endpoint, attrs);
+            }
         } else if ("get".equals(method)) {
             restResponse = get(endpoint, attrs);
         } else if ("delete".equals(method)) {
@@ -891,6 +895,22 @@ public class RestUtil {
                 .request(RESPONSE_TYPE)
                 .cookie(new Cookie(REST_TOKEN_COOKIE, getRestToken()))
                 .post(Entity.entity(formData, MediaType.APPLICATION_FORM_URLENCODED), Response.class);
+        RestResponse rr = RestResponse.getRestResponse(cr);
+        return rr;
+    }
+
+    public static RestResponse put(String address, Object payload, String contentType) {
+        WebTarget target = getJerseyClient().target(address);
+        if (contentType == null) {
+            contentType = MediaType.APPLICATION_JSON;
+        }
+        if (payload instanceof Map) {
+            payload = buildMultivalueMap((Map<String, Object>) payload);
+        }
+        Response cr = target.request(RESPONSE_TYPE).header("Content-Type", contentType)
+                .cookie(new Cookie(REST_TOKEN_COOKIE, getRestToken()))
+                //                .header("Content-type", MediaType.APPLICATION_FORM_URLENCODED)
+                .put(Entity.entity(payload, contentType), Response.class);
         RestResponse rr = RestResponse.getRestResponse(cr);
         return rr;
     }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright [2017] [Payara Foundation and/or its affiliates]
  */
 package org.glassfish.admingui.common.util;
 

--- a/appserver/admingui/jmx-monitoring-plugin/src/main/resources/fish/payara/admingui/jmxmonitoring/Strings.properties
+++ b/appserver/admingui/jmx-monitoring-plugin/src/main/resources/fish/payara/admingui/jmxmonitoring/Strings.properties
@@ -55,7 +55,7 @@ jmxmonitoring.TimeLabelHelpText=How often the JMX Monitoring Logging should repo
 jmxmonitoring.UnitLabel=Log Frequency Unit
 jmxmonitoring.UnitLabelHelp=The time unit to use 
 
-jmxmonitoring.link.to.documentation.text.prefix=For the additional properties below, 'Name' is the attribute to monitor and 'Value' is the MBean to which it belongs. For further information, see the 
+jmxmonitoring.link.to.documentation.text.prefix=For the attributes below, 'Attribute Name' is the name of the attribute to monitor and 'Object Name' is the MBean to which it belongs. For further information, see the 
 jmxmonitoring.link.to.documentation.text=documentation
 jmxmonitoring.link.to.documentation.text.suffix=.
 jmxmonitoring.link.to.documentation.hover=MBeans in Payara Server
@@ -70,3 +70,8 @@ jmxmonitoring.link.to.notification.page.text.prefix=Selected Notifiers need to b
 jmxmonitoring.link.to.notification.page.text=Notification Service
 jmxmonitoring.link.to.notification.page.text.suffix=to receive notifications.
 
+jmxmonitoring.monitored.attributes.table.name=Monitored Attributes
+jmxmonitoring.monitored.attributes.attribute.name=Attribute Name
+jmxmonitoring.monitored.attributes.object.name=Object Name
+jmxmonitoring.monitored.attributes.add.attribute=Add Attribute
+jmxmonitoring.monitored.attributes.del.attributes=Delete Attributes

--- a/appserver/admingui/jmx-monitoring-plugin/src/main/resources/jmxmonitoring/jmxmonitoring.jsf
+++ b/appserver/admingui/jmx-monitoring-plugin/src/main/resources/jmxmonitoring/jmxmonitoring.jsf
@@ -57,8 +57,8 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         gf.restRequest(endpoint="#{sessionScope.REST_URL}/get-monitoring-configuration?target=#{pageSession.configName}"  
                 method="GET" result="#{requestScope.resp}"); 
                 
-        gf.restRequest(endpoint="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/monitoring-service-configuration/property.json" method="GET" result="#{requestScope.propTable}")
-        setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.properties}");
+        gf.restRequest(endpoint="#{pageSession.JMXMONITORING_CONFIG_URL}/monitored-attribute.json" method="GET" result="#{requestScope.propTable}")
+        setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.monitoredAttributes}");
         setPageSessionAttribute(key="valueMap", value="#{requestScope.resp.data.extraProperties.jmxmonitoringConfiguration}");
         setPageSessionAttribute(key="valueNotifierMap", value="#{requestScope.resp.data.extraProperties.notifierListLOG}");
         mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.configName}");
@@ -72,7 +72,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         }
 
         setPageSessionAttribute(key="dynamic", value="true");
-        setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.properties}");
         setPageSessionAttribute(key="hasPropertyTable" value="#{true}" );
         
         gf.restRequest(endpoint="#{sessionScope.REST_URL}/notifier-list-services" method="GET" result="#{requestScope.respAllNotifiers}");
@@ -96,19 +95,18 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <sun:button id="saveButton" rendered="#{edit}" text="$resource{i18n.button.Save}"
                     onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) {submitAndDisable(this, '$resource{i18n.button.Processing}');}; return false;" >
                  <!command
-                    mapPut(map="#{pageSession.valueMap}" key="enabled" value="#{pageSession.enabledSelected}");
-                    mapPut(map="#{pageSession.valueMap}" key="amx" value="#{pageSession.amxSelected}");
-                    mapPut(map="#{pageSession.valueMap}" key="dynamic" value="#{pageSession.dynamic}");
-                    prepareSuccessfulMsg();
-                    gf.updateEntity(endpoint="#{sessionScope.REST_URL}/set-monitoring-configuration" 
-                            attrs="#{pageSession.valueMap}" convertToFalse="#{pageSession.convertToFalseList}");
-                            
+                     mapPut(map="#{pageSession.valueMap}" key="enabled" value="#{pageSession.enabledSelected}");
+                     mapPut(map="#{pageSession.valueMap}" key="amx" value="#{pageSession.amxSelected}");
+                     mapPut(map="#{pageSession.valueMap}" key="dynamic" value="#{pageSession.dynamic}");
+                     prepareSuccessfulMsg();
+                     gf.updateEntity(endpoint="#{sessionScope.REST_URL}/set-monitoring-configuration" 
+                     attrs="#{pageSession.valueMap}" convertToFalse="#{pageSession.convertToFalseList}");
+
                      if (#{pageSession.hasPropertyTable}) {
-                        removeEmptyProps(props="#{pageSession.tableList}" modifiedProps="#{pageSession.tableList}");
                         javaToJSON(obj="#{pageSession.tableList}" json="#{requestScope.tmpJSON}");
-                        gf.restRequest(endpoint="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/monitoring-service-configuration/property.json", method="POST", data="#{requestScope.tmpJSON}", result="#{requestScope.restResponse}");
-                    }
-                    py.updateNotifiers(endpoint="#{pageSession.JMXMONITORING_CONFIG_URL}" dynamic="#{pageSession.dynamic}" target="#{pageSession.configName}" selected="#{pageSession.enabledNotifiersArr}" notifiers="#{pageSession.allNotifiersArray}");
+                        gf.restRequest(endpoint="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/monitoring-service-configuration/monitored-attribute.json", method="PUT", data="#{requestScope.tmpJSON}", result="#{requestScope.restResponse}");
+                     }
+                     py.updateNotifiers(endpoint="#{pageSession.JMXMONITORING_CONFIG_URL}" dynamic="#{pageSession.dynamic}" target="#{pageSession.configName}" selected="#{pageSession.enabledNotifiersArr}" notifiers="#{pageSession.allNotifiersArray}");
 
                     />
             </sun:button>
@@ -172,7 +170,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             </sun:property>
         </sun:propertySheetSection>
     </sun:propertySheet>
-#include "/common/shared/propertyDescTable.inc"
+#include "/jmxmonitoring/monitoredAttributeTable.inc"
              </sun:title>
                 <!--< sun:hidden id="helpKey" value="$resource{helpjmx.jmxService}" /> -->
             </sun:form>

--- a/appserver/admingui/jmx-monitoring-plugin/src/main/resources/jmxmonitoring/monitoredAttributeTable.inc
+++ b/appserver/admingui/jmx-monitoring-plugin/src/main/resources/jmxmonitoring/monitoredAttributeTable.inc
@@ -1,0 +1,81 @@
+<!-- jmxmonitoring/monitoredAttributeTable.inc -->
+
+<!-- Table .... -->
+<sun:table id="basicTable"  style="padding: 10pt" title="$resource{i18njmx.jmxmonitoring.monitored.attributes.table.name}" 
+           deselectMultipleButton="$boolean{true}"
+           deselectMultipleButtonOnClick="setTimeout('admingui.table.changeOneTableButton(\\\\\'#{pageSession.topActionGroup}\\\\\', \\\\\'#{pageSession.tableId}\\\\\');', 0)"
+           selectMultipleButton="$boolean{true}"
+           selectMultipleButtonOnClick="setTimeout('admingui.table.changeOneTableButton(\\\\\'#{pageSession.topActionGroup}\\\\\', \\\\\'#{pageSession.tableId}\\\\\');', 0)" >
+    <!afterCreate
+        getClientId(component="$this{component}" clientId=>$page{tableId});
+    />
+    <!-- Actions (Top) -->
+    <!facet actionsTop>
+    <sun:panelGroup id="topActionsGroup1">
+        <!afterCreate
+            getClientId(component="$this{component}" clientId=>$page{topActionGroup});
+        />
+        <sun:button id="addSharedTableButton" disabled="#{false}" text="$resource{i18njmx.jmxmonitoring.monitored.attributes.add.attribute}" >   
+            <!command
+                getUIComponent(clientId="$pageSession{propertyTableRowGroupId}", component=>$attribute{tableRowGroup});
+                addRowToTable(TableRowGroup="$attribute{tableRowGroup}", NameList={"objectName", "attributeName", "description"});
+            />                                 
+        </sun:button>
+        <sun:button id="button1" text="$resource{i18njmx.jmxmonitoring.monitored.attributes.del.attributes}" disabled="#{true}" primary="#{false}">
+            <!command
+                getUIComponent(clientId="$pageSession{propertyTableRowGroupId}", component=>$attribute{trg});   
+                getSelectedTableRowKeys(tableRowGroup="${trg}" rowKeys=>$attribute{rowKeys});
+                deleteTableRows(tableRowGroup="${trg}" rowKeys="${rowKeys}");
+                commitTableRowGroup(tableRowGroup="${trg}");
+            />                                
+        </sun:button>
+    </sun:panelGroup>
+</facet>       
+<sun:tableRowGroup id="rowGroup1" selected="#{td.value.selected}" data={"$pageSession{tableList}", "$pageSession{tableList2}"}  sourceVar="td">
+    <ui:event type="beforeCreate">
+        // Ensure all required fields exist
+        foreach (var="item" list="#{pageSession.tableList}") {
+            if ("!(#{item.objectName}=#{null})") {
+                if ("#{item.attributeName}=#{null}") {
+                    mapPut(map="#{item}" key="attributeName" value="");
+                }
+                if ("#{item.description}=#{null}") {
+                    mapPut(map="#{item}" key="description" value="");
+                }
+            }
+        }
+
+        // Add extra table properties...
+        createList(size="0", result="#{pageSession.tableList2}");
+        foreach(var="row" list="#{pageSession.tableList}") {
+            selectiveEncode(value="#{row.objectName}" result="#{requestScope.tlEncObjName}");
+            gf.createAttributeMap(
+                keys={"selected", "encodedName", "description"},
+                values={"$boolean{false}", "$attribute{tlEncObjName}", ""},
+                map="#{requestScope.tlMap}");
+            listAdd(list="#{pageSession.tableList2}", value="#{requestScope.tlMap}");
+        }
+    </ui:event>
+    <ui:event type="afterCreate">
+        getClientId(component="$this{component}" clientId=>$page{propertyTableRowGroupId});
+    </ui:event>
+    <sun:tableColumn headerText="$resource{i18n.common.SelectHeader}" selectId="select" rowHeader="$boolean{false}" id="col1">
+        <sun:checkbox id="select"
+                      toolTip="$resource{i18n.common.select}" 
+                      selected="#{td.value.selected}" 
+                      selectedValue="$boolean{true}" 
+                      onClick="setTimeout('admingui.table.changeOneTableButton(\\\\\'#{pageSession.topActionGroup}\\\\\', \\\\\'#{pageSession.tableId}\\\\\'); admingui.table.initAllRows(\\\\\'#{pageSession.tableId}\\\\\');', 0);"
+                      />
+    </sun:tableColumn>                    
+    <sun:tableColumn headerText="$resource{i18njmx.jmxmonitoring.monitored.attributes.object.name}" sort="name" rowHeader="$boolean{true}" id="col2">
+        <sun:textField columns="$int{40}" maxLength="#{sessionScope.fieldLengths['maxLength.common.PropertyName']}" id="col1St" value="#{td.value.objectName}" />
+    </sun:tableColumn>
+    <sun:tableColumn headerText="$resource{i18njmx.jmxmonitoring.monitored.attributes.attribute.name}" sort="value" rowHeader="$boolean{false}" id="col3">
+        <sun:textField columns="$int{40}" maxLength="#{sessionScope.fieldLengths['maxLength.common.PropertyValue']}" id="col1St" value="#{td.value.attributeName}" />
+    </sun:tableColumn>
+    <sun:tableColumn headerText="$resource{i18n.common.description.header}" sort="value" rowHeader="$boolean{false}" id="col4" rendered="#{pageSession.showDescCol != 'false'}">
+        <sun:textField columns="$int{20}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}"  id="col1St" value="#{td.value.description}" />
+    </sun:tableColumn>
+    "<br/>
+</sun:tableRowGroup>
+</sun:table>

--- a/appserver/admingui/jmx-monitoring-plugin/src/main/resources/jmxmonitoring/monitoredAttributeTable.inc
+++ b/appserver/admingui/jmx-monitoring-plugin/src/main/resources/jmxmonitoring/monitoredAttributeTable.inc
@@ -1,3 +1,44 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) [2017] Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
+
 <!-- jmxmonitoring/monitoredAttributeTable.inc -->
 
 <!-- Table .... -->

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/LocalStrings.properties
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/LocalStrings.properties
@@ -38,6 +38,6 @@
 # JMX Monitoring
 jmxmonitoring.configure.status.success=Monitoring Service Status is set to {0} on {1}.
 
-jmxmonitoring.configure.attributes.too.few=Too few attributes. Required attributes are 'name' and 'value'.
-jmxmonitoring.configure.attributes.unknown=Unknown attribute: {0}. Valid attributes are: 'name', 'value' and 'description'.
-jmxmonitoring.configure.attributes.invalid=Invalid attribute: {0}.
+jmxmonitoring.configure.attributes.too.few=Too few properties. Required properties are 'objectName' and 'attributeName'.
+jmxmonitoring.configure.attributes.unknown=Unknown property: {0}. Valid properties are: 'objectName', 'attributeName' and 'description'.
+jmxmonitoring.configure.attributes.invalid=Invalid property: {0}.

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/LocalStrings.properties
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/LocalStrings.properties
@@ -39,5 +39,10 @@
 jmxmonitoring.configure.status.success=Monitoring Service Status is set to {0} on {1}.
 
 jmxmonitoring.configure.attributes.too.few=Too few properties. Required properties are 'objectName' and 'attributeName'.
-jmxmonitoring.configure.attributes.unknown=Unknown property: {0}. Valid properties are: 'objectName', 'attributeName' and 'description'.
-jmxmonitoring.configure.attributes.invalid=Invalid property: {0}.
+jmxmonitoring.configure.attributes.unknown=Unknown property: `{0}`. Valid properties are: 'objectName', 'attributeName' and 'description'.
+jmxmonitoring.configure.attributes.invalid=Invalid property: `{0}`.
+
+jmxmonitoring.configure.attribute.add=Attribute `objectName={0} attributeName={1}` successfully added.
+jmxmonitoring.configure.attribute.add.error=Attribute `objectName={0} attributeName={1}` already exists, so was ignored.
+jmxmonitoring.configure.attribute.remove=Attribute `objectName={0} attributeName={1}` successfully deleted.
+jmxmonitoring.configure.attribute.remove.error=Attribute `objectName={0} attributeName={1}` doesn't exist, so was ignored.

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/MonitoringService.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/MonitoringService.java
@@ -82,6 +82,7 @@ import java.util.ArrayList;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.ConfigView;
+import fish.payara.jmx.monitoring.configuration.MonitoredAttribute;
 
 /**
  * Service which monitors a set of MBeans and their attributes while logging the data as a series of key-value pairs.
@@ -247,13 +248,13 @@ public class MonitoringService implements EventListener {
     private List<MonitoringJob> buildJobs() {
         List<MonitoringJob> jobs = new LinkedList<>();
 
-        for (Property prop : configuration.getProperty()) {
+        for (MonitoredAttribute mbean : configuration.getMonitoredAttributes()) {
             boolean exists = false;
 
             for (MonitoringJob job : jobs) {
                 if (job.getMBean().getCanonicalKeyPropertyListString()
-                        .equals(prop.getValue())) {
-                    job.addAttribute(prop.getName());
+                        .equals(mbean.getObjectName())) {
+                    job.addAttribute(mbean.getAttributeName());
                     exists = true;
                     break;
                 }
@@ -263,9 +264,9 @@ public class MonitoringService implements EventListener {
                 ObjectName name;
                 List<String> list;
                 try {
-                    name = new ObjectName(prop.getValue());
+                    name = new ObjectName(mbean.getObjectName());
                     list = new LinkedList<>();
-                    list.add(prop.getName());
+                    list.add(mbean.getAttributeName());
                     jobs.add(new MonitoringJob(name, list));
                 } catch (MalformedObjectNameException ex) {
                     Logger.getLogger(MonitoringService.class.getName()).log(Level.SEVERE, null, ex);

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/GetMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/GetMonitoringConfiguration.java
@@ -75,6 +75,8 @@ import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.ConfigView;
 import org.jvnet.hk2.config.types.Property;
+import fish.payara.jmx.monitoring.configuration.MonitoredAttribute;
+import java.util.ArrayList;
 
 /**
  * Asadmin command to get the monitoring service's current configuration and pretty print it to the shell.
@@ -95,7 +97,7 @@ import org.jvnet.hk2.config.types.Property;
 })
 public class GetMonitoringConfiguration implements AdminCommand {
 
-    private final String ATTRIBUTE_HEADERS[] = {"|Name|", "|Value|", "|Description|"};
+    private final String ATTRIBUTE_HEADERS[] = {"|Object Name|", "|Attribute|", "|Description|"};
     private final static String NOTIFIER_HEADERS[] = {"Name", "Notifier Enabled"};
 
     @Inject
@@ -148,19 +150,21 @@ public class GetMonitoringConfiguration implements AdminCommand {
         extraProps.put("jmxmonitoringConfiguration", map);
         
         
-        Map<String, Object> propMap = new HashMap<>();
+        List<Map<String, String>> monitoredAttributes = new ArrayList<>();
         
-        for (Property property : monitoringConfig.getProperty()) {
+        for (MonitoredAttribute monitoredBean : monitoringConfig.getMonitoredAttributes()) {
             Object values[] = new Object[3];
-            values[0] = property.getName();
-            values[1] = property.getValue();
-            values[2] = property.getDescription();
-            propMap.put(property.getName(), property.getValue());
+            values[0] = monitoredBean.getObjectName();
+            values[1] = monitoredBean.getAttributeName();
+            values[2] = monitoredBean.getDescription();
+            Map<String, String> monitoredAttribute = new HashMap<>();
+            monitoredAttribute.put(monitoredBean.getObjectName(), monitoredBean.getAttributeName());
+            monitoredAttributes.add(monitoredAttribute);
             attributeColumnFormatter.addRow(values);
         }
         
         //Cannot change key in line below - required for admingui propertyDescTable.inc
-        extraProps.put("properties", propMap);
+        extraProps.put("monitored-beans", monitoredAttributes);
         
         actionReport.setExtraProperties(extraProps);
         

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
@@ -111,10 +111,10 @@ public class SetMonitoringConfiguration implements AdminCommand {
     @Param(name = "logfrequencyunit", optional = true, acceptableValues = "NANOSECONDS,MILLISECONDS,SECONDS,MINUTES,HOURS,DAYS")
     private String logfrequencyunit;
 
-    @Param(name = "addattribute", optional = true, multiple = true)
+    @Param(name = "addattribute", optional = true, multiple = true, alias = "addproperty")
     private List<String> attributesToAdd;
 
-    @Param(name = "delattribute", optional = true, multiple = true)
+    @Param(name = "delattribute", optional = true, multiple = true, alias = "delproperty")
     private List<String> attributesToRemove;
 
     @Param(name = "dynamic", optional = true, defaultValue = "false")
@@ -310,10 +310,10 @@ public class SetMonitoringConfiguration implements AdminCommand {
                         "Too few properties. Required properties are 'objectName' and 'attributeName'."));
             }
             switch (param[0]) {
-                case "attributeName":
+                case "attributeName": case "name":
                     attributeName = (param.length == 2) ? param[1] : null;
                     break;
-                case "objectName":
+                case "objectName": case "value":
                     objectName = (param.length == 2) ? param[1] : null;
                     break;
                 case "description":

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/SetMonitoringConfiguration.java
@@ -69,7 +69,7 @@ import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.SingleConfigCode;
 import org.jvnet.hk2.config.TransactionFailure;
-import org.jvnet.hk2.config.types.Property;
+import fish.payara.jmx.monitoring.configuration.MonitoredAttribute;
 
 /**
  * Asadmin command to set the monitoring service's configuration.
@@ -111,11 +111,11 @@ public class SetMonitoringConfiguration implements AdminCommand {
     @Param(name = "logfrequencyunit", optional = true, acceptableValues = "NANOSECONDS,MILLISECONDS,SECONDS,MINUTES,HOURS,DAYS")
     private String logfrequencyunit;
 
-    @Param(name = "addproperty", optional = true, multiple = true)
-    private List<String> propertiesToAdd;
+    @Param(name = "addattribute", optional = true, multiple = true)
+    private List<String> attributesToAdd;
 
-    @Param(name = "delproperty", optional = true, multiple = true)
-    private List<String> propertiesToDelete;
+    @Param(name = "delattribute", optional = true, multiple = true)
+    private List<String> attributesToRemove;
 
     @Param(name = "dynamic", optional = true, defaultValue = "false")
     protected Boolean dynamic;
@@ -143,7 +143,7 @@ public class SetMonitoringConfiguration implements AdminCommand {
                 @Override
                 public Object run(final MonitoringServiceConfiguration monitoringConfigProxy) throws PropertyVetoException, TransactionFailure {
                     updateConfiguration(monitoringConfigProxy);
-                    updateAttributes(actionReport, monitoringConfigProxy);
+                    updateAttributes(monitoringConfigProxy);
                     actionReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
                     return monitoringConfigProxy;
                 }
@@ -218,14 +218,14 @@ public class SetMonitoringConfiguration implements AdminCommand {
      * @throws PropertyVetoException
      * @throws TransactionFailure
      */
-    private void updateAttributes(ActionReport actionReport, MonitoringServiceConfiguration monitoringConfig) throws PropertyVetoException, TransactionFailure {
-        List<Property> attributes = monitoringConfig.getProperty();
+    private void updateAttributes(MonitoringServiceConfiguration monitoringConfig) throws PropertyVetoException, TransactionFailure {
+        List<MonitoredAttribute> attributes = monitoringConfig.getMonitoredAttributes();
 
-        if (propertiesToDelete != null && !propertiesToDelete.isEmpty()) {
-            for (String delProperty : propertiesToDelete) {
-                Property property = parseToProperty(delProperty, monitoringConfig.createChild(Property.class));
-                for (Property attribute : attributes) {
-                    if (attribute.getName().equals(property.getName()) && attribute.getValue().equals(property.getValue())) {
+        if (attributesToRemove != null && !attributesToRemove.isEmpty()) {
+            for (String delProperty : attributesToRemove) {
+                MonitoredAttribute monitoredAttribute = parseToMonitoredAttribute(delProperty, monitoringConfig.createChild(MonitoredAttribute.class));
+                for (MonitoredAttribute attribute : attributes) {
+                    if (attribute.getAttributeName().equals(monitoredAttribute.getAttributeName()) && attribute.getObjectName().equals(monitoredAttribute.getObjectName())) {
                         attributes.remove(attribute);
                         break;
                     }
@@ -233,18 +233,28 @@ public class SetMonitoringConfiguration implements AdminCommand {
             }
         }
 
-        if (propertiesToAdd != null && !propertiesToAdd.isEmpty()) {
-            for (String addProperty : propertiesToAdd) {
-                Property property = parseToProperty(addProperty, monitoringConfig.createChild(Property.class));
-                attributes.add(property);
+        if (attributesToAdd != null && !attributesToAdd.isEmpty()) {
+            for (String addProperty : attributesToAdd) {
+                MonitoredAttribute monitoredAttribute = parseToMonitoredAttribute(addProperty, monitoringConfig.createChild(MonitoredAttribute.class));
+                boolean attributeExists = false;
+                for(MonitoredAttribute attribute : attributes) {
+                    if (attribute.getAttributeName().equals(monitoredAttribute.getAttributeName()) && attribute.getObjectName().equals(monitoredAttribute.getObjectName())) {
+                        attributeExists = true;
+                        break;
+                    }
+                }
+                if (!attributeExists) {
+                    attributes.add(monitoredAttribute);
+                }
             }
         }
     }
-
+    
     /**
-     * Produces a {@link org.jvnet.hk2.config.types.Property Property} from a
-     * given string. The string should be in the following format:
-     * 'name=something value=something description=something'.
+     * Produces a
+     * {@link fish.payara.jms.monitoring.configuration.MonitoredBean MonitoredAttribute}
+     * from a given string. The string should be in the following format:
+     * 'attribute=something objectName=something description=something'.
      *
      * @param input the string to be parsed
      * @param property the property to configure as per the input string.
@@ -252,28 +262,33 @@ public class SetMonitoringConfiguration implements AdminCommand {
      * @throws PropertyVetoException if a config listener vetoes a property
      * attribute value.
      */
-    private Property parseToProperty(String input, Property property) throws PropertyVetoException {
+    private MonitoredAttribute parseToMonitoredAttribute(String input, MonitoredAttribute monitoredAttribute) throws PropertyVetoException {
         // Negative lookbehind - find space characters not preceeded by \
         String[] propertyTokens = input.split("(?<!\\\\) ");
-        String name = null;
-        String value = null;
+        String attributeName = null;
+        String objectName = null;
         String description = null;
 
         if (propertyTokens.length < 2) {
             throw new IllegalArgumentException(monitoringService.getLocalStringManager().getLocalString(
-                            "jmxmonitoring.configure.attributes.too.few",
-                            "Too few attributes. Required attributes are 'name' and 'value'."));
+                    "jmxmonitoring.configure.attributes.too.few",
+                    "Too few properties. Required properties are 'objectName' and 'attributeName'."));
         }
 
         for (String token : propertyTokens) {
             token = token.replaceAll("\\\\", "");
             String[] param = token.split("=", 2);
+            if (param.length != 2) {
+                throw new IllegalArgumentException(monitoringService.getLocalStringManager().getLocalString(
+                        "jmxmonitoring.configure.attributes.too.few",
+                        "Too few properties. Required properties are 'objectName' and 'attributeName'."));
+            }
             switch (param[0]) {
-                case "name":
-                    name = (param.length == 2) ? param[1] : null;
+                case "attributeName":
+                    attributeName = (param.length == 2) ? param[1] : null;
                     break;
-                case "value":
-                    value = (param.length == 2) ? param[1] : null;
+                case "objectName":
+                    objectName = (param.length == 2) ? param[1] : null;
                     break;
                 case "description":
                     description = (param.length == 2) ? param[1] : null;
@@ -281,30 +296,30 @@ public class SetMonitoringConfiguration implements AdminCommand {
                 default:
                     throw new IllegalArgumentException(monitoringService.getLocalStringManager().getLocalString(
                             "jmxmonitoring.configure.attributes.unknown",
-                            "Unknown attribute: {0}. Valid attributes are: 'name', 'value' and 'description'.",
+                            "Unknown property: {0}. Valid properties are: 'objectName', 'attributeName' and 'description'.",
                              param[0]));
             }
         }
-        if (name == null || name.isEmpty()) {
+        if (attributeName == null || attributeName.isEmpty()) {
             throw new IllegalArgumentException(monitoringService.getLocalStringManager().getLocalString(
                             "jmxmonitoring.configure.attributes.invalid",
-                            "Invalid attribute: {0}.",
-                             "name"));
+                            "Invalid property: {0}.",
+                             "attributeName"));
         }
-        if (value == null || value.isEmpty()) {
+        if (objectName == null || objectName.isEmpty()) {
             throw new IllegalArgumentException(monitoringService.getLocalStringManager().getLocalString(
                             "jmxmonitoring.configure.attributes.invalid",
-                            "Invalid attribute: {0}.",
-                             "value"));
+                            "Invalid property: {0}.",
+                             "objectName"));
         }
 
-        property.setName(name);
-        property.setValue(value);
+        monitoredAttribute.setAttributeName(attributeName);
+        monitoredAttribute.setObjectName(objectName);
 
         if (description != null) {
-            property.setDescription(description);
+            monitoredAttribute.setDescription(description);
         }
-        return property;
+        return monitoredAttribute;
     }
 
 }

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoredAttribute.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoredAttribute.java
@@ -6,23 +6,34 @@ import org.glassfish.api.admin.config.ConfigExtension;
 import org.jvnet.hk2.config.Attribute;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.Configured;
+import org.jvnet.hk2.config.DuckTyped;
 
 @Configured
 public interface MonitoredAttribute extends ConfigBeanProxy, ConfigExtension {
-    
+
     @XmlAttribute(required = true)
     @Attribute(required = true)
-    public String getAttributeName();
-    public void setAttributeName(String value) throws PropertyVetoException;
-    
+    String getAttributeName();
+    void setAttributeName(String value) throws PropertyVetoException;
+
     @XmlAttribute(required = true)
     @Attribute(required = true)
-    public String getObjectName();
-    public void setObjectName(String value) throws PropertyVetoException;
-    
+    String getObjectName();
+    void setObjectName(String value) throws PropertyVetoException;
+
     @XmlAttribute(required = false)
     @Attribute(required = false)
-    public String getDescription();
-    public void setDescription(String value) throws PropertyVetoException;
+    String getDescription();
+    void setDescription(String value) throws PropertyVetoException;
+
+    @DuckTyped
+    boolean equals(MonitoredAttribute attr);
+
+    public class Duck {
+        public static boolean equals(MonitoredAttribute attr1, MonitoredAttribute attr2) {
+            return attr1.getObjectName().equals(attr2.getObjectName())
+                    && attr1.getAttributeName().equals(attr2.getAttributeName());
+        }
+    }
 
 }

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoredAttribute.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoredAttribute.java
@@ -1,0 +1,28 @@
+package fish.payara.jmx.monitoring.configuration;
+
+import java.beans.PropertyVetoException;
+import javax.xml.bind.annotation.XmlAttribute;
+import org.glassfish.api.admin.config.ConfigExtension;
+import org.jvnet.hk2.config.Attribute;
+import org.jvnet.hk2.config.ConfigBeanProxy;
+import org.jvnet.hk2.config.Configured;
+
+@Configured
+public interface MonitoredAttribute extends ConfigBeanProxy, ConfigExtension {
+    
+    @XmlAttribute(required = true)
+    @Attribute(required = true)
+    public String getAttributeName();
+    public void setAttributeName(String value) throws PropertyVetoException;
+    
+    @XmlAttribute(required = true)
+    @Attribute(required = true)
+    public String getObjectName();
+    public void setObjectName(String value) throws PropertyVetoException;
+    
+    @XmlAttribute(required = false)
+    @Attribute(required = false)
+    public String getDescription();
+    public void setDescription(String value) throws PropertyVetoException;
+
+}

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoredAttribute.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoredAttribute.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.jmx.monitoring.configuration;
 
 import java.beans.PropertyVetoException;

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoringServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/configuration/MonitoringServiceConfiguration.java
@@ -43,15 +43,13 @@ import java.beans.PropertyVetoException;
 import java.util.List;
 import org.glassfish.api.admin.config.ConfigExtension;
 import org.jvnet.hk2.config.*;
-import org.jvnet.hk2.config.types.Property;
-import org.jvnet.hk2.config.types.PropertyBag;
 
 /**
  * @since 4.1.1.163
  * @author savage
  */
 @Configured
-public interface MonitoringServiceConfiguration extends ConfigBeanProxy, ConfigExtension, PropertyBag {
+public interface MonitoringServiceConfiguration extends ConfigBeanProxy, ConfigExtension {
 
     /**
      * Boolean value determining if the service is enabled or disabled.
@@ -88,15 +86,9 @@ public interface MonitoringServiceConfiguration extends ConfigBeanProxy, ConfigE
     @Attribute(defaultValue="SECONDS")
     String getLogFrequencyUnit();
     void setLogFrequencyUnit(String value) throws PropertyVetoException;
-  
-    /**
-     * Properties listed in the domain.xml.
-     *  Returns a list of properties which are present in the configuration block
-     * @return 
-     */
+    
     @Element
-    @Override
-    List<Property> getProperty();
+    List<MonitoredAttribute> getMonitoredAttributes();
     
     /**
      * Returns a list of the notifiers configured with the monitoring service

--- a/nucleus/admin/rest/rest-service/src/main/java/fish/payara/admin/rest/resources/MonitoredAttributeBagResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/fish/payara/admin/rest/resources/MonitoredAttributeBagResource.java
@@ -1,0 +1,239 @@
+package fish.payara.admin.rest.resources;
+
+import org.glassfish.admin.rest.resources.*;
+import com.sun.enterprise.util.LocalStringManagerImpl;
+
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.glassfish.admin.rest.utils.Util;
+import org.glassfish.admin.rest.results.ActionReportResult;
+import org.glassfish.admin.rest.results.OptionsResult;
+import org.glassfish.admin.rest.utils.ResourceUtil;
+import org.glassfish.admin.rest.utils.xml.RestActionReporter;
+import org.glassfish.api.ActionReport;
+import org.glassfish.config.support.TranslatedConfigView;
+import org.jvnet.hk2.config.Dom;
+import org.jvnet.hk2.config.TransactionFailure;
+
+/**
+ * Resource for managing monitored attributes. Supports GET, POST, PUT and
+ * DELETE commands.
+ */
+public class MonitoredAttributeBagResource extends AbstractResource {
+
+    public final static LocalStringManagerImpl LOCAL_STRINGS = new LocalStringManagerImpl(MonitoredAttributeBagResource.class);
+
+    /**
+     * A list of the monitored attributes in the service.
+     */
+    protected List<Dom> entity;
+
+    /**
+     * The service containing the monitored attributes.
+     */
+    protected Dom parent;
+
+    /**
+     * The name of the element the monitored attributes are stored under.
+     */
+    protected String tagName;
+
+    /**
+     * Gets the monitored-attributes.
+     *
+     * @return a list of the monitored-attributes after the transaction.
+     */
+    @GET
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public ActionReportResult get() {
+
+        RestActionReporter ar = new RestActionReporter();
+        ar.setActionExitCode(ActionReport.ExitCode.SUCCESS);
+        ar.setActionDescription("monitored-attribute");
+
+        List monitoredAttributes = getMonitoredAttributes();
+
+        Properties extraProperties = new Properties();
+        extraProperties.put("monitoredAttributes", monitoredAttributes);
+        ar.setExtraProperties(extraProperties);
+
+        return new ActionReportResult(tagName, ar, new OptionsResult(Util.getResourceName(uriInfo)));
+    }
+
+    /**
+     * Creates new monitored-attributes. This method deletes all of the existing
+     * monitored-attributes.
+     *
+     * @param attributes the list of monitored-attributes to be created.
+     * @return a list of the monitored-attributes after the transaction.
+     */
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_FORM_URLENCODED})
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public ActionReportResult put(List<Map<String, String>> attributes) {
+
+        RestActionReporter ar = new RestActionReporter();
+        ar.setActionExitCode(ActionReport.ExitCode.SUCCESS);
+        ar.setActionDescription("monitored-attribute");
+
+        try {
+            setMonitoredAttributes(attributes);
+
+            List monitoredAttributes = getMonitoredAttributes();
+
+            Properties extraProperties = new Properties();
+            extraProperties.put("monitoredAttributes", monitoredAttributes);
+            ar.setExtraProperties(extraProperties);
+        } catch (TransactionFailure ex) {
+            ar.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            ar.setMessage(ex.getMessage());
+        }
+
+        return new ActionReportResult(tagName, ar, new OptionsResult(Util.getResourceName(uriInfo)));
+    }
+
+    /**
+     * Creates new monitored-attributes. Existing monitored-attributes will be
+     * ignored, and others will be created.
+     *
+     * @param attributes the list of monitored-attributes to be created.
+     * @return a list of the monitored-attributes after the transaction.
+     */
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_FORM_URLENCODED})
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public ActionReportResult post(List<Map<String, String>> attributes) {
+        List<Map<String, String>> currentData = getMonitoredAttributes();
+        attributes.addAll(currentData);
+        return put(attributes);
+    }
+
+    /**
+     * Deletes all monitored-attributes.
+     *
+     * @return a list of the monitored-attributes after the transaction.
+     */
+    @DELETE
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public ActionReportResult delete() {
+        List<Map<String, String>> emptyList = new ArrayList<>();
+        return put(emptyList);
+    }
+
+    /**
+     * Gets all of the monitored attributes in the entity.
+     *
+     * @return a list of the monitored attributes
+     */
+    public List<Map<String, String>> getMonitoredAttributes() {
+        List<Map<String, String>> attributes = new ArrayList<>();
+
+        for (Dom child : entity) {
+            Map<String, String> entry = new HashMap<>();
+
+            entry.put("attributeName", child.attribute("attribute-name"));
+            entry.put("objectName", child.attribute("object-name"));
+            String description = child.attribute("description");
+            if (description != null) {
+                entry.put("description", description);
+            }
+
+            attributes.add(entry);
+        }
+        return attributes;
+    }
+
+    /**
+     * Sets the monitored attribute list to the specified list.
+     *
+     * @param attributes the intended list of attributes.
+     * @throws TransactionFailure if an error occurs in removing or adding
+     * attributes.
+     */
+    public void setMonitoredAttributes(List<Map<String, String>> attributes) throws TransactionFailure {
+        TranslatedConfigView.doSubstitution.set(false);
+        List<Map<String, String>> existingAttributes = getMonitoredAttributes();
+
+        // Get a list of attributes that need adding
+        List<Map<String, String>> attributesToAdd = new ArrayList<>(attributes);
+        // Start with the list of specified attributes, and remove any that are also in the existing list
+        Iterator<Map<String, String>> iterator = attributesToAdd.iterator();
+        while (iterator.hasNext()) {
+            Map<String, String> attributeToAdd = iterator.next();
+            for (Map<String, String> existingAttribute : existingAttributes) {
+                if (attributesAreEqual(existingAttribute, attributeToAdd)) {
+                    iterator.remove();
+                }
+            }
+        }
+
+        // Get a list of attributes that need deleting
+        List<Map<String, String>> attributesToDelete = new ArrayList<>(existingAttributes);
+        // Start with the list of existing attributes, and remove any that aren't also in the specified list
+        iterator = attributesToDelete.iterator();
+        while (iterator.hasNext()) {
+            Map<String, String> attributeToDelete = iterator.next();
+            boolean specified = false;
+            for (Map<String, String> specifiedAttribute : attributes) {
+                if (attributesAreEqual(specifiedAttribute, attributeToDelete)) {
+                    specified = true;
+                }
+            }
+            if (specified) {
+                iterator.remove();
+            }
+        }
+
+        try {
+            // Add all required attributes
+            for (Map<String, String> attribute : attributesToAdd) {
+                Map<String, String> parameters = new HashMap<>();
+                parameters.put("addattribute", String.format("attributeName=%s objectName=%s", attribute.get("attributeName"), attribute.get("objectName")));
+                RestActionReporter reporter = ResourceUtil.runCommand("set-monitoring-configuration", parameters, getSubject());
+                if (reporter.isFailure()) {
+                    throw new TransactionFailure(reporter.getMessage());
+                }
+            }
+            // Delete all unrequired attributes
+            for (Map<String, String> attribute : attributesToDelete) {
+                Map<String, String> parameters = new HashMap<>();
+                parameters.put("delattribute", String.format("attributeName=%s objectName=%s", attribute.get("attributeName"), attribute.get("objectName")));
+                RestActionReporter reporter = ResourceUtil.runCommand("set-monitoring-configuration", parameters, getSubject());
+                if (reporter.isFailure()) {
+                    throw new TransactionFailure(reporter.getMessage());
+                }
+            }
+        } finally {
+            TranslatedConfigView.doSubstitution.set(true);
+        }
+        entity = parent.nodeElements("monitored-attributes");
+    }
+
+    private boolean attributesAreEqual(Map<String, String> attribute1, Map<String, String> attribute2) {
+        return attribute1.get("attributeName").equals(attribute2.get("attributeName"))
+                && attribute1.get("objectName").equals(attribute2.get("objectName"));
+    }
+
+    /**
+     * Sets the parent and the tag name of the resource. The Dom entity will be
+     * derived from this information.
+     *
+     * @param parent
+     * @param tagName
+     */
+    public void setParentAndTagName(Dom parent, String tagName) {
+        this.parent = parent;
+        this.tagName = tagName;
+        if (parent != null) {
+            entity = parent.nodeElements("monitored-attributes");
+        }
+    }
+}

--- a/nucleus/admin/rest/rest-service/src/main/java/fish/payara/admin/rest/resources/MonitoredAttributeBagResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/fish/payara/admin/rest/resources/MonitoredAttributeBagResource.java
@@ -1,11 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.admin.rest.resources;
 
 import org.glassfish.admin.rest.resources.*;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 
 import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-//Portions Copyright [2016] [Payara Foundation]
+//Portions Copyright [2016-2017] [Payara Foundation]
 package org.glassfish.admin.rest.generator;
 
 import com.sun.enterprise.util.SystemPropertyConstants;

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
@@ -336,10 +336,16 @@ public class ASMClassWriter implements ClassWriter, Opcodes {
     @Override
     public void createGetChildResource(String path, String childResourceClassName) {
         String childClass;
-        if (childResourceClassName.equals("PropertiesBagResource")){
-            childClass = "org/glassfish/admin/rest/resources/PropertiesBagResource";
-        }else {
-            childClass = generatedPath + childResourceClassName;
+        switch (childResourceClassName) {
+            case "PropertiesBagResource":
+                childClass = "org/glassfish/admin/rest/resources/PropertiesBagResource";
+                break;
+            case "MonitoredAttributeBagResource":
+                childClass = "fish/payara/admin/rest/resources/MonitoredAttributeBagResource";
+                break;
+            default:
+                childClass = generatedPath + childResourceClassName;
+                break;
         }
 
         String methodName = "get" + childResourceClassName;

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ResourcesGeneratorBase.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ResourcesGeneratorBase.java
@@ -231,6 +231,8 @@ public abstract class ResourcesGeneratorBase implements ResourcesGenerator {
 
         if (beanName.equals("Property")) {
             classWriter.createGetChildResource("property", "PropertiesBagResource");
+        } else if (beanName.equals("MonitoredAttribute")) {
+            classWriter.createGetChildResource("monitored-attribute", "MonitoredAttributeBagResource");
         } else {
             String childResourceClassName = getClassName(beanName);
             if (childElement.isCollection()) {

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ResourcesGeneratorBase.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ResourcesGeneratorBase.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright [2017] [Payara Foundation]
  */
 package org.glassfish.admin.rest.generator;
 


### PR DESCRIPTION
- Updated command set-monitoring-configuration from the format `--addproperty name=x value=x` to `--addattribute attributeName=x objectName=x`. Old command syntax is maintained for backwards compatibility.
- Multiple properties are added by providing multiple --addproperty commands.
- Better validation and output messages added to set-monitoring-configuration command.
- New MonitoredAttribute bean created, and REST endpoint to access it: `monitoring-service-configuration/monitored-attribute.json`. Functions vastly similar to the old `property.json` page, but with the new format.
- Admin console updated to reflect new changes.
- Updated admin console REST util to allow data in the body of a PUT request.