### PR TITLE
PAYARA-3266 Using environment variable in logging.properties

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfig.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfig.java
@@ -90,10 +90,14 @@ public interface LoggingConfig {
 
     Map<String, String> getLoggingProperties(String targetServer) throws IOException;
 
+    Map<String, String> getLoggingProperties(String targetServer, boolean usePlaceholderReplacement) throws IOException;
+
     /* get the properties and corresponding values in the logging.properties file.
 	*/
 
     Map<String, String> getLoggingProperties() throws IOException;
+
+    Map<String, String> getLoggingProperties(boolean usePlaceholderReplacement) throws IOException;
 
     /* creates zip file for given sourceDirectory
         */

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
@@ -43,6 +43,7 @@
 package com.sun.common.util.logging;
 
 import static com.sun.common.util.logging.LoggingXMLNames.xmltoPropsMap;
+import com.sun.enterprise.util.PropertyPlaceholderHelper;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
@@ -263,10 +263,10 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
             }
             String property = (String) props.setProperty(key, e.getValue());
             if (e.getKey().contains("javax.enterprise.system.container.web")) {
-                setWebLoggers(e.getValue());
+                setWebLoggers(new PropertyPlaceholderHelper(System.getenv(), PropertyPlaceholderHelper.ENV_REGEX).replacePlaceholder(e.getValue()));
             }
             //build Map of entries to return
-            m.put(key, property);
+            m.put(key, new PropertyPlaceholderHelper(System.getenv(), PropertyPlaceholderHelper.ENV_REGEX).replacePlaceholder(property));
         }
         return m;
     }
@@ -293,9 +293,20 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
       */
 
     public synchronized Map<String, String> getLoggingProperties(String targetConfigName) throws IOException {
+        return getLoggingProperties(targetConfigName, true);
+    }
+
+    /**
+     * @param targetConfigName
+     * @param usePlaceholderReplacement - true for placeholder replacement, false returns original property value
+     * @return a Map of all the properties and corresponding values in the logging.properties file.
+     * @throws IOException 
+     */
+    @Override
+    public synchronized Map<String, String> getLoggingProperties(String targetConfigName, boolean usePlaceholderReplacement) throws IOException {
         loadLoggingProperties(targetConfigName);
         Enumeration e = props.propertyNames();
-        Map<String, String> m = getMap(e);
+        Map<String, String> m = getMap(e, usePlaceholderReplacement);
         return checkForLoggingProperties(m, targetConfigName);
     }
 
