### PR TITLE
PAYARA-2283 Illegal Type Error In Logs

### DIFF
--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbContainer.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbContainer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.ejb.config;
 

--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbContainer.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbContainer.java
@@ -254,7 +254,7 @@ public interface EjbContainer extends ConfigBeanProxy, PropertyBag, ConfigExtens
     @Attribute(defaultValue="6000", dataType = Integer.class)
     @Min(value=0)    
     @Max(value=30000)
-    Integer getMaxWaitTimeInMillis();
+    String getMaxWaitTimeInMillis();
 
     /**
      * Sets the value of the maxWaitTimeInMillis property.
@@ -262,7 +262,7 @@ public interface EjbContainer extends ConfigBeanProxy, PropertyBag, ConfigExtens
      * @param value allowed object is
      *              {@link Integer }
      */
-    void setMaxWaitTimeInMillis(Integer value) throws PropertyVetoException;
+    void setMaxWaitTimeInMillis(String value) throws PropertyVetoException;
 
     /**
      * Gets the value of the limitInstancesEnabled property.
@@ -271,7 +271,7 @@ public interface EjbContainer extends ConfigBeanProxy, PropertyBag, ConfigExtens
      *         {@link Boolean }
      */
     @Attribute(defaultValue = "false", dataType = Boolean.class)
-    Boolean getLimitInstancesEnabled();
+    String getLimitInstancesEnabled();
 
     /**
      * Sets the value of the limitInstancesEnabled property.
@@ -279,7 +279,7 @@ public interface EjbContainer extends ConfigBeanProxy, PropertyBag, ConfigExtens
      * @param value allowed object is
      *              {@link Boolean }
      */
-    void setLimitInstancesEnabled(Boolean value) throws PropertyVetoException;
+    void setLimitInstancesEnabled(String value) throws PropertyVetoException;
 
     /**
      * Gets the value of the cacheIdleTimeoutInSeconds property.

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatelessSessionContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatelessSessionContainer.java
@@ -781,8 +781,8 @@ public class StatelessSessionContainer
 
         public PoolProperties(EjbContainer ejbContainer, BeanPoolDescriptor beanPoolDes) {
 
-            maxWaitTimeInMillis = ejbContainer.getMaxWaitTimeInMillis();
-            if(!ejbContainer.getLimitInstancesEnabled()) {
+            maxWaitTimeInMillis = Integer.parseInt(ejbContainer.getMaxWaitTimeInMillis());
+            if(!Boolean.parseBoolean(ejbContainer.getLimitInstancesEnabled())) {
                 maxWaitTimeInMillis = -1;
             }
             maxPoolSize = Integer.parseInt(ejbContainer.getMaxPoolSize());

--- a/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/admin/SetZendeskSupportConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/admin/SetZendeskSupportConfigurationCommand.java
@@ -104,7 +104,7 @@ public class SetZendeskSupportConfigurationCommand implements AdminCommand {
                     public Object run(ZendeskSupportConfiguration config) {
                         
                          if(enabled != null) {
-                            config.setEnabled(enabled);
+                            config.setEnabled(Boolean.toString(enabled));
                         }
                          if (!Strings.isNullOrEmpty(emailAddress)){
                              config.setEmailAddress(emailAddress);

--- a/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/admin/SetZendeskSupportConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/admin/SetZendeskSupportConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/config/ZendeskSupportConfiguration.java
+++ b/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/config/ZendeskSupportConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/config/ZendeskSupportConfiguration.java
+++ b/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/config/ZendeskSupportConfiguration.java
@@ -39,7 +39,6 @@
  */
 package fish.payara.appserver.zendesk.config;
 
-import java.beans.PropertyVetoException;
 import org.glassfish.api.admin.config.ConfigExtension;
 import org.jvnet.hk2.config.Attribute;
 import org.jvnet.hk2.config.ConfigBeanProxy;
