### PR TITLE
PAYARA-2309 fix broken deployment when BeanDiscoveryMode is NONE

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -256,8 +256,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
                     bootstrap.startInitialization();
                     fireProcessInjectionTargetEvents(bootstrap, deploymentImpl);
                     bootstrap.deployBeans();
-
-
                     bootstrap.validateBeans();
                     bootstrap.endInitialization();
                 } catch (Throwable t) {
@@ -488,13 +486,14 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
         WeldBootstrap bootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP,
                 WeldBootstrap.class);
+        boolean setTransientAppMetaData = false;
         if ( bootstrap == null) {
             bootstrap = new WeldBootstrap();
             Application app = context.getModuleMetaData(Application.class);
             appToBootstrap.put(app, bootstrap);
+            setTransientAppMetaData = true;
             // Stash the WeldBootstrap instance, so we may access the WeldManager later..
             context.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
-            appInfo.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
             // Making sure that if WeldBootstrap is added, shutdown is set to false, as it is/would not have been called.
             appInfo.addTransientAppMetaData(WELD_BOOTSTRAP_SHUTDOWN, "false");
         }
@@ -556,6 +555,10 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
         BeanDeploymentArchive bda = deploymentImpl.getBeanDeploymentArchiveForArchive(archiveName);
         if (bda != null && !bda.getBeansXml().getBeanDiscoveryMode().equals(BeanDiscoveryMode.NONE)) {
+            if(setTransientAppMetaData) {
+                // Do this only if we have a root BDA
+                appInfo.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
+            }
 
             WebBundleDescriptor wDesc = context.getModuleMetaData(WebBundleDescriptor.class);
             boolean developmentMode = isDevelopmentMode(context);

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -486,11 +486,15 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
         WeldBootstrap bootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP,
                 WeldBootstrap.class);
+
+        if(bootstrap != null && appInfo.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class) == null) {
+            // no bootstrap if no CDI BDAs exist yet
+            bootstrap = null;
+        }
+
         boolean setTransientAppMetaData = false;
-        if ( bootstrap == null) {
+        if ( bootstrap == null ) {
             bootstrap = new WeldBootstrap();
-            Application app = context.getModuleMetaData(Application.class);
-            appToBootstrap.put(app, bootstrap);
             setTransientAppMetaData = true;
             // Stash the WeldBootstrap instance, so we may access the WeldManager later..
             context.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
@@ -557,6 +561,8 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         if (bda != null && !bda.getBeansXml().getBeanDiscoveryMode().equals(BeanDiscoveryMode.NONE)) {
             if(setTransientAppMetaData) {
                 // Do this only if we have a root BDA
+                Application app = context.getModuleMetaData(Application.class);
+                appToBootstrap.put(app, bootstrap);
                 appInfo.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
             }
 


### PR DESCRIPTION
Disable CDI when WAR bean archive is set to BeanDiscoveryMode.NONE so CDI extensions such as Soteria etc. won't fail

Fixes #2112