### PR TITLE
PAYARA-2592 Back Updated EclipseLink out of JDK7 Build

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -1157,6 +1157,16 @@
             <modules>
                 <module>javaee-api</module>
             </modules>
-        </profile>   
+        </profile>
+        
+        <profile>
+            <id>jdk7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
+            <properties>
+                <eclipselink.version>2.6.4.payara-p2</eclipselink.version>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
ASM Plugin bundled with EclipseLink 2.6.5 requires JDK8.