### PR TITLE
PAYARA-2500 Update Micro Arquillian Container For New Instance Descriptor Format

### DIFF
--- a/appserver/extras/arquillian-containers/payara-common/pom.xml
+++ b/appserver/extras/arquillian-containers/payara-common/pom.xml
@@ -126,10 +126,16 @@
             <artifactId>jersey-media-json-jackson</artifactId>
         </dependency>
         
-
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/appserver/extras/arquillian-containers/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
+++ b/appserver/extras/arquillian-containers/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
@@ -1,0 +1,59 @@
+package fish.payara.arquillian.container.payara;
+
+import java.util.Scanner;
+
+/**
+ * A utility class to store the Payara Version and check if it's more recent than another version.
+ */
+public class PayaraVersion {
+
+    private String versionString;
+
+    public PayaraVersion(String versionString) {
+        if (versionString == null || versionString.isEmpty()) {
+            throw new IllegalArgumentException("Invalid version string.");
+        }
+        this.versionString = versionString;
+    }
+
+    public boolean isMoreRecentThan(PayaraVersion minimum) {
+        String minString = minimum.versionString;
+        try (Scanner minScanner = new Scanner(minString); Scanner vScanner = new Scanner(versionString)) {
+            minScanner.useDelimiter("\\.");
+            vScanner.useDelimiter("\\.");
+
+            while (minScanner.hasNext() && vScanner.hasNext()) {
+                String minPartString = minScanner.next();
+                String vPartString = vScanner.next();
+
+                int minPart = 0;
+                try {
+                    minPart = Integer.parseInt(minPartString.replaceAll("[^0-9]", ""));
+                } catch (Exception ex) {
+                    // Leave the number at 0
+                }
+                int vPart = 0;
+                try {
+                    vPart = Integer.parseInt(vPartString.replaceAll("[^0-9]", ""));
+                } catch (Exception ex) {
+                    // Leave the number at 0
+                }
+
+                if (minPartString.toUpperCase().contains("-SNAPSHOT")) {
+                    minPart--;
+                }
+                if (vPartString.toUpperCase().contains("-SNAPSHOT")) {
+                    vPart--;
+                }
+
+                if (vPart > minPart) {
+                    return true;
+                }
+                if (minPart > vPart) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/appserver/extras/arquillian-containers/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
+++ b/appserver/extras/arquillian-containers/payara-common/src/main/java/fish/payara/arquillian/container/payara/PayaraVersion.java
@@ -1,3 +1,40 @@
+/*
+ * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.arquillian.container.payara;
 
 import java.util.Scanner;

--- a/appserver/extras/arquillian-containers/payara-common/src/test/java/fish/payara/arquillian/container/payara/PayaraVersionTest.java
+++ b/appserver/extras/arquillian-containers/payara-common/src/test/java/fish/payara/arquillian/container/payara/PayaraVersionTest.java
@@ -1,3 +1,40 @@
+/*
+ * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.arquillian.container.payara;
 
 import static org.junit.Assert.assertTrue;

--- a/appserver/extras/arquillian-containers/payara-common/src/test/java/fish/payara/arquillian/container/payara/PayaraVersionTest.java
+++ b/appserver/extras/arquillian-containers/payara-common/src/test/java/fish/payara/arquillian/container/payara/PayaraVersionTest.java
@@ -1,0 +1,42 @@
+package fish.payara.arquillian.container.payara;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PayaraVersionTest {
+
+    private PayaraVersion v1;
+    private PayaraVersion v2;
+
+    @Test
+    public void moreRecentVersionTest() {
+        v1 = new PayaraVersion("4.1.2.174");
+        v2 = new PayaraVersion("4.1.2.181");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+
+        v1 = new PayaraVersion("4.1.2.181");
+        v2 = new PayaraVersion("4.1.3.181");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+
+        v1 = new PayaraVersion("4.1.2.181");
+        v2 = new PayaraVersion("4.2.2.181");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+
+        v1 = new PayaraVersion("4.1.2.174");
+        v2 = new PayaraVersion("4.1.2.181-SNAPSHOT");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+
+        v1 = new PayaraVersion("4.1.2.181-SNAPSHOT");
+        v2 = new PayaraVersion("4.1.2.181");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+
+        v1 = new PayaraVersion("5.Beta2");
+        v2 = new PayaraVersion("5.181-SNAPSHOT");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+
+        v1 = new PayaraVersion("5.181-SNAPSHOT");
+        v2 = new PayaraVersion("5.181");
+        assertTrue("The version check failed.", v2.isMoreRecentThan(v1));
+    }
+}

--- a/appserver/extras/arquillian-containers/payara-micro/pom.xml
+++ b/appserver/extras/arquillian-containers/payara-micro/pom.xml
@@ -116,9 +116,10 @@
             <artifactId>arquillian-testenricher-initialcontext</artifactId>
         </dependency>
         
-         <dependency>
+        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         
         

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -34,7 +34,6 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
- *
  */
 package fish.payara.arquillian.container.payara.managed;
 

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -65,6 +65,8 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
 
     private String cmdOptions = getConfigurableVariable("payara.cmdOptions", "MICRO_CMD_OPTIONS", null);
 
+    private String extraMicroOptions = getConfigurableVariable("payara.extraMicroOptions", "EXTRA_MICRO_OPTIONS", null);
+
     public String getMicroJar() {
         return microJar;
     }
@@ -124,10 +126,21 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
     }
 
     /**
-     * @param cmdOptions extra command line options to pass to the Payara Micro instance.
+     * @param cmdOptions extra command line options to pass to the Payara Micro instance (between java and -jar).
      */
     public void setCmdOptions(String cmdOptions) {
         this.cmdOptions = cmdOptions;
+    }
+
+    public String getExtraMicroOptions() {
+        return extraMicroOptions;
+    }
+
+    /**
+     * @param extraMicroOptions extra command line options to pass to the Payara Micro instance (at the end of the command).
+     */
+    public void setExtraMicroOptions(String extraMicroOptions) {
+        this.extraMicroOptions = extraMicroOptions;
     }
 
     /**

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -63,6 +63,8 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
 
     private boolean debug = Boolean.parseBoolean(getConfigurableVariable("payara.debug", "MICRO_DEBUG", "false"));
 
+    private String cmdOptions = getConfigurableVariable("payara.cmdOptions", "MICRO_CMD_OPTIONS", null);
+
     public String getMicroJar() {
         return microJar;
     }
@@ -115,6 +117,17 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
      */
     public void setDebug(boolean debug) {
         this.debug = debug;
+    }
+
+    public String getCmdOptions() {
+        return cmdOptions;
+    }
+
+    /**
+     * @param cmdOptions extra command line options to pass to the Payara Micro instance.
+     */
+    public void setCmdOptions(String cmdOptions) {
+        this.cmdOptions = cmdOptions;
     }
 
     /**

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -63,7 +63,7 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
     private boolean outputToConsole = Boolean.parseBoolean(System.getenv().getOrDefault("MICRO_CONSOLE_OUTPUT", "true"))
             || System.getenv("MICRO_CONSOLE_OUTPUT").equals("");
 
-    private boolean debug; // TODO
+    private boolean debug = Boolean.parseBoolean(System.getenv("MICRO_DEBUG"));
 
     public String getMicroJar() {
         return microJar;

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroContainerConfiguration.java
@@ -54,16 +54,14 @@ import fish.payara.arquillian.container.payara.PayaraVersion;
 
 public class PayaraMicroContainerConfiguration implements ContainerConfiguration {
 
-    private String microJar = System.getenv("MICRO_JAR");
-
+    private String microJar = getConfigurableVariable("payara.microJar", "MICRO_JAR", null);
     private PayaraVersion microVersion = null;
 
-    private boolean clusterEnabled = Boolean.parseBoolean(System.getenv("MICRO_CLUSTER_ENABLED"));
+    private boolean clusterEnabled = Boolean.parseBoolean(getConfigurableVariable("payara.clusterEnabled", "MICRO_CLUSTER_ENABLED", "false"));
 
-    private boolean outputToConsole = Boolean.parseBoolean(System.getenv().getOrDefault("MICRO_CONSOLE_OUTPUT", "true"))
-            || System.getenv("MICRO_CONSOLE_OUTPUT").equals("");
+    private boolean outputToConsole = Boolean.parseBoolean(getConfigurableVariable("payara.consoleOutput", "MICRO_CONSOLE_OUTPUT", "true"));
 
-    private boolean debug = Boolean.parseBoolean(System.getenv("MICRO_DEBUG"));
+    private boolean debug = Boolean.parseBoolean(getConfigurableVariable("payara.debug", "MICRO_DEBUG", "false"));
 
     public String getMicroJar() {
         return microJar;
@@ -140,5 +138,21 @@ public class PayaraMicroContainerConfiguration implements ContainerConfiguration
                     "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.", e);
         }
         notNull(getMicroVersion(), "Unable to find Payara Micro Jar version. Please check the file is a valid Payara Micro Jar.");
+    }
+
+    private static String getConfigurableVariable(String systemPropertyName, String environmentVariableName, String defaultValue) {
+        String systemProperty = System.getProperty(systemPropertyName);
+        String environmentProperty = System.getenv(environmentVariableName);
+
+        if (systemProperty == null || systemProperty.isEmpty()) {
+            if (environmentProperty == null || environmentProperty.isEmpty()) {
+                if (defaultValue == null || defaultValue.isEmpty()) {
+                    return null;
+                }
+                return defaultValue;
+            }
+            return environmentProperty;
+        }
+        return systemProperty;
     }
 }

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -188,7 +188,6 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
             // Create the list of commands to start Payara Micro
             List<String> cmd = new ArrayList<>(asList(
                     "java", "-jar", configuration.getMicroJarFile().getAbsolutePath(),
-                    "--autoBindHttp",
                     "--logtofile", logFile.getAbsolutePath(),
                     "--postdeploycommandfile", commandFile.getAbsolutePath(),
                     "--deploy", deploymentFile.getAbsolutePath()

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -188,6 +188,7 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
             // Create the list of commands to start Payara Micro
             List<String> cmd = new ArrayList<>(asList(
                     "java", "-jar", configuration.getMicroJarFile().getAbsolutePath(),
+                    "--autoBindHttp",
                     "--logtofile", logFile.getAbsolutePath(),
                     "--postdeploycommandfile", commandFile.getAbsolutePath(),
                     "--deploy", deploymentFile.getAbsolutePath()

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -199,9 +199,14 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
                 cmd.add("--nocluster");
             }
 
-            // Enabled --showServletMappings if it's supported
+            // Enable --showServletMappings if it's supported
             if (configuration.getMicroVersion().isMoreRecentThan(new PayaraVersion("5.181-SNAPSHOT"))) {
                 cmd.add("--showServletMappings");
+            }
+
+            // Start Payara Micro in debug mode if it's been enabled
+            if (configuration.isDebug()) {
+                cmd.add(1, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006");
             }
 
             logger.info("Starting Payara Micro using cmd: " + cmd);

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -214,6 +214,11 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
                 cmd.add(1, configuration.getCmdOptions());
             }
 
+            // Add the extra micro options to the Payara Micro instance
+            if (configuration.getExtraMicroOptions() != null) {
+                cmd.add(configuration.getExtraMicroOptions());
+            }
+
             logger.info("Starting Payara Micro using cmd: " + cmd);
 
             // Register a watch service to wait for the logs to be zipped.

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -84,6 +84,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 
+import fish.payara.arquillian.container.payara.PayaraVersion;
 import fish.payara.arquillian.container.payara.file.LogReader;
 import fish.payara.arquillian.container.payara.file.StringConsumer;
 import fish.payara.arquillian.container.payara.process.OutputLoggingConsumer;
@@ -195,6 +196,11 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
             // Disable clustering if it's not explicitly enabled
             if (!configuration.isClusterEnabled()) {
                 cmd.add("--nocluster");
+            }
+
+            // Enabled --showServletMappings if it's supported
+            if (configuration.getMicroVersion().isMoreRecentThan(new PayaraVersion("5.181-SNAPSHOT"))) {
+                cmd.add("--showServletMappings");
             }
 
             logger.info("Starting Payara Micro using cmd: " + cmd);

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -209,6 +209,11 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
                 cmd.add(1, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006");
             }
 
+            // Add the extra cmd options to the Payara Micro instance
+            if (configuration.getCmdOptions() != null) {
+                cmd.add(1, configuration.getCmdOptions());
+            }
+
             logger.info("Starting Payara Micro using cmd: " + cmd);
 
             // Register a watch service to wait for the logs to be zipped.

--- a/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
+++ b/appserver/extras/arquillian-containers/payara-micro/src/main/java/fish/payara/arquillian/container/payara/managed/PayaraMicroDeployableContainer.java
@@ -41,27 +41,37 @@ package fish.payara.arquillian.container.payara.managed;
 import static java.lang.Runtime.getRuntime;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.SEVERE;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.DOTALL;
 import static java.util.regex.Pattern.MULTILINE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
 
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
@@ -89,17 +99,11 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
 
     private static final Logger logger = Logger.getLogger(PayaraMicroDeployableContainer.class.getName());
 
-    // Regexps parse the server log for config info and deployment info of Payara Micro.
-    // This should be in sync with fish.payara.appserver.micro.services.data.InstanceDescriptorImpl#toString
-
     private static final Pattern instanceConfigPattern = Pattern
-            .compile("Instance Configuration.*Host: (?<host>.*)$.*HTTP Port\\(s\\):(?<ports>.*)$.*HTTPS", DOTALL | MULTILINE);
-
-    // The following regexps parse a line such as this one:
-    // Deployed: 1284c7bc-4733-4b44-8d50-a0ad8a42a1a4 ( 1284c7bc-4733-4b44-8d50-a0ad8a42a1a4 war
-    // /1284c7bc-4733-4b44-8d50-a0ad8a42a1a4 [ < jsp *.jspx >< ArquillianServletRunner /ArquillianServletRunner >< jsp *.jsp
-    // >< default / > ] )
-
+            .compile("Instance Configuration(?<jsonFormat>\")?.*Host\"?: \"?(?<host>.*?)\"?,{0,1}$.*HTTP Port\\(s\\)\"?: \"?(?<ports>.*?)\"?,?$.*HTTPS", DOTALL | MULTILINE | CASE_INSENSITIVE);
+    
+    private static final Pattern jsonPattern = Pattern.compile(
+            "Deployed\": (?<jsonArray>\\[.+?\\])", DOTALL | MULTILINE);
     private static final Pattern appPattern = Pattern.compile(
             "Deployed: (?<appName>.*) \\( (?<modules>.*) \\)");
     private static final Pattern modulePattern = Pattern.compile(
@@ -226,15 +230,15 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
             executor.scheduleAtFixedRate(() -> {
                 log = consumer.getBuilder().toString();
                 // Check for app deployed
-                Matcher appMatcher = appPattern.matcher(log);
-                if (appMatcher.find()) {
-                    executor.shutdown();
+                Matcher startupMatcher = instanceConfigPattern.matcher(log);
+                if (startupMatcher.find()) {
                     payaraMicroStarted.countDown();
+                    executor.shutdown();
                 }
-            }, 500, 500, TimeUnit.MILLISECONDS);
+            }, 500, 500, MILLISECONDS);
 
             // Wait for Payara Micro to start up, or time out after 10 seconds
-            if (payaraMicroStarted.await(10, TimeUnit.SECONDS)) {
+            if (payaraMicroStarted.await(10, SECONDS)) {
 
                 // Create a matcher for the 'Instance Configured' message
                 Matcher instanceConfigMatcher = instanceConfigPattern.matcher(log);
@@ -245,33 +249,16 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
                     String host = instanceConfigMatcher.group("host").trim();
                     String[] ports = instanceConfigMatcher.group("ports").trim().split(" ");
                     int firstPort = Integer.parseInt(ports[0].trim());
-                    logger.info("Payara Micro running on host:" + host + " port: " + firstPort);
+                    logger.info("Payara Micro running on host: " + host + " port: " + firstPort);
 
                     HTTPContext httpContext = new HTTPContext(host, firstPort);
 
-                    // For all application that are deployed
-                    Matcher appMatcher = appPattern.matcher(log.substring(instanceConfigMatcher.start()));
-                    while (appMatcher.find()) {
-
-                        logger.info("Deployed application detected. Name: " + appMatcher.group("appName"));
-
-                        // For all modules within a single application
-                        Matcher moduleMatcher = modulePattern.matcher(appMatcher.group("modules"));
-                        while (moduleMatcher.find()) {
-
-                            logger.info("\tModule name: " + moduleMatcher.group("modName") + " root: "
-                                    + moduleMatcher.group("modContextRoot"));
-
-                            Matcher servletMappingsMatcher = servletMappingsPattern.matcher(moduleMatcher.group("servletMappings"));
-
-                            // For all Servlet mappings within a single module
-                            while (servletMappingsMatcher.find()) {
-                                logger.info("\t\tServlet name:" + servletMappingsMatcher.group("servletName"));
-                                httpContext.add(
-                                        new Servlet(servletMappingsMatcher.group("servletName"), moduleMatcher.group("modContextRoot")));
-                            }
-                        }
-
+                    // If the instance config is in the new JSON format, parse the JSON object.
+                    if (instanceConfigMatcher.group("jsonFormat") != null) {
+                        processDeploymentAsJson(log.substring(instanceConfigMatcher.start()), httpContext);
+                    } else {
+                        // Otherwise, parse it the old way
+                        processDeploymentOldMethod(log.substring(instanceConfigMatcher.start()), httpContext);
                     }
 
                     ProtocolMetaData protocolMetaData = new ProtocolMetaData();
@@ -297,6 +284,93 @@ public class PayaraMicroDeployableContainer implements DeployableContainer<Payar
         }
 
         throw new DeploymentException("No applications were found deployed to Payara Micro.");
+    }
+
+    private void processDeploymentAsJson(String deploymentInformation, HTTPContext httpContext) {
+        Matcher jsonMatcher = jsonPattern.matcher(deploymentInformation);
+        if (jsonMatcher.find()) {
+            // Convert the deployment information into a JsonArray
+            String jsonString = jsonMatcher.group("jsonArray");
+            try (JsonReader reader = Json.createReader(new StringReader(jsonString))) {
+                JsonArray array = reader.readArray();
+
+                // For each deployed application
+                for (JsonObject app : array.getValuesAs(JsonObject.class)) {
+
+                    // Print the application details
+                    printApplicationFound(app.getString("Name"));
+
+                    // Store all application servlet mappings
+                    Map<String, JsonObject> allMappings = new HashMap<>();
+
+                    // If there's only one module, the mappings and context root are directly under the application
+                    JsonObject appMappings = app.getJsonObject("Mappings");
+                    if (appMappings != null) {
+                        // Get the context root and store the relevant servlets
+                        String contextRoot = app.getString("Context Root");
+                        allMappings.put(contextRoot, app.getJsonObject("Mappings"));
+                    } else {
+                        JsonArray modules = app.getJsonArray("Modules");
+                        modules.forEach(moduleValue -> {
+                            // Get the context root and store the relevant servlets
+                            JsonObject module = (JsonObject) moduleValue;
+                            String contextRoot = module.getString("Context Root");
+                            printModuleFound(module.getString("Name"), contextRoot);
+                            allMappings.put(contextRoot, module);
+                        });
+                    }
+
+                    // Handle each set of servlet mappings
+                    for (String contextRoot : allMappings.keySet()) {
+                        JsonObject mappings = allMappings.get(contextRoot);
+                        mappings.values().forEach(name -> {
+                            String servletName = name.toString().replaceAll("\"", "");
+                            printServletFound(servletName);
+                            httpContext.add(new Servlet(servletName, contextRoot));
+                        });
+                    }
+                    
+                }
+            }
+        }
+    }
+
+    private void processDeploymentOldMethod(String deploymentInformation, HTTPContext httpContext) {
+        Matcher appMatcher = appPattern.matcher(deploymentInformation);
+        // For each deployed application
+        while (appMatcher.find()) {
+
+            printApplicationFound(appMatcher.group("appName"));
+
+            // For all modules within a single application
+            Matcher moduleMatcher = modulePattern.matcher(appMatcher.group("modules"));
+            while (moduleMatcher.find()) {
+
+                printModuleFound(moduleMatcher.group("modName"), moduleMatcher.group("modContextRoot"));
+
+                Matcher servletMappingsMatcher = servletMappingsPattern.matcher(moduleMatcher.group("servletMappings"));
+
+                // For all Servlet mappings within a single module
+                while (servletMappingsMatcher.find()) {
+                    printServletFound(servletMappingsMatcher.group("servletName"));
+                    httpContext.add(
+                            new Servlet(servletMappingsMatcher.group("servletName"), moduleMatcher.group("modContextRoot")));
+                }
+            }
+
+        }
+    }
+
+    private void printApplicationFound(String appName) {
+        logger.log(Level.INFO, "Deployed application detected. Name: \"{0}\".", appName);
+    }
+
+    private void printModuleFound(String moduleName, String contextRoot) {
+        logger.log(Level.INFO, "\tModule found. Name: \"{0}\". Context root: \"{1}\".", new Object[]{moduleName, contextRoot});
+    }
+
+    private void printServletFound(String servletName) {
+        logger.log(Level.INFO, "\t\tServlet found. Name: \"{0}\".", servletName);
     }
 
     @Override


### PR DESCRIPTION
- The Arquillian container now accepts either old or new instance descriptor format.
- Added hierarchy to container configuration variables. They will now take values from system properties if possible, then environment variables, then the default value.
- New configurable options are: 

| Option | Description | System Property | Environment Variable | Default |
| --- | --- | --- | --- | --- |
| `microJar` | Provides the location of the Payara Micro Jar | `payara.microJar` | `MICRO_JAR` | `null` |
| `clusterEnabled` | Enables clustering on the Micro instance. | `payara.clusterEnabled` | `MICRO_CLUSTER_ENABLED` | `false` |
| `consoleOutput` | Enables/disables console output on the Micro instance. | `payara.consoleOutput` | `MICRO_CONSOLE_OUTPUT` | `true` |
| `debug` | Enables debugging on the Micro instance | `payara.debug` | `MICRO_DEBUG` | `false` |
| `cmdOptions` | Provides additional options to the Java process running the Micro instance (I.e. between `java` and `-jar`.) | `payara.cmdOptions` | `MICRO_CMD_OPTIONS` | `null` |
| `extraMicroOptions` | Provides additional options to the Micro instance (I.e. at the end of the command.) | `payara.extraMicroOptions` | `EXTRA_MICRO_OPTIONS` | `null` |