### PR TITLE
QA-192 New module for tests based on payara-micro.jar

### DIFF
--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -54,6 +54,10 @@
     <packaging>pom</packaging>
     <name>GlassFish Tests related modules</name>
 
+    <modules>
+        <module>test-micro-jar</module>
+    </modules>
+
     <profiles>
         <profile>
             <id>ci</id>

--- a/appserver/tests/test-micro-jar/README.md
+++ b/appserver/tests/test-micro-jar/README.md
@@ -1,0 +1,27 @@
+# Payara Micro Jar Based Integration Tests
+
+This module provides plain JUnit tests that use `payara-micro.jar` as only
+compile and runtime dependency (+ junit itself).
+
+The setup makes sure the actual delivery is tested and keeps the setup simple
+and minimal. Tests do the programmtic equivalent of:
+
+        java -jar payara-micro.jar
+
+The `payara-micro.jar` is referenced using a relative path to the module that
+generates the jar. Should the jar not exist run: 
+
+        cd $PAYARA_HOME/appserver/extras/payara-micro/payara-micro-distribution
+        mvn install
+        
+Depending on the status of the build artifacts a full build might be required.
+
+Except from being dependent on a generated jar file the tests in this module
+are plain old JUnit tests that can be run using `mvn integration-test`
+(or `mvn verify`) or in the IDE as every other JUnit tests.
+
+While this takes full advantage of the simplicity Payara Micro has to offer for 
+the user it comes with the downside of not having further APIs and internals 
+available at compile time.
+Instead reflection has to be used if internal should be verified. 
+This module offers the `BeanProxy` utility class to ease reflection usage.

