### PR TITLE
PAYARA-2874 Enabling Security Manager Causes Log Errors

### DIFF
--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/provider/JDKPolicyFileWrapper.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/provider/JDKPolicyFileWrapper.java
@@ -429,10 +429,9 @@ public class JDKPolicyFileWrapper extends Policy {
     }
 
     private ContextProvider getContextProvider(String contextId, JaccConfigurationFactory configurationFactory) {
-        if (configurationFactory != null) {
+        if (configurationFactory != null && contextId != null) {
             return configurationFactory.getContextProviderByPolicyContextId(contextId);
         }
-
         return null;
     }
 


### PR DESCRIPTION
This fix stops the NullPointerExceptions, and I don't see any obvious problem with the contextID being null in the first place. Needs a review to make sure this is the case.