### PR TITLE
PAYARA-3466 Open API 1.1

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiVisitor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiVisitor.java
@@ -41,7 +41,6 @@ package fish.payara.microprofile.openapi.api.visitor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import javax.ws.rs.Consumes;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiVisitor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiVisitor.java
@@ -64,8 +64,10 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
 import org.eclipse.microprofile.openapi.annotations.callbacks.Callbacks;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extensions;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -126,6 +128,8 @@ public interface ApiVisitor {
 
     void visitExtension(Extension extension, AnnotatedElement element, ApiContext context);
 
+    void visitExtensions(Extensions extensions, AnnotatedElement element, ApiContext context);
+
     void visitOperation(Operation operation, AnnotatedElement element, ApiContext context);
 
     void visitCallback(Callback callback, AnnotatedElement element, ApiContext context);
@@ -139,6 +143,8 @@ public interface ApiVisitor {
     void visitAPIResponses(APIResponses apiResponses, AnnotatedElement element, ApiContext context);
 
     void visitParameter(Parameter parameter, AnnotatedElement element, ApiContext context);
+
+    void visitParameters(Parameters parameters, AnnotatedElement element, ApiContext context);
 
     void visitExternalDocumentation(ExternalDocumentation externalDocs, AnnotatedElement element, ApiContext context);
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -49,7 +49,6 @@ import fish.payara.microprofile.openapi.impl.processor.BaseProcessor;
 import fish.payara.microprofile.openapi.impl.processor.FileProcessor;
 import fish.payara.microprofile.openapi.impl.processor.FilterProcessor;
 import fish.payara.microprofile.openapi.impl.processor.ModelReaderProcessor;
-import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import java.beans.PropertyChangeEvent;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -58,7 +57,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -104,9 +102,6 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
 
     @Inject
     private OpenApiServiceConfiguration config;
-
-    @Inject
-    private PayaraExecutorService executor;
 
     @Inject
     private ServerEnvironment environment;
@@ -189,7 +184,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
         if (mappings.isEmpty() || !isEnabled()) {
             return null;
         }
-        return (OpenAPI) mappings.peekLast().getDocument();
+        return mappings.peekLast().getDocument();
     }
 
     /**
@@ -224,7 +219,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
      * @return a list of all loadable classes in the archive.
      */
     private static Set<Class<?>> getClassesFromArchive(ReadableArchive archive, ClassLoader appClassLoader) {
-        return Collections.list((Enumeration<String>) archive.entries()).stream()
+        return Collections.list(archive.entries()).stream()
                 // Only use the classes
                 .filter(x -> x.endsWith(".class"))
                 // Remove the WEB-INF/classes and return the proper class name format
@@ -262,12 +257,12 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
         private final OpenApiConfiguration appConfig;
         private volatile OpenAPI document;
 
-        private OpenApiMapping(ApplicationInfo appInfo) {
+        OpenApiMapping(ApplicationInfo appInfo) {
             this.appInfo = appInfo;
             this.appConfig = new OpenApiConfiguration(appInfo.getAppClassLoader());
         }
 
-        private ApplicationInfo getAppInfo() {
+        ApplicationInfo getAppInfo() {
             return appInfo;
         }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/admin/OpenApiServiceConfiguration.java
@@ -42,14 +42,13 @@ package fish.payara.microprofile.openapi.impl.admin;
 import java.beans.PropertyVetoException;
 import org.glassfish.api.admin.config.ConfigExtension;
 import org.jvnet.hk2.config.Attribute;
-import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.Configured;
 
 /**
  * Configuration for the OpenAPI Service.
  */
 @Configured(name = "microprofile-openapi-configuration")
-public interface OpenApiServiceConfiguration extends ConfigBeanProxy, ConfigExtension {
+public interface OpenApiServiceConfiguration extends ConfigExtension {
 
     /**
      * @return whether the service is enabled or not.

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
@@ -224,7 +224,7 @@ public class OpenApiConfiguration {
         return null;
     }
 
-    private boolean findScanDisableFromConfig(Config config) {
+    private static boolean findScanDisableFromConfig(Config config) {
         try {
             return config.getValue(SCAN_DISABLE_KEY, Boolean.class);
         } catch (NoSuchElementException ex) {
@@ -233,7 +233,7 @@ public class OpenApiConfiguration {
         return false;
     }
 
-    private List<String> findScanPackagesFromConfig(Config config) {
+    private static List<String> findScanPackagesFromConfig(Config config) {
         List<String> packages = new ArrayList<>();
         try {
             packages.addAll(Arrays.asList(config.getValue(SCAN_PACKAGES_KEY, String[].class)));
@@ -259,7 +259,7 @@ public class OpenApiConfiguration {
         return classes;
     }
 
-    private List<String> findExcludePackages(Config config) {
+    private static List<String> findExcludePackages(Config config) {
         List<String> packages = new ArrayList<>();
         try {
             packages.addAll(Arrays.asList(config.getValue(SCAN_EXCLUDE_PACKAGES_KEY, String[].class)));
@@ -285,7 +285,7 @@ public class OpenApiConfiguration {
         return classes;
     }
 
-    private List<String> findServers(Config config) {
+    private static List<String> findServers(Config config) {
         List<String> serverList = new ArrayList<>();
         try {
             serverList.addAll(Arrays.asList(config.getValue(SERVERS_KEY, String[].class)));
@@ -295,7 +295,7 @@ public class OpenApiConfiguration {
         return serverList;
     }
 
-    private Map<String, Set<String>> findPathServerMap(Config config) {
+    private static Map<String, Set<String>> findPathServerMap(Config config) {
         Map<String, Set<String>> map = new HashMap<>();
         try {
             for (String propertyName : config.getPropertyNames()) {
@@ -310,7 +310,7 @@ public class OpenApiConfiguration {
         return map;
     }
 
-    private Map<String, Set<String>> findOperationServerMap(Config config) {
+    private static Map<String, Set<String>> findOperationServerMap(Config config) {
         Map<String, Set<String>> map = new HashMap<>();
         try {
             for (String propertyName : config.getPropertyNames()) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
@@ -88,7 +88,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addSchema(String key, Schema schema) {
-        schemas.put(key, schema);
+        if (schema != null) {
+            schemas.put(key, schema);
+        }
         return this;
     }
 
@@ -109,7 +111,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addResponse(String key, APIResponse response) {
-        responses.put(key, response);
+        if (response != null) {
+            responses.put(key, response);
+        }
         return this;
     }
 
@@ -130,7 +134,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addParameter(String key, Parameter parameter) {
-        parameters.put(key, parameter);
+        if (parameter != null) {
+            parameters.put(key, parameter);
+        }
         return this;
     }
 
@@ -151,7 +157,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addExample(String key, Example example) {
-        examples.put(key, example);
+        if (example != null) {
+            examples.put(key, example);
+        }
         return this;
     }
 
@@ -172,7 +180,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addRequestBody(String key, RequestBody requestBody) {
-        requestBodies.put(key, requestBody);
+        if (requestBody != null) {
+            requestBodies.put(key, requestBody);
+        }
         return this;
     }
 
@@ -193,7 +203,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addHeader(String key, Header header) {
-        headers.put(key, header);
+        if (header != null) {
+            headers.put(key, header);
+        }
         return this;
     }
 
@@ -214,7 +226,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addSecurityScheme(String key, SecurityScheme securityScheme) {
-        securitySchemes.put(key, securityScheme);
+        if (securityScheme != null) {
+            securitySchemes.put(key, securityScheme);
+        }
         return this;
     }
 
@@ -235,7 +249,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addLink(String key, Link link) {
-        links.put(key, link);
+        if (link != null) {
+            links.put(key, link);
+        }
         return this;
     }
 
@@ -256,7 +272,9 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     @Override
     public Components addCallback(String key, Callback callback) {
-        callbacks.put(key, callback);
+        if (callback != null) {
+            callbacks.put(key, callback);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
@@ -64,7 +64,7 @@ import fish.payara.microprofile.openapi.impl.model.parameters.RequestBodyImpl;
 import fish.payara.microprofile.openapi.impl.model.responses.APIResponseImpl;
 import fish.payara.microprofile.openapi.impl.model.security.SecuritySchemeImpl;
 
-public class ComponentsImpl extends ExtensibleImpl implements Components {
+public class ComponentsImpl extends ExtensibleImpl<Components> implements Components {
 
     protected Map<String, Schema> schemas = new TreeMap<>();
     protected Map<String, APIResponse> responses = new TreeMap<>();
@@ -87,15 +87,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components schemas(Map<String, Schema> schemas) {
-        setSchemas(schemas);
+    public Components addSchema(String key, Schema schema) {
+        schemas.put(key, schema);
         return this;
     }
 
     @Override
-    public Components addSchema(String key, Schema schema) {
-        schemas.put(key, schema);
-        return this;
+    public void removeSchema(String key) {
+        schemas.remove(key);
     }
 
     @Override
@@ -109,15 +108,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components responses(Map<String, APIResponse> responses) {
-        setResponses(responses);
+    public Components addResponse(String key, APIResponse response) {
+        responses.put(key, response);
         return this;
     }
 
     @Override
-    public Components addResponse(String key, APIResponse response) {
-        responses.put(key, response);
-        return this;
+    public void removeResponse(String key) {
+        responses.remove(key);
     }
 
     @Override
@@ -131,15 +129,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components parameters(Map<String, Parameter> parameters) {
-        setParameters(parameters);
+    public Components addParameter(String key, Parameter parameter) {
+        parameters.put(key, parameter);
         return this;
     }
 
     @Override
-    public Components addParameter(String key, Parameter parameter) {
-        parameters.put(key, parameter);
-        return this;
+    public void removeParameter(String key) {
+        parameters.remove(key);
     }
 
     @Override
@@ -153,15 +150,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components examples(Map<String, Example> examples) {
-        setExamples(examples);
+    public Components addExample(String key, Example example) {
+        examples.put(key, example);
         return this;
     }
 
     @Override
-    public Components addExample(String key, Example example) {
-        examples.put(key, example);
-        return this;
+    public void removeExample(String key) {
+        examples.remove(key);
     }
 
     @Override
@@ -175,15 +171,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components requestBodies(Map<String, RequestBody> requestBodies) {
-        setRequestBodies(requestBodies);
+    public Components addRequestBody(String key, RequestBody requestBody) {
+        requestBodies.put(key, requestBody);
         return this;
     }
 
     @Override
-    public Components addRequestBody(String key, RequestBody requestBody) {
-        requestBodies.put(key, requestBody);
-        return this;
+    public void removeRequestBody(String key) {
+        requestBodies.remove(key);
     }
 
     @Override
@@ -197,15 +192,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components headers(Map<String, Header> headers) {
-        setHeaders(headers);
+    public Components addHeader(String key, Header header) {
+        headers.put(key, header);
         return this;
     }
 
     @Override
-    public Components addHeader(String key, Header header) {
-        headers.put(key, header);
-        return this;
+    public void removeHeader(String key) {
+        headers.remove(key);
     }
 
     @Override
@@ -219,15 +213,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components securitySchemes(Map<String, SecurityScheme> securitySchemes) {
-        setSecuritySchemes(securitySchemes);
+    public Components addSecurityScheme(String key, SecurityScheme securityScheme) {
+        securitySchemes.put(key, securityScheme);
         return this;
     }
 
     @Override
-    public Components addSecurityScheme(String key, SecurityScheme securityScheme) {
-        securitySchemes.put(key, securityScheme);
-        return this;
+    public void removeSecurityScheme(String key) {
+        securitySchemes.remove(key);
     }
 
     @Override
@@ -241,15 +234,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components links(Map<String, Link> links) {
-        setLinks(links);
+    public Components addLink(String key, Link link) {
+        links.put(key, link);
         return this;
     }
 
     @Override
-    public Components addLink(String key, Link link) {
-        links.put(key, link);
-        return this;
+    public void removeLink(String key) {
+        links.remove(key);
     }
 
     @Override
@@ -263,15 +255,14 @@ public class ComponentsImpl extends ExtensibleImpl implements Components {
     }
 
     @Override
-    public Components callbacks(Map<String, Callback> callbacks) {
-        setCallbacks(callbacks);
+    public Components addCallback(String key, Callback callback) {
+        callbacks.put(key, callback);
         return this;
     }
 
     @Override
-    public Components addCallback(String key, Callback callback) {
-        callbacks.put(key, callback);
-        return this;
+    public void removeCallback(String key) {
+        callbacks.remove(key);
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.Components from, Components to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.models.Extensible;
 
-public abstract class ExtensibleImpl implements Extensible {
+public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensible<T> {
 
     protected Map<String, Object> extensions = new HashMap<>();
 
@@ -58,9 +58,16 @@ public abstract class ExtensibleImpl implements Extensible {
         return extensions;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public void addExtension(String name, Object value) {
+    public T addExtension(String name, Object value) {
         extensions.put(name, value);
+        return (T) this;
+    }
+
+    @Override
+    public void removeExtension(String name) {
+        extensions.remove(name);
     }
 
     @Override
@@ -68,7 +75,7 @@ public abstract class ExtensibleImpl implements Extensible {
         this.extensions = extensions;
     }
 
-    public static void merge(Extension from, Extensible to, boolean override) {
+    public static void merge(Extension from, Extensible<?> to, boolean override) {
         if (isAnnotationNull(from)) {
             return;
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -51,17 +51,15 @@ import java.util.logging.Logger;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.models.Extensible;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensible<T> {
 
     private static final Logger LOGGER = Logger.getLogger(ExtensibleImpl.class.getName());
-    
+
     protected Map<String, Object> extensions = new LinkedHashMap<>();
 
-    @JsonAnyGetter
     @Override
     public Map<String, Object> getExtensions() {
         return extensions;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -46,6 +46,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Logger;
 
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
@@ -71,19 +72,26 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
     @Override
     public T addExtension(String name, Object value) {
         if (value != null) {
-            extensions.put(name, value);
+            extensions.put(extensionName(name), value);
         }
         return (T) this;
     }
 
     @Override
     public void removeExtension(String name) {
-        extensions.remove(name);
+        extensions.remove(extensionName(name));
     }
 
     @Override
     public void setExtensions(Map<String, Object> extensions) {
-        this.extensions = extensions;
+        this.extensions.clear();
+        for (Entry<String, Object> entry : extensions.entrySet()) {
+            this.extensions.put(extensionName(entry.getKey()), entry.getValue());
+        }
+    }
+
+    public static String extensionName(String name) {
+        return name.startsWith("x-") ? name : "x-" + name;
     }
 
     public static void merge(Extension from, Extensible<?> to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -51,6 +51,7 @@ import java.util.logging.Logger;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.models.Extensible;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -58,6 +59,7 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
 
     private static final Logger LOGGER = Logger.getLogger(ExtensibleImpl.class.getName());
 
+    @JsonIgnore
     protected Map<String, Object> extensions = new LinkedHashMap<>();
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -42,24 +42,20 @@ package fish.payara.microprofile.openapi.impl.model;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.isAnnotationNull;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import javax.json.Json;
 
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.models.Extensible;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensible<T> {
 
-    protected Map<String, Object> extensions = new HashMap<>();
+    protected Map<String, Object> extensions = new LinkedHashMap<>();
 
+    @JsonAnyGetter
     @Override
     public Map<String, Object> getExtensions() {
         return extensions;
@@ -68,7 +64,9 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
     @SuppressWarnings("unchecked")
     @Override
     public T addExtension(String name, Object value) {
-        extensions.put(name, value);
+        if (value != null) {
+            extensions.put(name, value);
+        }
         return (T) this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleLinkedHashMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleLinkedHashMap.java
@@ -1,0 +1,43 @@
+package fish.payara.microprofile.openapi.impl.model;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.models.Extensible;
+
+public abstract class ExtensibleLinkedHashMap<K, V, T extends Extensible<T>> extends LinkedHashMap<K, V>
+implements Extensible<T> {
+
+    protected Map<String, Object> extensions = new HashMap<>();
+
+    protected ExtensibleLinkedHashMap() {
+        super();
+    }
+
+    protected ExtensibleLinkedHashMap(Map<? extends K, ? extends V> items) {
+        super(items);
+    }
+
+    @Override
+    public final Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    @Override
+    public final void setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public final T addExtension(String name, Object value) {
+        this.extensions.put(name, value);
+        return (T) this;
+    }
+
+    @Override
+    public final void removeExtension(String name) {
+        this.extensions.remove(name);
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
@@ -6,9 +6,12 @@ import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.models.Extensible;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends TreeMap<String, V>
         implements Extensible<T> {
 
+    @JsonIgnore
     protected Map<String, Object> extensions = new LinkedHashMap<>();
 
     protected ExtensibleTreeMap() {
@@ -32,7 +35,7 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
     @SuppressWarnings("unchecked")
     @Override
     public final T addExtension(String name, Object value) {
-        if (value != null) {
+        if (value != null && name.startsWith("x-")) {
             this.extensions.put(name, value);
         }
         return (T) this;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
@@ -1,13 +1,24 @@
 package fish.payara.microprofile.openapi.impl.model;
 
+import static fish.payara.microprofile.openapi.impl.model.ExtensibleImpl.extensionName;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.Map.Entry;
 
 import org.eclipse.microprofile.openapi.models.Extensible;
+import org.eclipse.microprofile.openapi.models.Reference;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+@JsonSerialize(using = ExtensibleTreeMap.ExtensibleTreeMapSerializer.class)
 public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends TreeMap<String, V>
         implements Extensible<T> {
 
@@ -29,20 +40,61 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
 
     @Override
     public final void setExtensions(Map<String, Object> extensions) {
-        this.extensions = extensions;
+        this.extensions.clear();
+        for (Entry<String, Object> entry : extensions.entrySet()) {
+            this.extensions.put(extensionName(entry.getKey()), entry.getValue());
+        }
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public final T addExtension(String name, Object value) {
-        if (value != null && name.startsWith("x-")) {
-            this.extensions.put(name, value);
+        if (value != null) {
+            this.extensions.put(extensionName(name), value);
         }
         return (T) this;
     }
 
     @Override
     public final void removeExtension(String name) {
-        this.extensions.remove(name);
+        this.extensions.remove(extensionName(name));
+    }
+
+    /**
+     * Custom {@link JsonSerializer} that adds both the extended {@link TreeMap} entries as well as the
+     * {@link ExtensibleTreeMap#extensions} map to the output object unless the value represents a {@link Reference} in
+     * which case only the {@link Reference#getRef()} is added.
+     */
+    static class ExtensibleTreeMapSerializer extends JsonSerializer<ExtensibleTreeMap<?,?>> {
+
+        @Override
+        public void serialize(ExtensibleTreeMap<?,?> value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            if (value instanceof Reference) {
+                Reference<?> reference = (Reference<?>) value;
+                String ref = reference.getRef();
+                if (ref != null) {
+                    gen.writeStartObject(value);
+                    gen.writeFieldName("$ref");
+                    gen.writeString(ref);
+                    gen.writeEndObject();
+                    return; // if this is a ref no extensions or map entries are relevant
+                }
+            }
+            gen.writeStartObject(value);
+            ParameterizedType mapType = (ParameterizedType) value.getClass().getGenericSuperclass();
+            Class<?> valueType = (Class<?>) mapType.getActualTypeArguments()[0];
+            JsonSerializer<Object> valueSerializer = serializers.findValueSerializer(valueType);
+            for (Map.Entry<String,?> entry : value.entrySet()) {
+                gen.writeFieldName(entry.getKey());
+                valueSerializer.serialize(entry.getValue(), gen, serializers);
+            }
+            for (Map.Entry<String, Object> extension : value.getExtensions().entrySet()) {
+                gen.writeFieldName(extension.getKey());
+                Object extensionValue = extension.getValue();
+                serializers.findValueSerializer(extensionValue.getClass()).serialize(extensionValue, gen, serializers);
+            }
+            gen.writeEndObject();
+        }
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
@@ -6,8 +6,6 @@ import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.models.Extensible;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-
 public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends TreeMap<String, V>
         implements Extensible<T> {
 
@@ -21,7 +19,6 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
         super(items);
     }
 
-    @JsonAnyGetter
     @Override
     public final Map<String, Object> getExtensions() {
         return extensions;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
@@ -1,15 +1,17 @@
 package fish.payara.microprofile.openapi.impl.model;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.models.Extensible;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+
 public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends TreeMap<String, V>
         implements Extensible<T> {
 
-    protected Map<String, Object> extensions = new HashMap<>();
+    protected Map<String, Object> extensions = new LinkedHashMap<>();
 
     protected ExtensibleTreeMap() {
         super();
@@ -19,6 +21,7 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
         super(items);
     }
 
+    @JsonAnyGetter
     @Override
     public final Map<String, Object> getExtensions() {
         return extensions;
@@ -32,7 +35,9 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
     @SuppressWarnings("unchecked")
     @Override
     public final T addExtension(String name, Object value) {
-        this.extensions.put(name, value);
+        if (value != null) {
+            this.extensions.put(name, value);
+        }
         return (T) this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
@@ -1,21 +1,21 @@
 package fish.payara.microprofile.openapi.impl.model;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.models.Extensible;
 
-public abstract class ExtensibleLinkedHashMap<K, V, T extends Extensible<T>> extends LinkedHashMap<K, V>
-implements Extensible<T> {
+public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends TreeMap<String, V>
+        implements Extensible<T> {
 
     protected Map<String, Object> extensions = new HashMap<>();
 
-    protected ExtensibleLinkedHashMap() {
+    protected ExtensibleTreeMap() {
         super();
     }
 
-    protected ExtensibleLinkedHashMap(Map<? extends K, ? extends V> items) {
+    protected ExtensibleTreeMap(Map<String, ? extends V> items) {
         super(items);
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExternalDocumentationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExternalDocumentationImpl.java
@@ -44,7 +44,7 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeP
 
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 
-public class ExternalDocumentationImpl extends ExtensibleImpl implements ExternalDocumentation {
+public class ExternalDocumentationImpl extends ExtensibleImpl<ExternalDocumentation> implements ExternalDocumentation {
 
     protected String description;
     protected String url;
@@ -60,12 +60,6 @@ public class ExternalDocumentationImpl extends ExtensibleImpl implements Externa
     }
 
     @Override
-    public ExternalDocumentation description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public String getUrl() {
         return url;
     }
@@ -73,12 +67,6 @@ public class ExternalDocumentationImpl extends ExtensibleImpl implements Externa
     @Override
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    @Override
-    public ExternalDocumentation url(String url) {
-        setUrl(url);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.ExternalDocumentation from, ExternalDocumentation to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -61,7 +61,7 @@ import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 
-public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
+public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
 
     protected String openapi;
     protected Info info;
@@ -83,12 +83,6 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     }
 
     @Override
-    public OpenAPI openapi(String openapi) {
-        setOpenapi(openapi);
-        return this;
-    }
-
-    @Override
     public Info getInfo() {
         return info;
     }
@@ -96,12 +90,6 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     @Override
     public void setInfo(Info info) {
         this.info = info;
-    }
-
-    @Override
-    public OpenAPI info(Info info) {
-        setInfo(info);
-        return this;
     }
 
     @Override
@@ -115,12 +103,6 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     }
 
     @Override
-    public OpenAPI externalDocs(ExternalDocumentation externalDocs) {
-        setExternalDocs(externalDocs);
-        return this;
-    }
-
-    @Override
     public List<Server> getServers() {
         return servers;
     }
@@ -128,12 +110,6 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     @Override
     public void setServers(List<Server> servers) {
         this.servers = servers;
-    }
-
-    @Override
-    public OpenAPI servers(List<Server> servers) {
-        setServers(servers);
-        return this;
     }
 
     @Override
@@ -154,6 +130,11 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     }
 
     @Override
+    public void removeServer(Server server) {
+        servers.remove(server);
+    }
+
+    @Override
     public List<SecurityRequirement> getSecurity() {
         return security;
     }
@@ -164,15 +145,14 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     }
 
     @Override
-    public OpenAPI security(List<SecurityRequirement> security) {
-        setSecurity(security);
+    public OpenAPI addSecurityRequirement(SecurityRequirement securityRequirement) {
+        security.add(securityRequirement);
         return this;
     }
 
     @Override
-    public OpenAPI addSecurityRequirement(SecurityRequirement securityRequirement) {
-        security.add(securityRequirement);
-        return this;
+    public void removeSecurityRequirement(SecurityRequirement securityRequirement) {
+        security.remove(securityRequirement);
     }
 
     @Override
@@ -186,15 +166,14 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     }
 
     @Override
-    public OpenAPI tags(List<Tag> tags) {
-        setTags(tags);
+    public OpenAPI addTag(Tag tag) {
+        tags.add(tag);
         return this;
     }
 
     @Override
-    public OpenAPI addTag(Tag tag) {
-        tags.add(tag);
-        return this;
+    public void removeTag(Tag tag) {
+        tags.remove(tag);
     }
 
     @Override
@@ -205,12 +184,6 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     @Override
     public void setPaths(Paths paths) {
         this.paths = paths;
-    }
-
-    @Override
-    public OpenAPI paths(Paths paths) {
-        setPaths(paths);
-        return this;
     }
 
     @Override
@@ -227,12 +200,6 @@ public class OpenAPIImpl extends ExtensibleImpl implements OpenAPI {
     @Override
     public void setComponents(Components components) {
         this.components = components;
-    }
-
-    @Override
-    public OpenAPI components(Components components) {
-        setComponents(components);
-        return this;
     }
 
     public static void merge(OpenAPIDefinition from, OpenAPI to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -152,7 +152,9 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
 
     @Override
     public Operation addParameter(Parameter parameter) {
-        parameters.add(parameter);
+        if (parameter != null) {
+            parameters.add(parameter);
+        }
         return this;
     }
 
@@ -193,7 +195,9 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
 
     @Override
     public Operation addCallback(String key, Callback callback) {
-        this.callbacks.put(key, callback);
+        if (callback != null) {
+            this.callbacks.put(key, callback);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -64,7 +64,7 @@ import fish.payara.microprofile.openapi.impl.model.parameters.ParameterImpl;
 import fish.payara.microprofile.openapi.impl.model.parameters.RequestBodyImpl;
 import fish.payara.microprofile.openapi.impl.model.responses.APIResponsesImpl;
 
-public class OperationImpl extends ExtensibleImpl implements Operation {
+public class OperationImpl extends ExtensibleImpl<Operation> implements Operation {
 
     protected List<String> tags = new ArrayList<>();
     protected String summary;
@@ -90,15 +90,14 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation tags(List<String> tags) {
-        setTags(tags);
+    public Operation addTag(String tag) {
+        tags.add(tag);
         return this;
     }
 
     @Override
-    public Operation addTag(String tag) {
-        tags.add(tag);
-        return this;
+    public void removeTag(String tag) {
+        tags.remove(tag);
     }
 
     @Override
@@ -112,12 +111,6 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation summary(String summary) {
-        setSummary(summary);
-        return this;
-    }
-
-    @Override
     public String getDescription() {
         return description;
     }
@@ -125,12 +118,6 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     @Override
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    @Override
-    public Operation description(String description) {
-        setDescription(description);
-        return this;
     }
 
     @Override
@@ -144,12 +131,6 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation externalDocs(ExternalDocumentation externalDocs) {
-        setExternalDocs(externalDocs);
-        return this;
-    }
-
-    @Override
     public String getOperationId() {
         return operationId;
     }
@@ -157,12 +138,6 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     @Override
     public void setOperationId(String operationId) {
         this.operationId = operationId;
-    }
-
-    @Override
-    public Operation operationId(String operationId) {
-        setOperationId(operationId);
-        return this;
     }
 
     @Override
@@ -176,15 +151,14 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation parameters(List<Parameter> parameters) {
-        setParameters(parameters);
+    public Operation addParameter(Parameter parameter) {
+        parameters.add(parameter);
         return this;
     }
 
     @Override
-    public Operation addParameter(Parameter parameter) {
-        parameters.add(parameter);
-        return this;
+    public void removeParameter(Parameter parameter) {
+        parameters.remove(parameter);
     }
 
     @Override
@@ -198,12 +172,6 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation requestBody(RequestBody requestBody) {
-        setRequestBody(requestBody);
-        return this;
-    }
-
-    @Override
     public APIResponses getResponses() {
         return responses;
     }
@@ -211,12 +179,6 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     @Override
     public void setResponses(APIResponses responses) {
         this.responses = responses;
-    }
-
-    @Override
-    public Operation responses(APIResponses responses) {
-        setResponses(responses);
-        return this;
     }
 
     @Override
@@ -230,9 +192,14 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation callbacks(Map<String, Callback> callbacks) {
-        setCallbacks(callbacks);
+    public Operation addCallback(String key, Callback callback) {
+        this.callbacks.put(key, callback);
         return this;
+    }
+
+    @Override
+    public void removeCallback(String key) {
+        this.callbacks.remove(key);
     }
 
     @Override
@@ -262,15 +229,14 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation security(List<SecurityRequirement> security) {
-        setSecurity(security);
+    public Operation addSecurityRequirement(SecurityRequirement securityReq) {
+        security.add(securityReq);
         return this;
     }
 
     @Override
-    public Operation addSecurityRequirement(SecurityRequirement securityReq) {
-        security.add(securityReq);
-        return this;
+    public void removeSecurityRequirement(SecurityRequirement securityRequirement) {
+        security.remove(securityRequirement);
     }
 
     @Override
@@ -284,15 +250,14 @@ public class OperationImpl extends ExtensibleImpl implements Operation {
     }
 
     @Override
-    public Operation servers(List<Server> servers) {
-        setServers(servers);
+    public Operation addServer(Server server) {
+        servers.add(server);
         return this;
     }
 
     @Override
-    public Operation addServer(Server server) {
-        servers.add(server);
-        return this;
+    public void removeServer(Server server) {
+        servers.remove(server);
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.Operation from, Operation to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -50,8 +50,6 @@ import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.servers.Server;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
 
     protected String ref;
@@ -178,7 +176,6 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
         this.trace = trace;
     }
 
-    @JsonIgnore
     @Override
     public Map<HttpMethod, Operation> getOperations() {
         return readOperationsMap();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -178,16 +178,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
 
     @Override
     public Map<HttpMethod, Operation> getOperations() {
-        EnumMap<HttpMethod, Operation> operations = new EnumMap<>(HttpMethod.class);
-        operations.put(HttpMethod.DELETE, delete);
-        operations.put(HttpMethod.GET, get);
-        operations.put(HttpMethod.HEAD, head);
-        operations.put(HttpMethod.OPTIONS, options);
-        operations.put(HttpMethod.PATCH, patch);
-        operations.put(HttpMethod.POST, post);
-        operations.put(HttpMethod.PUT, put);
-        operations.put(HttpMethod.TRACE, trace);
-        return operations;
+        return readOperationsMap();
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -256,7 +256,9 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
 
     @Override
     public PathItem addServer(Server server) {
-        servers.add(server);
+        if (server != null) {
+            servers.add(server);
+        }
         return this;
     }
 
@@ -277,7 +279,9 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
 
     @Override
     public PathItem addParameter(Parameter parameter) {
-        parameters.add(parameter);
+        if (parameter != null) {
+            parameters.add(parameter);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -50,6 +50,8 @@ import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.servers.Server;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
 
     protected String ref;
@@ -176,6 +178,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
         this.trace = trace;
     }
 
+    @JsonIgnore
     @Override
     public Map<HttpMethod, Operation> getOperations() {
         return readOperationsMap();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -50,7 +50,7 @@ import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.servers.Server;
 
-public class PathItemImpl extends ExtensibleImpl implements PathItem {
+public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
 
     protected String ref;
     protected String summary;
@@ -77,12 +77,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem ref(String ref) {
-        setRef(ref);
-        return this;
-    }
-
-    @Override
     public String getSummary() {
         return summary;
     }
@@ -90,12 +84,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     @Override
     public void setSummary(String summary) {
         this.summary = summary;
-    }
-
-    @Override
-    public PathItem summary(String summary) {
-        setSummary(summary);
-        return this;
     }
 
     @Override
@@ -109,12 +97,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public Operation getGET() {
         return get;
     }
@@ -122,12 +104,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     @Override
     public void setGET(Operation get) {
         this.get = get;
-    }
-
-    @Override
-    public PathItem GET(Operation get) {
-        setGET(get);
-        return this;
     }
 
     @Override
@@ -141,12 +117,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem PUT(Operation put) {
-        setPUT(put);
-        return this;
-    }
-
-    @Override
     public Operation getPOST() {
         return post;
     }
@@ -154,12 +124,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     @Override
     public void setPOST(Operation post) {
         this.post = post;
-    }
-
-    @Override
-    public PathItem POST(Operation post) {
-        setPOST(post);
-        return this;
     }
 
     @Override
@@ -173,12 +137,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem DELETE(Operation delete) {
-        setDELETE(delete);
-        return this;
-    }
-
-    @Override
     public Operation getOPTIONS() {
         return options;
     }
@@ -186,12 +144,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     @Override
     public void setOPTIONS(Operation options) {
         this.options = options;
-    }
-
-    @Override
-    public PathItem OPTIONS(Operation options) {
-        setOPTIONS(options);
-        return this;
     }
 
     @Override
@@ -205,12 +157,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem HEAD(Operation head) {
-        setHEAD(head);
-        return this;
-    }
-
-    @Override
     public Operation getPATCH() {
         return patch;
     }
@@ -218,12 +164,6 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     @Override
     public void setPATCH(Operation patch) {
         this.patch = patch;
-    }
-
-    @Override
-    public PathItem PATCH(Operation patch) {
-        setPATCH(patch);
-        return this;
     }
 
     @Override
@@ -237,9 +177,17 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem TRACE(Operation trace) {
-        setTRACE(trace);
-        return this;
+    public Map<HttpMethod, Operation> getOperations() {
+        EnumMap<HttpMethod, Operation> operations = new EnumMap<>(HttpMethod.class);
+        operations.put(HttpMethod.DELETE, delete);
+        operations.put(HttpMethod.GET, get);
+        operations.put(HttpMethod.HEAD, head);
+        operations.put(HttpMethod.OPTIONS, options);
+        operations.put(HttpMethod.PATCH, patch);
+        operations.put(HttpMethod.POST, post);
+        operations.put(HttpMethod.PUT, put);
+        operations.put(HttpMethod.TRACE, trace);
+        return operations;
     }
 
     @Override
@@ -316,15 +264,14 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem servers(List<Server> servers) {
-        setServers(servers);
+    public PathItem addServer(Server server) {
+        servers.add(server);
         return this;
     }
 
     @Override
-    public PathItem addServer(Server server) {
-        servers.add(server);
-        return this;
+    public void removeServer(Server server) {
+        servers.remove(server);
     }
 
     @Override
@@ -338,15 +285,14 @@ public class PathItemImpl extends ExtensibleImpl implements PathItem {
     }
 
     @Override
-    public PathItem parameters(List<Parameter> parameters) {
-        setParameters(parameters);
+    public PathItem addParameter(Parameter parameter) {
+        parameters.add(parameter);
         return this;
     }
 
     @Override
-    public PathItem addParameter(Parameter parameter) {
-        parameters.add(parameter);
-        return this;
+    public void removeParameter(Parameter parameter) {
+        parameters.remove(parameter);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
@@ -60,7 +60,9 @@ public class PathsImpl extends ExtensibleTreeMap<PathItem, Paths> implements Pat
 
     @Override
     public Paths addPathItem(String name, PathItem item) {
-        put(name, item);
+        if (item != null) {
+            put(name, item);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
@@ -39,40 +39,45 @@
  */
 package fish.payara.microprofile.openapi.impl.model;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.Paths;
 
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 
-public class PathsImpl extends TreeMap<String, PathItem> implements Paths {
+public class PathsImpl extends ExtensibleLinkedHashMap<String, PathItem, Paths> implements Paths {
 
     private static final long serialVersionUID = -3876996963579977405L;
 
-    protected Map<String, Object> extensions = new HashMap<>();
+    public PathsImpl() {
+        super();
+    }
+
+    public PathsImpl(Map<? extends String, ? extends PathItem> items) {
+        super(items);
+    }
 
     @Override
     public Paths addPathItem(String name, PathItem item) {
-        super.put(name, item);
+        put(name, item);
         return this;
     }
 
     @Override
-    public Map<String, Object> getExtensions() {
-        return extensions;
+    public void removePathItem(String name) {
+        remove(name);
     }
 
     @Override
-    public void addExtension(String name, Object value) {
-        extensions.put(name, value);
+    public Map<String, PathItem> getPathItems() {
+        return new PathsImpl(this);
     }
 
     @Override
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions = extensions;
+    public void setPathItems(Map<String, PathItem> items) {
+        clear();
+        putAll(items);
     }
 
     public static void merge(Paths from, Paths to, boolean override) {
@@ -80,10 +85,10 @@ public class PathsImpl extends TreeMap<String, PathItem> implements Paths {
             return;
         }
         from.entrySet().forEach(entry -> {
-            if (!to.containsKey(entry.getKey())) {
+            if (!to.hasPathItem(entry.getKey())) {
                 to.addPathItem(entry.getKey(), entry.getValue());
             } else {
-                ModelUtils.merge(entry.getValue(), to.get(entry.getKey()), override);
+                ModelUtils.merge(entry.getValue(), to.getPathItem(entry.getKey()), override);
             }
         });
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.openapi.models.Paths;
 
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 
-public class PathsImpl extends ExtensibleLinkedHashMap<String, PathItem, Paths> implements Paths {
+public class PathsImpl extends ExtensibleTreeMap<PathItem, Paths> implements Paths {
 
     private static final long serialVersionUID = -3876996963579977405L;
 
@@ -54,7 +54,7 @@ public class PathsImpl extends ExtensibleLinkedHashMap<String, PathItem, Paths> 
         super();
     }
 
-    public PathsImpl(Map<? extends String, ? extends PathItem> items) {
+    public PathsImpl(Map<String, ? extends PathItem> items) {
         super(items);
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/callbacks/CallbackImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/callbacks/CallbackImpl.java
@@ -53,11 +53,11 @@ import org.eclipse.microprofile.openapi.models.PathItem.HttpMethod;
 import org.eclipse.microprofile.openapi.models.callbacks.Callback;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 
-import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+import fish.payara.microprofile.openapi.impl.model.ExtensibleTreeMap;
 import fish.payara.microprofile.openapi.impl.model.OperationImpl;
 import fish.payara.microprofile.openapi.impl.model.PathItemImpl;
 
-public class CallbackImpl extends ExtensibleLinkedHashMap<String, PathItem, Callback> implements Callback {
+public class CallbackImpl extends ExtensibleTreeMap<PathItem, Callback> implements Callback {
 
     private static final long serialVersionUID = 5549098533131353142L;
 
@@ -67,7 +67,7 @@ public class CallbackImpl extends ExtensibleLinkedHashMap<String, PathItem, Call
         super();
     }
 
-    public CallbackImpl(Map<? extends String, ? extends PathItem> items) {
+    public CallbackImpl(Map<String, ? extends PathItem> items) {
         super(items);
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/callbacks/CallbackImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/callbacks/CallbackImpl.java
@@ -44,8 +44,6 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.getHtt
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.getOrCreateOperation;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.isAnnotationNull;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.annotations.callbacks.CallbackOperation;
@@ -55,20 +53,44 @@ import org.eclipse.microprofile.openapi.models.PathItem.HttpMethod;
 import org.eclipse.microprofile.openapi.models.callbacks.Callback;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 
+import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
 import fish.payara.microprofile.openapi.impl.model.OperationImpl;
 import fish.payara.microprofile.openapi.impl.model.PathItemImpl;
 
-public class CallbackImpl extends LinkedHashMap<String, PathItem> implements Callback {
+public class CallbackImpl extends ExtensibleLinkedHashMap<String, PathItem, Callback> implements Callback {
 
     private static final long serialVersionUID = 5549098533131353142L;
 
     protected String ref;
-    protected Map<String, Object> extensions = new HashMap<>();
+
+    public CallbackImpl() {
+        super();
+    }
+
+    public CallbackImpl(Map<? extends String, ? extends PathItem> items) {
+        super(items);
+    }
 
     @Override
     public Callback addPathItem(String name, PathItem item) {
         this.put(name, item);
         return this;
+    }
+
+    @Override
+    public void removePathItem(String name) {
+        remove(name);
+    }
+
+    @Override
+    public Map<String, PathItem> getPathItems() {
+        return new CallbackImpl(this);
+    }
+
+    @Override
+    public void setPathItems(Map<String, PathItem> items) {
+        clear();
+        putAll(items);
     }
 
     @Override
@@ -84,27 +106,6 @@ public class CallbackImpl extends LinkedHashMap<String, PathItem> implements Cal
         this.ref = ref;
     }
 
-    @Override
-    public Callback ref(String ref) {
-        setRef(ref);
-        return this;
-    }
-
-    @Override
-    public Map<String, Object> getExtensions() {
-        return extensions;
-    }
-
-    @Override
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions = extensions;
-    }
-
-    @Override
-    public void addExtension(String name, Object value) {
-        this.extensions.put(name, value);
-    }
-
     public static void merge(org.eclipse.microprofile.openapi.annotations.callbacks.Callback from, Callback to,
             boolean override, Map<String, Schema> currentSchemas) {
         if (isAnnotationNull(from)) {
@@ -116,7 +117,7 @@ public class CallbackImpl extends LinkedHashMap<String, PathItem> implements Cal
         }
         if (!from.callbackUrlExpression().isEmpty()) {
             PathItem pathItem = to.getOrDefault(from.callbackUrlExpression(), new PathItemImpl());
-            to.put(from.callbackUrlExpression(), pathItem);
+            to.addPathItem(from.callbackUrlExpression(), pathItem);
             if (from.operations() != null) {
                 for (CallbackOperation callbackOperation : from.operations()) {
                     applyCallbackOperationAnnotation(pathItem, callbackOperation, override, currentSchemas);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/callbacks/CallbackImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/callbacks/CallbackImpl.java
@@ -73,7 +73,9 @@ public class CallbackImpl extends ExtensibleTreeMap<PathItem, Callback> implemen
 
     @Override
     public Callback addPathItem(String name, PathItem item) {
-        this.put(name, item);
+        if (item != null) {
+            this.put(name, item);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/examples/ExampleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/examples/ExampleImpl.java
@@ -50,7 +50,7 @@ import org.eclipse.microprofile.openapi.models.examples.Example;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class ExampleImpl extends ExtensibleImpl implements Example {
+public class ExampleImpl extends ExtensibleImpl<Example> implements Example {
 
     protected String summary;
     protected String description;
@@ -69,12 +69,6 @@ public class ExampleImpl extends ExtensibleImpl implements Example {
     }
 
     @Override
-    public Example summary(String summary) {
-        setSummary(summary);
-        return this;
-    }
-
-    @Override
     public String getDescription() {
         return description;
     }
@@ -82,12 +76,6 @@ public class ExampleImpl extends ExtensibleImpl implements Example {
     @Override
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    @Override
-    public Example description(String description) {
-        setDescription(description);
-        return this;
     }
 
     @Override
@@ -101,12 +89,6 @@ public class ExampleImpl extends ExtensibleImpl implements Example {
     }
 
     @Override
-    public Example value(Object value) {
-        setValue(value);
-        return this;
-    }
-
-    @Override
     public String getExternalValue() {
         return externalValue;
     }
@@ -114,12 +96,6 @@ public class ExampleImpl extends ExtensibleImpl implements Example {
     @Override
     public void setExternalValue(String externalValue) {
         this.externalValue = externalValue;
-    }
-
-    @Override
-    public Example externalValue(String externalValue) {
-        setExternalValue(externalValue);
-        return this;
     }
 
     @Override
@@ -133,12 +109,6 @@ public class ExampleImpl extends ExtensibleImpl implements Example {
             ref = "#/components/examples/" + ref;
         }
         this.ref = ref;
-    }
-
-    @Override
-    public Example ref(String ref) {
-        setRef(ref);
-        return this;
     }
 
     public static void merge(ExampleObject from, Example to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
@@ -164,7 +164,9 @@ public class HeaderImpl extends ExtensibleImpl<Header> implements Header {
 
     @Override
     public Header addExample(String key, Example examplesItem) {
-        this.examples.put(key, examplesItem);
+        if (examplesItem != null) {
+            this.examples.put(key, examplesItem);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
@@ -55,7 +55,7 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 
-public class HeaderImpl extends ExtensibleImpl implements Header {
+public class HeaderImpl extends ExtensibleImpl<Header> implements Header {
 
     protected String ref;
     protected String description;
@@ -83,12 +83,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     }
 
     @Override
-    public Header ref(String ref) {
-        setRef(ref);
-        return this;
-    }
-
-    @Override
     public String getDescription() {
         return description;
     }
@@ -96,12 +90,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     @Override
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    @Override
-    public Header description(String description) {
-        setDescription(description);
-        return this;
     }
 
     @Override
@@ -115,12 +103,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     }
 
     @Override
-    public Header required(Boolean required) {
-        setRequired(required);
-        return this;
-    }
-
-    @Override
     public Boolean getDeprecated() {
         return deprecated;
     }
@@ -128,12 +110,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     @Override
     public void setDeprecated(Boolean deprecated) {
         this.deprecated = deprecated;
-    }
-
-    @Override
-    public Header deprecated(Boolean deprecated) {
-        setDeprecated(deprecated);
-        return this;
     }
 
     @Override
@@ -147,12 +123,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     }
 
     @Override
-    public Header allowEmptyValue(Boolean allowEmptyValue) {
-        setAllowEmptyValue(allowEmptyValue);
-        return this;
-    }
-
-    @Override
     public Style getStyle() {
         return style;
     }
@@ -160,12 +130,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     @Override
     public void setStyle(Style style) {
         this.style = style;
-    }
-
-    @Override
-    public Header style(Style style) {
-        setStyle(style);
-        return this;
     }
 
     @Override
@@ -179,12 +143,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     }
 
     @Override
-    public Header explode(Boolean explode) {
-        setExplode(explode);
-        return this;
-    }
-
-    @Override
     public Schema getSchema() {
         return schema;
     }
@@ -192,12 +150,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     @Override
     public void setSchema(Schema schema) {
         this.schema = schema;
-    }
-
-    @Override
-    public Header schema(Schema schema) {
-        setSchema(schema);
-        return this;
     }
 
     @Override
@@ -211,15 +163,14 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     }
 
     @Override
-    public Header examples(Map<String, Example> examples) {
-        setExamples(examples);
+    public Header addExample(String key, Example examplesItem) {
+        this.examples.put(key, examplesItem);
         return this;
     }
 
     @Override
-    public Header addExample(String key, Example examplesItem) {
-        this.examples.put(key, examplesItem);
-        return this;
+    public void removeExample(String key) {
+        this.examples.remove(key);
     }
 
     @Override
@@ -233,12 +184,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     }
 
     @Override
-    public Header example(Object example) {
-        setExample(example);
-        return this;
-    }
-
-    @Override
     public Content getContent() {
         return content;
     }
@@ -246,12 +191,6 @@ public class HeaderImpl extends ExtensibleImpl implements Header {
     @Override
     public void setContent(Content content) {
         this.content = content;
-    }
-
-    @Override
-    public Header content(Content content) {
-        setContent(content);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.headers.Header from, Header to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/ContactImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/ContactImpl.java
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.openapi.models.info.Contact;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class ContactImpl extends ExtensibleImpl implements Contact {
+public class ContactImpl extends ExtensibleImpl<Contact> implements Contact {
 
     protected String name;
     protected String url;
@@ -63,12 +63,6 @@ public class ContactImpl extends ExtensibleImpl implements Contact {
     }
 
     @Override
-    public Contact name(String name) {
-        setName(name);
-        return this;
-    }
-
-    @Override
     public String getUrl() {
         return url;
     }
@@ -79,12 +73,6 @@ public class ContactImpl extends ExtensibleImpl implements Contact {
     }
 
     @Override
-    public Contact url(String url) {
-        setUrl(url);
-        return this;
-    }
-
-    @Override
     public String getEmail() {
         return email;
     }
@@ -92,12 +80,6 @@ public class ContactImpl extends ExtensibleImpl implements Contact {
     @Override
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    @Override
-    public Contact email(String email) {
-        setEmail(email);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.info.Contact from, Contact to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/InfoImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/InfoImpl.java
@@ -48,7 +48,7 @@ import org.eclipse.microprofile.openapi.models.info.License;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class InfoImpl extends ExtensibleImpl implements Info {
+public class InfoImpl extends ExtensibleImpl<Info> implements Info {
 
     protected String title;
     protected String description;
@@ -68,12 +68,6 @@ public class InfoImpl extends ExtensibleImpl implements Info {
     }
 
     @Override
-    public Info title(String title) {
-        setTitle(title);
-        return this;
-    }
-
-    @Override
     public String getDescription() {
         return description;
     }
@@ -81,12 +75,6 @@ public class InfoImpl extends ExtensibleImpl implements Info {
     @Override
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    @Override
-    public Info description(String description) {
-        setDescription(description);
-        return this;
     }
 
     @Override
@@ -100,12 +88,6 @@ public class InfoImpl extends ExtensibleImpl implements Info {
     }
 
     @Override
-    public Info termsOfService(String termsOfService) {
-        setTermsOfService(termsOfService);
-        return this;
-    }
-
-    @Override
     public Contact getContact() {
         return contact;
     }
@@ -113,12 +95,6 @@ public class InfoImpl extends ExtensibleImpl implements Info {
     @Override
     public void setContact(Contact contact) {
         this.contact = contact;
-    }
-
-    @Override
-    public Info contact(Contact contact) {
-        setContact(contact);
-        return this;
     }
 
     @Override
@@ -132,12 +108,6 @@ public class InfoImpl extends ExtensibleImpl implements Info {
     }
 
     @Override
-    public Info license(License license) {
-        setLicense(license);
-        return this;
-    }
-
-    @Override
     public String getVersion() {
         return version;
     }
@@ -145,12 +115,6 @@ public class InfoImpl extends ExtensibleImpl implements Info {
     @Override
     public void setVersion(String version) {
         this.version = version;
-    }
-
-    @Override
-    public Info version(String version) {
-        setVersion(version);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.info.Info from, Info to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.openapi.models.info.License;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class LicenseImpl extends ExtensibleImpl implements License {
+public class LicenseImpl extends ExtensibleImpl<License> implements License {
 
     protected String name;
     protected String url;
@@ -62,12 +62,6 @@ public class LicenseImpl extends ExtensibleImpl implements License {
     }
 
     @Override
-    public License name(String name) {
-        setName(name);
-        return this;
-    }
-
-    @Override
     public String getUrl() {
         return url;
     }
@@ -75,12 +69,6 @@ public class LicenseImpl extends ExtensibleImpl implements License {
     @Override
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    @Override
-    public License url(String url) {
-        setUrl(url);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.info.License from, License to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
@@ -53,7 +53,7 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class LinkImpl extends ExtensibleImpl implements Link {
+public class LinkImpl extends ExtensibleImpl<Link> implements Link {
 
     protected String operationRef;
     protected String operationId;
@@ -74,12 +74,6 @@ public class LinkImpl extends ExtensibleImpl implements Link {
     }
 
     @Override
-    public Link server(Server server) {
-        setServer(server);
-        return this;
-    }
-
-    @Override
     public String getOperationRef() {
         return operationRef;
     }
@@ -87,12 +81,6 @@ public class LinkImpl extends ExtensibleImpl implements Link {
     @Override
     public void setOperationRef(String operationRef) {
         this.operationRef = operationRef;
-    }
-
-    @Override
-    public Link operationRef(String operationRef) {
-        setOperationRef(operationRef);
-        return this;
     }
 
     @Override
@@ -106,12 +94,6 @@ public class LinkImpl extends ExtensibleImpl implements Link {
     }
 
     @Override
-    public Link requestBody(Object requestBody) {
-        setRequestBody(requestBody);
-        return this;
-    }
-
-    @Override
     public String getOperationId() {
         return operationId;
     }
@@ -119,12 +101,6 @@ public class LinkImpl extends ExtensibleImpl implements Link {
     @Override
     public void setOperationId(String operationId) {
         this.operationId = operationId;
-    }
-
-    @Override
-    public Link operationId(String operationId) {
-        setOperationId(operationId);
-        return this;
     }
 
     @Override
@@ -138,15 +114,14 @@ public class LinkImpl extends ExtensibleImpl implements Link {
     }
 
     @Override
-    public Link parameters(Map<String, Object> parameters) {
-        setParameters(parameters);
+    public Link addParameter(String name, Object parameter) {
+        this.parameters.put(name, parameter);
         return this;
     }
 
     @Override
-    public Link addParameter(String name, Object parameter) {
-        this.parameters.put(name, parameter);
-        return this;
+    public void removeParameter(String name) {
+        this.parameters.remove(name);
     }
 
     @Override
@@ -160,12 +135,6 @@ public class LinkImpl extends ExtensibleImpl implements Link {
     }
 
     @Override
-    public Link description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public String getRef() {
         return ref;
     }
@@ -176,12 +145,6 @@ public class LinkImpl extends ExtensibleImpl implements Link {
             ref = "#/components/links/" + ref;
         }
         this.ref = ref;
-    }
-
-    @Override
-    public Link ref(String ref) {
-        setRef(ref);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.links.Link from, Link to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
@@ -115,7 +115,9 @@ public class LinkImpl extends ExtensibleImpl<Link> implements Link {
 
     @Override
     public Link addParameter(String name, Object parameter) {
-        this.parameters.put(name, parameter);
+        if (parameter != null) {
+            this.parameters.put(name, parameter);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -111,6 +111,9 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
         for (ExampleObject example : from.examples()) {
             ExampleImpl.merge(example, to.getMediaType(typeName).getExamples(), override);
         }
+        if (!from.example().isEmpty()) {
+            to.getMediaType(typeName).setExample(from.example());
+        }
 
         // Merge schema
         if (!isAnnotationNull(from.schema())) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -66,7 +66,9 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
 
     @Override
     public Content addMediaType(String name, MediaType item) {
-        this.put(name, item);
+        if (item != null) {
+            this.put(name, item);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -56,10 +56,34 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
 
     private static final long serialVersionUID = 1575356277308242221L;
 
+    public ContentImpl() {
+        super();
+    }
+
+    public ContentImpl(Map<? extends String, ? extends MediaType> items) {
+        super(items);
+    }
+
     @Override
     public Content addMediaType(String name, MediaType item) {
         this.put(name, item);
         return this;
+    }
+
+    @Override
+    public void removeMediaType(String name) {
+        remove(name);
+    }
+
+    @Override
+    public Map<String, MediaType> getMediaTypes() {
+        return new ContentImpl(this);
+    }
+
+    @Override
+    public void setMediaTypes(Map<String, MediaType> mediaTypes) {
+        clear();
+        putAll(mediaTypes);
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.media.Content from, Content to,
@@ -76,16 +100,16 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
 
         // Get or create the corresponding media type
         MediaType mediaType = to.getOrDefault(typeName, new MediaTypeImpl());
-        to.put(typeName, mediaType);
+        to.addMediaType(typeName, mediaType);
 
         // Merge encoding
         for (Encoding encoding : from.encoding()) {
-            EncodingImpl.merge(encoding, to.get(typeName).getEncoding(), override, currentSchemas);
+            EncodingImpl.merge(encoding, to.getMediaType(typeName).getEncoding(), override, currentSchemas);
         }
 
         // Merge examples
         for (ExampleObject example : from.examples()) {
-            ExampleImpl.merge(example, to.get(typeName).getExamples(), override);
+            ExampleImpl.merge(example, to.getMediaType(typeName).getExamples(), override);
         }
 
         // Merge schema

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/DiscriminatorImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/DiscriminatorImpl.java
@@ -71,7 +71,9 @@ public class DiscriminatorImpl implements Discriminator {
 
     @Override
     public Discriminator addMapping(String name, String value) {
-        mapping.put(name, value);
+        if (value != null) {
+            mapping.put(name, value);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/DiscriminatorImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/DiscriminatorImpl.java
@@ -60,12 +60,6 @@ public class DiscriminatorImpl implements Discriminator {
     }
 
     @Override
-    public Discriminator propertyName(String propertyName) {
-        setPropertyName(propertyName);
-        return this;
-    }
-
-    @Override
     public Map<String, String> getMapping() {
         return mapping;
     }
@@ -76,15 +70,13 @@ public class DiscriminatorImpl implements Discriminator {
     }
 
     @Override
-    public Discriminator mapping(Map<String, String> mapping) {
-        setMapping(mapping);
-        return this;
-    }
-
-    @Override
     public Discriminator addMapping(String name, String value) {
         mapping.put(name, value);
         return this;
     }
 
+    @Override
+    public void removeMapping(String name) {
+        mapping.remove(name);
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
@@ -52,7 +52,7 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.headers.HeaderImpl;
 
-public class EncodingImpl extends ExtensibleImpl implements Encoding {
+public class EncodingImpl extends ExtensibleImpl<Encoding> implements Encoding {
 
     protected String contentType;
     protected Map<String, Header> headers = new HashMap<>();
@@ -71,12 +71,6 @@ public class EncodingImpl extends ExtensibleImpl implements Encoding {
     }
 
     @Override
-    public Encoding contentType(String contentType) {
-        setContentType(contentType);
-        return this;
-    }
-
-    @Override
     public Map<String, Header> getHeaders() {
         return headers;
     }
@@ -87,9 +81,14 @@ public class EncodingImpl extends ExtensibleImpl implements Encoding {
     }
 
     @Override
-    public Encoding headers(Map<String, Header> headers) {
-        setHeaders(headers);
+    public Encoding addHeader(String key, Header header) {
+        headers.put(key, header);
         return this;
+    }
+
+    @Override
+    public void removeHeader(String key) {
+        headers.remove(key);
     }
 
     @Override
@@ -103,12 +102,6 @@ public class EncodingImpl extends ExtensibleImpl implements Encoding {
     }
 
     @Override
-    public Encoding style(Style style) {
-        setStyle(style);
-        return this;
-    }
-
-    @Override
     public Boolean getExplode() {
         return explode;
     }
@@ -119,12 +112,6 @@ public class EncodingImpl extends ExtensibleImpl implements Encoding {
     }
 
     @Override
-    public Encoding explode(Boolean explode) {
-        setExplode(explode);
-        return this;
-    }
-
-    @Override
     public Boolean getAllowReserved() {
         return allowReserved;
     }
@@ -132,12 +119,6 @@ public class EncodingImpl extends ExtensibleImpl implements Encoding {
     @Override
     public void setAllowReserved(Boolean allowReserved) {
         this.allowReserved = allowReserved;
-    }
-
-    @Override
-    public Encoding allowReserved(Boolean allowReserved) {
-        setAllowReserved(allowReserved);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.media.Encoding from, Encoding to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
@@ -82,7 +82,9 @@ public class EncodingImpl extends ExtensibleImpl<Encoding> implements Encoding {
 
     @Override
     public Encoding addHeader(String key, Header header) {
-        headers.put(key, header);
+        if (header != null) {
+            headers.put(key, header);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/MediaTypeImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/MediaTypeImpl.java
@@ -49,7 +49,7 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class MediaTypeImpl extends ExtensibleImpl implements MediaType {
+public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaType {
 
     protected Schema schema;
     protected Map<String, Example> examples = new HashMap<>();
@@ -67,12 +67,6 @@ public class MediaTypeImpl extends ExtensibleImpl implements MediaType {
     }
 
     @Override
-    public MediaType schema(Schema schema) {
-        setSchema(schema);
-        return this;
-    }
-
-    @Override
     public Map<String, Example> getExamples() {
         return examples;
     }
@@ -83,15 +77,14 @@ public class MediaTypeImpl extends ExtensibleImpl implements MediaType {
     }
 
     @Override
-    public MediaType examples(Map<String, Example> examples) {
-        setExamples(examples);
+    public MediaType addExample(String key, Example example) {
+        this.examples.put(key, example);
         return this;
     }
 
     @Override
-    public MediaType addExample(String key, Example example) {
-        this.examples.put(key, example);
-        return this;
+    public void removeExample(String key) {
+        this.examples.remove(key);
     }
 
     @Override
@@ -105,12 +98,6 @@ public class MediaTypeImpl extends ExtensibleImpl implements MediaType {
     }
 
     @Override
-    public MediaType example(Object example) {
-        setExample(example);
-        return this;
-    }
-
-    @Override
     public Map<String, Encoding> getEncoding() {
         return encoding;
     }
@@ -121,15 +108,14 @@ public class MediaTypeImpl extends ExtensibleImpl implements MediaType {
     }
 
     @Override
-    public MediaType encoding(Map<String, Encoding> encoding) {
-        setEncoding(encoding);
+    public MediaType addEncoding(String key, Encoding encodingItem) {
+        this.encoding.put(key, encodingItem);
         return this;
     }
 
     @Override
-    public MediaType addEncoding(String key, Encoding encodingItem) {
-        this.encoding.put(key, encodingItem);
-        return this;
+    public void removeEncoding(String key) {
+        this.encoding.remove(key);
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/MediaTypeImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/MediaTypeImpl.java
@@ -78,7 +78,9 @@ public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaTyp
 
     @Override
     public MediaType addExample(String key, Example example) {
-        this.examples.put(key, example);
+        if (example != null) {
+            this.examples.put(key, example);
+        }
         return this;
     }
 
@@ -109,7 +111,9 @@ public class MediaTypeImpl extends ExtensibleImpl<MediaType> implements MediaTyp
 
     @Override
     public MediaType addEncoding(String key, Encoding encodingItem) {
-        this.encoding.put(key, encodingItem);
+        if (encodingItem != null) {
+            this.encoding.put(key, encodingItem);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -148,7 +148,9 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
 
     @Override
     public Schema addEnumeration(Object enumerationItem) {
-        this.enumeration.add(enumerationItem);
+        if (enumerationItem != null) {
+            this.enumeration.add(enumerationItem);
+        }
         return this;
     }
 
@@ -341,7 +343,9 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
 
     @Override
     public Schema addProperty(String key, Schema propertiesItem) {
-        this.properties.put(key, propertiesItem);
+        if (propertiesItem != null) {
+            this.properties.put(key, propertiesItem);
+        }
         return this;
     }
 
@@ -362,12 +366,12 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
 
     @Override
     public Schema getAdditionalPropertiesSchema() {
-        return (Schema) additionalProperties;
+        return additionalProperties instanceof Schema ? (Schema) additionalProperties : null;
     }
 
     @Override
     public Boolean getAdditionalPropertiesBoolean() {
-        return (Boolean) additionalProperties;
+        return additionalProperties instanceof Boolean ? (Boolean)additionalProperties : null;
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -62,7 +62,7 @@ import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.ExternalDocumentationImpl;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 
-public class SchemaImpl extends ExtensibleImpl implements Schema {
+public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
 
     private static final Logger LOGGER = Logger.getLogger(SchemaImpl.class.getName());
 
@@ -117,12 +117,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema discriminator(Discriminator discriminator) {
-        setDiscriminator(discriminator);
-        return this;
-    }
-
-    @Override
     public String getTitle() {
         return title;
     }
@@ -133,12 +127,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema title(String title) {
-        setTitle(title);
-        return this;
-    }
-
-    @Override
     public Object getDefaultValue() {
         return defaultValue;
     }
@@ -146,12 +134,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setDefaultValue(Object defaultValue) {
         this.defaultValue = defaultValue;
-    }
-
-    @Override
-    public Schema defaultValue(Object defaultValue) {
-        setDefaultValue(defaultValue);
-        return this;
     }
 
     @Override
@@ -171,6 +153,11 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
+    public void removeEnumeration(Object enumeration) {
+        this.enumeration.remove(enumeration);
+    }
+
+    @Override
     public BigDecimal getMultipleOf() {
         return multipleOf;
     }
@@ -178,12 +165,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setMultipleOf(BigDecimal multipleOf) {
         this.multipleOf = multipleOf;
-    }
-
-    @Override
-    public Schema multipleOf(BigDecimal multipleOf) {
-        setMultipleOf(multipleOf);
-        return this;
     }
 
     @Override
@@ -197,12 +178,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema maximum(BigDecimal maximum) {
-        setMaximum(maximum);
-        return this;
-    }
-
-    @Override
     public Boolean getExclusiveMaximum() {
         return exclusiveMaximum;
     }
@@ -210,12 +185,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setExclusiveMaximum(Boolean exclusiveMaximum) {
         this.exclusiveMaximum = exclusiveMaximum;
-    }
-
-    @Override
-    public Schema exclusiveMaximum(Boolean exclusiveMaximum) {
-        setExclusiveMaximum(exclusiveMaximum);
-        return this;
     }
 
     @Override
@@ -229,12 +198,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema minimum(BigDecimal minimum) {
-        setMinimum(minimum);
-        return this;
-    }
-
-    @Override
     public Boolean getExclusiveMinimum() {
         return exclusiveMinimum;
     }
@@ -242,12 +205,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setExclusiveMinimum(Boolean exclusiveMinimum) {
         this.exclusiveMinimum = exclusiveMinimum;
-    }
-
-    @Override
-    public Schema exclusiveMinimum(Boolean exclusiveMinimum) {
-        setExclusiveMinimum(exclusiveMinimum);
-        return this;
     }
 
     @Override
@@ -261,12 +218,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema maxLength(Integer maxLength) {
-        setMaxLength(maxLength);
-        return this;
-    }
-
-    @Override
     public Integer getMinLength() {
         return minLength;
     }
@@ -274,12 +225,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setMinLength(Integer minLength) {
         this.minLength = minLength;
-    }
-
-    @Override
-    public Schema minLength(Integer minLength) {
-        setMinLength(minLength);
-        return this;
     }
 
     @Override
@@ -293,12 +238,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema pattern(String pattern) {
-        setPattern(pattern);
-        return this;
-    }
-
-    @Override
     public Integer getMaxItems() {
         return maxItems;
     }
@@ -306,12 +245,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setMaxItems(Integer maxItems) {
         this.maxItems = maxItems;
-    }
-
-    @Override
-    public Schema maxItems(Integer maxItems) {
-        setMaxItems(maxItems);
-        return this;
     }
 
     @Override
@@ -325,12 +258,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema minItems(Integer minItems) {
-        setMinItems(minItems);
-        return this;
-    }
-
-    @Override
     public Boolean getUniqueItems() {
         return uniqueItems;
     }
@@ -338,12 +265,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setUniqueItems(Boolean uniqueItems) {
         this.uniqueItems = uniqueItems;
-    }
-
-    @Override
-    public Schema uniqueItems(Boolean uniqueItems) {
-        setUniqueItems(uniqueItems);
-        return this;
     }
 
     @Override
@@ -357,12 +278,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema maxProperties(Integer maxProperties) {
-        setMaxProperties(maxProperties);
-        return this;
-    }
-
-    @Override
     public Integer getMinProperties() {
         return minProperties;
     }
@@ -370,12 +285,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setMinProperties(Integer minProperties) {
         this.minProperties = minProperties;
-    }
-
-    @Override
-    public Schema minProperties(Integer minProperties) {
-        setMinProperties(minProperties);
-        return this;
     }
 
     @Override
@@ -389,16 +298,15 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema required(List<String> required) {
-        setRequired(required);
-        return this;
-    }
-
-    @Override
     public Schema addRequired(String requiredItem) {
         this.required.add(requiredItem);
         Collections.sort(required);
         return this;
+    }
+
+    @Override
+    public void removeRequired(String required) {
+        this.required.remove(required);
     }
 
     @Override
@@ -412,12 +320,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema type(SchemaType type) {
-        setType(type);
-        return this;
-    }
-
-    @Override
     public Schema getNot() {
         return not;
     }
@@ -425,12 +327,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setNot(Schema not) {
         this.not = not;
-    }
-
-    @Override
-    public Schema not(Schema not) {
-        setNot(not);
-        return this;
     }
 
     @Override
@@ -444,15 +340,14 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema properties(Map<String, Schema> properties) {
-        setProperties(properties);
+    public Schema addProperty(String key, Schema propertiesItem) {
+        this.properties.put(key, propertiesItem);
         return this;
     }
 
     @Override
-    public Schema addProperty(String key, Schema propertiesItem) {
-        this.properties.put(key, propertiesItem);
-        return this;
+    public void removeProperty(String key) {
+        this.properties.remove(key);
     }
 
     @Override
@@ -466,9 +361,23 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema additionalProperties(Schema additionalProperties) {
-        setAdditionalProperties(additionalProperties);
-        return this;
+    public Schema getAdditionalPropertiesSchema() {
+        return (Schema) additionalProperties;
+    }
+
+    @Override
+    public Boolean getAdditionalPropertiesBoolean() {
+        return (Boolean) additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalPropertiesSchema(Schema additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalPropertiesBoolean(Boolean additionalProperties) {
+        this.additionalProperties = additionalProperties;
     }
 
     @Override
@@ -482,12 +391,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public String getFormat() {
         return format;
     }
@@ -495,12 +398,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setFormat(String format) {
         this.format = format;
-    }
-
-    @Override
-    public Schema format(String format) {
-        setFormat(format);
-        return this;
     }
 
     @Override
@@ -517,12 +414,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema ref(String ref) {
-        setRef(ref);
-        return this;
-    }
-
-    @Override
     public Boolean getNullable() {
         return nullable;
     }
@@ -530,12 +421,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setNullable(Boolean nullable) {
         this.nullable = nullable;
-    }
-
-    @Override
-    public Schema nullable(Boolean nullable) {
-        setNullable(nullable);
-        return this;
     }
 
     @Override
@@ -549,12 +434,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema readOnly(Boolean readOnly) {
-        setReadOnly(readOnly);
-        return this;
-    }
-
-    @Override
     public Boolean getWriteOnly() {
         return writeOnly;
     }
@@ -562,12 +441,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setWriteOnly(Boolean writeOnly) {
         this.writeOnly = writeOnly;
-    }
-
-    @Override
-    public Schema writeOnly(Boolean writeOnly) {
-        setWriteOnly(writeOnly);
-        return this;
     }
 
     @Override
@@ -581,12 +454,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema example(Object example) {
-        setExample(example);
-        return this;
-    }
-
-    @Override
     public ExternalDocumentation getExternalDocs() {
         return externalDocs;
     }
@@ -594,12 +461,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setExternalDocs(ExternalDocumentation externalDocs) {
         this.externalDocs = externalDocs;
-    }
-
-    @Override
-    public Schema externalDocs(ExternalDocumentation externalDocs) {
-        setExternalDocs(externalDocs);
-        return this;
     }
 
     @Override
@@ -613,12 +474,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema deprecated(Boolean deprecated) {
-        setDeprecated(deprecated);
-        return this;
-    }
-
-    @Override
     public XML getXml() {
         return xml;
     }
@@ -626,12 +481,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     @Override
     public void setXml(XML xml) {
         this.xml = xml;
-    }
-
-    @Override
-    public Schema xml(XML xml) {
-        setXml(xml);
-        return this;
     }
 
     @Override
@@ -651,12 +500,6 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema items(Schema items) {
-        setItems(items);
-        return this;
-    }
-
-    @Override
     public List<Schema> getAllOf() {
         return allOf;
     }
@@ -667,15 +510,14 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema allOf(List<Schema> allOf) {
-        setAllOf(allOf);
+    public Schema addAllOf(Schema allOf) {
+        this.allOf.add(allOf);
         return this;
     }
 
     @Override
-    public Schema addAllOf(Schema allOf) {
-        this.allOf.add(allOf);
-        return this;
+    public void removeAllOf(Schema allOf) {
+        this.allOf.remove(allOf);
     }
 
     @Override
@@ -689,15 +531,14 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema anyOf(List<Schema> anyOf) {
-        setAnyOf(anyOf);
+    public Schema addAnyOf(Schema anyOf) {
+        this.anyOf.add(anyOf);
         return this;
     }
 
     @Override
-    public Schema addAnyOf(Schema anyOf) {
-        this.anyOf.add(anyOf);
-        return this;
+    public void removeAnyOf(Schema anyOf) {
+        this.anyOf.remove(anyOf);
     }
 
     @Override
@@ -711,26 +552,19 @@ public class SchemaImpl extends ExtensibleImpl implements Schema {
     }
 
     @Override
-    public Schema oneOf(List<Schema> oneOf) {
-        setOneOf(oneOf);
-        return this;
-    }
-
-    @Override
     public Schema addOneOf(Schema oneOf) {
         this.oneOf.add(oneOf);
         return this;
     }
 
     @Override
-    public void setAdditionalProperties(Boolean additionalProperties) {
-        this.additionalProperties = additionalProperties;
+    public void removeOneOf(Schema oneOf) {
+        this.oneOf.remove(oneOf);
     }
 
     @Override
-    public Schema additionalProperties(Boolean additionalProperties) {
-        setAdditionalProperties(additionalProperties);
-        return this;
+    public void setAdditionalProperties(Boolean additionalProperties) {
+        this.additionalProperties = additionalProperties;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.media.Schema from, Schema to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/XMLImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/XMLImpl.java
@@ -43,7 +43,7 @@ import org.eclipse.microprofile.openapi.models.media.XML;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class XMLImpl extends ExtensibleImpl implements XML {
+public class XMLImpl extends ExtensibleImpl<XML> implements XML {
 
     protected String name;
     protected String namespace;
@@ -62,12 +62,6 @@ public class XMLImpl extends ExtensibleImpl implements XML {
     }
 
     @Override
-    public XML name(String name) {
-        setName(name);
-        return this;
-    }
-
-    @Override
     public String getNamespace() {
         return namespace;
     }
@@ -75,12 +69,6 @@ public class XMLImpl extends ExtensibleImpl implements XML {
     @Override
     public void setNamespace(String namespace) {
         this.namespace = namespace;
-    }
-
-    @Override
-    public XML namespace(String namespace) {
-        setNamespace(namespace);
-        return this;
     }
 
     @Override
@@ -94,12 +82,6 @@ public class XMLImpl extends ExtensibleImpl implements XML {
     }
 
     @Override
-    public XML prefix(String prefix) {
-        setPrefix(prefix);
-        return this;
-    }
-
-    @Override
     public Boolean getAttribute() {
         return attribute;
     }
@@ -110,12 +92,6 @@ public class XMLImpl extends ExtensibleImpl implements XML {
     }
 
     @Override
-    public XML attribute(Boolean attribute) {
-        setAttribute(attribute);
-        return this;
-    }
-
-    @Override
     public Boolean getWrapped() {
         return wrapped;
     }
@@ -123,12 +99,6 @@ public class XMLImpl extends ExtensibleImpl implements XML {
     @Override
     public void setWrapped(Boolean wrapped) {
         this.wrapped = wrapped;
-    }
-
-    @Override
-    public XML wrapped(Boolean wrapped) {
-        setWrapped(wrapped);
-        return this;
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
@@ -190,7 +190,9 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
 
     @Override
     public Parameter addExample(String key, Example example) {
-        this.examples.put(key, example);
+        if (example != null) {
+            this.examples.put(key, example);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
@@ -60,7 +60,7 @@ import fish.payara.microprofile.openapi.impl.model.examples.ExampleImpl;
 import fish.payara.microprofile.openapi.impl.model.media.ContentImpl;
 import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 
-public class ParameterImpl extends ExtensibleImpl implements Parameter {
+public class ParameterImpl extends ExtensibleImpl<Parameter> implements Parameter {
 
     protected String name;
     protected In in;
@@ -89,12 +89,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter name(String name) {
-        setName(name);
-        return this;
-    }
-
-    @Override
     public In getIn() {
         return in;
     }
@@ -102,12 +96,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     @Override
     public void setIn(In in) {
         this.in = in;
-    }
-
-    @Override
-    public Parameter in(In in) {
-        setIn(in);
-        return this;
     }
 
     @Override
@@ -121,12 +109,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public Boolean getRequired() {
         return required;
     }
@@ -134,12 +116,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     @Override
     public void setRequired(Boolean required) {
         this.required = required;
-    }
-
-    @Override
-    public Parameter required(Boolean required) {
-        setRequired(required);
-        return this;
     }
 
     @Override
@@ -153,12 +129,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter deprecated(Boolean deprecated) {
-        setDeprecated(deprecated);
-        return this;
-    }
-
-    @Override
     public Boolean getAllowEmptyValue() {
         return allowEmptyValue;
     }
@@ -166,12 +136,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     @Override
     public void setAllowEmptyValue(Boolean allowEmptyValue) {
         this.allowEmptyValue = allowEmptyValue;
-    }
-
-    @Override
-    public Parameter allowEmptyValue(Boolean allowEmptyValue) {
-        setAllowEmptyValue(allowEmptyValue);
-        return this;
     }
 
     @Override
@@ -185,12 +149,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter style(Style style) {
-        setStyle(style);
-        return this;
-    }
-
-    @Override
     public Boolean getExplode() {
         return explode;
     }
@@ -198,12 +156,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     @Override
     public void setExplode(Boolean explode) {
         this.explode = explode;
-    }
-
-    @Override
-    public Parameter explode(Boolean explode) {
-        setExplode(explode);
-        return this;
     }
 
     @Override
@@ -217,12 +169,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter allowReserved(Boolean allowReserved) {
-        setAllowReserved(allowReserved);
-        return this;
-    }
-
-    @Override
     public Schema getSchema() {
         return schema;
     }
@@ -230,12 +176,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     @Override
     public void setSchema(Schema schema) {
         this.schema = schema;
-    }
-
-    @Override
-    public Parameter schema(Schema schema) {
-        setSchema(schema);
-        return this;
     }
 
     @Override
@@ -249,15 +189,14 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter examples(Map<String, Example> examples) {
-        setExamples(examples);
+    public Parameter addExample(String key, Example example) {
+        this.examples.put(key, example);
         return this;
     }
 
     @Override
-    public Parameter addExample(String key, Example example) {
-        this.examples.put(key, example);
-        return this;
+    public void removeExample(String key) {
+        this.examples.remove(key);
     }
 
     @Override
@@ -271,12 +210,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     }
 
     @Override
-    public Parameter example(Object example) {
-        setExample(example);
-        return this;
-    }
-
-    @Override
     public Content getContent() {
         return content;
     }
@@ -284,12 +217,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
     @Override
     public void setContent(Content content) {
         this.content = content;
-    }
-
-    @Override
-    public Parameter content(Content content) {
-        setContent(content);
-        return this;
     }
 
     @Override
@@ -303,12 +230,6 @@ public class ParameterImpl extends ExtensibleImpl implements Parameter {
             ref = "#/components/parameters/" + ref;
         }
         this.ref = ref;
-    }
-
-    @Override
-    public Parameter ref(String ref) {
-        setRef(ref);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.parameters.Parameter from, Parameter to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/RequestBodyImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/RequestBodyImpl.java
@@ -52,7 +52,7 @@ import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.media.ContentImpl;
 
-public class RequestBodyImpl extends ExtensibleImpl implements RequestBody {
+public class RequestBodyImpl extends ExtensibleImpl<RequestBody> implements RequestBody {
 
     protected String description;
     protected Content content = new ContentImpl();
@@ -70,12 +70,6 @@ public class RequestBodyImpl extends ExtensibleImpl implements RequestBody {
     }
 
     @Override
-    public RequestBody description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public Content getContent() {
         return content;
     }
@@ -83,12 +77,6 @@ public class RequestBodyImpl extends ExtensibleImpl implements RequestBody {
     @Override
     public void setContent(Content content) {
         this.content = content;
-    }
-
-    @Override
-    public RequestBody content(Content content) {
-        setContent(content);
-        return this;
     }
 
     @Override
@@ -102,12 +90,6 @@ public class RequestBodyImpl extends ExtensibleImpl implements RequestBody {
     }
 
     @Override
-    public RequestBody required(Boolean required) {
-        setRequired(required);
-        return this;
-    }
-
-    @Override
     public String getRef() {
         return ref;
     }
@@ -118,12 +100,6 @@ public class RequestBodyImpl extends ExtensibleImpl implements RequestBody {
             ref = "#/components/requestBodies/" + ref;
         }
         this.ref = ref;
-    }
-
-    @Override
-    public RequestBody ref(String ref) {
-        setRef(ref);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.parameters.RequestBody from, RequestBody to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -57,7 +57,7 @@ import fish.payara.microprofile.openapi.impl.model.headers.HeaderImpl;
 import fish.payara.microprofile.openapi.impl.model.links.LinkImpl;
 import fish.payara.microprofile.openapi.impl.model.media.ContentImpl;
 
-public class APIResponseImpl extends ExtensibleImpl implements APIResponse {
+public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIResponse {
 
     protected String description;
     protected Map<String, Header> headers = new HashMap<>();
@@ -76,12 +76,6 @@ public class APIResponseImpl extends ExtensibleImpl implements APIResponse {
     }
 
     @Override
-    public APIResponse description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public Map<String, Header> getHeaders() {
         return headers;
     }
@@ -92,15 +86,14 @@ public class APIResponseImpl extends ExtensibleImpl implements APIResponse {
     }
 
     @Override
-    public APIResponse headers(Map<String, Header> headers) {
-        setHeaders(headers);
+    public APIResponse addHeader(String name, Header header) {
+        headers.put(name, header);
         return this;
     }
 
     @Override
-    public APIResponse addHeader(String name, Header header) {
-        headers.put(name, header);
-        return this;
+    public void removeHeader(String name) {
+        headers.remove(name);
     }
 
     @Override
@@ -114,12 +107,6 @@ public class APIResponseImpl extends ExtensibleImpl implements APIResponse {
     }
 
     @Override
-    public APIResponse content(Content content) {
-        setContent(content);
-        return this;
-    }
-
-    @Override
     public Map<String, Link> getLinks() {
         return links;
     }
@@ -130,15 +117,14 @@ public class APIResponseImpl extends ExtensibleImpl implements APIResponse {
     }
 
     @Override
-    public APIResponse links(Map<String, Link> links) {
-        setLinks(links);
+    public APIResponse addLink(String name, Link link) {
+        links.put(name, link);
         return this;
     }
 
     @Override
-    public APIResponse addLink(String name, Link link) {
-        links.put(name, link);
-        return this;
+    public void removeLink(String name) {
+        links.remove(name);
     }
 
     @Override
@@ -152,12 +138,6 @@ public class APIResponseImpl extends ExtensibleImpl implements APIResponse {
             ref = "#/components/responses/" + ref;
         }
         this.ref = ref;
-    }
-
-    @Override
-    public APIResponse ref(String ref) {
-        setRef(ref);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.responses.APIResponse from, APIResponse to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -87,7 +87,9 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
 
     @Override
     public APIResponse addHeader(String name, Header header) {
-        headers.put(name, header);
+        if (header != null) {
+            headers.put(name, header);
+        }
         return this;
     }
 
@@ -118,7 +120,9 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
 
     @Override
     public APIResponse addLink(String name, Link link) {
-        links.put(name, link);
+        if (link != null) {
+            links.put(name, link);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -41,7 +41,6 @@ package fish.payara.microprofile.openapi.impl.model.responses;
 
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.isAnnotationNull;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
@@ -54,8 +53,6 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
         implements APIResponses {
 
     private static final long serialVersionUID = 2811935761440110541L;
-
-    protected Map<String, Object> extensions = new HashMap<>();
 
     public APIResponsesImpl() {
         super();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -41,37 +41,60 @@ package fish.payara.microprofile.openapi.impl.model.responses;
 
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.isAnnotationNull;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 
-public class APIResponsesImpl extends LinkedHashMap<String, APIResponse> implements APIResponses {
+import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+
+public class APIResponsesImpl extends ExtensibleLinkedHashMap<String, APIResponse, APIResponses>
+        implements APIResponses {
 
     private static final long serialVersionUID = 2811935761440110541L;
 
-	@Override
-    public APIResponses addApiResponse(String name, APIResponse item) {
-        put(name, item);
+    protected Map<String, Object> extensions = new HashMap<>();
+
+    public APIResponsesImpl() {
+        super();
+    }
+
+    public APIResponsesImpl(Map<String, APIResponse> responses) {
+        super(responses);
+    }
+
+    @Override
+    public APIResponses addAPIResponse(String name, APIResponse apiResponse) {
+        put(name, apiResponse);
         return this;
     }
 
     @Override
-    public APIResponse getDefault() {
+    public void removeAPIResponse(String name) {
+        remove(name);
+    }
+
+    @Override
+    public Map<String, APIResponse> getAPIResponses() {
+        return new APIResponsesImpl(this);
+    }
+
+    @Override
+    public void setAPIResponses(Map<String, APIResponse> items) {
+        clear();
+        putAll(items);
+    }
+
+    @Override
+    public APIResponse getDefaultValue() {
         return this.get(DEFAULT);
     }
 
     @Override
     public void setDefaultValue(APIResponse defaultValue) {
-        addApiResponse(DEFAULT, defaultValue);
-    }
-
-    @Override
-    public APIResponses defaultValue(APIResponse defaultValue) {
-        setDefaultValue(defaultValue);
-        return this;
+        addAPIResponse(DEFAULT, defaultValue);
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.responses.APIResponse from, APIResponses to,
@@ -87,7 +110,7 @@ public class APIResponsesImpl extends LinkedHashMap<String, APIResponse> impleme
 
         org.eclipse.microprofile.openapi.models.responses.APIResponse response = to
                 .getOrDefault(responseName, new APIResponseImpl());
-        to.addApiResponse(responseName, response);
+        to.addAPIResponse(responseName, response);
 
         APIResponseImpl.merge(from, response, override, currentSchemas);
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -67,7 +67,9 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
 
     @Override
     public APIResponses addAPIResponse(String name, APIResponse apiResponse) {
-        put(name, apiResponse);
+        if (apiResponse != null) {
+            put(name, apiResponse);
+        }
         return this;
     }
 
@@ -94,7 +96,7 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
 
     @Override
     public void setDefaultValue(APIResponse defaultValue) {
-        addAPIResponse(DEFAULT, defaultValue);
+        put(DEFAULT, defaultValue); // this is not the same as addAPIResponse as null is set but not added
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.responses.APIResponse from, APIResponses to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -48,9 +48,9 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 
-import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+import fish.payara.microprofile.openapi.impl.model.ExtensibleTreeMap;
 
-public class APIResponsesImpl extends ExtensibleLinkedHashMap<String, APIResponse, APIResponses>
+public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponses>
         implements APIResponses {
 
     private static final long serialVersionUID = 2811935761440110541L;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowImpl.java
@@ -48,7 +48,7 @@ import org.eclipse.microprofile.openapi.models.security.Scopes;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class OAuthFlowImpl extends ExtensibleImpl implements OAuthFlow {
+public class OAuthFlowImpl extends ExtensibleImpl<OAuthFlow> implements OAuthFlow {
 
     protected String authorizationUrl;
     protected String tokenUrl;
@@ -66,12 +66,6 @@ public class OAuthFlowImpl extends ExtensibleImpl implements OAuthFlow {
     }
 
     @Override
-    public OAuthFlow authorizationUrl(String authorizationUrl) {
-        setAuthorizationUrl(authorizationUrl);
-        return this;
-    }
-
-    @Override
     public String getTokenUrl() {
         return tokenUrl;
     }
@@ -79,12 +73,6 @@ public class OAuthFlowImpl extends ExtensibleImpl implements OAuthFlow {
     @Override
     public void setTokenUrl(String tokenUrl) {
         this.tokenUrl = tokenUrl;
-    }
-
-    @Override
-    public OAuthFlow tokenUrl(String tokenUrl) {
-        setTokenUrl(tokenUrl);
-        return this;
     }
 
     @Override
@@ -98,12 +86,6 @@ public class OAuthFlowImpl extends ExtensibleImpl implements OAuthFlow {
     }
 
     @Override
-    public OAuthFlow refreshUrl(String refreshUrl) {
-        setRefreshUrl(refreshUrl);
-        return this;
-    }
-
-    @Override
     public Scopes getScopes() {
         return scopes;
     }
@@ -111,12 +93,6 @@ public class OAuthFlowImpl extends ExtensibleImpl implements OAuthFlow {
     @Override
     public void setScopes(Scopes scopes) {
         this.scopes = scopes;
-    }
-
-    @Override
-    public OAuthFlow scopes(Scopes scopes) {
-        setScopes(scopes);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.security.OAuthFlow from, OAuthFlow to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowsImpl.java
@@ -47,7 +47,7 @@ import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class OAuthFlowsImpl extends ExtensibleImpl implements OAuthFlows {
+public class OAuthFlowsImpl extends ExtensibleImpl<OAuthFlows> implements OAuthFlows {
 
     protected OAuthFlow implicit;
     protected OAuthFlow password;
@@ -65,12 +65,6 @@ public class OAuthFlowsImpl extends ExtensibleImpl implements OAuthFlows {
     }
 
     @Override
-    public OAuthFlows implicit(OAuthFlow implicit) {
-        setImplicit(implicit);
-        return this;
-    }
-
-    @Override
     public OAuthFlow getPassword() {
         return password;
     }
@@ -78,12 +72,6 @@ public class OAuthFlowsImpl extends ExtensibleImpl implements OAuthFlows {
     @Override
     public void setPassword(OAuthFlow password) {
         this.password = password;
-    }
-
-    @Override
-    public OAuthFlows password(OAuthFlow password) {
-        setPassword(password);
-        return this;
     }
 
     @Override
@@ -97,12 +85,6 @@ public class OAuthFlowsImpl extends ExtensibleImpl implements OAuthFlows {
     }
 
     @Override
-    public OAuthFlows clientCredentials(OAuthFlow clientCredentials) {
-        setClientCredentials(clientCredentials);
-        return this;
-    }
-
-    @Override
     public OAuthFlow getAuthorizationCode() {
         return authorizationCode;
     }
@@ -110,12 +92,6 @@ public class OAuthFlowsImpl extends ExtensibleImpl implements OAuthFlows {
     @Override
     public void setAuthorizationCode(OAuthFlow authorizationCode) {
         this.authorizationCode = authorizationCode;
-    }
-
-    @Override
-    public OAuthFlows authorizationCode(OAuthFlow authorizationCode) {
-        setAuthorizationCode(authorizationCode);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.security.OAuthFlows from, OAuthFlows to,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/ScopesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/ScopesImpl.java
@@ -39,17 +39,23 @@
  */
 package fish.payara.microprofile.openapi.impl.model.security;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.security.Scopes;
 
-public class ScopesImpl extends LinkedHashMap<String, String> implements Scopes {
+import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+
+public class ScopesImpl extends ExtensibleLinkedHashMap<String, String, Scopes> implements Scopes {
 
     private static final long serialVersionUID = -615440059031779085L;
 
-    protected Map<String, Object> extensions = new HashMap<>();
+    public ScopesImpl() {
+        super();
+    }
+
+    public ScopesImpl(Map<? extends String, ? extends String> scopes) {
+        super(scopes);
+    }
 
     @Override
     public Scopes addScope(String name, String item) {
@@ -58,18 +64,19 @@ public class ScopesImpl extends LinkedHashMap<String, String> implements Scopes 
     }
 
     @Override
-    public Map<String, Object> getExtensions() {
-        return extensions;
+    public void removeScope(String scope) {
+        this.remove(scope);
     }
 
     @Override
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions = extensions;
+    public Map<String, String> getScopes() {
+        return new ScopesImpl(this);
     }
 
     @Override
-    public void addExtension(String name, Object value) {
-        this.extensions.put(name, value);
+    public void setScopes(Map<String, String> items) {
+        clear();
+        putAll(items);
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/ScopesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/ScopesImpl.java
@@ -59,7 +59,7 @@ public class ScopesImpl extends ExtensibleTreeMap<String, Scopes> implements Sco
 
     @Override
     public Scopes addScope(String name, String item) {
-        this.put(name, item);
+        this.put(name, item); // this DOES accept null!
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/ScopesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/ScopesImpl.java
@@ -43,9 +43,9 @@ import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.security.Scopes;
 
-import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+import fish.payara.microprofile.openapi.impl.model.ExtensibleTreeMap;
 
-public class ScopesImpl extends ExtensibleLinkedHashMap<String, String, Scopes> implements Scopes {
+public class ScopesImpl extends ExtensibleTreeMap<String, Scopes> implements Scopes {
 
     private static final long serialVersionUID = -615440059031779085L;
 
@@ -53,7 +53,7 @@ public class ScopesImpl extends ExtensibleLinkedHashMap<String, String, Scopes> 
         super();
     }
 
-    public ScopesImpl(Map<? extends String, ? extends String> scopes) {
+    public ScopesImpl(Map<String, ? extends String> scopes) {
         super(scopes);
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
@@ -63,13 +63,13 @@ public class SecurityRequirementImpl extends LinkedHashMap<String, List<String>>
 
     @Override
     public SecurityRequirement addScheme(String name, String item) {
-        this.put(name, Arrays.asList(item));
+        this.put(name, item == null ? new ArrayList<>() : Arrays.asList(item));
         return this;
     }
 
     @Override
     public SecurityRequirement addScheme(String name, List<String> item) {
-        this.put(name, item);
+        this.put(name, item == null ? new ArrayList<>() : item);
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
@@ -45,12 +45,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 
 public class SecurityRequirementImpl extends LinkedHashMap<String, List<String>> implements SecurityRequirement {
 
     private static final long serialVersionUID = -677783376083861245L;
+
+    public SecurityRequirementImpl() {
+        super();
+    }
+
+    public SecurityRequirementImpl(Map<? extends String, ? extends List<String>> items) {
+        super(items);
+    }
 
     @Override
     public SecurityRequirement addScheme(String name, String item) {
@@ -68,6 +77,22 @@ public class SecurityRequirementImpl extends LinkedHashMap<String, List<String>>
     public SecurityRequirement addScheme(String name) {
         this.put(name, new ArrayList<>());
         return this;
+    }
+
+    @Override
+    public void removeScheme(String securitySchemeName) {
+        this.remove(securitySchemeName);
+    }
+
+    @Override
+    public Map<String, List<String>> getSchemes() {
+        return new SecurityRequirementImpl(this);
+    }
+
+    @Override
+    public void setSchemes(Map<String, List<String>> items) {
+        clear();
+        putAll(items);
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement from,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
@@ -50,7 +50,7 @@ import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme {
+public class SecuritySchemeImpl extends ExtensibleImpl<SecurityScheme> implements SecurityScheme {
 
     protected SecurityScheme.Type type;
     protected String description;
@@ -74,12 +74,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     }
 
     @Override
-    public SecurityScheme type(SecurityScheme.Type type) {
-        setType(type);
-        return this;
-    }
-
-    @Override
     public String getDescription() {
         return description;
     }
@@ -87,12 +81,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     @Override
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    @Override
-    public SecurityScheme description(String description) {
-        setDescription(description);
-        return this;
     }
 
     @Override
@@ -106,12 +94,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     }
 
     @Override
-    public SecurityScheme name(String name) {
-        setName(name);
-        return this;
-    }
-
-    @Override
     public SecurityScheme.In getIn() {
         return in;
     }
@@ -119,12 +101,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     @Override
     public void setIn(SecurityScheme.In in) {
         this.in = in;
-    }
-
-    @Override
-    public SecurityScheme in(SecurityScheme.In in) {
-        setIn(in);
-        return this;
     }
 
     @Override
@@ -138,12 +114,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     }
 
     @Override
-    public SecurityScheme scheme(String scheme) {
-        setScheme(scheme);
-        return this;
-    }
-
-    @Override
     public String getBearerFormat() {
         return bearerFormat;
     }
@@ -151,12 +121,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     @Override
     public void setBearerFormat(String bearerFormat) {
         this.bearerFormat = bearerFormat;
-    }
-
-    @Override
-    public SecurityScheme bearerFormat(String bearerFormat) {
-        setBearerFormat(bearerFormat);
-        return this;
     }
 
     @Override
@@ -170,12 +134,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     }
 
     @Override
-    public SecurityScheme flows(OAuthFlows flows) {
-        setFlows(flows);
-        return this;
-    }
-
-    @Override
     public String getOpenIdConnectUrl() {
         return openIdConnectUrl;
     }
@@ -183,12 +141,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
     @Override
     public void setOpenIdConnectUrl(String openIdConnectUrl) {
         this.openIdConnectUrl = openIdConnectUrl;
-    }
-
-    @Override
-    public SecurityScheme openIdConnectUrl(String openIdConnectUrl) {
-        setOpenIdConnectUrl(openIdConnectUrl);
-        return this;
     }
 
     @Override
@@ -202,12 +154,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl implements SecurityScheme
             ref = "#/components/securitySchemes/" + ref;
         }
         this.ref = ref;
-    }
-
-    @Override
-    public SecurityScheme ref(String ref) {
-        setRef(ref);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.security.SecurityScheme from,

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
@@ -44,9 +44,15 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeP
 
 import java.util.Map;
 
+import javax.json.bind.annotation.JsonbProperty;
+import javax.xml.bind.annotation.XmlTransient;
+
 import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
@@ -78,14 +84,18 @@ public class ServerImpl extends ExtensibleImpl<Server> implements Server {
 
     @Override
     public ServerVariables getVariables() {
-        return variables instanceof ServerVariables ? (ServerVariables) variables : new ServerVariablesImpl(variables);
+        return variables instanceof ServerVariables || variables == null 
+                ? (ServerVariables) variables
+                : new ServerVariablesImpl(variables);
     }
 
+    @JsonIgnore
     @Override
     public void setVariables(ServerVariables variables) {
         this.variables = variables;
     }
 
+    @JsonProperty("variables")
     @Override
     public void setVariables(Map<String, ServerVariable> variables) {
         this.variables = variables;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
@@ -48,9 +48,6 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
 public class ServerImpl extends ExtensibleImpl<Server> implements Server {
@@ -86,13 +83,11 @@ public class ServerImpl extends ExtensibleImpl<Server> implements Server {
                 : new ServerVariablesImpl(variables);
     }
 
-    @JsonIgnore
     @Override
     public void setVariables(ServerVariables variables) {
         this.variables = variables;
     }
 
-    @JsonProperty("variables")
     @Override
     public void setVariables(Map<String, ServerVariable> variables) {
         this.variables = variables;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
@@ -42,17 +42,19 @@ package fish.payara.microprofile.openapi.impl.model.servers;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.isAnnotationNull;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 
-import org.eclipse.microprofile.openapi.annotations.servers.ServerVariable;
+import java.util.Map;
+
 import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class ServerImpl extends ExtensibleImpl implements Server {
+public class ServerImpl extends ExtensibleImpl<Server> implements Server {
 
     protected String url;
     protected String description;
-    protected ServerVariables variables;
+    protected Map<String, ServerVariable> variables;
 
     @Override
     public String getUrl() {
@@ -62,12 +64,6 @@ public class ServerImpl extends ExtensibleImpl implements Server {
     @Override
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    @Override
-    public Server url(String url) {
-        setUrl(url);
-        return this;
     }
 
     @Override
@@ -81,14 +77,8 @@ public class ServerImpl extends ExtensibleImpl implements Server {
     }
 
     @Override
-    public Server description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public ServerVariables getVariables() {
-        return variables;
+        return variables instanceof ServerVariables ? (ServerVariables) variables : new ServerVariablesImpl(variables);
     }
 
     @Override
@@ -97,9 +87,8 @@ public class ServerImpl extends ExtensibleImpl implements Server {
     }
 
     @Override
-    public Server variables(ServerVariables variables) {
-        setVariables(variables);
-        return this;
+    public void setVariables(Map<String, ServerVariable> variables) {
+        this.variables = variables;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.servers.Server from, Server to,
@@ -113,7 +102,7 @@ public class ServerImpl extends ExtensibleImpl implements Server {
             if (to.getVariables() == null) {
                 to.setVariables(new ServerVariablesImpl());
             }
-            for (ServerVariable variable : from.variables()) {
+            for (org.eclipse.microprofile.openapi.annotations.servers.ServerVariable variable : from.variables()) {
                 ServerVariablesImpl.merge(variable, to.getVariables(), override);
             }
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
@@ -44,9 +44,6 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeP
 
 import java.util.Map;
 
-import javax.json.bind.annotation.JsonbProperty;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
@@ -85,7 +85,7 @@ public class ServerVariableImpl extends ExtensibleImpl<ServerVariable> implement
 
     @Override
     public ServerVariable addEnumeration(String enumeration) {
-        if (!this.enumeration.contains(enumeration)) {
+        if (enumeration != null && !this.enumeration.contains(enumeration)) {
             this.enumeration.add(enumeration);
         }
         return this;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 
-public class ServerVariableImpl extends ExtensibleImpl implements ServerVariable {
+public class ServerVariableImpl extends ExtensibleImpl<ServerVariable> implements ServerVariable {
 
     protected String description;
     protected String defaultValue;
@@ -64,12 +64,6 @@ public class ServerVariableImpl extends ExtensibleImpl implements ServerVariable
     }
 
     @Override
-    public ServerVariable description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public String getDefaultValue() {
         return defaultValue;
     }
@@ -77,12 +71,6 @@ public class ServerVariableImpl extends ExtensibleImpl implements ServerVariable
     @Override
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
-    }
-
-    @Override
-    public ServerVariable defaultValue(String defaultValue) {
-        setDefaultValue(defaultValue);
-        return this;
     }
 
     @Override
@@ -96,17 +84,16 @@ public class ServerVariableImpl extends ExtensibleImpl implements ServerVariable
     }
 
     @Override
-    public ServerVariable enumeration(List<String> enumeration) {
-        setEnumeration(enumeration);
-        return this;
-    }
-
-    @Override
     public ServerVariable addEnumeration(String enumeration) {
         if (!this.enumeration.contains(enumeration)) {
             this.enumeration.add(enumeration);
         }
         return this;
+    }
+
+    @Override
+    public void removeEnumeration(String enumeration) {
+        this.enumeration.remove(enumeration);
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariablesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariablesImpl.java
@@ -64,7 +64,9 @@ public class ServerVariablesImpl extends ExtensibleTreeMap<ServerVariable, Serve
 
     @Override
     public ServerVariables addServerVariable(String name, ServerVariable item) {
-        this.put(name, item);
+        if (item != null) {
+            this.put(name, item);
+        }
         return this;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariablesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariablesImpl.java
@@ -48,9 +48,9 @@ import java.util.Map;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 
-import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+import fish.payara.microprofile.openapi.impl.model.ExtensibleTreeMap;
 
-public class ServerVariablesImpl extends ExtensibleLinkedHashMap<String, ServerVariable, ServerVariables> implements ServerVariables {
+public class ServerVariablesImpl extends ExtensibleTreeMap<ServerVariable, ServerVariables> implements ServerVariables {
 
     private static final long serialVersionUID = 8869393484826870024L;
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariablesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariablesImpl.java
@@ -43,18 +43,24 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.isAnno
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 
-public class ServerVariablesImpl extends LinkedHashMap<String, ServerVariable> implements ServerVariables {
+import fish.payara.microprofile.openapi.impl.model.ExtensibleLinkedHashMap;
+
+public class ServerVariablesImpl extends ExtensibleLinkedHashMap<String, ServerVariable, ServerVariables> implements ServerVariables {
 
     private static final long serialVersionUID = 8869393484826870024L;
 
-    protected Map<String, Object> extensions = new HashMap<>();
+    public ServerVariablesImpl() {
+        super();
+    }
+
+    public ServerVariablesImpl(Map<String, ServerVariable> variables) {
+        super(variables);
+    }
 
     @Override
     public ServerVariables addServerVariable(String name, ServerVariable item) {
@@ -63,18 +69,19 @@ public class ServerVariablesImpl extends LinkedHashMap<String, ServerVariable> i
     }
 
     @Override
-    public Map<String, Object> getExtensions() {
-        return extensions;
+    public void removeServerVariable(String name) {
+        remove(name);
     }
 
     @Override
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions = extensions;
+    public Map<String, ServerVariable> getServerVariables() {
+        return new ServerVariablesImpl(this);
     }
 
     @Override
-    public void addExtension(String name, Object value) {
-        this.extensions.put(name, value);
+    public void setServerVariables(Map<String, ServerVariable> items) {
+        clear();
+        putAll(items);
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.servers.ServerVariable from,
@@ -93,7 +100,7 @@ public class ServerVariablesImpl extends LinkedHashMap<String, ServerVariable> i
                 variable.addEnumeration(value);
             }
         }
-        if ((to.containsKey(from.name()) && override) || !to.containsKey(from.name())) {
+        if ((to.hasServerVariable(from.name()) && override) || !to.hasServerVariable(from.name())) {
             to.addServerVariable(from.name(), variable);
         }
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
@@ -51,7 +51,7 @@ import org.eclipse.microprofile.openapi.models.tags.Tag;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.ExternalDocumentationImpl;
 
-public class TagImpl extends ExtensibleImpl implements Tag {
+public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
 
     protected String name;
     protected String description;
@@ -68,12 +68,6 @@ public class TagImpl extends ExtensibleImpl implements Tag {
     }
 
     @Override
-    public Tag name(String name) {
-        setName(name);
-        return this;
-    }
-
-    @Override
     public String getDescription() {
         return description;
     }
@@ -84,12 +78,6 @@ public class TagImpl extends ExtensibleImpl implements Tag {
     }
 
     @Override
-    public Tag description(String description) {
-        setDescription(description);
-        return this;
-    }
-
-    @Override
     public ExternalDocumentation getExternalDocs() {
         return externalDocs;
     }
@@ -97,12 +85,6 @@ public class TagImpl extends ExtensibleImpl implements Tag {
     @Override
     public void setExternalDocs(ExternalDocumentation externalDocs) {
         this.externalDocs = externalDocs;
-    }
-
-    @Override
-    public Tag externalDocs(ExternalDocumentation externalDocs) {
-        setExternalDocs(externalDocs);
-        return this;
     }
 
     public static void merge(org.eclipse.microprofile.openapi.annotations.tags.Tag from, Tag to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -313,6 +313,12 @@ public final class ModelUtils {
         if (type2 == null) {
             return type1;
         }
+        if (type1 == SchemaType.OBJECT || type2 == SchemaType.OBJECT) {
+            return SchemaType.OBJECT;
+        }
+        if (type1 == SchemaType.STRING || type2 == SchemaType.STRING) {
+            return SchemaType.STRING;
+        }
         if (type1 != type2) {
             return SchemaType.STRING;
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -194,8 +194,8 @@ public final class ModelUtils {
      */
     public static Operation getOrCreateOperation(PathItem pathItem, HttpMethod httpMethod) {
         Operation operation = new OperationImpl();
-        if (pathItem.readOperationsMap().get(httpMethod) != null) {
-            return pathItem.readOperationsMap().get(httpMethod);
+        if (pathItem.getOperations().get(httpMethod) != null) {
+            return pathItem.getOperations().get(httpMethod);
         }
         switch (httpMethod) {
         case GET:
@@ -231,7 +231,7 @@ public final class ModelUtils {
     public static Operation findOperation(OpenAPI api, Method method, String path) {
         Operation foundOperation = null;
         try {
-            return api.getPaths().get(path).readOperationsMap().get(getHttpMethod(method));
+            return api.getPaths().getPathItem(path).getOperations().get(getHttpMethod(method));
         } catch (NullPointerException ex) {
             // Operation not found
         }
@@ -405,7 +405,7 @@ public final class ModelUtils {
                             return false;
                         } else if (value instanceof Collection && !Collection.class.cast(value).isEmpty()) {
                             return false;
-                        } else if (value instanceof Boolean && Boolean.class.cast(value)) {
+                        } else if (value instanceof Boolean && ((Boolean)value).booleanValue()) {
                             return false;
                         } else if (value.getClass().equals(Class.class)
                                 && !Class.class.cast(value).getTypeName().equals("java.lang.Void")) {
@@ -425,6 +425,18 @@ public final class ModelUtils {
             }
         }
         return allNull;
+    }
+
+    public static Boolean mergeProperty(Boolean current, boolean offer, boolean override) {
+        return mergeProperty(current, Boolean.valueOf(offer), override);
+    }
+
+    public static Boolean mergeProperty(boolean current, Boolean offer, boolean override) {
+        return mergeProperty(Boolean.valueOf(current), offer, override);
+    }
+
+    public static Boolean mergeProperty(boolean current, boolean offer, boolean override) {
+        return mergeProperty(Boolean.valueOf(current), Boolean.valueOf(offer), override);
     }
 
     public static <E> E mergeProperty(E current, E offer, boolean override) {
@@ -547,10 +559,10 @@ public final class ModelUtils {
             OpenAPI api, Map<String, Set<Class<?>>> resourceMapping) {
         String path = getResourcePath(method, resourceMapping);
         if (path != null) {
-            PathItem pathItem = api.getPaths().get(path);
+            PathItem pathItem = api.getPaths().getPathItem(path);
             if (pathItem != null) {
                 PathItem.HttpMethod httpMethod = getHttpMethod(method);
-                return pathItem.readOperationsMap().get(httpMethod);
+                return pathItem.getOperations().get(httpMethod);
             }
         }
         return null;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -313,12 +313,6 @@ public final class ModelUtils {
         if (type2 == null) {
             return type1;
         }
-        if (type1 == SchemaType.OBJECT || type2 == SchemaType.OBJECT) {
-            return SchemaType.OBJECT;
-        }
-        if (type1 == SchemaType.STRING || type2 == SchemaType.STRING) {
-            return SchemaType.STRING;
-        }
         if (type1 != type2) {
             return SchemaType.STRING;
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -513,111 +513,118 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     @Override
     public void visitSchema(Schema schema, AnnotatedElement element, ApiContext context) {
         if (element instanceof Class) {
-
-            // Get the schema object name
-            String schemaName = (schema == null) ? null : schema.name();
-            if (schemaName == null || schemaName.isEmpty()) {
-                schemaName = Class.class.cast(element).getSimpleName();
-            }
-
-            // Add a new schema
-            org.eclipse.microprofile.openapi.models.media.Schema newSchema = new SchemaImpl();
-            context.getApi().getComponents().addSchema(schemaName, newSchema);
-
-            // If there is an annotation
-            if (schema != null) {
-                SchemaImpl.merge(schema, newSchema, true, context.getApi().getComponents().getSchemas());
-            } else {
-                newSchema.setType(SchemaType.OBJECT);
-                Map<String, org.eclipse.microprofile.openapi.models.media.Schema> fields = new LinkedHashMap<>();
-                for (Field field : Class.class.cast(element).getDeclaredFields()) {
-                    if (!Modifier.isTransient(field.getModifiers())) {
-                        fields.put(field.getName(), createSchema(context, element, field.getType()));
-                    }
-                }
-                newSchema.setProperties(fields);
-            }
-
-            // If there is an extending class, add the data
-            if (Class.class.cast(element).getSuperclass() != null) {
-                Class<?> superClass = Class.class.cast(element).getSuperclass();
-
-                // If the super class is legitimate
-                if (!superClass.equals(Object.class)) {
-
-                    // Get the parent schema annotation
-                    Schema parentSchema = superClass.getDeclaredAnnotation(Schema.class);
-
-                    // Create a schema for the parent
-                    visitSchema(parentSchema, superClass, context);
-
-                    // Get the superclass schema name
-                    String parentSchemaName = (parentSchema == null) ? null : parentSchema.name();
-                    if (parentSchemaName == null || parentSchemaName.isEmpty()) {
-                        parentSchemaName = Class.class.cast(superClass).getSimpleName();
-                    }
-
-                    // Link the schemas
-                    newSchema.addAllOf(new SchemaImpl().ref(parentSchemaName));
-                }
-            }
+            visitSchemaClass(schema, (Class<?>) element, context);
         }
         if (element instanceof Field) {
-
-            // Get the schema object name
-            String schemaName = schema.name();
-            if (schemaName == null || schemaName.isEmpty()) {
-                schemaName = Field.class.cast(element).getName();
-            }
-
-            // Get the parent schema object name
-            String parentName = null;
-            if (Field.class.cast(element).getDeclaringClass().isAnnotationPresent(Schema.class)) {
-                parentName = Field.class.cast(element).getDeclaringClass().getDeclaredAnnotation(Schema.class).name();
-            }
-            if (parentName == null || parentName.isEmpty()) {
-                parentName = Field.class.cast(element).getDeclaringClass().getSimpleName();
-            }
-
-            // Get or create the parent schema object
-            org.eclipse.microprofile.openapi.models.media.Schema parent = context.getApi().getComponents().getSchemas()
-                    .getOrDefault(parentName, new SchemaImpl());
-            context.getApi().getComponents().getSchemas().put(parentName, parent);
-
-            org.eclipse.microprofile.openapi.models.media.Schema property = new SchemaImpl();
-            parent.addProperty(schemaName, property);
-            property.setType(ModelUtils.getSchemaType(Field.class.cast(element).getType()));
-            SchemaImpl.merge(schema, property, true, context.getApi().getComponents().getSchemas());
+            visitSchemaField(schema, (Field) element, context);
         }
         if (element instanceof java.lang.reflect.Parameter) {
+            visitSchemaParameter(schema, (java.lang.reflect.Parameter) element, context);
+        }
+    }
 
-            // If this is being parsed at the start, ignore it as the path doesn't exist
-            if (context.getWorkingOperation() == null) {
-                return;
+    private void visitSchemaClass(Schema schema, Class<?> clazz, ApiContext context) {
+        // Get the schema object name
+        String schemaName = (schema == null) ? null : schema.name();
+        if (schemaName == null || schemaName.isEmpty()) {
+            schemaName = clazz.getSimpleName();
+        }
+
+        // Add a new schema
+        org.eclipse.microprofile.openapi.models.media.Schema newSchema = new SchemaImpl();
+        context.getApi().getComponents().addSchema(schemaName, newSchema);
+
+        // If there is an annotation
+        if (schema != null) {
+            SchemaImpl.merge(schema, newSchema, true, context.getApi().getComponents().getSchemas());
+        } else {
+            newSchema.setType(SchemaType.OBJECT);
+            Map<String, org.eclipse.microprofile.openapi.models.media.Schema> fields = new LinkedHashMap<>();
+            for (Field field : clazz.getDeclaredFields()) {
+                if (!Modifier.isTransient(field.getModifiers())) {
+                    fields.put(field.getName(), createSchema(context, clazz, field.getType()));
+                }
             }
+            newSchema.setProperties(fields);
+        }
 
-            java.lang.reflect.Parameter parameter = (java.lang.reflect.Parameter) element;
-            // Check if it's a request body
-            if (ModelUtils.isRequestBody(parameter)) {
-                if (context.getWorkingOperation().getRequestBody() == null) {
-                    context.getWorkingOperation().setRequestBody(new RequestBodyImpl());
+        // If there is an extending class, add the data
+        if (clazz.getSuperclass() != null) {
+            Class<?> superClass = clazz.getSuperclass();
+
+            // If the super class is legitimate
+            if (!superClass.equals(Object.class)) {
+
+                // Get the parent schema annotation
+                Schema parentSchema = superClass.getDeclaredAnnotation(Schema.class);
+
+                // Create a schema for the parent
+                visitSchema(parentSchema, superClass, context);
+
+                // Get the superclass schema name
+                String parentSchemaName = (parentSchema == null) ? null : parentSchema.name();
+                if (parentSchemaName == null || parentSchemaName.isEmpty()) {
+                    parentSchemaName = superClass.getSimpleName();
                 }
-                // Insert the schema to the request body media type
-                MediaType mediaType = context.getWorkingOperation().getRequestBody().getContent()
-                        .getMediaType(javax.ws.rs.core.MediaType.WILDCARD);
-                SchemaImpl.merge(schema, mediaType.getSchema(), true, context.getApi().getComponents().getSchemas());
-                if (schema.ref() != null && !schema.ref().isEmpty()) {
-                    mediaType.setSchema(new SchemaImpl().ref(schema.ref()));
-                }
-            } else if (ModelUtils.getParameterType(parameter) != null) {
-                for (org.eclipse.microprofile.openapi.models.parameters.Parameter param : context.getWorkingOperation()
-                        .getParameters()) {
-                    if (param.getName().equals(ModelUtils.getParameterName(parameter))) {
-                        SchemaImpl.merge(schema, param.getSchema(), true,
-                                context.getApi().getComponents().getSchemas());
-                        if (schema.ref() != null && !schema.ref().isEmpty()) {
-                            param.setSchema(new SchemaImpl().ref(schema.ref()));
-                        }
+
+                // Link the schemas
+                newSchema.addAllOf(new SchemaImpl().ref(parentSchemaName));
+            }
+        }
+    }
+
+    private void visitSchemaField(Schema schema, Field field, ApiContext context) {
+        // Get the schema object name
+        String schemaName = schema.name();
+        if (schemaName == null || schemaName.isEmpty()) {
+            schemaName = field.getName();
+        }
+
+        // Get the parent schema object name
+        String parentName = null;
+        if (field.getDeclaringClass().isAnnotationPresent(Schema.class)) {
+            parentName = field.getDeclaringClass().getDeclaredAnnotation(Schema.class).name();
+        }
+        if (parentName == null || parentName.isEmpty()) {
+            parentName = field.getDeclaringClass().getSimpleName();
+        }
+
+        // Get or create the parent schema object
+        org.eclipse.microprofile.openapi.models.media.Schema parent = context.getApi().getComponents().getSchemas()
+                .getOrDefault(parentName, new SchemaImpl());
+        context.getApi().getComponents().getSchemas().put(parentName, parent);
+
+        org.eclipse.microprofile.openapi.models.media.Schema property = new SchemaImpl();
+        parent.addProperty(schemaName, property);
+        property.setType(ModelUtils.getSchemaType(field.getType()));
+        SchemaImpl.merge(schema, property, true, context.getApi().getComponents().getSchemas());
+    }
+
+    private void visitSchemaParameter(Schema schema, java.lang.reflect.Parameter parameter, ApiContext context) {
+        // If this is being parsed at the start, ignore it as the path doesn't exist
+        if (context.getWorkingOperation() == null) {
+            return;
+        }
+        // Check if it's a request body
+        if (ModelUtils.isRequestBody(parameter)) {
+            if (context.getWorkingOperation().getRequestBody() == null) {
+                context.getWorkingOperation().setRequestBody(new RequestBodyImpl());
+            }
+            // Insert the schema to the request body media type
+            MediaType mediaType = context.getWorkingOperation().getRequestBody().getContent()
+                    .getMediaType(javax.ws.rs.core.MediaType.WILDCARD);
+            SchemaImpl.merge(schema, mediaType.getSchema(), true, context.getApi().getComponents().getSchemas());
+            if (schema.ref() != null && !schema.ref().isEmpty()) {
+                mediaType.setSchema(new SchemaImpl().ref(schema.ref()));
+            }
+        } else if (ModelUtils.getParameterType(parameter) != null) {
+            for (org.eclipse.microprofile.openapi.models.parameters.Parameter param : context.getWorkingOperation()
+                    .getParameters()) {
+                if (param.getName().equals(ModelUtils.getParameterName(parameter))) {
+                    SchemaImpl.merge(schema, param.getSchema(), true,
+                            context.getApi().getComponents().getSchemas());
+                    if (schema.ref() != null && !schema.ref().isEmpty()) {
+                        param.setSchema(new SchemaImpl().ref(schema.ref()));
                     }
                 }
             }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -407,8 +407,8 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
             // Set the request body type accordingly.
             context.getWorkingOperation().getRequestBody().getContent()
-            .getMediaType(javax.ws.rs.core.MediaType.WILDCARD).getSchema()
-            .setType(formSchemaType);
+                .getMediaType(javax.ws.rs.core.MediaType.WILDCARD).getSchema()
+                .setType(formSchemaType);
         }
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
@@ -46,9 +46,7 @@ import fish.payara.microprofile.openapi.impl.model.info.InfoImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.normaliseUrl;
 import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -105,16 +103,16 @@ public class BaseProcessor implements OASProcessor {
                 String path = normaliseUrl(entry.getKey());
 
                 // If the path doesn't exist, create it
-                if (!api.getPaths().containsKey(path)) {
+                if (!api.getPaths().hasPathItem(path)) {
                     api.getPaths().addPathItem(path, new PathItemImpl());
                 }
 
                 // Clear the current list of servers
-                api.getPaths().get(path).getServers().clear();
+                api.getPaths().getPathItem(path).getServers().clear();
 
                 // Add each url
                 for (String serverUrl : entry.getValue()) {
-                    api.getPaths().get(path).addServer(new ServerImpl().url(serverUrl));
+                    api.getPaths().getPathItem(path).addServer(new ServerImpl().url(serverUrl));
                 }
             }
         }
@@ -125,7 +123,7 @@ public class BaseProcessor implements OASProcessor {
 
                 // Find the matching operation
                 for (PathItem pathItem : api.getPaths().values()) {
-                    for (Operation operation : pathItem.readOperations()) {
+                    for (Operation operation : pathItem.getOperations().values()) {
                         if (operation.getOperationId().equals(entry.getKey())) {
 
                             // Clear the current list of servers
@@ -141,19 +139,13 @@ public class BaseProcessor implements OASProcessor {
             }
         }
 
-        removeEmptyPaths(api, config);
+        removeEmptyPaths(api);
 
         return api;
     }
 
-    private OpenAPI removeEmptyPaths(OpenAPI api, OpenApiConfiguration config) {
-        Iterator<Map.Entry<String, PathItem>> it = api.getPaths().entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<String, PathItem> entry = it.next();
-            if (new PathItemImpl().equals(entry.getValue())) {
-                it.remove();
-            }
-        }
-        return api;
+    private static void removeEmptyPaths(OpenAPI api) {
+        PathItem emptyItem = new PathItemImpl();
+        api.getPaths().entrySet().removeIf(entry -> emptyItem.equals(entry.getValue()));
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
@@ -91,9 +91,8 @@ public class FilterProcessor implements OASProcessor {
         }
         if (filter != null) {
             return (OpenAPI) filterObject(api);
-        } else {
-            LOGGER.fine("No OASFilter provided.");
         }
+        LOGGER.fine("No OASFilter provided.");
         return api;
     }
 
@@ -134,7 +133,7 @@ public class FilterProcessor implements OASProcessor {
                 }
 
                 for (Object removeTarget : resultsToRemove) {
-                    Iterator<Object> iterator = (Iterator<Object>) Iterable.class.cast(object).iterator();
+                    Iterator<Object> iterator = Iterable.class.cast(object).iterator();
                     while (iterator.hasNext()) {
                         if (iterator.next().equals(removeTarget)) {
                             iterator.remove();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ModelReaderProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ModelReaderProcessor.java
@@ -75,9 +75,8 @@ public class ModelReaderProcessor implements OASProcessor {
             OpenAPI model = reader.buildModel();
             if (model != null) {
                 return model;
-            } else {
-                LOGGER.log(WARNING, "The OpenAPI model returned by " + reader.getClass().getName() + " was null!");
             }
+            LOGGER.log(WARNING, "The OpenAPI model returned by " + reader.getClass().getName() + " was null!");
         } else {
             LOGGER.fine("No OASModelReader provided.");
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/mixin/ExtensionsMixin.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/mixin/ExtensionsMixin.java
@@ -40,33 +40,51 @@
 package fish.payara.microprofile.openapi.impl.rest.app.provider.mixin;
 
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.PathItem.HttpMethod;
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 
 public interface ExtensionsMixin {
 
     @JsonProperty("enum")
-    public abstract void getEnumeration();
+    void getEnumeration();
 
     @JsonProperty("default")
-    public abstract void getDefaultValue();
+    void getDefaultValue();
 
     @JsonProperty("$ref")
-    public abstract void getRef();
+    void getRef();
 
     @JsonIgnore
-    public abstract void setAdditionalProperties(Boolean additionalProperties);
+    void setAdditionalProperties(Boolean additionalProperties);
 
     @JsonInclude(Include.NON_EMPTY)
-    public abstract List<SecurityRequirement> getSecurity();
+    List<SecurityRequirement> getSecurity();
 
     @JsonInclude(Include.ALWAYS)
-    public abstract Paths getPaths();
+    Paths getPaths();
+
+    @JsonAnyGetter
+    Map<String, Object> getExtensions();
+
+    @JsonIgnore
+    Map<HttpMethod, Operation> getOperations();
+
+    @JsonIgnore
+    void setVariables(ServerVariables variables);
+
+    @JsonProperty("variables")
+    void setVariables(Map<String, ServerVariable> variables);
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -74,8 +74,10 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
 import org.eclipse.microprofile.openapi.annotations.callbacks.Callbacks;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extensions;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -153,11 +155,13 @@ public class OpenApiWalker implements ApiWalker {
         // All other OpenAPI annotations
         processAnnotations(Schema.class, visitor::visitSchema, true);
         processAnnotations(Server.class, visitor::visitServer, Servers.class, visitor::visitServers, true);
+        processAnnotations(Extensions.class, visitor::visitExtensions, true);
         processAnnotations(Extension.class, visitor::visitExtension, true);
         processAnnotations(Operation.class, visitor::visitOperation);
         processAnnotations(Callback.class, visitor::visitCallback, Callbacks.class, visitor::visitCallbacks);
         processAnnotations(APIResponse.class, visitor::visitAPIResponse, APIResponses.class,
                 visitor::visitAPIResponses, true);
+        processAnnotations(Parameters.class, visitor::visitParameters, true);
         processAnnotations(Parameter.class, visitor::visitParameter, true);
         processAnnotations(ExternalDocumentation.class, visitor::visitExternalDocumentation, true);
         processAnnotations(Tag.class, visitor::visitTag, Tags.class, visitor::visitTags, true);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/resource/classloader/ApplicationClassLoader.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/resource/classloader/ApplicationClassLoader.java
@@ -106,10 +106,10 @@ public class ApplicationClassLoader extends ClassLoader {
         InputStream stream = getClass().getClassLoader().getResourceAsStream(name);
         int size = stream.available();
         byte buff[] = new byte[size];
-        DataInputStream in = new DataInputStream(stream);
-        // Reading the binary data
-        in.readFully(buff);
-        in.close();
+        try (DataInputStream in = new DataInputStream(stream)) {
+            // Reading the binary data
+            in.readFully(buff);
+        }
         return buff;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/ResponseTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/ResponseTest.java
@@ -88,20 +88,20 @@ public class ResponseTest {
 
     @Test
     public void inheritedMediaTypeTest() {
-        APIResponses responses = document.getPaths().get("/test/response").getGET().getResponses();
+        APIResponses responses = document.getPaths().getPathItem("/test/response").getGET().getResponses();
         // Test the default response doesn't exist
-        assertNull("The default response should be removed when not used.", responses.getDefault());
+        assertNull("The default response should be removed when not used.", responses.getDefaultValue());
 
         // Test the 200 response
-        assertNotNull("The 200 response should have been created.", responses.get("200"));
+        assertNotNull("The 200 response should have been created.", responses.getAPIResponse("200"));
         assertNotNull("The 200 response should return application/json.",
-                responses.get("200").getContent().get(APPLICATION_JSON));
+                responses.getAPIResponse("200").getContent().getMediaType(APPLICATION_JSON));
         assertEquals("The 200 response application/json should match the specified schema.", "hello!",
-                responses.get("200").getContent().get(APPLICATION_JSON).getSchema().getDescription());
+                responses.getAPIResponse("200").getContent().getMediaType(APPLICATION_JSON).getSchema().getDescription());
         assertNotNull("The 200 response should return application/xml.",
-                responses.get("200").getContent().get(APPLICATION_XML));
+                responses.getAPIResponse("200").getContent().getMediaType(APPLICATION_XML));
         assertEquals("The 200 response application/xml should match the specified schema.", "hello!",
-                responses.get("200").getContent().get(APPLICATION_XML).getSchema().getDescription());
+                responses.getAPIResponse("200").getContent().getMediaType(APPLICATION_XML).getSchema().getDescription());
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/RootPathTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/RootPathTest.java
@@ -77,8 +77,8 @@ public class RootPathTest {
 
     @Test
     public void testRoot() {
-        assertNotNull("The root resource wasn't found.", document.getPaths().get("/test"));
+        assertNotNull("The root resource wasn't found.", document.getPaths().getPathItem("/test"));
         assertEquals("The root resource had the wrong origin.", "getRoot",
-                document.getPaths().get("/test").getGET().getOperationId());
+                document.getPaths().getPathItem("/test").getGET().getOperationId());
     }
 }

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -206,7 +206,7 @@
          <microprofile-healthcheck.version>1.0.payara-p1</microprofile-healthcheck.version>
          <microprofile-metrics.version>1.1.payara-p1</microprofile-metrics.version>
          <microprofile-rest-client.version>1.1-payara-p1</microprofile-rest-client.version>
-         <microprofile-openapi.version>1.1.1</microprofile-openapi.version>
+         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
 
          <nimbus-jose-jwt.version>5.4</nimbus-jose-jwt.version>
          <accessors-smart.version>1.2.payara-p2</accessors-smart.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -206,7 +206,7 @@
          <microprofile-healthcheck.version>1.0.payara-p1</microprofile-healthcheck.version>
          <microprofile-metrics.version>1.1.payara-p1</microprofile-metrics.version>
          <microprofile-rest-client.version>1.1-payara-p1</microprofile-rest-client.version>
-         <microprofile-openapi.version>1.0</microprofile-openapi.version>
+         <microprofile-openapi.version>1.1.1</microprofile-openapi.version>
 
          <nimbus-jose-jwt.version>5.4</nimbus-jose-jwt.version>
          <accessors-smart.version>1.2.payara-p2</accessors-smart.version>


### PR DESCRIPTION
Summary:

* Add generics to `Extensible` hierarchy (added in 1.1)
* Implemented new methods (mostly explicit type-safe add/remove/contains)
* Replaced usage of deprecated methods with type-safe replacements added in 1.1
* Removed methods now implemented as `default` methods in the API interfaces
* Added processing of `@Parameters` (missed both by TCK and us in 1.0)
* Added processing of `@Extensions` (missed both by TCK and us in 1.0)
* Added `null` check to `addX` methods (I think 1.1 addec this semantic or 1.0 TCK missed to check)
* Added _copy constructor_ for `Map` model types for their "copy getter" (see API javadoc) 
* Extracted a common base type for `Extensible` `Map`s (share impl.)
* Some more specific local fixes for minor deviations from the spec since 1.0 that TCK 1.1 now found
* Fixed some serialisation issues (present since 1.0)