### PR TITLE
PAYARA-3344 Added System Property for Shutdown Grace Period

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/MicroGlassFish.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/MicroGlassFish.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/MicroGlassFish.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/MicroGlassFish.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.micro.boot.runtime;
 
+import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
 import com.sun.enterprise.module.bootstrap.ModuleStartup;
 import java.util.Properties;
 import org.glassfish.embeddable.CommandRunner;
@@ -74,19 +75,20 @@ public class MicroGlassFish implements GlassFish {
     }
 
     @Override
-    public void stop() throws GlassFishException {
+    public synchronized void stop() throws GlassFishException {
         if (status == Status.STOPPED || status == Status.STOPPING || status == Status.DISPOSED) {
             throw new IllegalStateException("Already in " + status + " state.");
         }
-        
+
         status = Status.STOPPING;
+        GlassFishImpl.sleepShutdownGracePeriod();
         kernel.stop();
         habitat.shutdown();
         status = Status.STOPPED;
     }
 
     @Override
-    public void dispose() throws GlassFishException {
+    public synchronized void dispose() throws GlassFishException {
         if (status == Status.DISPOSED) {
             throw new IllegalStateException("Already disposed.");
         } else if (status != Status.STOPPED) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -103,7 +103,8 @@ public enum RUNTIME_OPTION {
     sslcert(true),
     help(false),
     enablesni(false),
-    hzpublicaddress(true);
+    hzpublicaddress(true),
+    shutdowngrace(true, new IntegerValidator(1, Integer.MAX_VALUE));
 
     private RUNTIME_OPTION(boolean hasValue) {
         this(hasValue, new Validator());

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -77,6 +77,7 @@ import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.embeddable.GlassFishRuntime;
 import com.sun.appserv.server.util.Version;
 import com.sun.enterprise.glassfish.bootstrap.Constants;
+import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
 import com.sun.enterprise.server.logging.ODLLogFormatter;
 import fish.payara.micro.PayaraMicroRuntime;
 import fish.payara.micro.boot.PayaraMicroBoot;
@@ -1381,6 +1382,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         break;
                     case hzpublicaddress:
                         publicAddress = value;
+                        break;
+                    case shutdowngrace:
+                        System.setProperty(GlassFishImpl.PAYARA_SHUTDOWNGRACE_PROPERTY, value);
                         break;
                     default:
                         break;

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2019] Payara Foundation and/or affiliates
  */
 
 package com.sun.enterprise.glassfish.bootstrap;

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
@@ -47,12 +47,9 @@ import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.Deployer;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
-import org.glassfish.grizzly.threadpool.Threads;
 import org.glassfish.hk2.api.ServiceLocator;
 
 import java.util.Properties;
-
-import javax.swing.plaf.SliderUI;
 
 /**
  * @author Sanjeeb.Sahoo@Sun.COM

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
@@ -57,6 +57,8 @@ import java.util.Properties;
 
 public class GlassFishImpl implements GlassFish {
 
+    public static final String PAYARA_SHUTDOWNGRACE_PROPERTY = "fish.payara.shutdowngrace";
+
     private ModuleStartup gfKernel;
     private ServiceLocator habitat;
     volatile Status status = Status.INIT;
@@ -93,7 +95,7 @@ public class GlassFishImpl implements GlassFish {
     }
 
     public static void sleepShutdownGracePeriod() {
-        String shutdowngrace = System.getProperty("fish.payara.shutdowngrace");
+        String shutdowngrace = System.getProperty(PAYARA_SHUTDOWNGRACE_PROPERTY);
         if (shutdowngrace != null) {
             try {
                 Thread.sleep(Integer.parseInt(shutdowngrace));

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
@@ -47,9 +47,12 @@ import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.Deployer;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
+import org.glassfish.grizzly.threadpool.Threads;
 import org.glassfish.hk2.api.ServiceLocator;
 
 import java.util.Properties;
+
+import javax.swing.plaf.SliderUI;
 
 /**
  * @author Sanjeeb.Sahoo@Sun.COM
@@ -87,8 +90,22 @@ public class GlassFishImpl implements GlassFish {
             throw new IllegalStateException("Already in " + status + " state.");
         }
         status = Status.STOPPING;
+        sleepShutdownGracePeriod();
         gfKernel.stop();
         status = Status.STOPPED;
+    }
+
+    public static void sleepShutdownGracePeriod() {
+        String shutdowngrace = System.getProperty("fish.payara.shutdowngrace");
+        if (shutdowngrace != null) {
+            try {
+                Thread.sleep(Integer.parseInt(shutdowngrace));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (NumberFormatException e) {
+                // no sleep, continue shutdown
+            }
+        }
     }
 
     public synchronized void dispose() throws GlassFishException {


### PR DESCRIPTION
Initially the plan was to use `domain.xml` based configuration for the grace period setting. I looked into it but it turned out to be overly complicated due to module dependencies and access limitations. So I went for the simpler option using `System` property `fish.payara.shutdowngrace` instead. The period is given is milliseconds. E.g. `-Dfish.payara.shutdowngrace=1000` for 1 second grace period.

After a first look into where to add the waiting it seamed most appropriate on the outermost level, like the `PayaraMicroImpl#shutdown` and equivalent methods. After deeper investigation on possible paths during shutdown I found that the common abstraction to server, micro and embedded that is called independent on how the shutdown was initiated should be the `GlassFish` abstraction. While there are a handful of implementations some of them are wrappers that delegate or extensions that extend. I think there are only 2 relevant implementations: `GlassFishImpl` and `MicroGlassFish`. As `MicroGlassFish` has access to `GlassFishImpl` it seamed a good way to share the code by making it a static method in `GlassFishImpl`. Surely no ideal place for common code but I could not find a better place in a common utility class. I believe that this modification includes embedded as embedded seams to wrap one of the other implementations.

In case of thread interruption or illegal value the grace period is zero and the shutdown continues as usual.

While testing the feature for payara micro I got exceptions logged during or after the grade period caused by further calls to `stop`/`dispose` as those were not `synchronized` for micro.
```java
Cjava.lang.IllegalStateException: Already in STOPPING state.
	at fish.payara.micro.boot.runtime.MicroGlassFish.stop(MicroGlassFish.java:80)
	at fish.payara.micro.boot.runtime.MicroGlassFish.dispose(MicroGlassFish.java:96)
	at fish.payara.micro.impl.PayaraMicroImpl.bootStrap(PayaraMicroImpl.java:1045)
	at fish.payara.micro.impl.PayaraMicroImpl.main(PayaraMicroImpl.java:200)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at fish.payara.micro.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48)
	at fish.payara.micro.boot.loader.Launcher.launch(Launcher.java:107)
	at fish.payara.micro.boot.loader.Launcher.launch(Launcher.java:70)
	at fish.payara.micro.boot.PayaraMicroLauncher.main(PayaraMicroLauncher.java:79)
	at fish.payara.micro.PayaraMicro.main(PayaraMicro.java:397)
java.lang.NullPointerException
	at fish.payara.micro.boot.runtime.MicroGlassFish.stop(MicroGlassFish.java:85)
	at fish.payara.micro.boot.runtime.MicroGlassFish.dispose(MicroGlassFish.java:96)
	at fish.payara.micro.impl.PayaraMicroImpl$1.run(PayaraMicroImpl.java:1600)
```
Since the `GlassFishImpl` does synchronize these methods it seams logical that micro should do this as well. I applied it and tested it and it seams to prevent the problem.

As requested I also added a command line option for payara micro: `--shutdowngrace <duration-ms>`.