### PR TITLE
PAYARA-3172: Improve support for building in parallel

### DIFF
--- a/appserver/admin/gf_template/pom.xml
+++ b/appserver/admin/gf_template/pom.xml
@@ -52,7 +52,16 @@
     <artifactId>appserver-domain</artifactId>
     <name>Appserver template</name>
     <description>Appserver template</description>
-	
+
+    <dependencies>
+        <dependency>
+             <groupId>org.glassfish.main.admin</groupId>
+             <artifactId>nucleus-domain</artifactId>
+             <version>${project.version}</version>
+             <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/appserver/admin/gf_template/pom.xml
+++ b/appserver/admin/gf_template/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2019] [Payara Foundation and/or its affiliates] -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
     

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -51,7 +51,16 @@
     <artifactId>appserver-domain-web</artifactId>
     <name>Web Appserver template</name>
     <description>Web Appserver template</description>
-	
+
+    <dependencies>
+        <dependency>
+             <groupId>org.glassfish.main.admin</groupId>
+             <artifactId>nucleus-domain</artifactId>
+             <version>${project.version}</version>
+             <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   
-   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -27,7 +27,16 @@
     <artifactId>production-domain</artifactId>
     <name>Production Domain Template</name>
     <description>Production Domain Template</description>
-	
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.admin</groupId>
+            <artifactId>nucleus-domain</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -14,6 +14,7 @@
  * When distributing the software, include this License Header Notice in each
  * file and include the License file at packager/legal/LICENSE.txt.
  -->
+<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -1,21 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
- *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
- -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
 
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
     

--- a/appserver/admin/production_domain_template_web/pom.xml
+++ b/appserver/admin/production_domain_template_web/pom.xml
@@ -52,7 +52,16 @@
     <artifactId>production-domain-web</artifactId>
     <name>Web Production Template</name>
     <description>Web Production Template</description>
-	
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.admin</groupId>
+            <artifactId>nucleus-domain</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/appserver/admin/production_domain_template_web/pom.xml
+++ b/appserver/admin/production_domain_template_web/pom.xml
@@ -3,7 +3,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   
-   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
There were implicit dependencies between domain templates and
nucleus-domain.

They made dependency:unpack plugin to fail, as the artifact could not be found in local repo