### PR TITLE
PAYARA-3154 Add .factorypath to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ appserver/packager/pkg_conf.py
 .classpath
 .project
 .settings/
+.factorypath
 target/
 *~
 *.iml


### PR DESCRIPTION
Eclipse and VScode use this file for annotation processing. It should be removed from the codebase.