### PR TITLE
PAYARA-3576: Don't leak dependencies of embedded

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -375,6 +375,7 @@
             <artifactId>notification-xmpp</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>
@@ -443,6 +444,7 @@
             <artifactId>yubikey-authentication</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -301,12 +301,14 @@
             <artifactId>notification-email</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>
             <artifactId>notification-hipchat</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>
@@ -386,6 +388,7 @@
             <artifactId>yubikey-authentication</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+            <optional>true</optional>
         </dependency>
         <!-- roles api -->
         <dependency>


### PR DESCRIPTION
All of the dependencies of embedded modules must be optional, so they
don't pull other artifacts to the user's classpath.