--- a/appserver/tests/test-micro-jar/pom.xml
+++ b/appserver/tests/test-micro-jar/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.main.tests</groupId>
+        <artifactId>tests</artifactId>
+        <version>5.192-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-micro-jar</artifactId>
+
+    <name>Integration Tests based on payara-micro.jar file</name>
+    <description>NOTE: this module is dependent on the payara-micro-distribution being run previously 
+    but it cannot have a dependency on this module as this would mess up the classpath for test execution 
+    as some classes get in from the modules that have to be taken only from the generated jar file.
+
+    The idea is to test the actual artifact created.
+    This is not suitable for all kinds of tests as the accessible API is the minumal payara micro API.
+    </description>
+
+    <dependencies>
+        <!-- NOTE that the dependency is of type "pom". We don't want its jars in classpath - 
+        only that the module is build before this one so that the payara-micro.jar exists -->
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-micro</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- NOTE: This is a purely fictional module. Maven simply insists that anything is a module 
+            so we pretend it is -->
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-micro-jar</artifactId>
+            <version>as-is-on-disk</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../../extras/payara-micro/payara-micro-distribution/target/payara-micro.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*.class</include>
+                    </includes>
+                    <excludedGroups>fish.payara.test.util.IntegrationTest</excludedGroups>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <groups>fish.payara.test.util.IntegrationTest</groups>
+                        <!-- run all tests in a single thread (less server start/stop, occupied ports etc.) -->
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/*.class</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/tests/test-micro-jar/src/test/java/fish/payara/admin/cli/AsAdminIntegrationTest.java
+++ b/appserver/tests/test-micro-jar/src/test/java/fish/payara/admin/cli/AsAdminIntegrationTest.java
@@ -1,0 +1,209 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.admin.cli;
+
+import static fish.payara.micro.ClusterCommandResult.ExitStatus.FAILURE;
+import static fish.payara.micro.ClusterCommandResult.ExitStatus.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+
+import fish.payara.micro.ClusterCommandResult;
+import fish.payara.micro.ClusterCommandResult.ExitStatus;
+import fish.payara.test.util.IntegrationTest;
+import fish.payara.test.util.PayaraMicroServer;
+
+@Category(IntegrationTest.class)
+public abstract class AsAdminIntegrationTest {
+
+    private static final String UNSATISFIED_DEPENDENCY_EXCEPTION_CLASS_NAME = 
+            "org.jvnet.hk2.config.UnsatisfiedDependencyException";
+    private static final String UNACCEPTABLE_VALUE_EXCEPTION_CLASS_NAME = 
+            "org.glassfish.common.util.admin.UnacceptableValueException";
+
+    protected final PayaraMicroServer server;
+    private final String[] args;
+
+    protected AsAdminIntegrationTest() {
+        this(new String[0]);
+    }
+
+    protected AsAdminIntegrationTest(String... args) {
+        this.args = args;
+        this.server = PayaraMicroServer.newInstance();
+    }
+
+    @Before
+    public void serverSetUp() throws Exception {
+        if (args.length == 0) {
+            server.start();
+        } else {
+            server.start(args);
+        }
+    }
+
+    protected static void assertUnchanged(boolean expected, boolean actual) {
+        assertEquals(Boolean.valueOf(expected), Boolean.valueOf(actual));
+    }
+
+    protected static void assertContains(String expected, String actual) {
+        assertThat(actual, CoreMatchers.containsString(expected));
+    }
+
+    protected static void assertSuccess(ClusterCommandResult result) {
+        ExitStatus actual = result.getExitStatus();
+        if (SUCCESS != actual) {
+            String msg = result.getOutput();
+            if (actual == FAILURE && result.getFailureCause() != null) {
+                StringWriter writer = new StringWriter();
+                result.getFailureCause().printStackTrace(new PrintWriter(writer));
+                msg = writer.toString();
+            }
+            if (msg != null) {
+                assertEquals(msg, SUCCESS, actual);
+            } else {
+                assertEquals(SUCCESS, actual);
+            }
+        }
+    }
+
+    protected static void assertFailure(ClusterCommandResult result) {
+        assertEquals(FAILURE, result.getExitStatus());
+    }
+
+    private static void assertStatesUsage(ClusterCommandResult result) {
+        assertTrue("No usage was given.", result.getOutput().contains("Usage: "));
+    }
+
+    protected final void assertMissingParameter(String name, ClusterCommandResult result) {
+        assertFailure(result);
+        Class<?> expectedExceptionType = server.getClass(UNSATISFIED_DEPENDENCY_EXCEPTION_CLASS_NAME);
+        Throwable cause = result.getFailureCause();
+        assertNotNull(cause);
+        assertTrue("Error is not caused by a missing parameter but " + cause.getClass().getName(),
+                expectedExceptionType.isAssignableFrom(cause.getClass()));
+        String text = result.getOutput();
+        int afterName = text.indexOf(" with class ");
+        int beforeName = text.substring(0, afterName).lastIndexOf('.');
+        String actualName = text.substring(beforeName + 1, afterName);
+        assertEquals("Error was about another parameter", name, actualName);
+        assertStatesUsage(result);
+    }
+
+    protected final void assertUnacceptableParameter(String name, ClusterCommandResult result) {
+        assertFailure(result);
+        Class<?> expectedExceptionType = server.getClass(UNACCEPTABLE_VALUE_EXCEPTION_CLASS_NAME);
+        Throwable cause = result.getFailureCause();
+        assertNotNull(cause);
+        assertTrue("Error is not caused by a unacceptable parameter but " + cause.getClass().getName(),
+                expectedExceptionType.isAssignableFrom(cause.getClass()));
+        String text = result.getOutput();
+        try {
+            assertContains("Invalid parameter: " + name, text);
+        } catch (AssertionError e) {
+            assertContains("on parameter [ "+name+" ]", text);
+        }
+        assertStatesUsage(result);
+    }
+
+    /**
+     * Runs an as-admin command on the {@link #server} 
+     */
+    protected final ClusterCommandResult asadmin(String command, String...args) {
+        return new PlainClusterCommandResult(server.getInstance().executeLocalAsAdmin(command, args));
+    }
+
+    protected final Class<?> getClass(String name) {
+        return server.getClass(name);
+    }
+
+    protected final <T> T getExtensionByType(String target, Class<T> type) {
+        return server.getExtensionByType(target, type);
+    }
+
+    private static final class PlainClusterCommandResult implements ClusterCommandResult {
+
+        final ClusterCommandResult wrapped;
+
+        public PlainClusterCommandResult(ClusterCommandResult wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public ExitStatus getExitStatus() {
+            return wrapped.getExitStatus();
+        }
+
+        @Override
+        public Throwable getFailureCause() {
+            return wrapped.getFailureCause();
+        }
+
+        @Override
+        public String getOutput() {
+            String output = wrapped.getOutput();
+            if (!output.startsWith("PlainTextActionReporter")) {
+                return output;
+            }
+            int index = output.indexOf("SUCCESS");
+            if (index < 0) {
+                index = output.indexOf("FAILURE");
+            }
+            if (index > 0) {
+                return output.substring(index + 7);
+            }
+            return output;
+        }
+
+        @Override
+        public String toString() {
+            return getExitStatus() + ": " + getOutput();
+        }
+    }
+
+}

