### PR TITLE
PAYARA-3490 Code level improvements for payara micro argument and property parsing 

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -91,6 +91,7 @@ import java.io.FileNotFoundException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 
@@ -1209,7 +1210,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         autoBindRange = Integer.parseInt(value);
                         break;
                     case enablehealthcheck:
-                        enableHealthCheck = Boolean.valueOf(value);
+                        enableHealthCheck = Boolean.parseBoolean(value);
                         break;
                     case deployfromgav:
                         if (GAVs == null) {
@@ -1240,40 +1241,20 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                             if (requestTracing.length <= 2) {
                                 // If the first entry is a number
                                 if (requestTracing[0].matches("\\d+")) {
-                                    try {
-                                        requestTracingThresholdValue = Long.parseLong(requestTracing[0]);
-                                        
-                                    } catch (NumberFormatException e) {
-                                        LOGGER.log(Level.WARNING, "{0} is not a valid request tracing "
-                                                + "threshold value", requestTracing[0]);
-                                        throw e;
-                                    }
+                                    requestTracingThresholdValue = parseArgument(requestTracing[0], 
+                                            "request tracing threshold value", Long::parseLong).longValue();
                                     // If there is a second entry, and it's a String
                                     if (requestTracing.length == 2 && requestTracing[1].matches("\\D+")) {
-                                        String parsedUnit = parseRequestTracingUnit(requestTracing[1]);
-                                        try {
-                                            TimeUnit.valueOf(parsedUnit.toUpperCase());
-                                            requestTracingThresholdUnit = parsedUnit.toUpperCase();
-                                        } catch (IllegalArgumentException e) {
-                                            LOGGER.log(Level.WARNING, "{0} is not a valid request "
-                                                    + "tracing threshold unit", requestTracing[1]);
-                                            throw e;
-                                        }
+                                        requestTracingThresholdUnit = parseTimeUnit(requestTracing[1], 
+                                                "request tracing threshold unit").name();
                                     } // If there is a second entry, and it's not a String
                                     else if (requestTracing.length == 2 && !requestTracing[1].matches("\\D+")) {
                                         throw new IllegalArgumentException();
                                     }
                                 } // If the first entry is a String
                                 else if (requestTracing[0].matches("\\D+")) {
-                                    String parsedUnit = parseRequestTracingUnit(requestTracing[0]);
-                                    try {
-                                        TimeUnit.valueOf(parsedUnit.toUpperCase());
-                                        requestTracingThresholdUnit = parsedUnit.toUpperCase();
-                                    } catch (IllegalArgumentException e) {
-                                        LOGGER.log(Level.WARNING, "{0} is not a valid request "
-                                                + "tracing threshold unit", requestTracing[0]);
-                                        throw e;
-                                    }
+                                    requestTracingThresholdUnit = parseTimeUnit(requestTracing[0], 
+                                            "request tracing threshold unit").name();
                                     // There shouldn't be a second entry
                                     if (requestTracing.length == 2) {
                                         throw new IllegalArgumentException();
@@ -1285,55 +1266,29 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         }
                         break;
                     case requesttracingthresholdunit:
-                        try {
-                            String parsedUnit = parseRequestTracingUnit(value);
-                            TimeUnit.valueOf(parsedUnit.toUpperCase());
-                            requestTracingThresholdUnit = parsedUnit.toUpperCase();
-                        } catch (IllegalArgumentException e) {
-                            LOGGER.log(Level.WARNING, "{0} is not a valid value for --requestTracingThresholdUnit",
-                                    value);
-                            throw e;
-                        }
+                        requestTracingThresholdUnit = parseTimeUnit(value, "value for --requestTracingThresholdUnit").name();
                         break;
                     case requesttracingthresholdvalue:
-                        try {
-                            requestTracingThresholdValue = Long.parseLong(value);
-                        } catch (NumberFormatException e) {
-                            LOGGER.log(Level.WARNING, "{0} is not a valid value for --requestTracingThresholdValue",
-                                    value);
-                            throw e;
-                        }
+                        requestTracingThresholdValue = parseArgument(value, "value for --requestTracingThresholdValue", 
+                                Long::parseLong).longValue();
                         break;
                     case enablerequesttracingadaptivesampling:
                         enableRequestTracingAdaptiveSampling = true;
                         break;
                     case requesttracingadaptivesamplingtargetcount:
                         enableRequestTracingAdaptiveSampling = true;
-                        try {
-                            requestTracingAdaptiveSamplingTargetCount = Integer.parseInt(value);
-                        } catch (NumberFormatException e) {
-                            LOGGER.log(Level.WARNING, "{0} is not a valid value for --requestTracingAdaptiveSamplingTargetCount", value);
-                            throw e;
-                        }
+                        requestTracingAdaptiveSamplingTargetCount = parseArgument(value,
+                                "value for --requestTracingAdaptiveSamplingTargetCount", Integer::parseInt).intValue();
                         break;
                     case requesttracingadaptivesamplingtimevalue:
                         enableRequestTracingAdaptiveSampling = true;
-                        try {
-                            requestTracingAdaptiveSamplingTimeValue = Integer.parseInt(value);
-                        } catch (NumberFormatException e) {
-                            LOGGER.log(Level.WARNING, "{0} is not a valid value for --requestTracingAdaptiveSamplingTimeValue", value);
-                            throw e;
-                        }
+                        requestTracingAdaptiveSamplingTimeValue = parseArgument(value,
+                                "value for --requestTracingAdaptiveSamplingTimeValue", Integer::parseInt).intValue();
                         break;
                     case requesttracingadaptivesamplingtimeunit:
                         enableRequestTracingAdaptiveSampling = true;
-                        try {
-                            TimeUnit.valueOf(value.toUpperCase());
-                            requestTracingAdaptiveSamplingTimeUnit = value.toUpperCase();
-                        } catch (IllegalArgumentException e) {
-                            LOGGER.log(Level.WARNING, "{0} is not a valid value for --requestTracingAdaptiveSamplingTimeUnit", value);
-                            throw e;
-                        }
+                        requestTracingAdaptiveSamplingTimeUnit = parseTimeUnit(value,
+                                "value for --requestTracingAdaptiveSamplingTimeUnit").name();
                         break;
                     case help:
                         RuntimeOptions.printHelp();
@@ -1369,7 +1324,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         break;
                     case interfaces:
                         interfaces = value;
-			            break;
+                        break;
                     case secretsdir:
                         secretsDir = value;
                         break;
@@ -2349,44 +2304,48 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         creator.buildUberJar();
     }
 
-    private String parseRequestTracingUnit(String option) {
-        String returnValue = option;
-
+    private static String unifyTimeUnit(String option) {
         switch (option.toLowerCase()) {
             case "nanosecond":
             case "ns":
-                returnValue = "NANOSECONDS";
-                break;
+                return "NANOSECONDS";
             case "microsecond":
             case "us":
             case "µs":
-                returnValue = "MICROSECONDS";
-                break;
+                return "MICROSECONDS";
             case "millisecond":
             case "ms":
-                returnValue = "MILLISECONDS";
-                break;
+                return "MILLISECONDS";
             case "second":
             case "s":
-                returnValue = "SECONDS";
-                break;
+                return "SECONDS";
             case "m":
             case "minute":
             case "min":
             case "mins":
-                returnValue = "MINUTES";
-                break;
+                return "MINUTES";
             case "hour":
             case "h":
-                returnValue = "HOURS";
-                break;
+                return "HOURS";
             case "day":
             case "d":
-                returnValue = "DAYS";
-                break;
+                return "DAYS";
+            default:
+                return option;
         }
+    }
 
-        return returnValue;
+    private static TimeUnit parseTimeUnit(String value, String errorText) {
+        return parseArgument(value, errorText, val -> TimeUnit.valueOf(unifyTimeUnit(val).toUpperCase()));
+    }
+
+    private static <T> T parseArgument(String value, String errorText, Function<String, T> parser) {
+        try {
+            return parser.apply(value);
+        } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.WARNING, "{0} is not a valid " + errorText, value);
+            throw e;
+        }
     }
 
     private void printVersion() {
@@ -2527,7 +2486,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         LOGGER.log(Level.INFO, "{0} ready in {1} (ms)", new Object[]{Version.getFullVersion(), bootTime});
     }
 
-    private String getProperty(String value) {
+    private static String getProperty(String value) {
         String result;
         result = System.getProperty(value);
         if (result == null) {
@@ -2536,7 +2495,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         return result;
     }
 
-    private String getProperty(String value, String defaultValue) {
+    private static String getProperty(String value, String defaultValue) {
         String result = getProperty(value);
         if (result == null) {
             result = defaultValue;
@@ -2544,7 +2503,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         return result;
     }
 
-    private Boolean getBooleanProperty(String value) {
+    private static boolean getBooleanProperty(String value) {
         String property;
         property = System.getProperty(value);
         if (property == null) {
@@ -2552,8 +2511,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
         return "true".equals(property);
     }
-    
-    private Boolean getBooleanProperty(String value, String defaultValue) {
+
+    private static boolean getBooleanProperty(String value, String defaultValue) {
         String property;
         property = System.getProperty(value);
         if (property == null) {
@@ -2566,7 +2525,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     }
 
 
-    private Integer getIntegerProperty(String value, Integer defaultValue) {
+    private static int getIntegerProperty(String value, int defaultValue) {
         String property;
         property = System.getProperty(value);
         if (property == null) {
@@ -2574,12 +2533,11 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
         if (property == null) {
             return defaultValue;
-        } else {
-            return Integer.decode(property);
         }
+        return Integer.decode(property).intValue();
     }
 
-    private Long getLongProperty(String value, Long defaultValue) {
+    private static long getLongProperty(String value, long defaultValue) {
         String property;
         property = System.getProperty(value);
         if (property == null) {
@@ -2587,9 +2545,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
         if (property == null) {
             return defaultValue;
-        } else {
-            return Long.decode(property);
         }
+        return Long.decode(property).longValue();
     }
 
     /**


### PR DESCRIPTION
Adding an option (see #3702) I noticed some duplication in the argument parsing of payara micro.
This PR does some smaller code level improvements.

Mainly the reoccurring `try`-`catch` block to parse arguments to `TimeUnit`, `int` or `long` was extracted to a common helper method.

IDE warned me that the property parsing method unnecessarily would use wrapper types. While the methods all returned wrappers the fields the values were assigned to were all primitive. So I switched those to primitive.