### PR TITLE
PAYARA-3028 Fix remote monitoring of instances from the admin console

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestAdapter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestAdapter.java
@@ -180,11 +180,10 @@ public abstract class RestAdapter extends HttpHandler implements ProxiedRestAdap
                 }
 
                 ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
-                boolean monitoring = false;
+                boolean monitoring = context.equals("/monitoring");
                 try {
                     // Temporarily switch classloader for monitoring so that the HK2 injection manager can be found
-                    if (context.equals("/monitoring")) {
-                        monitoring = true;
+                    if (monitoring) {
                         ClassLoader apiClassLoader = sc.getCommonClassLoader();
                         Thread.currentThread().setContextClassLoader(apiClassLoader);
                     }

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -974,7 +974,7 @@ Parent is ${project.parent}</echo>
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>
                 <artifactId>jersey-hk2</artifactId>
-                <version>2.26-b06</version>
+                <version>${jersey.version}</version>
             </dependency>
 
 


### PR DESCRIPTION
Fixes retrieving the monitoring data of remote instances from the DAS.
When using the module / bundle classloader, it fails to find any of the Jersey services (despite them being present). This change takes inspiration from [here](https://github.com/payara/Payara/blob/master/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestAdapter.java#L299) to switch the classloader to the common one, which *can* find the Jersey services,