### PR TITLE
Configurable .gfclient directory

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -88,13 +88,13 @@ public class AsadminSecurityUtil {
     	 * export AS_GFCLIENT="/var/www/html/payara5/.gfclient"
          */
 		String AS_GFCLIENT = System.getenv("AS_GFCLIENT");
-		logger.info("Variabile di ambiente AS_GFCLIENT: " + AS_GFCLIENT);
+		logger.finer("AS_GFCLIENT: " + AS_GFCLIENT);
 		if (AS_GFCLIENT != null) {
     		DEFAULT_CLIENT_DIR = new File(AS_GFCLIENT);
 		}else {
     		DEFAULT_CLIENT_DIR = new File(System.getProperty("user.home"), ".gfclient");
 		}
-		logger.info("Impostata Directory .gfclient a : " + DEFAULT_CLIENT_DIR);
+		logger.finer("Set .gfclient directory to: " + DEFAULT_CLIENT_DIR);
     }
 
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security.store;
 
 import java.io.BufferedInputStream;

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -80,19 +80,19 @@ public class AsadminSecurityUtil {
 
     static {
 
-    	/** Patch to make dir $HOME/.gfclient configurable.
-    	 *
-    	 * To set a different gfclient directory, add in /payara5/glassfish/config/[asenv.bat/asenv.conf]
-    	 * the  AS_GFCLIENT variable.
-    	 * Example:
-    	 * export AS_GFCLIENT="/var/www/html/payara5/.gfclient"
-         */
+		/** Patch to make dir $HOME/.gfclient configurable.
+		 *
+		 * To set a different gfclient directory, add in /payara5/glassfish/config/[asenv.bat/asenv.conf]
+		 * the  AS_GFCLIENT variable.
+		 * Example:
+		 * export AS_GFCLIENT="/var/www/html/payara5/.gfclient"
+		 */
 		String AS_GFCLIENT = System.getenv("AS_GFCLIENT");
 		logger.finer("AS_GFCLIENT: " + AS_GFCLIENT);
 		if (AS_GFCLIENT != null) {
-    		DEFAULT_CLIENT_DIR = new File(AS_GFCLIENT);
-		}else {
-    		DEFAULT_CLIENT_DIR = new File(System.getProperty("user.home"), ".gfclient");
+    			DEFAULT_CLIENT_DIR = new File(AS_GFCLIENT);
+		} else {
+    			DEFAULT_CLIENT_DIR = new File(System.getProperty("user.home"), ".gfclient");
 		}
 		logger.finer("Set .gfclient directory to: " + DEFAULT_CLIENT_DIR);
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security.store;
 
 import java.io.BufferedInputStream;


### PR DESCRIPTION
Make Payara `$HOME/.gfclient` directory configurable, to change it set the `AS_GFCLIENT` variable in `asenv.bat/asenv.sh`.
This is fundamental when the user who launch Payara does not have an home directory with write right granted
(this can happen for security reasons/company policies).
[asenv_examples.zip](https://github.com/payara/Payara/files/2378330/asenv_examples.zip)
