### PR TITLE
Temp revert Grizzly-NPN Upgrade

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -252,7 +252,7 @@
         <servlet-api.version>4.0.0</servlet-api.version>
         <grizzly.version>2.4.3.payara-p5</grizzly.version>
         <!-- Requires JDK8u161 or above-->
-        <grizzly.npn.version>1.8.1</grizzly.npn.version>
+        <grizzly.npn.version>1.8</grizzly.npn.version>
         
         <!-- Microprofile -->
         <microprofile-config.version>1.3</microprofile-config.version>


### PR DESCRIPTION
This upgrade mandates the use of JDK8u191 or higher, which isn't widely available yet.