### PR TITLE
PAYARA-2511 Ensure Optional property is returned as empty and not as unconfigured value

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -102,7 +102,9 @@ public class ConfigProducer {
             
             // use the config to get a converted version of the property
             Object value = config.getValue(property.name(), property.defaultValue(),clazzValue);
-            result = Optional.ofNullable(value);
+            if (!value.toString().equals(ConfigProperty.UNCONFIGURED_VALUE)) {
+                result = Optional.ofNullable(value);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Fix to Microprofile Config api to ensure the optional is injected as empty if no value is specified for the property
```java
@Inject
@ConfigProperty(name="test")
Optional<String> value;
```
