### PR TITLE
Sonar critical no1: division by zero in MachineMemoryUsageHealthCheck

### DIFF
--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseThresholdHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseThresholdHealthCheck.java
@@ -76,13 +76,14 @@ public abstract class BaseThresholdHealthCheck<O extends HealthCheckWithThreshol
     protected HealthCheckResultStatus decideOnStatusWithRatio(Double percentage) {
         if (percentage > options.getThresholdCritical()) {
             return HealthCheckResultStatus.CRITICAL;
-        } else if (percentage > options.getThresholdWarning()) {
-            return HealthCheckResultStatus.WARNING;
-        } else if (percentage >= options.getThresholdGood()) {
-            return HealthCheckResultStatus.GOOD;
-        } else {
-            return HealthCheckResultStatus.FINE;
         }
+        if (percentage > options.getThresholdWarning()) {
+            return HealthCheckResultStatus.WARNING;
+        }
+        if (percentage >= options.getThresholdGood()) {
+            return HealthCheckResultStatus.GOOD;
+        }
+		return HealthCheckResultStatus.FINE;
     }
 
     @Override

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HeapMemoryUsageHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HeapMemoryUsageHealthCheck.java
@@ -91,7 +91,7 @@ public class HeapMemoryUsageHealthCheck extends BaseThresholdHealthCheck<HealthC
         return result;
     }
 
-    private Double calculatePercentage(MemoryUsage usage) {
+    private static Double calculatePercentage(MemoryUsage usage) {
         if (usage.getMax() > 0) {
             return Math.floor(((double)usage.getUsed() / (double)usage.getMax()) * 100);
         }

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/MachineMemoryUsageHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/MachineMemoryUsageHealthCheck.java
@@ -91,110 +91,111 @@ public class MachineMemoryUsageHealthCheck extends BaseThresholdHealthCheck<Heal
 
     @Override
     public HealthCheckResult doCheck() {
-        HealthCheckResult result = new HealthCheckResult();
-
-        long memAvailable = 0;
-        long memFree = 0;
-        long memTotal = 0;
-        long memActiveFile = 0;
-        long memInactiveFile = 0;
-        long memReclaimable= 0;
-
-        boolean memAvailableFound = false;
-
         if (isLinux()) {
-            try {
-                List<String> lines = Files.readAllLines(Paths.get("/proc/meminfo"), StandardCharsets.UTF_8);
-                if (lines.isEmpty()) {
-                    return result;
-                }
-
-                for (String line : lines) {
-                    String[] parts = line.split("\\s+");
-
-                    if (parts.length > 1) {
-                        String part = parts[0];
-                        if (MEMAVAILABLE.equals(part)) {
-                            memAvailable = parseMemInfo(parts);
-                            memAvailableFound = true;
-                        }
-                        if (MEMFREE.equals(part)) {
-                            memFree = parseMemInfo(parts);
-                        }
-                        if (MEMTOTAL.equals(part)) {
-                            memTotal = parseMemInfo(parts);
-                        }
-                        if (ACTIVEFILE.equals(part)) {
-                            memActiveFile = parseMemInfo(parts);
-                        }
-                        if (INACTIVEFILE.equals(part)) {
-                            memInactiveFile = parseMemInfo(parts);
-                        }
-                        if (RECLAIMABLE.equals(part)) {
-                            memReclaimable = parseMemInfo(parts);
-                        }
-                    }
-                }
-
-                if (!memAvailableFound) {
-                    memAvailable = memFree + memActiveFile + memInactiveFile + memReclaimable;
-                }
-
-                double usedPercentage = ((double) (memTotal - memAvailable) / memTotal) * 100;
-
-                result.add(new HealthCheckResultEntry(decideOnStatusWithRatio(usedPercentage),
-                        "Physical Memory Used: " + prettyPrintBytes(memTotal - memAvailable) + " - " +
-                                "Total Physical Memory: " + prettyPrintBytes(memTotal) + " - " +
-                                "Memory Used%: " + new DecimalFormat("#.00").format(usedPercentage) + "%"));
-
-            } catch (IOException exception) {
-                result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR,
-                        "Memory information cannot be read for retrieving physical memory usage values",
-                        exception));
-            } catch (ArithmeticException exception) {
-                result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR,
-                        "Error occurred while calculating memory usage values. Total memory is " + memTotal,
-                        exception));
-            }
+        	return doCheckLinux();
         }
-        else {
-            try {
-                OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
-                Long totalPhysicalMemSize = invokeMethodFor(osBean, "getTotalPhysicalMemorySize");
-                Long freePhysicalMemSize = invokeMethodFor(osBean, "getFreePhysicalMemorySize");
-
-                double usedPercentage = ((double) (totalPhysicalMemSize - freePhysicalMemSize) / totalPhysicalMemSize) *
-                        100;
-
-                result.add(new HealthCheckResultEntry(decideOnStatusWithRatio(usedPercentage),
-                        "Physical Memory Used: " + prettyPrintBytes((totalPhysicalMemSize - freePhysicalMemSize)) + " - " +
-                                "Total Physical Memory: " + prettyPrintBytes(totalPhysicalMemSize) + " - " +
-                                "Memory Used%: " + new DecimalFormat("#.00").format(usedPercentage) + "%"));
-
-            } catch (Exception exception) {
-                result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR,
-                        "Operating system methods cannot be invoked for retrieving physical memory usage values",
-                        exception));
-            }
-        }
-
-        return result;
+		return doCheckNonLinux();
     }
 