--- a/appserver/tests/test-micro-jar/src/test/java/fish/payara/test/util/BeanProxy.java
+++ b/appserver/tests/test-micro-jar/src/test/java/fish/payara/test/util/BeanProxy.java
@@ -1,0 +1,158 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.test.util;
+
+import static org.junit.Assert.fail;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.concurrent.Callable;
+
+/**
+ * Base class for test wrappers on beans of classes only available at runtime.
+ */
+public class BeanProxy {
+
+    private final Object bean;
+
+    public BeanProxy(Object bean) {
+        this.bean = bean;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return obj != null && obj.getClass() == getClass() && bean.equals(((BeanProxy)obj).bean);
+    }
+
+    @Override
+    public final int hashCode() {
+        return bean.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return bean.getClass().getSimpleName();
+    }
+
+    public final boolean booleanValue(String name) {
+        Object res = propertyValue(name, Boolean.class);
+        return res instanceof Boolean ? ((Boolean)res).booleanValue() : Boolean.parseBoolean((String)res);
+    }
+
+    public final int intValue(String name) {
+        Integer res = integerValue(name);
+        return res == null ? 0 : res.intValue();
+    }
+
+    public final Integer integerValue(String name) {
+        Object res = propertyValue(name, Integer.class);
+        return res instanceof Integer || res == null ? ((Integer)res) : Integer.valueOf((String)res);
+    }
+
+    public final Long longValue(String name) {
+        Object res = propertyValue(name, Long.class);
+        return res instanceof Long || res == null ? ((Long)res) : Long.valueOf((String)res);
+    }
+
+    public final String stringValue(String name) {
+        Object res = propertyValue(name, String.class);
+        return res instanceof String || res == null ? (String) res : String.valueOf(res);
+    }
+
+    public final Enum<?> enumValue(String name) {
+        return (Enum<?>) propertyValue(name, Enum.class);
+    }
+    @SuppressWarnings("unchecked")
+    public final <E extends Enum<E>> E enumValue(String name, Class<E> type) {
+        Object val = propertyValue(name, type);
+        if (val == null || type.isAssignableFrom(val.getClass())) {
+            return (E) val;
+        }
+        if (val instanceof String) {
+            return Enum.valueOf(type, (String)val);
+        }
+        fail("Unexpected value type for enum: " + name);
+        return null;
+    }
+
+    public final Object propertyValue(String name) {
+        return propertyValue(name, Object.class);
+    }
+
+    public final Object propertyValue(String name, Class<?> type) {
+        String errorText = "Failed to get " + type.getSimpleName() + " value for property " + name;
+        return name.startsWith("get") || name.startsWith("is") || bean instanceof Annotation
+                ? callMethod(name, errorText)
+                : accessField(name, errorText);
+    }
+
+    public final Object callMethod(String name, String errorText) {
+        return failAsAssertionError(errorText, () ->  bean.getClass().getMethod(name, new Class[0]).invoke(bean));
+    }
+
+    public final <P> Object callMethod(String name, String errorText, Class<P> parameter, P argument) {
+        return failAsAssertionError(errorText + " for method " + name,
+                () -> bean.getClass().getMethod(name, new Class[] { parameter }).invoke(bean, argument));
+    }
+
+    public final Object accessField(String name, String errorText) {
+        return failAsAssertionError(errorText + " for field " + name, () -> {
+            Field field = bean.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return field.get(bean);
+        });
+    }
+
+    public static AssertionError asAssertionError(String msg, Throwable e) {
+        return e.getClass() == AssertionError.class ? (AssertionError)e : new AssertionError(msg, e);
+    }
+
+    public final static <T> T failAsAssertionError(Callable<T> operation) {
+        return failAsAssertionError("Failed to run operation: ", operation);
+    }
+
+    public final static <T> T failAsAssertionError(String msg, Callable<T> operation) {
+        try {
+            return operation.call();
+        } catch (Throwable e) {
+            throw asAssertionError(msg, e);
+        }
+    }
+}

--- a/appserver/tests/test-micro-jar/src/test/java/fish/payara/test/util/IntegrationTest.java
+++ b/appserver/tests/test-micro-jar/src/test/java/fish/payara/test/util/IntegrationTest.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.test.util;
+
+/**
+ * Marker interface to be used together with junit's {@link org.junit.experimental.categories.Category} to mark
+ * integration tests.
+ */
+public interface IntegrationTest {
+    // marker
+}