@@ -57,6 +56,6 @@ public interface ZendeskSupportConfiguration extends ConfigBeanProxy, ConfigExte
     public void setEmailAddress(String emailAddress);
     
     @Attribute(defaultValue = "true", dataType = Boolean.class)
-    Boolean getEnabled();
-    public void setEnabled(Boolean value);
+    String getEnabled();
+    public void setEnabled(String value);
 }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
@@ -126,7 +126,7 @@ public final class AMXStartupService
 
 
     private void shutdown() {
-        logger.fine("AMXStartupService: Shutting down AMX MBeans");
+        logger.fine("AMX Startup Service: Shutting down AMX MBeans");
         unloadAMXMBeans();
 
         final ObjectName allAMXPattern = AMXUtil.newObjectName(AMXGlassfish.DEFAULT.amxJMXDomain(), "*");
@@ -139,7 +139,7 @@ public final class AMXStartupService
             }
         }
         FeatureAvailability.getInstance().deRegisterFeatures();
-        logger.log(Level.INFO,"AMXStartupService: AMX MBeans shutdown: {0}.",mMBeanServer.queryNames(allAMXPattern, null));
+        logger.log(Level.INFO,"AMX Startup Service: AMX MBeans shutdown: {0}.",mMBeanServer.queryNames(allAMXPattern, null));
     }
 
 
@@ -149,7 +149,7 @@ public final class AMXStartupService
         SingletonEnforcer.register(this.getClass(), this);
 
         if (mMBeanServer == null) {
-            throw new Error("AMXStartupService: MBeanServer was null.");
+            throw new Error("AMX Startup Service: MBeanServer was null.");
         }
 
         try {
@@ -164,18 +164,18 @@ public final class AMXStartupService
             //final StandardMBean supportMBean = new StandardMBean(mMBeanTracker, MBeanTrackerMBean.class);
             mMBeanServer.registerMBean(mMBeanTracker, MBeanTrackerMBean.MBEAN_TRACKER_OBJECT_NAME);
         } catch (final Exception e) {
-            logger.log(Level.WARNING, "AMXStartupService: Initialisation error.", e);
+            logger.log(Level.WARNING, "AMX Startup Service: Initialisation error.", e);
             throw new Error(e);
         }
         //debug( "AMXStartupService.postConstruct(): registered: " + OBJECT_NAME );
-        logger.log(Level.INFO,"AMXStartupService: Created in {0}ms. MBean: `{1}`.",new Object[] {delta.elapsedMillis(),OBJECT_NAME});
+        logger.log(Level.INFO,"AMX Startup Service: Created in {0}ms. MBean: `{1}`.",new Object[] {delta.elapsedMillis(),OBJECT_NAME});
 
         mEvents.register(new ShutdownListener());
     }
 
 
     public void preDestroy() {
-        logger.log(Level.INFO,"AMXStartupService: Destroying service.");
+        logger.log(Level.INFO,"AMX Startup Service: Destroying service.");
         unloadAMXMBeans();
     }
 
@@ -225,7 +225,7 @@ public final class AMXStartupService
             try {
                 objectName = _loadAMXMBeans();
             } catch (final Exception e) {
-                logger.log(Level.SEVERE,"AMXStartupService: Error loading AMX Beans.",e);
+                logger.log(Level.SEVERE,"AMX Startup Service: Error loading AMX Beans.",e);
                 throw new RuntimeException(e);
             }
         }
