### PR TITLE
PAYARA-1165 allow setting of context root on Payara Micro deployments

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
@@ -1,0 +1,62 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.micro.cmd.options;
+
+/**
+ *
+ * @author steve
+ */
+public class DeploymentFileValidator  extends FileSystemItemValidator {
+    
+    public DeploymentFileValidator(boolean exists, boolean readable, boolean writable, boolean filesAllowed, boolean directoryAllowed) {
+        super(exists, readable, writable, filesAllowed, directoryAllowed);
+    }
+
+    @Override
+    boolean validate(String optionValue) throws ValidationException {
+        // first look for a : to indicate a context root
+        String filePath = optionValue;
+        if (optionValue.contains(":")) {
+            filePath = filePath.substring(0,optionValue.indexOf(':'));
+        }
+        return super.validate(filePath);
+    }
+    
+}

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
@@ -39,9 +39,11 @@
  */
 package fish.payara.micro.cmd.options;
 
+import java.io.File;
+
 /**
  *
- * @author steve
+ * @author Steve Millidge
  */
 public class DeploymentFileValidator  extends FileSystemItemValidator {
     
@@ -53,9 +55,9 @@ public class DeploymentFileValidator  extends FileSystemItemValidator {
     boolean validate(String optionValue) throws ValidationException {
         // first look for a : to indicate a context root
         String filePath = optionValue;
-        if (optionValue.contains(":")) {
-            filePath = filePath.substring(0,optionValue.indexOf(':'));
-        }
+        if (optionValue.contains(File.pathSeparator)) {
+            filePath = filePath.substring(0,optionValue.indexOf(File.pathSeparator));
+        } 
         return super.validate(filePath);
     }
     

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -46,7 +46,7 @@ package fish.payara.micro.cmd.options;
 public enum RUNTIME_OPTION {
     nocluster(false),
     deploydir(true, new DirectoryValidator(true, true, false)),
-    deploy(true, new FileSystemItemValidator(true, true, false, true, true)),
+    deploy(true, new DeploymentFileValidator(true, true, false, true, true)),
     port(true, new PortValidator()),
     sslport(true, new PortValidator()),
     name(true),
@@ -104,7 +104,8 @@ public enum RUNTIME_OPTION {
     help(false),
     enablesni(false),
     hzpublicaddress(true),
-    shutdowngrace(true, new IntegerValidator(1, Integer.MAX_VALUE));
+    shutdowngrace(true, new IntegerValidator(1, Integer.MAX_VALUE)),
+    contextroot(true);
 
     private RUNTIME_OPTION(boolean hasValue) {
         this(hasValue, new Validator());

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1194,9 +1194,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         }                        
                         String fileName = value;
                         String deployContext = null;
-                        if (value.contains(":")) {
-                            fileName = value.substring(0,value.indexOf(':'));
-                            deployContext = value.substring(value.indexOf(':')+1);
+                        if (value != null && value.contains(File.pathSeparator)) {
+                            fileName = value.substring(0,value.indexOf(File.pathSeparatorChar));
+                            deployContext = value.substring(value.indexOf(File.pathSeparatorChar)+1);
                         }
                         File deployment = new File(fileName);
                         deployments.add(deployment);
@@ -2016,12 +2016,17 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     deploymentURLsMap = new LinkedHashMap<>();
                 }
 
-                String contextRoot = artefactMapEntry.getKey();
-                if ("ROOT".equals(contextRoot)) {
-                    contextRoot = "/";
+                String defaultContext = artefactMapEntry.getKey();
+                if (this.contextRoot == null) {
+                    if ("ROOT".equals(defaultContext)) {
+                        defaultContext = "/";
+                    }
+                } else {
+                    defaultContext = this.contextRoot;
+                    contextRoot = null; // use only once
                 }
 
-                deploymentURLsMap.put(contextRoot, artefactMapEntry.getValue());
+                deploymentURLsMap.put(defaultContext, artefactMapEntry.getValue());
             } catch (MalformedURLException ex) {
                 throw new GlassFishException(ex.getMessage());
             }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -91,6 +91,7 @@ import fish.payara.nucleus.hazelcast.HazelcastCore;
 import java.io.FileNotFoundException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -108,6 +109,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
     private static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
     private static final String USER_PROPS_FILE = "MICRO-INF/deploy/payaramicro.properties";
+    private static final String CONTEXT_PROPS_FILE = "MICRO-INF/deploy/contexts.properties";
+    
     private static final Logger LOGGER = Logger.getLogger("PayaraMicro");
     private static PayaraMicroImpl instance;
 
@@ -121,11 +124,13 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private int maxHttpThreads = Integer.MIN_VALUE;
     private int minHttpThreads = Integer.MIN_VALUE;
     private String instanceName;
+    private String contextRoot;
     private File rootDir;
     private File deploymentRoot;
     private File alternateDomainXML;
     private File alternateHZConfigFile;
     private List<File> deployments;
+    private Properties contextRoots;
     private List<File> libraries;
     private GlassFish gf;
     private PayaraMicroRuntimeImpl runtime;
@@ -1182,11 +1187,22 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         }
                         break;
                     case deploy:
-                        File deployment = new File(value);
+                        // check for context root definition
                         if (deployments == null) {
                             deployments = new LinkedList<>();
+                            contextRoots = new Properties();
+                        }                        
+                        String fileName = value;
+                        String deployContext = null;
+                        if (value.contains(":")) {
+                            fileName = value.substring(0,value.indexOf(':'));
+                            deployContext = value.substring(value.indexOf(':')+1);
                         }
+                        File deployment = new File(fileName);
                         deployments.add(deployment);
+                        if (deployContext != null) {
+                            contextRoots.put(deployment.getName(), deployContext);
+                        }
                         break;
                     case domainconfig:
                         alternateDomainXML = new File(value);
@@ -1386,6 +1402,15 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     case shutdowngrace:
                         System.setProperty(GlassFishImpl.PAYARA_SHUTDOWNGRACE_PROPERTY, value);
                         break;
+                    case contextroot:
+                        if (contextRoot != null) {
+                            LOGGER.warning("Multiple --contextroot arguments only the last one will apply");
+                        }
+                        contextRoot = value;
+                        if (contextRoot.equals("ROOT")) {
+                            contextRoot = "/";
+                        }
+                        break;
                     default:
                         break;
                 }
@@ -1486,6 +1511,22 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         // Deploy from within the jar first.
         int deploymentCount = 0;
         Deployer deployer = gf.getDeployer();
+        
+        // load context roots from uber jar
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(CONTEXT_PROPS_FILE)) {
+            if (is != null) {
+                Properties props = new Properties();
+                props.load(is);
+                for (Map.Entry<?, ?> entry : props.entrySet()) {
+                    if (contextRoots == null) {
+                        contextRoots = new Properties();
+                    }
+                    contextRoots.setProperty((String)entry.getKey(), (String)entry.getValue());
+                }
+            }
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, "", ex);
+        }
 
         // search and deploy from MICRO-INF/deploy directory.
         // if there is a deployment called ROOT deploy to the root context /