--- a/appserver/tests/test-micro-jar/src/test/java/fish/payara/test/util/PayaraMicroServer.java
+++ b/appserver/tests/test-micro-jar/src/test/java/fish/payara/test/util/PayaraMicroServer.java
@@ -1,0 +1,247 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.test.util;
+
+import static fish.payara.test.util.BeanProxy.asAssertionError;
+import static fish.payara.test.util.BeanProxy.failAsAssertionError;
+import static org.junit.Assert.fail;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import fish.payara.micro.PayaraInstance;
+import fish.payara.micro.PayaraMicroRuntime;
+import fish.payara.micro.boot.PayaraMicroBoot;
+import fish.payara.micro.boot.PayaraMicroLauncher;
+
+/**
+ * A wrapper on the {@link PayaraMicroRuntime} and {@link PayaraInstance} to ease test setup and verification.
+ * 
+ * This test setup works directly with the {@code payara-micro.jar} as its only dependency. While this has the benefit
+ * of testing the actual artefact this comes as the downside that there are only a few API classes available at compile
+ * time as the server itself is packaged within micro and only accessible at runtime using the right
+ * {@link ClassLoader}.
+ * 
+ * Tests using the {@link PayaraMicroServer} should call {@link #start()} before the test(s) and {@link #stop()} after.
+ */
+public final class PayaraMicroServer {
+
+    static {
+        System.setProperty("java.util.logging.config.file", "src/test/resources/logging.properties");
+    }
+
+    private static final PayaraMicroServer INSTANCE = new PayaraMicroServer();
+
+    public static PayaraMicroServer newInstance() {
+        return INSTANCE;
+    }
+
+    private static final String GALSSFISH_CLASS_NAME = "org.glassfish.embeddable.GlassFish";
+    private static final String SERVICE_LOCATOR_CLASS_NAME = "org.glassfish.hk2.api.ServiceLocator";
+    private static final String TARGET_CLASS_NAME = "org.glassfish.internal.api.Target";
+    private static final String DOMAIN_CLASS_NAME = "com.sun.enterprise.config.serverbeans.Domain";
+
+    private static final int defaultHttpPort = 28989;
+
+    private final AtomicBoolean starting = new AtomicBoolean(false);
+    private final AtomicBoolean stopping = new AtomicBoolean(false);
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    private int httpPort;
+    private String[] options;
+    private PayaraMicroBoot boot;
+    private PayaraMicroRuntime runtime;
+    private PayaraInstance instance;
+
+    private ClassLoader serverClassLoader;
+    private Object glassfish;
+    private Object serviceLocator;
+    private Object targetUtil;
+    private BeanProxy domain;
+
+    private PayaraMicroServer() {
+    }
+
+    public PayaraInstance getInstance() {
+        return instance;
+    }
+
+    public PayaraMicroRuntime getRuntime() {
+        return runtime;
+    }
+
+    /**
+     * Only start if not already started. This means the caller is satisfied with whatever setup of the server.
+     */
+    public void start() {
+        if (!isStarted()) {
+            start("--port", "" + defaultHttpPort, "--autobindhttp");
+        }
+    }
+
+    public void start(String... args) {
+        try {
+            int port = port(args);
+            if (port < 0) {
+                port = defaultHttpPort;
+                args = Arrays.copyOf(args, args.length + 2);
+                args[args.length - 2] = "--port";
+                args[args.length - 1] = "" + port;
+            }
+            if (!starting.compareAndSet(false, true)) {
+                if (running.get()) {
+                    if (Arrays.equals(options, args)) {
+                        return; // started with same options already
+                    }
+                    stop();
+                } else {
+                    fail("Previous start was not successful.");
+                }
+            }
+            start(args, PayaraMicroLauncher.create(args), port);
+        } catch (Exception e) {
+            asAssertionError("Failed to start micro server", e);
+        } finally {
+            starting.set(false);
+        }
+    }
+
+    private static int port(String[] args) {
+        for (int i = 0; i < args.length; i++) {
+            if ("--port".equals(args[i]) || "--sslport".equals(args[i])) {
+                return Integer.parseInt(args[i+1]);
+            }
+        }
+        return -1;
+    }
+
+    private void start(String[] args, PayaraMicroBoot boot, int port) throws Exception {
+        this.options = args;
+        this.httpPort = port;
+        this.boot = boot;
+        runtime = boot.getRuntime();
+        if (running.compareAndSet(false, true)) {
+            starting.set(false);
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> stop()));
+        }
+        instance = getField(PayaraInstance.class, runtime);
+        // classes are on the CP of the server but not of the test
+        serverClassLoader = instance.getClass().getClassLoader();
+        glassfish = getField(getClass(GALSSFISH_CLASS_NAME), runtime);
+        serviceLocator = getField(getClass(SERVICE_LOCATOR_CLASS_NAME), glassfish);
+        targetUtil = getService(getClass(TARGET_CLASS_NAME));
+        domain = new BeanProxy(getService(getClass(DOMAIN_CLASS_NAME)));
+
+    }
+
+    public void stop() {
+        if (!isStarted()) {
+            return; // don't try to stop if not started successfully
+        }
+        if (!stopping.compareAndSet(false, true)) {
+            return; // already stopping...
+        }
+        try {
+            boot.shutdown();
+            running.set(false);
+        } catch (Exception e) {
+            // ignore...
+        } finally {
+            stopping.set(false);
+        }
+    }
+
+    private boolean isStarted() {
+        return running.get();
+    }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public <T> T getDomainExtensionByType(Class<T> type) {
+        return failAsAssertionError(() -> type.cast(domain.callMethod("getExtensionByType",
+                "Failed to get Domain extension of type " + type.getName(), Class.class, type)));
+    }
+
+    public <T> T getExtensionByType(String target, Class<T> type) {
+        return failAsAssertionError(() -> {
+            Method getConfig = targetUtil.getClass().getMethod("getConfig", String.class);
+            Object config = getConfig.invoke(targetUtil, target);
+            Method getExtensionByType = config.getClass().getMethod("getExtensionByType", Class.class);
+            return type.cast(getExtensionByType.invoke(config, type));
+        });
+    }
+
+    public Class<?> getClass(String name) {
+        return failAsAssertionError(() -> serverClassLoader.loadClass(name));
+    }
+
+    public <T> T getService(Class<T> type) {
+        return failAsAssertionError(() -> type.cast(serviceLocator.getClass()
+                        .getMethod("getService", Class.class, Annotation[].class)
+                        .invoke(serviceLocator, type, new Annotation[0])));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> List<T> getAllServices(Class<T> type) {
+        return failAsAssertionError(() -> (List<T>) serviceLocator.getClass()
+                    .getMethod("getAllServices", Class.class, Annotation[].class)
+                    .invoke(serviceLocator, type, new Annotation[0]));
+    }
+
+    private static <T> T getField(Class<T> fieldType, Object obj) {
+        for (Field f : obj.getClass().getDeclaredFields()) {
+            if (fieldType.isAssignableFrom(f.getType())) {
+                return failAsAssertionError(() -> {
+                    f.setAccessible(true);
+                    return fieldType.cast(f.get(obj));
+                });
+            }
+        }
+        fail("Could not find instance field in runtime");
+        return null;
+    }
+
+}

