### PR TITLE
PAYARA-2889 Defer OpenAPI Scanning Until Endpoint Visit

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/OpenAPIBuildException.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/OpenAPIBuildException.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.openapi.api;
+
+public class OpenAPIBuildException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+	public OpenAPIBuildException(Throwable t) {
+        super(t);
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -280,25 +280,27 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
 
 		@Override
 		public void run() {
-            OpenAPI openapi = new OpenAPIImpl();
+            if (!future.isDone()) {
+                OpenAPI openapi = new OpenAPIImpl();
 
-            String contextRoot = getContextRoot(mapping.getAppInfo());
-            ReadableArchive archive = mapping.getAppInfo().getSource();
-            Set<Class<?>> classes = getClassesFromArchive(archive, mapping.getAppInfo().getAppClassLoader());
+                String contextRoot = getContextRoot(mapping.getAppInfo());
+                ReadableArchive archive = mapping.getAppInfo().getSource();
+                Set<Class<?>> classes = getClassesFromArchive(archive, mapping.getAppInfo().getAppClassLoader());
 
-            try {
-                openapi = new ModelReaderProcessor().process(openapi, mapping.getAppConfig());
-                openapi = new FileProcessor(mapping.getAppInfo().getAppClassLoader()).process(openapi, mapping.getAppConfig());
-                openapi = new ApplicationProcessor(classes).process(openapi, mapping.getAppConfig());
-                openapi = new BaseProcessor(contextRoot).process(openapi, mapping.getAppConfig());
-                openapi = new FilterProcessor().process(openapi, mapping.getAppConfig());
-            } catch (Throwable t) {
-                future.completeExceptionally(t);
-                return;
+                try {
+                    openapi = new ModelReaderProcessor().process(openapi, mapping.getAppConfig());
+                    openapi = new FileProcessor(mapping.getAppInfo().getAppClassLoader()).process(openapi, mapping.getAppConfig());
+                    openapi = new ApplicationProcessor(classes).process(openapi, mapping.getAppConfig());
+                    openapi = new BaseProcessor(contextRoot).process(openapi, mapping.getAppConfig());
+                    openapi = new FilterProcessor().process(openapi, mapping.getAppConfig());
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                    return;
+                }
+
+                LOGGER.info("OpenAPI document created.");
+                future.complete(openapi);
             }
-
-            LOGGER.info("OpenAPI document created.");
-            future.complete(openapi);
 		}
 
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -278,8 +278,8 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
             this.future = future;
         }
 
-		@Override
-		public void run() {
+        @Override
+        public void run() {
             if (!future.isDone()) {
                 OpenAPI openapi = new OpenAPIImpl();
 
@@ -301,7 +301,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
                 LOGGER.info("OpenAPI document created.");
                 future.complete(openapi);
             }
-		}
+        }
 
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -149,7 +149,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
             ApplicationInfo appInfo = (ApplicationInfo) event.hook();
 
             // Create all the relevant resources
-            if (isEnabled() && isValidApp(appInfo)) {
+            if (isValidApp(appInfo)) {
                 // Store the application mapping in the list
                 mappings.add(new OpenApiMapping(appInfo));
             }
@@ -171,7 +171,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
      * @throws InterruptedException if creating the document was interrupted.
      */
     public OpenAPI getDocument() throws InterruptedException, ExecutionException, TimeoutException {
-        if (mappings.isEmpty()) {
+        if (mappings.isEmpty() || !isEnabled()) {
             return null;
         }
         return (OpenAPI) mappings.peekLast().getDocument();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -310,7 +310,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitProduces(Produces produces, AnnotatedElement element, ApiContext context) {
-        if (element instanceof Method) {
+        if (element instanceof Method && context.getWorkingOperation() != null) {
             for (org.eclipse.microprofile.openapi.models.responses.APIResponse response : context.getWorkingOperation()
                     .getResponses().values()) {
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -40,10 +40,13 @@
 package fish.payara.microprofile.openapi.impl.rest.app.service;
 
 import static fish.payara.microprofile.openapi.impl.rest.app.OpenApiApplication.APPLICATION_YAML;
+import static java.util.logging.Level.WARNING;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletResponse;
@@ -75,11 +78,16 @@ public class OpenApiResource {
         }
 
         // Get the OpenAPI document
-        OpenAPI document = OpenApiService.getInstance().getDocument();
+        OpenAPI document = null;
+        try {
+            document = OpenApiService.getInstance().getDocument();
+        } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+            LOGGER.log(WARNING, "OpenAPI document creation failed.", ex);
+        }
 
         // If there are none, return an empty OpenAPI document
         if (document == null) {
-            LOGGER.info("No document found.");
+            LOGGER.info("No OpenAPI document found.");
             return Response.status(Status.NOT_FOUND).entity(new OpenAPIImpl()).build();
         }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -45,8 +45,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletResponse;
@@ -59,6 +57,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 
+import fish.payara.microprofile.openapi.api.OpenAPIBuildException;
 import fish.payara.microprofile.openapi.impl.OpenApiService;
 import fish.payara.microprofile.openapi.impl.model.OpenAPIImpl;
 
@@ -81,7 +80,7 @@ public class OpenApiResource {
         OpenAPI document = null;
         try {
             document = OpenApiService.getInstance().getDocument();
-        } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+        } catch (OpenAPIBuildException ex) {
             LOGGER.log(WARNING, "OpenAPI document creation failed.", ex);
         }
 


### PR DESCRIPTION
- Deferred OpenAPI scanning until the `/openapi` endpoint is visited.
- Allowed document creation for apps deployed while the OpenAPI service is disabled, since it's now created on endpoint visiting.
- Added a null check to prevent potential `@Produces` errors.