### PR TITLE
PAYARA-2691 fix ResourceValidator Class Loaders

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ResourceValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ResourceValidator.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.deployment.util;
 
@@ -110,7 +110,7 @@ public class ResourceValidator implements EventListener, ResourceValidatorVisito
     private Domain domain;
     
     @Inject
-    JavaEEContextUtil contextUtil;
+    private JavaEEContextUtil contextUtil;
 
     private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(ResourceValidator.class);
 
@@ -123,7 +123,7 @@ public class ResourceValidator implements EventListener, ResourceValidatorVisito
     }
 
     @Override
-    public void event(Event event) {
+    public void event(Event<?> event) {
         if (event.is(Deployment.AFTER_APPLICATION_CLASSLOADER_CREATION)) {
             DeploymentContext deploymentContext = (DeploymentContext) event.hook();
             Application application = deploymentContext.getModuleMetaData(Application.class);
@@ -139,18 +139,9 @@ public class ResourceValidator implements EventListener, ResourceValidatorVisito
             AppResources appResources = new AppResources();
             // Puts all resources found in the application via annotation or xml into appResources
             parseResources(deploymentContext, application, appResources);
-            
+
             // Ensure we have a valid component invocation before triggering lookups
-            String componentId = null;
-            for (BundleDescriptor bundleDescriptor : application.getBundleDescriptors()) {
-                if (bundleDescriptor instanceof JndiNameEnvironment) {
-                    componentId = DOLUtils.getComponentEnvId((JndiNameEnvironment) bundleDescriptor);
-                    if (componentId != null) {
-                        break;
-                    }
-                }
-            }
-            contextUtil.setInstanceComponentId(componentId);
+            contextUtil.setEmptyInvocation();
             try (Context ctx = contextUtil.pushContext()) {
                 validateResources(deploymentContext, application, appResources);
             }

--- a/appserver/web/gf-web-connector/src/main/java/fish/payara/appserver/context/ContextImpl.java
+++ b/appserver/web/gf-web-connector/src/main/java/fish/payara/appserver/context/ContextImpl.java
@@ -63,9 +63,9 @@ class ContextImpl {
             }
         }
 
-        private final ClassLoader oldClassLoader;
         private final ComponentInvocation invocation;
         private final InvocationManager invMgr;
+        private final ClassLoader oldClassLoader;
     }
 
     @RequiredArgsConstructor

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/JavaEEContextUtil.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/JavaEEContextUtil.java
@@ -100,6 +100,12 @@ public interface JavaEEContextUtil {
      */
     String getInstanceComponentId();
 
+    /**
+     * Set a valid component invocation that's empty,
+     * i.e. doesn't belong to any module
+     */
+    void setEmptyInvocation();
+
     interface Context extends Closeable {};
     interface Closeable extends AutoCloseable {
         @Override


### PR DESCRIPTION
unset capturedInvocation (reset to null) if JNDI environment is not present,

signifying invalid invocation.  fixes #2581