### PR TITLE
Implemented PAYARA-3505 Disable Option for JLine Logging in Asadmin Multimode

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -187,8 +187,7 @@ public class MultimodeCommand extends CLICommand {
     }
     
     private static void checkToDisableJLineLogging(){
-        String value = System.getProperty("fish.payara.admin.command.jline.log.disable");        
-        if(Objects.equals(value, "true")){
+        if (Boolean.getBoolean("fish.payara.admin.command.jline.log.disable")) {
             System.setProperty("jline.log.jul", "false");
             final OutputStream noOpOutputStream = new OutputStream() {
                 @Override

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -138,6 +138,7 @@ public class MultimodeCommand extends CLICommand {
         ConsoleReader reader = null;
         programOpts.setEcho(echo);       // restore echo flag, saved in validate
         try {
+            checkToDisableJLineLogging();
             if (file == null) {
                 System.out.println(strings.get("multimodeIntro"));
                 reader = new ConsoleReader(ASADMIN, System.in, System.out, null, encoding);
@@ -162,8 +163,7 @@ public class MultimodeCommand extends CLICommand {
                     public void write(byte[] b, int off, int len) throws IOException {
                         return;
                     }
-                };
-
+                };                
                 reader = new ConsoleReader(ASADMIN, new FileInputStream(file), out, null, encoding);
             }
             
@@ -183,6 +183,20 @@ public class MultimodeCommand extends CLICommand {
             catch (Exception e) {
                 // ignore it
             }
+        }
+    }
+    
+    private static void checkToDisableJLineLogging(){
+        String value = System.getProperty("fish.payara.admin.command.jline.log.disable");        
+        if(Objects.equals(value, "true")){
+            System.setProperty("jline.log.jul", "false");
+            final OutputStream noOpOutputStream = new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    //NO-OP
+                }
+            };
+            jline.internal.Log.setOutput(new PrintStream(noOpOutputStream));
         }
     }
 


### PR DESCRIPTION
In order to prevent unwanted JLine logging in the asadmin multiline mode, a new system property can be used in the respective `asadmin` to disable it:

```
set JAVA=java
:run
%JAVA% -fish.payara.admin.command.jline.log.disable=true -jar "%~dp0..\glassfish\lib\client\appserver-cli.jar" %*
```