### PR TITLE
Bugfix: listener not using the correct keystore

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishSSLImpl.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishSSLImpl.java
@@ -43,6 +43,7 @@ package com.sun.enterprise.security.ssl;
 import java.net.Socket;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSocket;
+import org.glassfish.grizzly.config.ssl.JSSE14SocketFactory;
 import org.glassfish.grizzly.config.ssl.SSLImplementation;
 import org.glassfish.grizzly.config.ssl.ServerSocketFactory;
 import org.glassfish.grizzly.ssl.SSLSupport;
@@ -64,7 +65,7 @@ public class GlassfishSSLImpl extends SSLImplementation {
     }
 
     public ServerSocketFactory getServerSocketFactory() {
-        return new GlassfishServerSocketFactory();
+        return new JSSE14SocketFactory();
     }
 
     public SSLSupport getSSLSupport(Socket socket) {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishSSLImpl.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishSSLImpl.java
@@ -57,6 +57,9 @@ import org.jvnet.hk2.annotations.Service;
 @Service(name="com.sun.enterprise.security.ssl.GlassfishSSLImpl")
 @ContractsProvided({GlassfishSSLImpl.class, SSLImplementation.class})
 public class GlassfishSSLImpl extends SSLImplementation {
+    public static final String PROP_GLASSFISH_SOCKETFACTORY =
+            "fish.payara.ssl.GlassfishServerSocketFactory";
+
     public GlassfishSSLImpl() {
     }
 
@@ -65,7 +68,12 @@ public class GlassfishSSLImpl extends SSLImplementation {
     }
 
     public ServerSocketFactory getServerSocketFactory() {
-        return new JSSE14SocketFactory();
+        if(Boolean.valueOf(System.getProperty(PROP_GLASSFISH_SOCKETFACTORY, "false"))) {
+            return new GlassfishServerSocketFactory();
+        } else {
+            // Fixes Payara-499, Payara-2613 and 1047
+            return new JSSE14SocketFactory();
+        }
     }
 
     public SSLSupport getSSLSupport(Socket socket) {

--- a/nucleus/security/core/src/test/java/com/sun/enterprise/security/ssl/GlassfishSSLImplTest.java
+++ b/nucleus/security/core/src/test/java/com/sun/enterprise/security/ssl/GlassfishSSLImplTest.java
@@ -1,0 +1,79 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2016-2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package com.sun.enterprise.security.ssl;
+
+import org.glassfish.grizzly.config.ssl.JSSE14SocketFactory;
+import org.glassfish.grizzly.config.ssl.ServerSocketFactory;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author rex
+ */
+public class GlassfishSSLImplTest {
+
+    GlassfishSSLImpl cut = new GlassfishSSLImpl();
+
+
+    @Test
+    public void testGetServerSocketFactoryGF() {
+        System.setProperty(GlassfishSSLImpl.PROP_GLASSFISH_SOCKETFACTORY, "true");
+        ServerSocketFactory factory = cut.getServerSocketFactory();
+        assertTrue(factory instanceof GlassfishServerSocketFactory);
+    }
+
+
+    @Test
+    public void testGetServerSocketFactoryJSSE14() {
+        System.setProperty(GlassfishSSLImpl.PROP_GLASSFISH_SOCKETFACTORY, "false");
+        ServerSocketFactory factory = cut.getServerSocketFactory();
+        assertTrue(factory instanceof JSSE14SocketFactory);
+    }
+
+    @Test
+    public void testGetServerSocketFactoryNotSet() {
+        System.clearProperty(GlassfishSSLImpl.PROP_GLASSFISH_SOCKETFACTORY);
+        ServerSocketFactory factory = cut.getServerSocketFactory();
+        assertTrue(factory instanceof JSSE14SocketFactory);
+    }
+
+}


### PR DESCRIPTION
Based on the analysis in https://github.com/payara/Payara/issues/2613 i'd like to present a one-liner fix. This fix has the added benefit of reloading the relevant keystore(s) whenever a listener is enabled. 
Thus this change makes the procedure outlined in https://github.com/payara/Payara/issues/1047, specifically,
```
asadmin set server.network-config.network-listeners.network-listener.http-listener-2.enabled=false
asadmin set server.network-config.network-listeners.network-listener.http-listener-2.enabled=true
```
to activate the new keypair from letsencrypt (and alias) working.

I have tested this with secure-admin enabled admin port (4848), as well as two separate listeners on different ports and using different keystores/aliases. All was working.

According to my research, the only references to GlassfishSSLImpl in the project are inside domain.xml configurations as SSL implementations for the listener(s).

The simplicity of this fix raises the question, why is/was the existing solution (using GlassfishServerSocketFactory employing SecuritySupportImpl) necessary in the first place? It seems an overly complicated code and lots of lines to be able to load the default keystore(s), and ignore any others? Especially, because all the code providing keystore and truststore unification is useless, because the `SecuritySupport` contract does not allow specifying the necessary keystore(s) for the given listener or adding more keystores. From this perspective, this "Pluggable" is broken as well, which would deserve its own bug.