### PR TITLE
PAYARA-3702 Fixing NPE with standalone server deploying an application containing EJB singletons

### DIFF
--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -100,12 +100,12 @@ public class IiopFolbGmsClient implements ClusterListener {
     private Map<String, ClusterInstanceInfo> currentMembers;
 
     private GroupInfoService gis;
-    
+
     private PayaraCluster cluster;
-    
+
     private static final String USE_NODE_HOST_FOR_LOCAL_NODE_PROPERTY = "useNodeHostForLocalNode";
-    
-    private static final String USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY = "fish.payara.iiop.gmsClient." 
+
+    private static final String USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY = "fish.payara.iiop.gmsClient."
             + USE_NODE_HOST_FOR_LOCAL_NODE_PROPERTY;
 
     private void fineLog( String fmt, Object... args ) {
@@ -195,13 +195,13 @@ public class IiopFolbGmsClient implements ClusterListener {
     //
     // Implementation
     //
-    
+
     private boolean isDeploymentGroupsActive() {
     	return cluster != null && cluster.isEnabled() && cluster.getClusterMembers().size() > 1;
     }
-    
+
     private boolean isTraditionalClusterActive() {
-    	return myServer.getCluster() != null;
+    	return myServer != null && myServer.getCluster() != null;
     }
 
     private void removeMember(final String signal)
@@ -247,7 +247,7 @@ public class IiopFolbGmsClient implements ClusterListener {
                     fineLog( "IiopFolbGmsClient.addMember: {0} already present: no action",
                             instanceName);
 		} else {
-		    ClusterInstanceInfo clusterInstanceInfo = 
+		    ClusterInstanceInfo clusterInstanceInfo =
                         getClusterInstanceInfo(instanceName) ;
 
 		    currentMembers.put( clusterInstanceInfo.name(),
@@ -261,7 +261,7 @@ public class IiopFolbGmsClient implements ClusterListener {
                     fineLog( "IiopFolbGmsClient.addMember: {0} - notification complete",
                         instanceName);
 		}
-	    }	
+	    }
 	} finally {
             fineLog( "IiopFolbGmsClient.addMember<-: {0}", instanceName);
 	}
@@ -305,15 +305,15 @@ public class IiopFolbGmsClient implements ClusterListener {
 
         final IiopService iservice = config.getExtensionByType(IiopService.class) ;
         fineLog( "getClusterInstanceInfo: iservice {0}", iservice ) ;
-        
+
         final String nodeName = server.getNodeRef() ;
         String hostName = nodeName ;
         if (nodes != null) {
             Node node = nodes.getNode( nodeName ) ;
             if (node != null) {
-                // If this is the local node, and the useNodeHostForLocalNode property has not been set at the ORB or 
+                // If this is the local node, and the useNodeHostForLocalNode property has not been set at the ORB or
                 // System level, use the local host name
-                if ((node.isLocal() && !Boolean.getBoolean(USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY)) 
+                if ((node.isLocal() && !Boolean.getBoolean(USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY))
                         && (node.isLocal() && !Boolean.parseBoolean(iservice.getOrb().getPropertyValue(
                                 USE_NODE_HOST_FOR_LOCAL_NODE_PROPERTY, "false")))) {
                     try {
@@ -452,7 +452,7 @@ public class IiopFolbGmsClient implements ClusterListener {
 
     class GroupInfoServiceGMSImpl extends GroupInfoServiceBase {
         @Override
-        public List<ClusterInstanceInfo> internalClusterInstanceInfo( 
+        public List<ClusterInstanceInfo> internalClusterInstanceInfo(
             List<String> endpoints) {
 
             fineLog( "internalClusterInstanceInfo: currentMembers {0}",


### PR DESCRIPTION
When deploying an app containing EJB Singletons to a standalone (non-clustered, no-deployment-group, no-instances) server the EJB-Container fails to start with a NullPointerException. This has been introduced to Payara 5.191 class IiopFolbGmsClient with commit `44b99bda4fae6ddcf7219b4c7c7abb75eb2de3be`.

Does anyone know about a workaround? We are trying to migrate to Payara 5.191.

```
 UTIL6009:Unexpected Exception in createORB.
java.lang.NullPointerException
	at org.glassfish.enterprise.iiop.impl.IiopFolbGmsClient.isTraditionalClusterActive(IiopFolbGmsClient.java:204)
	at org.glassfish.enterprise.iiop.impl.IiopFolbGmsClient.isGMSAvailable(IiopFolbGmsClient.java:191)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.setFOLBProperties(GlassFishORBManager.java:440)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.initORB(GlassFishORBManager.java:474)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.getORB(GlassFishORBManager.java:273)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBFactoryImpl.createORB(GlassFishORBFactoryImpl.java:93)
	at org.glassfish.enterprise.iiop.api.GlassFishORBHelper.getORB(GlassFishORBHelper.java:167)
	at org.glassfish.enterprise.iiop.api.GlassFishORBHelper.getProtocolManager(GlassFishORBHelper.java:235)
	at com.sun.ejb.containers.BaseContainer.initializeProtocolManager(BaseContainer.java:916)
	at com.sun.ejb.containers.BaseContainer.<init>(BaseContainer.java:651)
	at com.sun.ejb.containers.AbstractSingletonContainer.<init>(AbstractSingletonContainer.java:133)
	at com.sun.ejb.containers.CMCSingletonContainer.<init>(CMCSingletonContainer.java:76)
	at com.sun.ejb.containers.SingletonContainerFactory.createContainer(SingletonContainerFactory.java:68)
	at org.glassfish.ejb.startup.EjbApplication.loadContainers(EjbApplication.java:225)
	at org.glassfish.ejb.startup.EjbDeployer.load(EjbDeployer.java:287)
	at org.glassfish.ejb.startup.EjbDeployer.load(EjbDeployer.java:105)
	at org.glassfish.internal.data.ModuleInfo.load(ModuleInfo.java:209)
	at org.glassfish.internal.data.ApplicationInfo.load(ApplicationInfo.java:318)
	at com.sun.enterprise.v3.server.ApplicationLifecycle.prepare(ApplicationLifecycle.java:485)
	at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:540)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:557)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:553)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:552)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:583)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:575)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:574)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1483)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.access$1300(CommandRunnerImpl.java:119)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1865)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1741)
	at com.sun.enterprise.v3.admin.AdminAdapter.doCommand(AdminAdapter.java:564)
	at com.sun.enterprise.v3.admin.AdminAdapter.onMissingResource(AdminAdapter.java:251)
	at org.glassfish.grizzly.http.server.StaticHttpHandlerBase.service(StaticHttpHandlerBase.java:166)
	at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
	at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
	at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:182)
	at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:156)
	at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:218)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
	at org.glassfish.grizzly.portunif.PUFilter.handleRead(PUFilter.java:208)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
	at org.glassfish.grizzly.portunif.PUFilter.handleRead(PUFilter.java:208)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
	at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:524)
	at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:89)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:94)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$0(WorkerThreadIOStrategy.java:90)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:114)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
	at java.lang.Thread.run(Thread.java:748)
|#]

java.lang.RuntimeException: EJB Container initialization error
	at org.glassfish.ejb.startup.EjbApplication.loadContainers(EjbApplication.java:237)
	at org.glassfish.ejb.startup.EjbDeployer.load(EjbDeployer.java:287)
	at org.glassfish.ejb.startup.EjbDeployer.load(EjbDeployer.java:105)
	at org.glassfish.internal.data.ModuleInfo.load(ModuleInfo.java:209)
	at org.glassfish.internal.data.ApplicationInfo.load(ApplicationInfo.java:318)
	at com.sun.enterprise.v3.server.ApplicationLifecycle.prepare(ApplicationLifecycle.java:485)
	at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:540)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:557)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:553)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:552)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:583)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:575)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:574)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1483)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.access$1300(CommandRunnerImpl.java:119)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1865)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1741)
	at com.sun.enterprise.v3.admin.AdminAdapter.doCommand(AdminAdapter.java:564)
	at com.sun.enterprise.v3.admin.AdminAdapter.onMissingResource(AdminAdapter.java:251)
	at org.glassfish.grizzly.http.server.StaticHttpHandlerBase.service(StaticHttpHandlerBase.java:166)
	at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
	at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
	at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:182)
	at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:156)
	at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:218)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
	at org.glassfish.grizzly.portunif.PUFilter.handleRead(PUFilter.java:208)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
	at org.glassfish.grizzly.portunif.PUFilter.handleRead(PUFilter.java:208)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
	at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:524)
	at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:89)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:94)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$0(WorkerThreadIOStrategy.java:90)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:114)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: IIOP Protocol Manager initialization failed.  Possible cause is that ORB is not available in this container
	at com.sun.ejb.containers.BaseContainer.initializeProtocolManager(BaseContainer.java:921)
	at com.sun.ejb.containers.BaseContainer.<init>(BaseContainer.java:651)
	at com.sun.ejb.containers.AbstractSingletonContainer.<init>(AbstractSingletonContainer.java:133)
	at com.sun.ejb.containers.CMCSingletonContainer.<init>(CMCSingletonContainer.java:76)
	at com.sun.ejb.containers.SingletonContainerFactory.createContainer(SingletonContainerFactory.java:68)
	at org.glassfish.ejb.startup.EjbApplication.loadContainers(EjbApplication.java:225)
	... 56 more
Caused by: java.lang.RuntimeException: Orb initialization erorr
	at org.glassfish.enterprise.iiop.api.GlassFishORBHelper.getORB(GlassFishORBHelper.java:195)
	at org.glassfish.enterprise.iiop.api.GlassFishORBHelper.getProtocolManager(GlassFishORBHelper.java:235)
	at com.sun.ejb.containers.BaseContainer.initializeProtocolManager(BaseContainer.java:916)
	... 61 more
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.initORB(GlassFishORBManager.java:652)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.getORB(GlassFishORBManager.java:273)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBFactoryImpl.createORB(GlassFishORBFactoryImpl.java:93)
	at org.glassfish.enterprise.iiop.api.GlassFishORBHelper.getORB(GlassFishORBHelper.java:167)
	... 63 more
Caused by: java.lang.NullPointerException
	at org.glassfish.enterprise.iiop.impl.IiopFolbGmsClient.isTraditionalClusterActive(IiopFolbGmsClient.java:204)
	at org.glassfish.enterprise.iiop.impl.IiopFolbGmsClient.isGMSAvailable(IiopFolbGmsClient.java:191)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.setFOLBProperties(GlassFishORBManager.java:440)
	at org.glassfish.enterprise.iiop.impl.GlassFishORBManager.initORB(GlassFishORBManager.java:474)
	... 66 more
|#]
```