### PR TITLE
PAYARA-2515 Micro Arquillian Tests Fail In Parallel

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PortBinder.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PortBinder.java
@@ -2,7 +2,7 @@
 
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
- Copyright (c) 2016 Payara Foundation. All rights reserved.
+ Copyright (c) [2016-2018] Payara Foundation. All rights reserved.
 
  The contents of this file are subject to the terms of the Common Development
  and Distribution License("CDDL") (collectively, the "License").  You

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PortBinder.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PortBinder.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.ServerSocket;
 
+import fish.payara.kernel.services.impl.MicroNetworkListener;
+
 /**
  *
  * @author Andrew Pielage
@@ -40,9 +42,11 @@ public class PortBinder {
         boolean foundAvailablePort = false;
 
         for (int i = 0; i <= autoBindRange; i++) {   
-            try (ServerSocket serverSocket = new ServerSocket(port);) {
+            try {
+                ServerSocket serverSocket = new ServerSocket(port);
                 returnPort = port;
                 foundAvailablePort = true;
+                MicroNetworkListener.addReservedSocket(port, serverSocket);
                 break;
             } catch (IOException ex) {
                 port++;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ * 
+ * Portions Copyright [2018] [Payara Foundation and/or its affiliates]
  */
 
 package com.sun.enterprise.v3.services.impl;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
@@ -278,20 +278,16 @@ public class GrizzlyProxy implements NetworkProxy {
         try {
             grizzlyListener.start();
         } catch (BindException e) {
-            if (logger.isLoggable(Level.SEVERE)) {
-                logger.log(Level.SEVERE, KernelLoggerInfo.grizzlyUnableToBind,
-                    new Object[]{Grizzly.getDotedVersion(),
-                    grizzlyListener.getAddress() + ":" + grizzlyListener.getPort()});
-            }
+            logger.log(Level.SEVERE, KernelLoggerInfo.listenerUnableToBind,
+                new Object[]{Grizzly.getDotedVersion(),
+                grizzlyListener.getAddress() + ":" + grizzlyListener.getPort()});
             throw e;
         }
 
-        if (logger.isLoggable(Level.INFO)) {
-            logger.log(Level.INFO, KernelLoggerInfo.grizzlyStarted,
-                    new Object[]{Grizzly.getDotedVersion(),
-                    System.currentTimeMillis() - t1,
-                    grizzlyListener.getAddress() + ":" + grizzlyListener.getPort()});
-        }
+        logger.log(Level.INFO, KernelLoggerInfo.listenerStarted,
+                new Object[]{grizzlyListener.getName(),
+                System.currentTimeMillis() - t1,
+                grizzlyListener.getAddress() + ":" + grizzlyListener.getPort()});
     }
     
     @Override

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyProxy.java
@@ -41,6 +41,7 @@
 package com.sun.enterprise.v3.services.impl;
 
 import org.glassfish.grizzly.config.dom.NetworkListener;
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.container.EndpointRegistrationException;
 import org.glassfish.api.deployment.ApplicationContainer;
 
@@ -64,6 +65,8 @@ import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.impl.FutureImpl;
 import org.glassfish.grizzly.utils.Futures;
 import org.glassfish.kernel.KernelLoggerInfo;
+
+import fish.payara.kernel.services.impl.MicroNetworkListener;
 
 /**
  * This class is responsible for configuring Grizzly.
@@ -127,11 +130,18 @@ public class GrizzlyProxy implements NetworkProxy {
 
     protected GrizzlyListener createGrizzlyListener(
             final NetworkListener networkListener) {
+        ServerEnvironment env = grizzlyService.getHabitat().getService(ServerEnvironment.class);
+        if (env != null && env.isMicro()) {
+            return createMicroListener(networkListener);
+        }
         if (GrizzlyService.isLightWeightListener(networkListener)) {
             return createServiceInitializerListener(networkListener);
-        } else {
-            return createGlassfishListener(networkListener);
         }
+        return createGlassfishListener(networkListener);
+    }
+
+    protected GrizzlyListener createMicroListener(final NetworkListener networkListener) {
+        return new MicroNetworkListener(grizzlyService, networkListener, logger);
     }
 
     protected GrizzlyListener createGlassfishListener(

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyService.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ * 
+ * Portions Copyright [2018] [Payara Foundation and/or its affiliates]
  */
 
 package com.sun.enterprise.v3.services.impl;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyService.java
@@ -53,6 +53,7 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,6 +72,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.glassfish.api.FutureProvider;
@@ -84,6 +87,7 @@ import org.glassfish.api.event.EventTypes;
 import org.glassfish.api.event.Events;
 import org.glassfish.api.event.RestrictTo;
 import org.glassfish.common.util.Constants;
