### PR TITLE
PAYARA-3129 add dependencies for classes removed in JDK11

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -460,7 +460,22 @@
             <optional>true</optional>
         </dependency>
         
-        <!-- For packages removed in JDK11 -->
+         <!-- For packages removed in JDK11 -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
         <dependency>
             <groupId>com.sun.istack</groupId>
             <artifactId>istack-commons-runtime</artifactId>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -459,6 +459,18 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
+        
+        <!-- For packages removed in JDK11 -->
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+            <version>3.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -140,33 +140,6 @@
             <version>${javassist.version}</version>
         </dependency>
         
-        <!-- For packages removed in JDK11 -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.3.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.istack</groupId>
-            <artifactId>istack-commons-runtime</artifactId>
-            <version>3.0.7</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <version>1.2.0</version>
-        </dependency>
-       
    </dependencies>
 </project>
 

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -139,6 +139,33 @@
             <artifactId>javassist</artifactId>
             <version>${javassist.version}</version>
         </dependency>
+        
+        <!-- For packages removed in JDK11 -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+            <version>3.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
+        </dependency>
        
    </dependencies>
 </project>


### PR DESCRIPTION
With this PR Payara Micro works on JDK11 with the command
java --add-opens java.base/jdk.internal.loader=ALL-UNNAMED -jar payara-micro.jar