### PR TITLE
Remove Unnecessary Dependency

### DIFF
--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -144,11 +144,6 @@
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
-            <version>${microprofile-opentracing.version}</version>
-        </dependency>
     </dependencies>
 </project>
 

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -175,10 +175,5 @@
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
-            <version>${microprofile-opentracing.version}</version>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
These modules don't actually need the MicroProfile API as they're not injecting the Tracer.