### PR TITLE
Update FileDirContext.java

### DIFF
--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
@@ -55,6 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
 
 package org.apache.naming.resources;
 
@@ -897,7 +898,7 @@ public class FileDirContext extends BaseDirContext {
             // Check that this file belongs to our root path
             String canPath = null;
             try {
-                canPath = file.getCanonicalPath();
+                canPath = file.toPath().toRealPath().toString();
             } catch (IOException e) {
             }
             if (canPath == null) {


### PR DESCRIPTION
I've noticed that Payara on Windows delivers files that are located in a junction folder in docroot, although the parameter "allowlinking" is set to false. This is because a path check of the docroot base path with the canonical path of the file is performed in the FileDirContext class. According to Javadoc, the function getCanonicalPath resolves symlinks only on Unix systems. Therefore the junction could not be recognized under Windows. Switching to the function getRealPath solves this problem under Windows. The function has to be tested under the other operating systems.