### PR TITLE
PAYARA-2615 Add support for Payara Micro command line option --sslCert

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -210,6 +210,10 @@ public class PayaraMicro {
     public int getSslPort() {
         return wrappee.getSslPort();
     }
+    
+    public String getSslCert() {
+        return wrappee.getSslCert();
+    }
 
     public File getUberJar() {
         return wrappee.getUberJar();
@@ -360,6 +364,11 @@ public class PayaraMicro {
 
     public PayaraMicro setSslPort(int sslPort) {
         wrappee.setSslPort(sslPort);
+        return this;
+    }
+    
+    public PayaraMicro setSslCert(String alias) {
+        wrappee.setSslCert(alias);
         return this;
     }
 

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroBoot.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroBoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -42,7 +42,6 @@ package fish.payara.micro.boot;
 import fish.payara.micro.BootstrapException;
 import fish.payara.micro.PayaraMicroRuntime;
 import java.io.File;
-import java.net.URL;
 
 /**
  *
@@ -227,6 +226,12 @@ public interface PayaraMicroBoot {
      * @return The HTTPS port
      */
     int getSslPort();
+    
+    /**
+     * The name of the SSL certificate to use in the keystore
+     * @return 
+     */
+    String getSslCert();
 
     /**
      * The UberJar to create
@@ -466,6 +471,13 @@ public interface PayaraMicroBoot {
      * @return
      */
     PayaraMicroBoot setSslPort(int sslPort);
+    
+    /**
+     * Sets the name of the certificate to use in the keystore
+     * @param alias the name of the certificate in the keystore
+     * @return 
+     */
+    PayaraMicroBoot setSslCert(String alias);
 
     /**
      * Set user defined file for the Log entries

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -40,8 +40,8 @@
 package fish.payara.micro.cmd.options;
 
 /**
- *
- * @author steve
+ * ENUM used for command line switches for Payara Micro
+ * @author Steve Millidge (Payara Services Limited)
  */
 public enum RUNTIME_OPTION {
     nocluster(false),
@@ -100,6 +100,7 @@ public enum RUNTIME_OPTION {
     unpackdir(true, new DirectoryValidator(true, true, true)),
     clustermode(true,new PrefixStringListValidator("tcpip","domain","multicast")),
     interfaces(true),
+    sslcert(true),
     help(false);
 
     private RUNTIME_OPTION(boolean hasValue) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -216,6 +216,10 @@ public class UberJarCreator {
                         is = new FileInputStream(postDeployCommands);
                     }else if (entry.toString().contains("MICRO-INF/domain/domain.xml") && (domainXML != null)) {
                         is = new FileInputStream(domainXML);
+                    }else if (entry.toString().contains("MICRO-INF/domain/keystore.jks") && (System.getProperty("javax.net.ssl.keyStore") != null)) {
+                        is = new FileInputStream(System.getProperty("javax.net.ssl.keyStore"));
+                    }else if (entry.toString().contains("MICRO-INF/domain/cacerts.jks") && (System.getProperty("javax.net.ssl.trustStore") != null)) {
+                        is = new FileInputStream(System.getProperty("javax.net.ssl.trustStore"));
                     }
 
                     byte[] buffer = new byte[4096];

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishServerSocketFactory.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishServerSocketFactory.java
@@ -71,6 +71,20 @@ public class GlassfishServerSocketFactory extends JSSE14SocketFactory {
         if (logger.isLoggable(Level.FINE)) {
             logger.log(Level.FINE, "Keystore type= {0}", keystoreType);
         }
+        
+        // validate that the alias is in one of the keystores otherwise emit warning
+        boolean aliasFound = false;
+        for (KeyStore keyStore : sslUtils.getKeyStores()) {
+            if (keyStore.isKeyEntry(keyAlias)) {
+                aliasFound = true;
+                break;
+            }
+        }
+        
+        if (!aliasFound) {
+            logger.log(Level.WARNING, "Unable to find key pair alias {0} in any of the configured key stores, therefore the server may not be able to present a valid SSL Certificate", keyAlias);
+        }
+        
         KeyManager[] kMgrs = sslUtils.getKeyManagers(algorithm);
         if (keyAlias != null && keyAlias.length() > 0 && kMgrs != null) {
             for (int i = 0; i < kMgrs.length; i++) {

--- a/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/impl/SecuritySupportImpl.java
+++ b/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/impl/SecuritySupportImpl.java
@@ -248,6 +248,7 @@ public class SecuritySupportImpl extends SecuritySupport {
             keyStorePasswords.add(Arrays.copyOf(keyStorePass, keyStorePass.length));
             tokenNames.add(tokenName);
         } catch (Exception ex) {
+            _logger.severe("Failed to load key stores " + ex.getMessage());
             throw new IllegalStateException(ex);
         }
     }


### PR DESCRIPTION
to specify the certificate alias to use in the keystore

Also adds some extra logging is SSL is misconfigured
Also correctly packages up alternate keystores into the Uber Jar if specified via system properties