### PR TITLE
PAYARA-3508 Throw informative error in ConnectionPool.getResouce if Interrupted

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -59,6 +59,7 @@ import com.sun.enterprise.resource.pool.waitqueue.PoolWaitQueueFactory;
 import com.sun.enterprise.transaction.api.JavaEETransaction;
 import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.logging.LogDomains;
+import java.lang.annotation.Annotation;
 import org.glassfish.resourcebase.resources.api.PoolInfo;
 
 import javax.naming.NamingException;
@@ -68,6 +69,8 @@ import javax.transaction.Transaction;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.internal.api.Globals;
 
 /**
  * Connection Pool for Connector & JDBC resources<br>
@@ -434,8 +437,13 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
                             waitMonitor.wait(remainingWaitTime);
 
                         } catch (InterruptedException ex) {
-                            //Could be system shutdown.
-                            break;
+                           if (Globals.getDefaultHabitat().getService(ServerEnvironment.class, new Annotation[0]).getStatus() == ServerEnvironment.Status.stopping) {
+                               String msg = localStrings.getStringWithDefault("poolmgr.interrupted.shutdown", "Server is shutting down, cannot get connection");
+                               throw new PoolingException(msg);
+                           } else {
+                               String msg = localStrings.getStringWithDefault("poolmgr.interrupted.notshutdown", "Resource Pool: Interrupted retrieving connection");
+                               throw new PoolingException(msg, ex);
+                           }          
                         }
 
                         //try to remove in case that the monitor has timed
@@ -463,8 +471,13 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
                                 reconfigWaitMonitor.wait(reconfigWaitTime);
                             }
                         } catch (InterruptedException ex) {
-                            //Could be system shutdown.
-                            break;
+                           if (Globals.getDefaultHabitat().getService(ServerEnvironment.class, new Annotation[0]).getStatus() == ServerEnvironment.Status.stopping) {
+                               String msg = localStrings.getStringWithDefault("poolmgr.interrupted.shutdown", "Server is shutting down, cannot get connection");
+                               throw new PoolingException(msg);
+                           } else {
+                               String msg = localStrings.getStringWithDefault("poolmgr.interrupted.notshutdown", "Resource Pool: Interrupted retrieving connection");
+                               throw new PoolingException(msg, ex);
+                           }
                         }
                         //try to remove in case that the monitor has timed
                         // out.  We don't expect the queue to grow to great numbers

--- a/appserver/connectors/connectors-runtime/src/main/resources/com/sun/enterprise/resource/pool/LocalStrings.properties
+++ b/appserver/connectors/connectors-runtime/src/main/resources/com/sun/enterprise/resource/pool/LocalStrings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2018] Payara Foundation and/or affiliates
 
 poolmgr.no.available.resource=In-use connections equal max-pool-size and expired max-wait-time. Cannot allocate more connections.
 monitoring.statistics=Monitoring Statistics :
@@ -44,3 +45,5 @@ reclaim.leaked.connection=Reclaiming the leaked connection of pool [ {0} ] and d
   and any other request that can potentially acquire the same connection from the pool end up using the \
   connection at the same time
 poolmgr.flush_noop_pool_not_initialized=Flush Connection Pool did not happen as pool - {0} is not initialized
+poolmgr.interrupted.shutdown=Server is shutting down, cannot get connection
+poolmgr.interrupted.notshutdown=Resource Pool: Interrupted retrieving connection


### PR DESCRIPTION
This instead of throwing a NPE a short while later