@@ -1507,19 +1548,23 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
                 for (String entry : microInfEntries) {
                     File file = new File(entry);
-                    String contextRoot = file.getName();
-                    String name = contextRoot.substring(0, contextRoot.length() - 4);
-                    if (contextRoot.endsWith(".ear") || contextRoot.endsWith(".war") || contextRoot.endsWith(".jar") || contextRoot.endsWith(".rar")) {
-                        contextRoot = name;
+                    String deployContext = file.getName();
+                    String name = deployContext.substring(0, deployContext.length() - 4);
+                    if (deployContext.endsWith(".ear") || deployContext.endsWith(".war") || deployContext.endsWith(".jar") || deployContext.endsWith(".rar")) {
+                        deployContext = name;
                     }
 
-                    if (contextRoot.equals("ROOT")) {
-                        contextRoot = "/";
+                    if (deployContext.equals("ROOT")) {
+                        deployContext = "/";
+                    }
+                    
+                    if (contextRoots != null && contextRoots.containsKey(file.getName())) {
+                        deployContext = contextRoots.getProperty(file.getName());
                     }
 
                     deployer.deploy(this.getClass().getClassLoader().getResourceAsStream(entry), "--availabilityenabled",
                             "true", "--contextroot",
-                            contextRoot, "--name", name, "--force","true", "--loadOnly", "true");
+                            deployContext, "--name", name, "--force","true", "--loadOnly", "true");
                     deploymentCount++;
                 }
             } catch (IOException ioe) {
@@ -1533,11 +1578,19 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         // Deploy command line provided files
         if (deployments != null) {
             for (File war : deployments) {
+                String deployContext = war.getName().substring(0, war.getName().length() - 4);
+                if (contextRoots != null && contextRoots.containsKey(war.getName())) {
+                    deployContext = contextRoots.getProperty(war.getName());
+                } else if (contextRoot != null) {
+                    deployContext = contextRoot;
+                    // unset so only used once
+                    contextRoot = null;
+                }
                 if (war.exists() && war.canRead()) {
                     if (war.getName().startsWith("ROOT.")) {
                         deployer.deploy(war, "--availabilityenabled=true", "--force=true", "--contextroot=/", "--loadOnly", "true");
                     } else {
-                        deployer.deploy(war, "--availabilityenabled=true", "--force=true", "--loadOnly", "true");
+                        deployer.deploy(war, "--availabilityenabled=true", "--force=true", "--loadOnly", "true", "--contextroot", deployContext);
                     }
                     deploymentCount++;
                 } else {
@@ -1556,10 +1609,18 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             for (File entry : deploymentDirEntries) {
                 String entryPath = entry.getAbsolutePath();
                 if (entry.isFile() && entry.canRead() && (entryPath.endsWith(".war") || entryPath.endsWith(".ear") || entryPath.endsWith(".jar") || entryPath.endsWith(".rar"))) {
+                    String deployContext = entry.getName().substring(0, entry.getName().length() - 4);
+                    if (contextRoots != null && contextRoots.containsKey(entry.getName())) {
+                        deployContext = contextRoots.getProperty(entry.getName());
+                    } else if (contextRoot != null) {
+                        deployContext = contextRoot;
+                        // unset so only used once
+                        contextRoot = null;
+                    }
                     if (entry.getName().startsWith("ROOT.")) {
                         deployer.deploy(entry, "--availabilityenabled=true", "--force=true", "--contextroot=/", "--loadOnly", "true");
                     } else {
-                        deployer.deploy(entry, "--availabilityenabled=true", "--force=true", "--loadOnly", "true");
+                        deployer.deploy(entry, "--availabilityenabled=true", "--force=true", "--loadOnly", "true", "--contextroot",deployContext);
                     }
                     deploymentCount++;
                 }
@@ -2131,6 +2192,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         secretsDir = getProperty("payaramicro.secretsDir");
         showServletMappings = getBooleanProperty("payaramicro.showServletMappings", "false");
         publicAddress = getProperty("payaramicro.publicAddress");
+        contextRoot = getProperty("payaramicro.contextRoot");
 
         // Set the rootDir file
         String rootDirFileStr = getProperty("payaramicro.rootDir");
@@ -2191,6 +2253,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         if (copyDirectory != null) {
             creator.setDirectoryToCopy(copyDirectory);
         }
+        
+        creator.setContextRoots(contextRoots);
 
         if (GAVs != null) {
             try {
@@ -2269,6 +2333,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         
         if (sslCert != null) {
             props.setProperty("payaramicro.sslCert", sslCert);
+        }
+        
+        if (contextRoot != null) {
+            props.setProperty("payaramicro.contextRoot", contextRoot);
         }
 
         props.setProperty("payaramicro.autoBindHttp", Boolean.toString(autoBindHttp));

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -85,6 +85,7 @@ public class UberJarCreator {
     private File alternateHZConfigFile;
     private File preBootCommands;
     private File postBootCommands;
+    private Properties contextRoots;
 
     private static final Logger LOGGER = Logger.getLogger(UberJarCreator.class.getName());
     private File postDeployCommands;
@@ -111,6 +112,10 @@ public class UberJarCreator {
 
     public void setAlternateHZConfigFile(File alternateHZConfigFile) {
         this.alternateHZConfigFile = alternateHZConfigFile;
+    }
+    
+    public void setContextRoots(Properties props) {
+        contextRoots = props;
     }
 
     public void setDeploymentDir(File deploymentDir) {
@@ -298,6 +303,15 @@ public class UberJarCreator {
             bootProperties.store(jos, "");
             jos.flush();
             jos.closeEntry();
+            
+            // write context roots
+            if (contextRoots != null) {
+                JarEntry crs = new JarEntry("MICRO-INF/deploy/contexts.properties");
+                jos.putNextEntry(crs);
+                contextRoots.store(jos, "");
+                jos.flush();
+                jos.closeEntry();                
+            }
 
             // add the alternate hazelcast config to the uberJar
             if (alternateHZConfigFile != null) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/resources/commandoptions.properties
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/resources/commandoptions.properties
@@ -95,3 +95,4 @@ interfaces=Specifies the Interfaces that the data grid discovery mode should use
 secretsdir=Directory to read secrets files using the Microprofile config api.
 showservletmappings=Shows the servlet mappings in the deployment summary message.
 hzpublicaddress=Sets the Public Address of the Data Grid for use where NAT translation is used (including in Docker)
+contextroot=Specifies the context root of the first deployment without a context root specified


### PR DESCRIPTION
This PR allows to set the context path in two ways:

1. use `--contextroot`
```bash
java -jar payara-micro.jar --deploy myapp.war --contextroot mycontext
```
2. use `--deploy` with `:root` after the file name
```bash
java -jar payara-micro.jar --deploy myapp.war:mycontext
```
Both examples configure a effective root context of `/mycontext/`

When both are specified the root given with `--deploy` takes precedence. That means `--contextroot` works as a default or fallback for all applications where no root context was specified explicitly.

```bash
java -jar payara-micro.jar --deploy app1.war:foo --deploy app2.war --contextroot bar
```
This will deploy `app1` in `/foo/` and `app2` in `/bar/`.

Note: `--deploy app.war:/` is the same as `--deploy app.war` and even `--deploy app.war:` which all deploy in the root `/`.
That means a leading `/` is not necessary but can be given. In contrast a tailing `/` should not be given and seems to not work. While the configuration keeps it as `"Context Root": "/foo/"` browsing to `/foo` or `/foo/` forwards to `/foo//` which fails to resolve to the expected page.