### PR TITLE
PAYARA-2430 fixes #2305 ManagedExecutorService does not execute tasks…

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/EnableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/EnableCommand.java
@@ -258,14 +258,22 @@ public class EnableCommand extends StateCommandParameters implements AdminComman
         try {
             Application app = applications.getApplication(name()); 
             ApplicationRef appRef = domain.getApplicationRefInServer(server.getName(), name());
+            
+            // update enabled so anything that triggers an action during startup can see the 
+            // application is enabled.
+            try {
+                deployment.updateAppEnabledAttributeInDomainXML(name(), target, true);
+            } catch(TransactionFailure e) {
+                    logger.log(Level.WARNING, "failed to set enable attribute for " + name(), e);
+            }
 
             DeploymentContext dc = deployment.enable(target, app, appRef, report, logger);
             suppInfo.setDeploymentContext((ExtendedDeploymentContext)dc);
 
-            if (!report.getActionExitCode().equals(ActionReport.ExitCode.FAILURE)) {
+            if (report.getActionExitCode().equals(ActionReport.ExitCode.FAILURE)) {
                 // update the domain.xml
                 try {
-                    deployment.updateAppEnabledAttributeInDomainXML(name(), target, true);
+                    deployment.updateAppEnabledAttributeInDomainXML(name(), target, false);
                 } catch(TransactionFailure e) {
                     logger.log(Level.WARNING, "failed to set enable attribute for " + name(), e);
                 }


### PR DESCRIPTION
… when enabling application

Changed Enable command to update the domain.xml to indicate the application is enabled before starting the application
This ensures that when the ManagedExecutorService checks whether the application is enabled for the submitted task it gets the result true

Fixes #2305