@@ -304,13 +315,27 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
       */
 
     public synchronized Map<String, String> getLoggingProperties() throws IOException {
+        return getLoggingProperties(true);
+    }
+
+    /**
+     * @param usePlaceholderReplacement - true for placeholder replacement, false returns original property value
+     * @return a Map of all the properties and corresponding values in the logging.properties file.
+     * @throws IOException 
+     */
+    @Override
+    public synchronized Map<String, String> getLoggingProperties(boolean usePlaceholderReplacement) throws IOException {
         loadLoggingProperties();
         Enumeration e = props.propertyNames();
-        Map<String, String> m = getMap(e);
+        Map<String, String> m = getMap(e, usePlaceholderReplacement);
         return checkForLoggingProperties(m, "");
     }
 
     private Map<String, String> getMap(Enumeration e) {
+        return getMap(e, true);
+    }
+
+    private Map<String, String> getMap(Enumeration e, boolean usePlaceholderReplacement) {
         Map<String, String> m = new HashMap<>();
         while (e.hasMoreElements()) {
             String key = (String) e.nextElement();
@@ -318,7 +343,8 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
             if (LoggingXMLNames.xmltoPropsMap.get(key) != null) {
                 key = LoggingXMLNames.xmltoPropsMap.get(key);
             }
-            m.put(key, props.getProperty(key));
+            String value = usePlaceholderReplacement ? new PropertyPlaceholderHelper(System.getenv(), PropertyPlaceholderHelper.ENV_REGEX).replacePlaceholder(props.getProperty(key)) : props.getProperty(key);
+            m.put(key, value);
         }
         return m;
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/PropertyPlaceholderHelper.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/PropertyPlaceholderHelper.java
@@ -42,7 +42,6 @@
  */
 package com.sun.enterprise.util;
 
-//import java.util.Map;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/PropertyPlaceholderHelper.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/PropertyPlaceholderHelper.java
@@ -1,0 +1,113 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package com.sun.enterprise.util;
+
+//import java.util.Map;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Zdeněk Soukup
+ */
+public class PropertyPlaceholderHelper {
+
+    public final static String ENV_REGEX = "([^\\$]*)\\$\\{ENV=([^\\}]*)\\}([^\\$]*)";
+    private final Pattern pattern;
+
+    private final Map<String, String> properties;
+
+    private final int MAX_SUBSTITUTION_DEPTH = 100;
+
+    public PropertyPlaceholderHelper(Map<String, String> properties, String regex) {
+        this.properties = properties;
+        this.pattern = Pattern.compile(regex);
+    }
+
+    public String getPropertyValue(String key) {
+        return properties.get(key);
+    }
+
+    public Properties replacePropertiesPlaceholder(Properties properties) {
+        final Properties p = new Properties();
+        Set<String> keys = properties.stringPropertyNames();
+
+        for (String key : keys) {
+            p.setProperty(key, replacePlaceholder(properties.getProperty(key)));
+        }
+        return p;
+    }
+
+    public String replacePlaceholder(String value) {
+        if (value != null && value.indexOf('$') != -1) {
+            String origValue = value;
+            int i = 0;
+            // Perform Environment variable substitution
+            Matcher m = getPattern().matcher(value);
+
+            while (m.find() && i < MAX_SUBSTITUTION_DEPTH) {
+                String matchValue = m.group(2).trim();
+                String newValue = getPropertyValue(matchValue);
+                if (newValue != null) {
+                    value = m.replaceFirst(Matcher.quoteReplacement(m.group(1) + newValue + m.group(3)));
+                    m.reset(value);
+                }
+                i++;
+            }
+
+            if (i >= MAX_SUBSTITUTION_DEPTH) {
+                Logger.getLogger(PropertyPlaceholderHelper.class.getName()).log(Level.SEVERE, "System property substitution exceeded maximum of {0}", MAX_SUBSTITUTION_DEPTH);
+            }
+        }
+        return value;
+    }
+
+    public Pattern getPattern() {
+        return pattern;
+    }
+}

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/PropertyPlaceholderHelperTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/PropertyPlaceholderHelperTest.java
@@ -1,0 +1,129 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package com.sun.enterprise.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Zdeněk Soukup
+ */
+public class PropertyPlaceholderHelperTest {
+
+    private Map<String, String> env = new HashMap<>();
+
+    public PropertyPlaceholderHelperTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+        env.put("testEnvironmentHandlers", "java.util.logging.ConsoleHandler");
+        env.put("testEnvironmentHandlerServices", "com.sun.enterprise.server.logging.GFFileHandler,com.sun.enterprise.server.logging.SyslogHandler");
+    }
+
+    @After
+    public void tearDown() {
+        env = null;
+    }
+
+    /**
+     * Test of getPropertyValue method, of class PropertyPlaceholderHelper.
+     *
+     */
+    @Test
+    public void testGetPropertyValueFromEnv() {
+        System.out.println("getPropertyValueFromEnv");
+        String loggingProperty1 = "testEnvironmentHandlers";
+        String loggingProperty2 = "testEnvironmentHandlerServices";
+
+        PropertyPlaceholderHelper propertyPlaceholderHelper = new PropertyPlaceholderHelper(env, PropertyPlaceholderHelper.ENV_REGEX);
+        String expResult1 = "java.util.logging.ConsoleHandler";
+        String result1 = propertyPlaceholderHelper.getPropertyValue(loggingProperty1);
+        assertEquals(expResult1, result1);
+
+        propertyPlaceholderHelper = new PropertyPlaceholderHelper(env, PropertyPlaceholderHelper.ENV_REGEX);
+        String expResult2 = "com.sun.enterprise.server.logging.GFFileHandler,com.sun.enterprise.server.logging.SyslogHandler";
+        String result2 = propertyPlaceholderHelper.getPropertyValue(loggingProperty2);
+        assertEquals(expResult2, result2);
+    }
+
+    /**
+     * Test of replacePropertiesPlaceholder method, of class
+     *
+     */
+    @Test
+    public void testReplacePropertiesPlaceholder() {
+        System.out.println("replacePropertiesPlaceholder");
+        Properties props = new Properties();
+        props.setProperty("testEnvironmentHandlersProperties", "${ENV=testEnvironmentHandlers}");
+        props.setProperty("testEnvironmentHandlerServicesProperties", "${ENV=testEnvironmentHandlerServices}");
+
+        Properties expResultProps = new Properties();
+        expResultProps.setProperty("testEnvironmentHandlersProperties", "java.util.logging.ConsoleHandler");
+        expResultProps.setProperty("testEnvironmentHandlerServicesProperties", "com.sun.enterprise.server.logging.GFFileHandler,com.sun.enterprise.server.logging.SyslogHandler");
+
+        PropertyPlaceholderHelper propertyPlaceholderHelper = new PropertyPlaceholderHelper(env, PropertyPlaceholderHelper.ENV_REGEX);
+        Properties result = propertyPlaceholderHelper.replacePropertiesPlaceholder(props);
+
+        assertEquals(expResultProps.getProperty("testEnvironmentHandlersProperties"), result.getProperty("testEnvironmentHandlersProperties"));
+        assertEquals(expResultProps.getProperty("testEnvironmentHandlerServicesProperties"), result.getProperty("testEnvironmentHandlerServicesProperties"));
+    }
+
+}

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogFacade.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogFacade.java
@@ -116,4 +116,9 @@ public class LogFacade {
     @LogMessageInfo(message = "The formatter class {0} could not be instantiated.", level="WARNING")
     public static final String INVALID_FORMATTER_CLASS_NAME = "NCLS-LOGGING-00013";    
 
+    @LogMessageInfo(message = "Unable to replace placeholders with values from system environment variables in logging properties.", level="SEVERE",
+            cause="An exception has occurred while replacing placeholders with values from system environment variables in logging properties.",
+            action="Take appropriate action based on the exception message.")
+    public static final String ERROR_PLACEHOLDERS_REPLACEMENT = "NCLS-LOGGING-00014";
+
 }

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/ListLogAttributes.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/ListLogAttributes.java
@@ -124,9 +124,9 @@ public class ListLogAttributes implements AdminCommand {
             boolean isDas = targetInfo.isDas();
             
             if (targetConfigName != null && !targetConfigName.isEmpty()) {
-                props = (HashMap<String, String>) loggingConfig.getLoggingProperties(targetConfigName);
+                props = (HashMap<String, String>) loggingConfig.getLoggingProperties(targetConfigName, false);
             } else if (isDas) {
-                props = (HashMap<String, String>) loggingConfig.getLoggingProperties();
+                props = (HashMap<String, String>) loggingConfig.getLoggingProperties(false);
             } else {
                 report.setActionExitCode(ActionReport.ExitCode.FAILURE);
                 String msg = localStrings.getLocalString("invalid.target.sys.props",


### PR DESCRIPTION
Now it's possible to use references to environment variables in logging.properties.

${ENV=XXX}, where XXX is environment variable