+import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.config.GenericGrizzlyListener;
 import org.glassfish.grizzly.config.dom.NetworkConfig;
 import org.glassfish.grizzly.config.dom.NetworkListener;
@@ -538,11 +542,32 @@ public class GrizzlyService implements RequestDispatcher, PostConstruct, PreDest
             boolean isAtLeastOneProxyStarted = false;
             
             futures = new ArrayList<Future<Result<Thread>>>();
+
+            // Record how long it took for the listeners to start up
+            final long startTime = System.currentTimeMillis();
+
+            // Keep a list of successfully started listeners
+            List<NetworkListener> startedListeners = new ArrayList<>();
             for (NetworkListener listener : networkConfig.getNetworkListeners().getNetworkListener()) {
-                isAtLeastOneProxyStarted |= (createNetworkProxy(listener) != null);
+                if (createNetworkProxy(listener) != null) {
+                    isAtLeastOneProxyStarted = true;
+                    startedListeners.add(listener);
+                }
             }
             
             if (isAtLeastOneProxyStarted) {
+                
+                // Get the startup time
+                final long startupTime = System.currentTimeMillis() - startTime;
+
+                // Log the listeners which started.
+                String boundAddresses = Arrays.toString(
+                        startedListeners.stream()
+                            .map(listener -> listener.getAddress() + ":" + listener.getPort())
+                            .collect(Collectors.toList())
+                        .toArray());
+                LOGGER.log(Level.INFO, KernelLoggerInfo.grizzlyStarted,
+                        new Object[] { Grizzly.getDotedVersion(), startupTime, boundAddresses });
                 registerContainerAdapters();
             }
         } catch(RuntimeException e) { // So far postConstruct can not throw any other exception type

--- a/nucleus/core/kernel/src/main/java/fish/payara/kernel/services/impl/MicroNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/kernel/services/impl/MicroNetworkListener.java
@@ -1,0 +1,53 @@
+package fish.payara.kernel.services.impl;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.sun.enterprise.v3.services.impl.GlassfishNetworkListener;
+import com.sun.enterprise.v3.services.impl.GrizzlyService;
+
+import org.glassfish.grizzly.config.dom.NetworkListener;
+
+public class MicroNetworkListener extends GlassfishNetworkListener {
+
+    private static final Logger LOGGER = Logger.getLogger(MicroNetworkListener.class.getName());
+
+    private static Map<Integer, ServerSocket> reservedSocketMap = new HashMap<>();
+
+    public MicroNetworkListener(final GrizzlyService grizzlyService, final NetworkListener networkListener,
+            final Logger logger) {
+        super(grizzlyService, networkListener, logger);
+    }
+
+    @Override
+    public void start() throws IOException {
+        if (reservedSocketMap.containsKey(port)) {
+            ServerSocket reservedSocket = reservedSocketMap.get(port);
+            LOGGER.log(Level.INFO, "Found reserved socket on port: {0,number,#}.", port);
+            if (reservedSocket.isBound()) {
+                reservedSocket.close();
+                reservedSocketMap.remove(port);
+            }
+        }
+        super.start();
+    }
+
+    public static void addReservedSocket(int boundPort, ServerSocket socket) {
+        LOGGER.log(Level.INFO, "Reserving port: {0,number,#}", boundPort);
+        reservedSocketMap.put(boundPort, socket);
+    }
+
+    public static void clearReservedSockets() throws IOException {
+        for (ServerSocket socket : reservedSocketMap.values()) {
+            if (!socket.isClosed()) {
+                socket.close();
+            }
+        }
+        reservedSocketMap.clear();
+    }
+
+}

--- a/nucleus/core/kernel/src/main/java/fish/payara/kernel/services/impl/MicroNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/kernel/services/impl/MicroNetworkListener.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.kernel.services.impl;
 
 import java.io.IOException;
@@ -12,10 +51,18 @@ import com.sun.enterprise.v3.services.impl.GrizzlyService;
 
 import org.glassfish.grizzly.config.dom.NetworkListener;
 
+/**
+ * Extension of the default network listener that reusing ports allocated by the
+ * Payara Micro {@link fish.payara.micro.impl.PortBinder PortBinder} when
+ * <code>--autoBindHttp</code> is enabled.
+ */
 public class MicroNetworkListener extends GlassfishNetworkListener {
 
     private static final Logger LOGGER = Logger.getLogger(MicroNetworkListener.class.getName());
 
+    /**
+     * A list of open sockets that Payara Micro already has bound.
+     */
     private static Map<Integer, ServerSocket> reservedSocketMap = new HashMap<>();
 
     public MicroNetworkListener(final GrizzlyService grizzlyService, final NetworkListener networkListener,
@@ -36,11 +83,17 @@ public class MicroNetworkListener extends GlassfishNetworkListener {
         super.start();
     }
 
+    /**
+     * Adds a currently open socket to be allocated to a listener.
+     */
     public static void addReservedSocket(int boundPort, ServerSocket socket) {
         LOGGER.log(Level.INFO, "Reserving port: {0,number,#}", boundPort);
         reservedSocketMap.put(boundPort, socket);
     }
 
+    /**
+     * Clears the list of open sockets, to make sure none are left open but unused.
+     */
     public static void clearReservedSockets() throws IOException {
         for (ServerSocket socket : reservedSocketMap.values()) {
             if (!socket.isClosed()) {

--- a/nucleus/core/kernel/src/main/java/fish/payara/kernel/services/impl/MicroNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/kernel/services/impl/MicroNetworkListener.java
@@ -72,12 +72,16 @@ public class MicroNetworkListener extends GlassfishNetworkListener {
 
     @Override
     public void start() throws IOException {
+        // Check if Payara Micro has already allocated the socket
         if (reservedSocketMap.containsKey(port)) {
             ServerSocket reservedSocket = reservedSocketMap.get(port);
-            LOGGER.log(Level.INFO, "Found reserved socket on port: {0,number,#}.", port);
+            LOGGER.log(Level.FINEST, "Found reserved socket on port: {0,number,#}.", port);
+
+            // Release it for Grizzly to bind to
             if (reservedSocket.isBound()) {
                 reservedSocket.close();
                 reservedSocketMap.remove(port);
+                LOGGER.log(Level.FINEST, "Closed socket bound to port: {0,number,#}.", reservedSocket.getLocalPort());
             }
         }
         super.start();
@@ -87,7 +91,7 @@ public class MicroNetworkListener extends GlassfishNetworkListener {
      * Adds a currently open socket to be allocated to a listener.
      */
     public static void addReservedSocket(int boundPort, ServerSocket socket) {
-        LOGGER.log(Level.INFO, "Reserving port: {0,number,#}", boundPort);
+        LOGGER.log(Level.FINER, "Reserving port: {0,number,#}.", boundPort);
         reservedSocketMap.put(boundPort, socket);
     }
 
@@ -98,6 +102,7 @@ public class MicroNetworkListener extends GlassfishNetworkListener {
         for (ServerSocket socket : reservedSocketMap.values()) {
             if (!socket.isClosed()) {
                 socket.close();
+                LOGGER.log(Level.FINEST, "Closed socket bound to port: {0,number,#}.", socket.getLocalPort());
             }
         }
         reservedSocketMap.clear();

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
@@ -589,7 +589,7 @@ public class KernelLoggerInfo {
     public static final String badAddress = LOGMSG_PREFIX + "-00086";
 
     @LogMessageInfo(
-            message = "Grizzly Framework {0} started in: {1}ms - bound to [{2}]",
+            message = "Grizzly {0} started in: {1}ms - bound to {2}",
             level = "INFO")
     public static final String grizzlyStarted = LOGMSG_PREFIX + "-00087";
     
@@ -649,9 +649,9 @@ public class KernelLoggerInfo {
     public static final String checkpointAutoResumeDone = LOGMSG_PREFIX + "-00096";
 
     @LogMessageInfo(
-            message = "Grizzly Framework {0} could not start - unable to bind to [{1}]",
+            message = "Network Listener `{0}` could not start - unable to bind to [{1}]",
             level = "INFO")
-    public static final String grizzlyUnableToBind = LOGMSG_PREFIX + "-00097";
+    public static final String listenerUnableToBind = LOGMSG_PREFIX + "-00097";
     
     @LogMessageInfo(
             message = "Cannot find h2db client jar file, h2 jdbc driver will not be available by default.",
@@ -669,5 +669,10 @@ public class KernelLoggerInfo {
             cause="The parent ID extracted from the request header is either null or not a valid UUID",
             level = "WARNING")
     public static final String invalidPropagatedParentId = LOGMSG_PREFIX + "-00100";
+
+    @LogMessageInfo(
+            message = "Network Listener {0} started in: {1}ms - bound to [{2}]",
+            level = "INFO")
+    public static final String listenerStarted = LOGMSG_PREFIX + "-00101";
     
 }

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
@@ -36,8 +36,9 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ * 
+ * Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.kernel;
 


### PR DESCRIPTION
- Payara Micro now reserves the ports it's configured once it's found them, so that two Micro instances starting up simultaneously don't choose the same port. Allows many Micro instances to startup at the same time.
- Merged `Started Grizzly Framework` messages into one.