### PR TITLE
PAYARA-3512 Check for failOn override on correct annotation

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/interceptors/CircuitBreakerInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/interceptors/CircuitBreakerInterceptor.java
@@ -192,7 +192,7 @@ public class CircuitBreakerInterceptor implements Serializable {
         Class<? extends Throwable>[] failOn = circuitBreaker.failOn();
         try {
             Optional optionalFailOn = FaultToleranceCdiUtils.getOverrideValue(
-                    config, Retry.class, "failOn", invocationContext, String.class);
+                    config, CircuitBreaker.class, "failOn", invocationContext, String.class);
             if (optionalFailOn.isPresent()) {
                 String failOnString = (String) optionalFailOn.get();
                 List<Class> classList = new ArrayList<>();


### PR DESCRIPTION
For some reason the CircuitBreaker interceptor was checking for overrides of the failOn parameter on the Retry annotation - presumably a copy-pasta bug as I can't immediately see why it should do this.