### PR TITLE
PAYARA-2910 RuntimeException in Admin Console JVM Options

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/InstanceHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/InstanceHandler.java
@@ -97,7 +97,7 @@ public class InstanceHandler {
             }
             handlerCtx.setOutputValue("result", optionValues);
         } catch (Exception ex){
-            handlerCtx.setOutputValue("result", new HashMap());
+            handlerCtx.setOutputValue("result", new ArrayList<>());
             GuiUtil.getLogger().info(GuiUtil.getCommonMessage("log.error.getJvmOptionsValues") + ex.getLocalizedMessage());
             if (GuiUtil.getLogger().isLoggable(Level.FINE)){
                 ex.printStackTrace();
@@ -106,15 +106,17 @@ public class InstanceHandler {
     }
     
     public static List<Map<String, String>> getJvmOptions(HandlerContext handlerCtx) {
-        ArrayList<Map<String, String>> list;
+        List<Map<String, String>> list;
         String endpoint = (String) handlerCtx.getInputValue("endpoint");
         if (!endpoint.endsWith(".json"))
             endpoint = endpoint + ".json";
         Map<String, Object> attrs = (Map<String, Object>) handlerCtx.getInputValue("attrs");
         Map<String, Map> result = (Map<String, Map>) RestUtil.restRequest(endpoint, attrs, "get", handlerCtx, false).get("data");
-        list = (ArrayList<Map<String, String>>) result.get("extraProperties").get("leafList");
-        if (list == null)
+        if (result == null) {
             list = new ArrayList<>();
+        } else {
+            list = (ArrayList<Map<String, String>>) result.get("extraProperties").get("leafList");
+        }
         return list;
     }
  

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
@@ -108,14 +108,17 @@ public abstract class CollectionLeafResource extends AbstractResource {
     public void setParentAndTagName(Dom parent, String tagName) {
         this.parent = parent;
         this.tagName = tagName;
-        if (parent!=null){
-            if (parent.getImplementationClass().equals(JavaConfig.class) && isJvmOptions(tagName)) {
-                JavaConfig javaConfig = (JavaConfig)parent.get();
-                entity = javaConfig.getJvmRawOptions();
-                isJvmOptions = true;
-            }
-            else {
-                synchronized (parent) {
+        if (parent != null) {
+            synchronized (parent) {
+                if (parent.getImplementationClass().equals(JavaConfig.class) && isJvmOptions(tagName)) {
+                    JavaConfig javaConfig = (JavaConfig) parent.get();
+                    if (javaConfig != null) {
+                        entity = javaConfig.getJvmRawOptions();
+                    } else {
+                        entity = parent.leafElements(tagName);
+                    }
+                    isJvmOptions = true;
+                } else {
                     entity = parent.leafElements(tagName);
                 }
             }


### PR DESCRIPTION
- Fixed error handling in InstanceHandler to not obscure error.
- Removed HashMap from result output.
- Configured the dynamic JVM options to be built before a restart.