### PR TITLE
PAYARA-3087 Add support for property replacement for ${MPCONFIG=value…

### DIFF
--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -1360,6 +1360,6 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
     }
 
     private boolean isSlowQueryLoggingEnabled() {
-            return !IS_SLOW_SQL_LOGGING_DISABLED.equals(connectionPool.getSlowQueryThresholdInSeconds());
+        return !IS_SLOW_SQL_LOGGING_DISABLED.equals(connectionPool.getSlowQueryThresholdInSeconds());
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -1360,10 +1360,6 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
     }
 
     private boolean isSlowQueryLoggingEnabled() {
-        if (connectionPool == null) {
-            return false;
-        } else {
             return !IS_SLOW_SQL_LOGGING_DISABLED.equals(connectionPool.getSlowQueryThresholdInSeconds());
-        }
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -1360,6 +1360,10 @@ public class ManagedConnectionImpl implements javax.resource.spi.ManagedConnecti
     }
 
     private boolean isSlowQueryLoggingEnabled() {
-        return !IS_SLOW_SQL_LOGGING_DISABLED.equals(connectionPool.getSlowQueryThresholdInSeconds());
+        if (connectionPool == null) {
+            return false;
+        } else {
+            return !IS_SLOW_SQL_LOGGING_DISABLED.equals(connectionPool.getSlowQueryThresholdInSeconds());
+        }
     }
 }

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -38,7 +38,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-
+Portions Copyright [2018] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>1.3</version>
+            <version>${microprofile-config.version}</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -180,6 +180,12 @@
             <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>1.3</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     
 </project>

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
@@ -124,7 +124,7 @@ public class ConfigProviderResolverImpl extends ConfigProviderResolver {
     // Gives access to deployed applications
     @Inject
     ApplicationRegistry applicationRegistry;
-
+    
     // This injects the configuration from the domain.xml magically
     // and for the correct server configuation
     @Inject

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -55,8 +55,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.Converter;


### PR DESCRIPTION
…} from server level MP Config Sources e.g. SecretsDir

Does not support replacement using application deployed ConfigSources or properties.
Fixes #3085