### PR TITLE
PAYARA-3537 Added CORS headers support to Microprofile OpenAPI module

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -129,6 +129,10 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
         return Boolean.parseBoolean(config.getEnabled());
     }
 
+    public boolean withCorsHeaders() {
+        return Boolean.parseBoolean(config.getCorsHeaders());
+    }
+
     /**
      * Listen for OpenAPI config changes.
      */
@@ -177,8 +181,8 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
     }
 
     /**
-     * @return the document for the most recently deployed application. Creates one
-     *         if it hasn't already been created.
+     * @return the document for the most recently deployed application. Creates
+     * one if it hasn't already been created.
      * @throws OpenAPIBuildException if creating the document failed.
      */
     public OpenAPI getDocument() throws OpenAPIBuildException {
@@ -201,9 +205,9 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
      */
     private static boolean isValidApp(ApplicationInfo appInfo) {
         return appInfo.getMetaData(WebBundleDescriptorImpl.class) != null
-            && !appInfo.getSource().getURI().getPath().contains("glassfish/lib/install")
-            && !appInfo.getSource().getURI().getPath().contains("javadb/lib")
-            && !appInfo.getSource().getURI().getPath().contains("mq/lib");
+                && !appInfo.getSource().getURI().getPath().contains("glassfish/lib/install")
+                && !appInfo.getSource().getURI().getPath().contains("javadb/lib")
+                && !appInfo.getSource().getURI().getPath().contains("mq/lib");
     }
 
     /**
@@ -215,7 +219,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
     }
 
     /**
-     * @param archive        the archive to read from.
+     * @param archive the archive to read from.
      * @param appClassLoader the classloader to use to load the classes.
      * @return a list of all loadable classes in the archive.
      */
@@ -319,27 +323,27 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
                 .filter(networkListener -> Boolean.parseBoolean(networkListener.getEnabled()))
                 .forEach(networkListener -> {
 
-            int port;
-            try {
-                // get the dynamic config port
-                port = habitat.getService(GrizzlyService.class).getRealPort(networkListener);
-            } catch (MultiException ex) {
-                LOGGER.log(WARNING, "Failed to get running Grizzly listener.", ex);
-                // get the port in the domain xml
-                port = Integer.parseInt(networkListener.getPort());
-            }
+                    int port;
+                    try {
+                        // get the dynamic config port
+                        port = habitat.getService(GrizzlyService.class).getRealPort(networkListener);
+                    } catch (MultiException ex) {
+                        LOGGER.log(WARNING, "Failed to get running Grizzly listener.", ex);
+                        // get the port in the domain xml
+                        port = Integer.parseInt(networkListener.getPort());
+                    }
 
-            // Check if this listener is using HTTP or HTTPS
-            boolean securityEnabled = Boolean.parseBoolean(networkListener.findProtocol().getSecurityEnabled());
-            List<Integer> ports = securityEnabled ? httpPorts : httpsPorts;
+                    // Check if this listener is using HTTP or HTTPS
+                    boolean securityEnabled = Boolean.parseBoolean(networkListener.findProtocol().getSecurityEnabled());
+                    List<Integer> ports = securityEnabled ? httpPorts : httpsPorts;
 
-            // If this listener isn't the admin listener, it must be an HTTP/HTTPS listener
-            if (!networkListener.getName().equals(adminListener)) {
-                ports.add(port);
-            } else if (instanceType.equals("MICRO")) {
-                // micro instances can use the admin listener as both an admin and HTTP/HTTPS port
-                ports.add(port);
-            }
+                    // If this listener isn't the admin listener, it must be an HTTP/HTTPS listener
+                    if (!networkListener.getName().equals(adminListener)) {
+                        ports.add(port);
+                    } else if (instanceType.equals("MICRO")) {
+                        // micro instances can use the admin listener as both an admin and HTTP/HTTPS port
+                        ports.add(port);
+                    }
                 });
 
         for (Integer httpPort : httpPorts) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/GetOpenApiConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/GetOpenApiConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/GetOpenApiConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/GetOpenApiConfigurationCommand.java
@@ -76,7 +76,7 @@ import org.jvnet.hk2.annotations.Service;
 })
 public class GetOpenApiConfigurationCommand implements AdminCommand {
 
-    private final String OUTPUT_HEADERS[] = {"Enabled", "VirtualServers"};
+    private final String OUTPUT_HEADERS[] = {"Enabled", "VirtualServers", "CorsHeaders"};
 
     @Inject
     private Target targetUtil;
@@ -101,7 +101,8 @@ public class GetOpenApiConfigurationCommand implements AdminCommand {
         ColumnFormatter columnFormatter = new ColumnFormatter(OUTPUT_HEADERS);
         Object[] outputValues = {
             openApiConfig.getEnabled(),
-            openApiConfig.getVirtualServers()
+            openApiConfig.getVirtualServers(),
+            openApiConfig.getCorsHeaders()
         };
         columnFormatter.addRow(outputValues);
 
@@ -110,6 +111,7 @@ public class GetOpenApiConfigurationCommand implements AdminCommand {
         Map<String, Object> extraPropertiesMap = new HashMap<>();
         extraPropertiesMap.put("enabled", openApiConfig.getEnabled());
         extraPropertiesMap.put("virtualServers", openApiConfig.getVirtualServers());
+        extraPropertiesMap.put("corsHeaders", openApiConfig.getCorsHeaders());
 
         Properties extraProperties = new Properties();
         extraProperties.put("openApiConfiguration", extraPropertiesMap);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/GetOpenApiConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/GetOpenApiConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
@@ -60,6 +60,16 @@ public interface OpenApiServiceConfiguration extends ConfigBeanProxy, ConfigExte
     void setEnabled(String value) throws PropertyVetoException;
 
     /**
+     * Defines if CORS headers are set on the OpenApi response.
+     * 
+     * @return whether to set CORS headers or not
+     */
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    String getCorsHeaders();
+
+    void setCorsHeaders(String value) throws PropertyVetoException;
+    
+    /**
      * String value defines the attached virtual servers.
      *
      * @return

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/SetOpenApiConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/SetOpenApiConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/SetOpenApiConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/SetOpenApiConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/SetOpenApiConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/SetOpenApiConfigurationCommand.java
@@ -82,10 +82,13 @@ public class SetOpenApiConfigurationCommand implements AdminCommand {
 
     @Param(name = "enabled", optional = true)
     private Boolean enabled;
-
+    
     @Param(name = "virtualServers", optional = true)
     private String virtualServers;
 
+    @Param(name = "corsHeaders", optional = true, defaultValue = "false")
+    private Boolean corsHeaders;
+    
     @Param(optional = true, defaultValue = "server-config")
     private String target;
 
@@ -109,6 +112,9 @@ public class SetOpenApiConfigurationCommand implements AdminCommand {
                 }
                 if (virtualServers != null) {
                     configProxy.setVirtualServers(virtualServers);
+                }
+                if (corsHeaders != null) {
+                    configProxy.setCorsHeaders(Boolean.toString(corsHeaders));
                 }
                 return configProxy;
             }, config);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/OpenApiApplication.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/OpenApiApplication.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/OpenApiApplication.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/OpenApiApplication.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -40,13 +40,13 @@
 package fish.payara.microprofile.openapi.impl.rest.app;
 
 import static fish.payara.microprofile.openapi.impl.rest.app.OpenApiApplication.OPEN_API_APPLICATION_PATH;
-import fish.payara.microprofile.openapi.impl.rest.app.provider.CorsHeadersFilter;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import javax.ws.rs.ApplicationPath;
 
 import org.glassfish.jersey.server.ResourceConfig;
 
+import fish.payara.microprofile.openapi.impl.rest.app.provider.CorsHeadersFilter;
 import fish.payara.microprofile.openapi.impl.rest.app.provider.QueryFormatFilter;
 import fish.payara.microprofile.openapi.impl.rest.app.provider.writer.JsonWriter;
 import fish.payara.microprofile.openapi.impl.rest.app.provider.writer.YamlWriter;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/CorsHeadersFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/CorsHeadersFilter.java
@@ -37,34 +37,33 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.microprofile.openapi.impl.rest.app;
+package fish.payara.microprofile.openapi.impl.rest.app.provider;
 
-import static fish.payara.microprofile.openapi.impl.rest.app.OpenApiApplication.OPEN_API_APPLICATION_PATH;
-import fish.payara.microprofile.openapi.impl.rest.app.provider.CorsHeadersFilter;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import fish.payara.microprofile.openapi.impl.OpenApiService;
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
 
-import javax.ws.rs.ApplicationPath;
+/**
+ * A respone filter to add CORS deaders to the OpenAPI response.
+ */
+@Provider
+public class CorsHeadersFilter implements ContainerResponseFilter {
 
-import org.glassfish.jersey.server.ResourceConfig;
+    @Override
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException {
+        OpenApiService openApiService = OpenApiService.getInstance();
+        if (openApiService.isEnabled() && openApiService.withCorsHeaders()) {
+            MultivaluedMap<String, Object> headers = response.getHeaders();
 
-import fish.payara.microprofile.openapi.impl.rest.app.provider.QueryFormatFilter;
-import fish.payara.microprofile.openapi.impl.rest.app.provider.writer.JsonWriter;
-import fish.payara.microprofile.openapi.impl.rest.app.provider.writer.YamlWriter;
-import fish.payara.microprofile.openapi.impl.rest.app.service.OpenApiResource;
-
-@ApplicationPath(OPEN_API_APPLICATION_PATH)
-public class OpenApiApplication extends ResourceConfig {
-
-    public static final String OPEN_API_APPLICATION_PATH = "/openapi";
-    public static final String APPLICATION_YAML = TEXT_PLAIN;
-
-    public OpenApiApplication() {
-        register(OpenApiResource.class);
-        register(QueryFormatFilter.class);
-        register(CorsHeadersFilter.class);
-        register(YamlWriter.class);
-        register(JsonWriter.class);
-        property("payara-internal", "true");
+            headers.add("Access-Control-Allow-Origin", "*");
+            headers.add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization");
+            headers.add("Access-Control-Allow-Credentials", "true");
+            headers.add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+        }
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/CorsHeadersFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/CorsHeadersFilter.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
This adds CORS headers support to the Microprofile OpenAPI module of Payara as suggested in #3787. There now is an additional configuration command to enable CORS headers. The default is 'false' to be backwards compatible. The CORS headers are added using a JAX-RS container response filter, whenever OpenAPI + CORS headers are enabled.