### PR TITLE
PAYARA-2923 Fix OpenTracing IllegalStateException

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingFilter.java
@@ -112,6 +112,8 @@ public class JaxrsContainerRequestTracingFilter implements ContainerRequestFilte
                 beanManager = CDI.current().getBeanManager();
             } catch (IllegalStateException ise) {
                 // *Should* only get here if CDI hasn't been initialised, indicating that the app isn't using it
+                logger.log(Level.FINE, "Error getting Bean Manager, presumably due to this application not using CDI", 
+                        ise);
             }
 
             // Get the Traced annotation from the target method if CDI is initialised
@@ -170,6 +172,8 @@ public class JaxrsContainerRequestTracingFilter implements ContainerRequestFilte
                     beanManager = CDI.current().getBeanManager();
                 } catch (IllegalStateException ise) {
                     // *Should* only get here if CDI hasn't been initialised, indicating that the app isn't using it
+                    logger.log(Level.FINE, "Error getting Bean Manager, presumably due to this application not using CDI", 
+                            ise);
                 }
 
                 // Get the Traced annotation from the target method if CDI is initialised

--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingFilter.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -105,10 +106,20 @@ public class JaxrsContainerRequestTracingFilter implements ContainerRequestFilte
     public void filter(ContainerRequestContext requestContext) throws IOException {
         // If request tracing is enabled, and there's a trace in progress (which there should be!)
         if (requestTracing != null && requestTracing.isRequestTracingEnabled() && requestTracing.isTraceInProgress()) {
-            // Get the Traced annotation from the target method
-            Traced tracedAnnotation = OpenTracingCdiUtils.getAnnotation(CDI.current().getBeanManager(), 
-                    Traced.class, resourceInfo);
+            // Check if CDI has been initialised by trying to get the BeanManager
+            BeanManager beanManager = null;
+            try {
+                beanManager = CDI.current().getBeanManager();
+            } catch (IllegalStateException ise) {
+                // *Should* only get here if CDI hasn't been initialised, indicating that the app isn't using it
+            }
 
+            // Get the Traced annotation from the target method if CDI is initialised
+            Traced tracedAnnotation = null;
+            if (beanManager != null) {
+                tracedAnnotation = OpenTracingCdiUtils.getAnnotation(beanManager, Traced.class, resourceInfo);
+            }
+            
             // If there is no annotation, or if there is an annotation and a config override indicating that we should
             // trace the method...
             if (tracedAnnotation == null || (boolean) OpenTracingCdiUtils.getConfigOverrideValue(
@@ -153,9 +164,19 @@ public class JaxrsContainerRequestTracingFilter implements ContainerRequestFilte
                     && requestTracing.isRequestTracingEnabled()
                     && requestTracing.isTraceInProgress()) {
 
-                // Get the traced annotation from the method
-                Traced tracedAnnotation = OpenTracingCdiUtils.getAnnotation(CDI.current().getBeanManager(),
-                        Traced.class, resourceInfo);
+                // Check if CDI has been initialised by trying to get the BeanManager
+                BeanManager beanManager = null;
+                try {
+                    beanManager = CDI.current().getBeanManager();
+                } catch (IllegalStateException ise) {
+                    // *Should* only get here if CDI hasn't been initialised, indicating that the app isn't using it
+                }
+
+                // Get the Traced annotation from the target method if CDI is initialised
+                Traced tracedAnnotation = null;
+                if (beanManager != null) {
+                    tracedAnnotation = OpenTracingCdiUtils.getAnnotation(beanManager, Traced.class, resourceInfo);
+                }
 
                 // If there is no annotation, or if there is an annotation and a config override indicating that we 
                 // should trace the method...


### PR DESCRIPTION
Fixes an IllegalStateException that can occur when a JAX-RS method of an app with no CDI beans is called with request tracing enabled.