--- a/appserver/tests/test-micro-jar/src/test/resources/logging.properties
+++ b/appserver/tests/test-micro-jar/src/test/resources/logging.properties
@@ -1,0 +1,5 @@
+# Logging setup for testing that makes the output a lot less verbose
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+com.sun.enterprise.server.logging.ODLLogFormatter.ansiColor=false
+java.util.logging.ConsoleHandler.level=INFO


### PR DESCRIPTION
This PR provides the module setup and test infrastructure common to all tests added based on the `payara-micro.jar` used by several test PRs.

This PR itself is dependent on #3810 to compile as the `PayaraMicroServer` utility makes used of the programmatic bootstrapping using the launched added by #3810.

This PR adds JUnit based integration test setup that make use of the `payara-micro.jar` generated during the build. The tests use the generated jar as dependency to run Payara Micro. The provided  `AsAdminIntegrationTest` base class makes testing _as-admin_ commands straight forward.

This has the benefit of a simple setup that works on command line and in the IDE as any other JUnit based test. The setup also makes sure we test the actual delivery artefact.
Because of the "dependency" on the generated `payara-micro.jar` the tests fit best in the `Payara` repository as they can reference the jar with a relative path. This also has the benefit of running the tests during normal build.

To run in the `integration-test` phase of the build the module configures test classes annotated with `@Category(IntegrationTest.class)` to be run by failsafe and not surefire. This has the benefit of visibility/discoverability and automatic inheritance from base test classes.

Due to the packaging of Payara Micro the internal classes are not accessible at compile time so that reflection is required to check internal state. This PR also adds some basic utilities for this that can be reused for further tests based on the `payara-micro.jar`.