@@ -247,7 +247,7 @@ public final class AMXStartupService
             loadSystemInfo();
         } catch (final Exception e) {
             final Throwable rootCause = ExceptionUtil.getRootCause(e);
-            logger.log(Level.INFO, "AMXStartupService: Error loading domain root.", rootCause);
+            logger.log(Level.INFO, "AMX Startup Service: Error loading domain root.", rootCause);
             throw new RuntimeException(rootCause);
         }
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright [2018] [Payara Foundation and/or its affiliates]
  */
 package org.glassfish.admin.amx.impl;
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
@@ -126,7 +126,7 @@ public final class AMXStartupService
 
 
     private void shutdown() {
-        logger.fine("AMXStartupService: shutting down AMX MBeans");
+        logger.fine("AMXStartupService: Shutting down AMX MBeans");
         unloadAMXMBeans();
 
         final ObjectName allAMXPattern = AMXUtil.newObjectName(AMXGlassfish.DEFAULT.amxJMXDomain(), "*");
@@ -139,7 +139,7 @@ public final class AMXStartupService
             }
         }
         FeatureAvailability.getInstance().deRegisterFeatures();
-        logger.log(Level.INFO,"amx.shutdown.unregistered",mMBeanServer.queryNames(allAMXPattern, null));
+        logger.log(Level.INFO,"AMXStartupService: AMX MBeans shutdown: {0}.",mMBeanServer.queryNames(allAMXPattern, null));
     }
 
 
@@ -149,7 +149,7 @@ public final class AMXStartupService
         SingletonEnforcer.register(this.getClass(), this);
 
         if (mMBeanServer == null) {
-            throw new Error("AMXStartup: null MBeanServer");
+            throw new Error("AMXStartupService: MBeanServer was null.");
         }
 
         try {
@@ -164,18 +164,18 @@ public final class AMXStartupService
             //final StandardMBean supportMBean = new StandardMBean(mMBeanTracker, MBeanTrackerMBean.class);
             mMBeanServer.registerMBean(mMBeanTracker, MBeanTrackerMBean.MBEAN_TRACKER_OBJECT_NAME);
         } catch (final Exception e) {
-            logger.log(Level.INFO, "amx.fatal.error", e);
+            logger.log(Level.WARNING, "AMXStartupService: Initialisation error.", e);
             throw new Error(e);
         }
         //debug( "AMXStartupService.postConstruct(): registered: " + OBJECT_NAME );
-        logger.log(Level.INFO,"amx.startupService",new Object[] {delta.elapsedMillis(),OBJECT_NAME});
+        logger.log(Level.INFO,"AMXStartupService: Created in {0}ms. MBean: `{1}`.",new Object[] {delta.elapsedMillis(),OBJECT_NAME});
 
         mEvents.register(new ShutdownListener());
     }
 
 
     public void preDestroy() {
-        logger.log(Level.INFO,"amx.preDestroy");
+        logger.log(Level.INFO,"AMXStartupService: Destroying service.");
         unloadAMXMBeans();
     }
 
@@ -225,7 +225,7 @@ public final class AMXStartupService
             try {
                 objectName = _loadAMXMBeans();
             } catch (final Exception e) {
-                logger.log(Level.SEVERE,"amx.error.loadAMXBeans",e);
+                logger.log(Level.SEVERE,"AMXStartupService: Error loading AMX Beans.",e);
                 throw new RuntimeException(e);
             }
         }
@@ -247,7 +247,7 @@ public final class AMXStartupService
             loadSystemInfo();
         } catch (final Exception e) {
             final Throwable rootCause = ExceptionUtil.getRootCause(e);
-            logger.log(Level.INFO, "amx.error.load.DomainRoot", rootCause);
+            logger.log(Level.INFO, "AMXStartupService: Error loading domain root.", rootCause);
             throw new RuntimeException(rootCause);
         }
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
@@ -346,7 +346,7 @@ public final class AMXConfigLoader
             // Now the Config subsystem is ready: after the first queue of ConfigBeans are registered as MBeans
             // and after the above MBeans are registered.
             final ObjectName domainObjectName = ConfigBeanRegistry.getInstance().getObjectNameForProxy(getDomain());
-            mLogger.log(Level.INFO,"amx.domain.config.registered", domainObjectName);
+            mLogger.log(Level.INFO,"AMX Config Loader: Domain started: `{0}`.", domainObjectName);
             FeatureAvailability.getInstance().registerFeature(AMXConfigConstants.AMX_CONFIG_READY_FEATURE, domainObjectName);
         }
         return null;

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
@@ -38,7 +38,7 @@
  * holder.
  */
  
- // Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+ // Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
  
 package org.glassfish.admin.amx.impl.config;
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/GetConfigOrdinal.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/GetConfigOrdinal.java
@@ -91,35 +91,35 @@ public class GetConfigOrdinal implements AdminCommand {
             Integer result = -1;
             switch (source) {
                 case "domain": {
-                    result = serviceConfig.getDomainOrdinality();
+                    result = Integer.parseInt(serviceConfig.getDomainOrdinality());
                     break;
                 }
                 case "config": {
-                    result = serviceConfig.getConfigOrdinality();
+                    result = Integer.parseInt(serviceConfig.getConfigOrdinality());
                     break;
                 }
                 case "server": {
-                    result = serviceConfig.getServerOrdinality();
+                    result = Integer.parseInt(serviceConfig.getServerOrdinality());
                     break;
                 }
                 case "application": {
-                    result = serviceConfig.getApplicationOrdinality();
+                    result = Integer.parseInt(serviceConfig.getApplicationOrdinality());
                     break;
                 }
                 case "module": {
-                    result = serviceConfig.getModuleOrdinality();
+                    result = Integer.parseInt(serviceConfig.getModuleOrdinality());
                     break;
                 }
                 case "cluster": {
-                    result = serviceConfig.getClusterOrdinality();
+                    result = Integer.parseInt(serviceConfig.getClusterOrdinality());
                     break;
                 }
                 case "jndi": {
-                    result = serviceConfig.getJNDIOrdinality();
+                    result = Integer.parseInt(serviceConfig.getJNDIOrdinality());
                     break;
                 }
                 case "secrets": {
-                    result = serviceConfig.getSecretDirOrdinality();
+                    result = Integer.parseInt(serviceConfig.getSecretDirOrdinality());
                     break;
                 }
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/GetConfigOrdinal.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/GetConfigOrdinal.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/SetConfigOrdinal.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/SetConfigOrdinal.java
@@ -102,35 +102,35 @@ public class SetConfigOrdinal implements AdminCommand {
 
                         switch (source) {
                             case "domain": {
-                                config.setDomainOrdinality(ordinal);
+                                config.setDomainOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "config": {
-                                config.setConfigOrdinality(ordinal);
+                                config.setConfigOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "server": {
-                                config.setServerOrdinality(ordinal);
+                                config.setServerOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "application": {
-                                config.setApplicationOrdinality(ordinal);
+                                config.setApplicationOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "module": {
-                                config.setModuleOrdinality(ordinal);
+                                config.setModuleOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "cluster": {
-                                config.setClusterOrdinality(ordinal);
+                                config.setClusterOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "jndi": {
-                                config.setJNDIOrdinality(ordinal);
+                                config.setJNDIOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                             case "secrets": {
-                                config.setSecretDirOrdinality(ordinal);
+                                config.setSecretDirOrdinality(Integer.toString(ordinal));
                                 break;
                             }
                         }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/SetConfigOrdinal.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/admin/SetConfigOrdinal.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ApplicationConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ApplicationConfigSource.java
@@ -80,7 +80,7 @@ public class ApplicationConfigSource extends PayaraConfigSource implements Confi
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getApplicationOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getApplicationOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ApplicationConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ApplicationConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ClusterConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ClusterConfigSource.java
@@ -71,7 +71,7 @@ public class ClusterConfigSource extends PayaraConfigSource implements ConfigSou
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getClusterOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getClusterOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ClusterConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ClusterConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ConfigConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ConfigConfigSource.java
@@ -81,7 +81,7 @@ public class ConfigConfigSource extends PayaraConfigSource implements ConfigSour
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getConfigOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getConfigOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ConfigConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ConfigConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/DomainConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/DomainConfigSource.java
@@ -71,7 +71,7 @@ public class DomainConfigSource extends PayaraConfigSource implements ConfigSour
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getDomainOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getDomainOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/DomainConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/DomainConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
@@ -77,7 +77,7 @@ public class JNDIConfigSource extends PayaraConfigSource implements ConfigSource
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getJNDIOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getJNDIOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ModuleConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ModuleConfigSource.java
@@ -86,7 +86,7 @@ public class ModuleConfigSource extends PayaraConfigSource implements ConfigSour
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getModuleOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getModuleOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ModuleConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ModuleConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/SecretsDirConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/SecretsDirConfigSource.java
@@ -88,7 +88,7 @@ public class SecretsDirConfigSource extends PayaraConfigSource implements Config
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getSecretDirOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getSecretDirOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/SecretsDirConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/SecretsDirConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ServerConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ServerConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ServerConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ServerConfigSource.java
@@ -80,7 +80,7 @@ public class ServerConfigSource extends PayaraConfigSource implements ConfigSour
 
     @Override
     public int getOrdinal() {
-        return configService.getMPConfig().getServerOrdinality();
+        return Integer.parseInt(configService.getMPConfig().getServerOrdinality());
     }
 
     @Override

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/MicroprofileConfigConfiguration.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/MicroprofileConfigConfiguration.java
@@ -52,39 +52,39 @@ import org.jvnet.hk2.config.Configured;
 public interface MicroprofileConfigConfiguration extends ConfigBeanProxy, ConfigExtension {
     
     @Attribute(defaultValue = "110", dataType = Integer.class)
-    Integer getDomainOrdinality();
-    public void setDomainOrdinality(Integer message);
+    String getDomainOrdinality();
+    public void setDomainOrdinality(String message);
 
     @Attribute(defaultValue = "120", dataType = Integer.class)
-    Integer getConfigOrdinality();
-    public void setConfigOrdinality(Integer message);    
+    String getConfigOrdinality();
+    public void setConfigOrdinality(String message);    
     
     @Attribute(defaultValue = "130", dataType = Integer.class)
-    Integer getServerOrdinality();
-    public void setServerOrdinality(Integer message);
+    String getServerOrdinality();
+    public void setServerOrdinality(String message);
 
     @Attribute(defaultValue = "140", dataType = Integer.class)
-    Integer getApplicationOrdinality();
-    public void setApplicationOrdinality(Integer message);    
+    String getApplicationOrdinality();
+    public void setApplicationOrdinality(String message);    
 
     @Attribute(defaultValue = "150", dataType = Integer.class)
-    Integer getModuleOrdinality();
-    public void setModuleOrdinality(Integer message);    
+    String getModuleOrdinality();
+    public void setModuleOrdinality(String message);    
 
     @Attribute(defaultValue = "160", dataType = Integer.class)
-    Integer getClusterOrdinality();
-    public void setClusterOrdinality(Integer message);    
+    String getClusterOrdinality();
+    public void setClusterOrdinality(String message);    
     
     @Attribute(defaultValue = "115", dataType = Integer.class)
-    Integer getJNDIOrdinality();
-    public void setJNDIOrdinality(Integer message);  
+    String getJNDIOrdinality();
+    public void setJNDIOrdinality(String message);  
     
     @Attribute(defaultValue = "secrets", dataType = String.class)
     String getSecretDir();
     public void setSecretDir(String directory);
     
     @Attribute(defaultValue = "90", dataType = Integer.class)
-    Integer getSecretDirOrdinality();
-    public void setSecretDirOrdinality(Integer message);  
+    String getSecretDirOrdinality();
+    public void setSecretDirOrdinality(String message);  
     
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/MicroprofileConfigConfiguration.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/MicroprofileConfigConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
- Changed HK2 Config properties to String data type.
- Added appropriate conversions.
- Converted error messages with no localisation to an appropriate string.