### PR TITLE
PAYARA-2341 repackage JCIP annotations with OSGi headers

### DIFF
--- a/appserver/packager/external/jcip/pom.xml
+++ b/appserver/packager/external/jcip/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 2 only ("GPL") or the Common Development
+and Distribution License("CDDL") (collectively, the "License").  You
+may not use this file except in compliance with the License.  You can
+obtain a copy of the License at
+https://github.com/payara/Payara/blob/master/LICENSE.txt
+See the License for the specific
+language governing permissions and limitations under the License.
+
+When distributing the software, include this License Header Notice in each
+file and include the License file at glassfish/legal/LICENSE.txt.
+
+GPL Classpath Exception:
+The Payara Foundation designates this particular file as subject to the "Classpath"
+exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+file that accompanied this code.
+
+Modifications:
+If applicable, add the following below the License Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyright [year] [name of copyright owner]"
+
+Contributor(s):
+If you wish your version of this file to be governed by only the CDDL or
+only the GPL Version 2, indicate your decision by adding "[Contributor]
+elects to include this software in this distribution under the [CDDL or GPL
+Version 2] license."  If you don't indicate a single choice of license, a
+recipient has the option to distribute your version of this file under
+either the CDDL, the GPL Version 2 or to extend the choice of license to
+its licensees as provided above.  However, if you add GPL Version 2 code
+and therefore, elected the GPL Version 2 license, then the option applies
+only if the new code is made subject to such option by the copyright
+holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.external</groupId>
+        <artifactId>external</artifactId>
+        <version>4.1.2.181-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jcip-annotations-repackaged</artifactId>
+    <packaging>jar</packaging>
+
+    <name>jcip-annotations repackaged</name>
+    <description>Java Concurrency In Practice annotations (JCIP) repackaged as a module</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.github.stephenc.jcip</groupId>
+                                    <artifactId>jcip-annotations</artifactId>
+                                    <version>1.0-1</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <unpackBundle>true</unpackBundle>
+                    <instructions>
+                        <Bundle-Name>fish.payara.jcip-annotations</Bundle-Name>
+                        <Bundle-SymbolicName>fish.payara.jcip-annotations</Bundle-SymbolicName>
+                        <Export-Package>*</Export-Package>
+                    </instructions>
+                </configuration>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/appserver/packager/external/jcip/pom.xml
+++ b/appserver/packager/external/jcip/pom.xml
@@ -81,7 +81,7 @@ holder.
                                 <artifactItem>
                                     <groupId>com.github.stephenc.jcip</groupId>
                                     <artifactId>jcip-annotations</artifactId>
-                                    <version>1.0-1</version>
+                                    <version>${jcip-annotations.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/classes</outputDirectory>

--- a/appserver/packager/legal/src/main/resources/glassfish/legal/PAYARA-3RD-PARTY-LICENSE.txt
+++ b/appserver/packager/legal/src/main/resources/glassfish/legal/PAYARA-3RD-PARTY-LICENSE.txt
@@ -31,6 +31,7 @@ smack 4.1.9
 jxmpp 0.4.2
 xpp3 1.1.4c_7
 snmp4j 2.5.3
+jcip-annotations 1.0-1
 Code from SpringBoot for Launching Executable JARS
 Code from JBoss as base for the Payara Arquillian Containers
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -117,6 +117,7 @@
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
         <webservices.version>2.3.2-b608.payara-p3</webservices.version>
         <jsr181-api.version>1.0-MR1</jsr181-api.version>
+        <jcip-annotations.version>1.0-1</jcip-annotations.version>
         <jaxb-api.version>2.2.13-b141020.1521</jaxb-api.version>
         <jaxb.version>2.2.12-b141219.1637</jaxb.version>
         <stax2-api.version>3.1.1</stax2-api.version>


### PR DESCRIPTION
PAYARA-2341 creates a JCIP jar with the OSGi headers in MANIFEST.MF, but does not yet add this as a dependency to Payara.