-    private boolean isLinux() {
+	private HealthCheckResult doCheckLinux() {
+		HealthCheckResult result = new HealthCheckResult();
+		long memTotal = 0;
+		try {
+		    List<String> lines = Files.readAllLines(Paths.get("/proc/meminfo"), StandardCharsets.UTF_8);
+		    if (lines.isEmpty()) {
+		        return result;
+		    }
+		    long memAvailable = 0;
+		    long memFree = 0;
+		    long memActiveFile = 0;
+		    long memInactiveFile = 0;
+		    long memReclaimable= 0;
+		    boolean memAvailableFound = false;
+
+		    for (String line : lines) {
+		        String[] parts = line.split("\\s+");
+
+		        if (parts.length > 1) {
+		            String part = parts[0];
+		            if (MEMAVAILABLE.equals(part)) {
+		                memAvailable = parseMemInfo(parts);
+		                memAvailableFound = true;
+		            }
+		            if (MEMFREE.equals(part)) {
+		                memFree = parseMemInfo(parts);
+		            }
+		            if (MEMTOTAL.equals(part)) {
+		                memTotal = parseMemInfo(parts);
+		            }
+		            if (ACTIVEFILE.equals(part)) {
+		                memActiveFile = parseMemInfo(parts);
+		            }
+		            if (INACTIVEFILE.equals(part)) {
+		                memInactiveFile = parseMemInfo(parts);
+		            }
+		            if (RECLAIMABLE.equals(part)) {
+		                memReclaimable = parseMemInfo(parts);
+		            }
+		        }
+		    }
+
+		    if (!memAvailableFound) {
+		        memAvailable = memFree + memActiveFile + memInactiveFile + memReclaimable;
+		    }
+
+		    double usedPercentage = memTotal == 0L ? 0d :((double) (memTotal - memAvailable) / memTotal) * 100;
+
+		    result.add(new HealthCheckResultEntry(decideOnStatusWithRatio(usedPercentage),
+		            "Physical Memory Used: " + prettyPrintBytes(memTotal - memAvailable) + " - " +
+		                    "Total Physical Memory: " + prettyPrintBytes(memTotal) + " - " +
+		                    "Memory Used%: " + new DecimalFormat("#.00").format(usedPercentage) + "%"));
+
+		} catch (IOException exception) {
+		    result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR,
+		            "Memory information cannot be read for retrieving physical memory usage values",
+		            exception));
+		} catch (ArithmeticException exception) {
+		    result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR,
+		            "Error occurred while calculating memory usage values. Total memory is " + memTotal,
+		            exception));
+		}
+		return result;
+	}
+
+	private HealthCheckResult doCheckNonLinux() {
+		HealthCheckResult result = new HealthCheckResult();
+		try {
+		    OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+		    Long totalPhysicalMemSize = invokeMethodFor(osBean, "getTotalPhysicalMemorySize");
+		    Long freePhysicalMemSize = invokeMethodFor(osBean, "getFreePhysicalMemorySize");
+
+		    double usedPercentage = ((double) (totalPhysicalMemSize - freePhysicalMemSize) / totalPhysicalMemSize) *
+		            100;
+
+		    result.add(new HealthCheckResultEntry(decideOnStatusWithRatio(usedPercentage),
+		            "Physical Memory Used: " + prettyPrintBytes((totalPhysicalMemSize - freePhysicalMemSize)) + " - " +
+		                    "Total Physical Memory: " + prettyPrintBytes(totalPhysicalMemSize) + " - " +
+		                    "Memory Used%: " + new DecimalFormat("#.00").format(usedPercentage) + "%"));
+
+		} catch (Exception exception) {
+		    result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR,
+		            "Operating system methods cannot be invoked for retrieving physical memory usage values",
+		            exception));
+		}
+		return result;
+	}
+
+    private static boolean isLinux() {
         String osName = System.getProperty("os.name");
-        if (osName.startsWith("Linux") ||
+        return osName.startsWith("Linux") ||
                 osName.startsWith("FreeBSD") ||
                 osName.startsWith("OpenBSD") ||
                 osName.startsWith("gnu") ||
                 osName.startsWith("gnu/kfreebsd") ||
-                osName.startsWith("netbsd")) {
-            return true;
-        }
-        return false;
+                osName.startsWith("netbsd");
     }
 
-    private long parseMemInfo(String[] parts) {
+    private static long parseMemInfo(String[] parts) {
         long memory = 0;
 
         if (parts.length >= 2) {
@@ -206,7 +207,7 @@ public class MachineMemoryUsageHealthCheck extends BaseThresholdHealthCheck<Heal
         return memory;
     }
 
-    private Long invokeMethodFor(OperatingSystemMXBean osBean, String methodName) throws Exception {
+    private static Long invokeMethodFor(OperatingSystemMXBean osBean, String methodName) throws Exception {
         Method m = osBean.getClass().getDeclaredMethod(methodName);
         m.setAccessible(true);
         return (Long) m.invoke(osBean);


### PR DESCRIPTION
Mainly created this PR as a test to get into the routines. Picked a random critical bug reported by sonar.

This is a change of behaviour and the `catch` for `ArithmeticException` will no longer be used but a total of zero computes to a percentage of zero. Not sure if this is what we want but it seams more sensible to me.

Also cleaned some minor warnings that don't change of behaviour:
* added `static` modifiers (where possible to `private` methods only), 
* extracted methods to reduce complexity, 
* moved local vars into blocks to reduce scope, 
* removed unnecessary else (as by our style guide)