### PR TITLE
PAYARA-3507 Set executor core pool size to 0 and queue to max on Micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -57,8 +57,8 @@ Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
             <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
         </jdbc-connection-pool>
         <context-service description="context service" jndi-name="concurrent/__defaultContextService" object-type="system-all"></context-service>
-        <managed-executor-service maximum-pool-size="200" core-pool-size="2" long-running-tasks="true" keep-alive-seconds="300" hung-after-seconds="300" task-queue-capacity="20000" jndi-name="concurrent/__defaultManagedExecutorService" object-type="system-all"></managed-executor-service>
-        <managed-scheduled-executor-service core-pool-size="2" long-running-tasks="true" keep-alive-seconds="300" hung-after-seconds="300" jndi-name="concurrent/__defaultManagedScheduledExecutorService" object-type="system-all"></managed-scheduled-executor-service>
+        <managed-executor-service maximum-pool-size="200" core-pool-size="0" long-running-tasks="true" keep-alive-seconds="300" hung-after-seconds="300" task-queue-capacity="2147483647" jndi-name="concurrent/__defaultManagedExecutorService" object-type="system-all"></managed-executor-service>
+        <managed-scheduled-executor-service core-pool-size="0" long-running-tasks="true" keep-alive-seconds="300" hung-after-seconds="300" jndi-name="concurrent/__defaultManagedScheduledExecutorService" object-type="system-all"></managed-scheduled-executor-service>
         <managed-thread-factory description="thread factory" jndi-name="concurrent/__defaultManagedThreadFactory" object-type="system-all"></managed-thread-factory>
     </resources>
     <servers>


### PR DESCRIPTION
With the current settings, Micro will only create 2 threads and queue 20000 tasks before expanding the pool size any further. With these settings, Micro will create up to 200 threads _as required_ before queuing tasks.