### PR TITLE
QA-192 POC to launch micro via cmd line args runner programmatically

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/PayaraMicro.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/PayaraMicro.java
@@ -51,7 +51,7 @@ import java.util.logging.Logger;
  *
  * @author steve
  */
-public class PayaraMicro {
+public class PayaraMicro implements PayaraMicroBoot {
     
     
     private PayaraMicroBoot wrappee;

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroBoot.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroBoot.java
@@ -260,14 +260,14 @@ public interface PayaraMicroBoot {
      *
      * @param filePath
      */
-    void setAccessLogDir(String filePath);
+    PayaraMicroBoot setAccessLogDir(String filePath);
 
     /**
      * Set user defined formatting for the access log
      *
      * @param format
      */
-    void setAccessLogFormat(String format);
+    PayaraMicroBoot setAccessLogFormat(String format);
 
     /**
      * Sets the path to a domain.xml file PayaraMicro should use to boot. If

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroLauncher.java
@@ -69,6 +69,14 @@ public class PayaraMicroLauncher extends ExecutableArchiveLauncher {
      * @throws Exception 
      */
     public static void main(String args[]) throws Exception {
+        create("main", args);
+    }
+
+    public static PayaraMicroBoot create(String args[]) throws Exception {
+        return create("create", args);
+    }
+
+    private static PayaraMicroBoot create(String method, String args[]) throws Exception {
         PayaraMicroLauncher launcher = new PayaraMicroLauncher();
         // set system property for our jar file
         ProtectionDomain protectionDomain = PayaraMicroLauncher.class.getProtectionDomain();
@@ -76,9 +84,9 @@ public class PayaraMicroLauncher extends ExecutableArchiveLauncher {
         URI location = (codeSource == null ? null : codeSource.getLocation().toURI());
         System.setProperty(MICRO_JAR_PROPERTY, location.toString());
         mainBoot = true;
-        launcher.launch(args);
+        return (PayaraMicroBoot) launcher.launch(method, args);
     }
-    
+
     /**
      * Boot method via Micro.getInstance()
      * @return

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
@@ -43,7 +43,7 @@ public abstract class Launcher {
 	 * @param args the incoming arguments
 	 * @throws Exception if the application fails to launch
 	 */
-	protected void launch(String[] args) throws Exception {
+	protected Object launch(String method, String[] args) throws Exception {
             boolean explode = true;
             String unpackDir = null;
             for (int i = 0; i < args.length; i++) {
@@ -67,7 +67,7 @@ public abstract class Launcher {
                         classLoader = new ExplodedURLClassloader();
                     }
             }
-            launch(args, getMainClass(), classLoader);
+            return launch(method, args, getMainClass(), classLoader);
 	}
 
 	/**
@@ -101,10 +101,10 @@ public abstract class Launcher {
 	 * @param classLoader the classloader
 	 * @throws Exception if the launch fails
 	 */
-	protected void launch(String[] args, String mainClass, ClassLoader classLoader)
+	protected Object launch(String method, String[] args, String mainClass, ClassLoader classLoader)
 			throws Exception {
 		Thread.currentThread().setContextClassLoader(classLoader);
-		createMainMethodRunner(mainClass, args, classLoader).run();
+		return createMainMethodRunner(mainClass, method, args, classLoader).run();
 	}
 
 	/**
@@ -114,9 +114,9 @@ public abstract class Launcher {
 	 * @param classLoader the classloader
 	 * @return the main method runner
 	 */
-	protected MainMethodRunner createMainMethodRunner(String mainClass, String[] args,
+	protected MainMethodRunner createMainMethodRunner(String mainClass, String method, String[] args,
 			ClassLoader classLoader) {
-		return new MainMethodRunner(mainClass, args);
+		return new MainMethodRunner(mainClass, args, method);
 	}
 
 	/**

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/MainMethodRunner.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/MainMethodRunner.java
@@ -28,24 +28,26 @@ import java.lang.reflect.Method;
 public class MainMethodRunner {
 
 	private final String mainClassName;
-
+	private final String mainMethodName;
 	private final String[] args;
+
 
 	/**
 	 * Create a new {@link MainMethodRunner} instance.
 	 * @param mainClass the main class
 	 * @param args incoming arguments
 	 */
-	public MainMethodRunner(String mainClass, String[] args) {
+	public MainMethodRunner(String mainClass, String[] args, String mainMethodName) {
 		this.mainClassName = mainClass;
+        this.mainMethodName = mainMethodName;
 		this.args = (args == null ? null : args.clone());
 	}
 
-	public void run() throws Exception {
+	public Object run() throws Exception {
 		Class<?> mainClass = Thread.currentThread().getContextClassLoader()
 				.loadClass(this.mainClassName);
-		Method mainMethod = mainClass.getDeclaredMethod("main", String[].class);
-		mainMethod.invoke(null, new Object[] { this.args });
+		Method mainMethod = mainClass.getDeclaredMethod(mainMethodName, String[].class);
+		return mainMethod.invoke(null, new Object[] { this.args });
 	}
 
 }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -197,7 +197,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      * @throws BootstrapException If there is a problem booting the server
      */
     public static void main(String args[]) throws Exception {
+        create(args);
+    }
 
+    public static PayaraMicroBoot create(String[] args) throws Exception {
         // configure boot system properties
         setBootProperties();
         PayaraMicroImpl main = getInstance();
@@ -207,6 +210,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         } else {
             main.bootStrap();
         }
+        return main;
     }
 
     /**
@@ -337,22 +341,26 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      * Set user defined file directory for the access log
      *
      * @param filePath
+     * @return 
      */
     @Override
-    public void setAccessLogDir(String filePath) {
+    public PayaraMicroBoot setAccessLogDir(String filePath) {
         this.userAccessLogDirectory = filePath;
         enableAccessLog = true;
+        return this;
     }
 
     /**
      * Set user defined formatting for the access log
      *
      * @param format
+     * @return 
      */
     @Override
-    public void setAccessLogFormat(String format) {
+    public PayaraMicroBoot setAccessLogFormat(String format) {
         this.accessLogFormat = format;
         this.enableAccessLogFormat = true;
+        return this;
     }
 
     /**


### PR DESCRIPTION
Using the programmatic API of `PayaraMicro` to bootstrap a micro instance has shown to have classloading isses when deploying a simple war with a JSP page. This is not the case when starting the server via the `PayaraMicroLauncher`. The problem encountered illustrated that two code paths to do the same thing is problematic. This lead to the idea to transition to one common code path of `PayaraMicroLauncher` (as this is the working one).  This should not mean that the programmatic bootrapping **API** (as provided by `PayaraMicro`)  should be abandoned, just that this API can be nothing more then a builder API to assemble the `String[]` arguments passed to the launcher. From there is is a common code path.

This "prove-of-concept" PR only changes enough to allow using the `PayaraMicroLauncher` to run payara micro programmatically and receive the instance as possible via `PayaraMicro`.

The first change is to add an "overloaded" version of a _main_ method(s) used to start the server that returns the started `PayaraMicroBoot` instance. To avoid conflicts for tools using the `main` method the new method is not called _main_ but `create` and the main method is left untouched signature wise.

The second small change is that `PayaraMicro` now implements `PayaraMicroBoot`. Thereby both programmatic ways return `PayaraMicroBoot` instance. Judging from the code I believe this was always planned but simply was forgotten and by chance two of the setters did not return the instance for chaining (but `void`).

With these changes it effectively becomes possible to do:
```java
PayaraMicroBoot instance = PayaraMicroLauncher.create(args);
```
And it shows that using `PayaraMicro` and `PayaraMicroLauncher` conceptually yields the same `PayaraMicroBoot` instance.

This should be understood as a first step. Following steps can gradually remove one code path and change the implementation of the fluent API to assemble the argument list passed to the launcher.