### PR TITLE
PAYARA-3125 Set OpenTracing Exception Mapper to the lowest priority

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingExceptionMapper.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JaxrsContainerRequestTracingExceptionMapper.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.opentracing.jaxrs;
 
+import javax.annotation.Priority;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.StatusType;
@@ -50,6 +51,7 @@ import javax.ws.rs.ext.ExceptionMapper;
  * 
  * @author Andrew Pielage <andrew.pielage@payara.fish>
  */
+@Priority(Integer.MAX_VALUE)
 public class JaxrsContainerRequestTracingExceptionMapper implements ExceptionMapper<Throwable> {
     
     @Override

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -261,7 +261,7 @@
         <!-- JAX-RS -->
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1</jax-rs-api.impl.version>
-        <jersey.version>2.27.payara-p12</jersey.version>
+        <jersey.version>2.27.payara-p13</jersey.version>
 
         <!-- Bean Validation -->
         <javax.validation.version>2.0.1.Final</javax.validation.version>


### PR DESCRIPTION
Also updates Jersey so that priority ordering actually works

See:
* 2.27.payara-p13 - source change (original): payara/patched-src-jersey@ad9e68a
* 2.27.payara-p13 - jar deployment:   https://github.com/payara/Payara_PatchedProjects/pull/195/commits/7f9002a4912e31ab7350c46455f48b21cf9b2e6c