### PR TITLE
PAYARA-2432 MP-Metrics log warning fix

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/extension/MetricCDIExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/extension/MetricCDIExtension.java
@@ -54,6 +54,7 @@
  */
 package fish.payara.microprofile.metrics.cdi.extension;
 
+import fish.payara.microprofile.metrics.MetricsService;
 import fish.payara.microprofile.metrics.cdi.MetricsAnnotationBinding;
 import fish.payara.microprofile.metrics.cdi.MetricsHelper;
 import fish.payara.microprofile.metrics.cdi.MetricsResolver;
@@ -96,6 +97,7 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.glassfish.internal.api.Globals;
 
 public class MetricCDIExtension implements Extension {
 
@@ -159,7 +161,8 @@ public class MetricCDIExtension implements Extension {
     }
 
     private void registerCustomMetrics(@Observes AfterDeploymentValidation adv, BeanManager manager) {
-        MetricRegistry registry = getReference(manager, MetricRegistry.class);
+        MetricsService metricsService = Globals.getDefaultBaseServiceLocator().getService(MetricsService.class);
+        MetricRegistry registry = metricsService.getOrAddRegistry(metricsService.getApplicationName());
         MetricsHelper helper = getReference(manager, MetricsHelper.class);
         for (Map.Entry<Producer<?>, AnnotatedMember<?>> entry : metrics.entrySet()) {
             AnnotatedMember<?> annotatedMember = entry.getValue();

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/interceptor/AbstractInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/interceptor/AbstractInterceptor.java
@@ -54,7 +54,7 @@ import javax.interceptor.InvocationContext;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.glassfish.internal.api.Globals;
 
-public abstract class AbstractInterceptor {
+/* package-private */ abstract class AbstractInterceptor {
 
     @Inject
     protected MetricRegistry registry;

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/interceptor/MetricsInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/interceptor/MetricsInterceptor.java
@@ -82,15 +82,18 @@ import org.glassfish.internal.api.Globals;
 @Priority(Interceptor.Priority.LIBRARY_BEFORE)
 public class MetricsInterceptor {
 
-    @Inject
-    public MetricRegistry registry;
+    private MetricRegistry registry;
 
-    @Inject
     private MetricsResolver resolver;
 
+    private Bean<?> bean;
+    
     @Inject
-    @Intercepted
-    protected Bean<?> bean;
+    private MetricsInterceptor(MetricRegistry registry, MetricsResolver resolver, @Intercepted Bean<?> bean) {
+        this.registry = registry;
+        this.resolver = resolver;
+        this.bean = bean;
+    }
 
     @AroundConstruct
     private Object constructorInvocation(InvocationContext context) throws Exception {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/rest/MetricsResource.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/rest/MetricsResource.java
@@ -87,7 +87,7 @@ public class MetricsResource extends HttpServlet {
             return;
         }
         if(!request.isSecure() && !metricsService.isInsucreMetricEnabled()){
-            response.sendError(SC_FORBIDDEN, "MP Metrics security is enbaled");
+            response.sendError(SC_FORBIDDEN, "MP Metrics security is enabled");
             return;
         }
         MetricsRequest metricsRequest = new MetricsRequest(request);


### PR DESCRIPTION
MP-Metrics log warning fix :

Warning: The following warnings have been detected: WARNING: Parameter bean of type javax.enterprise.inject.spi.Bean from protected javax.enterprise.inject.spi.Bean fish.payara.microprofile.metrics.cdi.interceptor.MetricsInterceptor.bean is not resolvable to a concrete type.

Severe: No valid EE environment for injection of fish.payara.microprofile.metrics.cdi.producer.MetricRegistryProducer

