### PR TITLE
PAYARA-2977 The resource type of a JDBC connection pool can't be changed in the second step of creation

### DIFF
--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -281,7 +281,12 @@ public class JDBCConnectionPoolManager implements ResourceManager {
 
     public void setAttributes(HashMap attrList) {
         datasourceclassname = (String) attrList.get(DATASOURCE_CLASS);
+        // empty string is converted to null
         restype = (String) attrList.get(RES_TYPE);
+        if (restype != null && "".equals(restype.trim())) {
+            restype = null;
+        }
+
         steadypoolsize = (String) attrList.get(STEADY_POOL_SIZE);
         maxpoolsize = (String) attrList.get(MAX_POOL_SIZE);
         maxwait = (String) attrList.get(MAX_WAIT_TIME_IN_MILLIS);


### PR DESCRIPTION
Fixed problem during creation a JDBC connection pool, when resource type was not specified and the value was empty string instead of null.