### PR TITLE
PAYARA-3125 Add lowest possible priority to top-level exception mapper

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingExceptionMapper.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingExceptionMapper.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.opentracing.jaxrs;
 
+import javax.annotation.Priority;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.StatusType;
@@ -50,6 +51,7 @@ import javax.ws.rs.ext.ExceptionMapper;
  * 
  * @author Andrew Pielage <andrew.pielage@payara.fish>
  */
+@Priority(Integer.MAX_VALUE)
 public class JaxrsContainerRequestTracingExceptionMapper implements ExceptionMapper<Throwable> {
     
     @Override


### PR DESCRIPTION
This should help prevent clashes with other top-level exception mappers as it will defer to using the other (assuming it has a higher priority).