### PR TITLE
Fix for #2986 Missing String ConfigProperty should cause DeploymentException

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -204,10 +204,6 @@ public class PayaraConfig implements Config {
     }
     
     private <T> T convertString(String value, Class<T>  propertyType) {
-        if (String.class.equals(propertyType)) {
-            return (T) value;
-        }
-        
         // find a converter
         Converter<T> converter = getConverter(propertyType);
         if (converter == null) {


### PR DESCRIPTION
When the ConfigProperty is used with Injection the PayaraConfig is always called with a default value (org.eclipse.microprofile.config.configproperty.unconfigureddvalue).

The logic to notice that no property is found requires the StringConverter to throw the DeploymentException. The cast to String and return before Converters are determined prevents this.

Removed this line of code.

Fixes issue #2986.