### PR TITLE
Payara-3419: Support deploying timers to deployment group and non-persistent timer service

### DIFF
--- a/appserver/admingui/ejb/src/main/resources/configuration/ejbContainerTimerService.jsf
+++ b/appserver/admingui/ejb/src/main/resources/configuration/ejbContainerTimerService.jsf
@@ -101,11 +101,7 @@
             <sun:property id="persistenceServiceProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_ejb.ejbTimerSettings.persistenceServiceLabel}"  helpText="$resource{i18n_ejb.ejbTimerSettings.persistenceServiceHelp}" visible="#{true}" >
                 <sun:dropDown id="EjbTimerService" selected="#{pageSession.valueMap['ejbTimerService']}" required="#{false}" value="#{pageSession.valueMap['ejbTimerService']}" labels={"Database","DataGrid","None"} values={"Database","DataGrid","None"} >
                 </sun:dropDown>
-            </sun:property>            
-            <sun:property id="clusterFiringModeProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_ejb.ejbTimerSettings.clusterFiringModeLabel}"  helpText="$resource{i18n_ejb.ejbTimerSettings.clusterFiringModeHelp}" visible="#{true}" >
-                <sun:dropDown id="ClusterFiringMode" selected="#{pageSession.valueMap['clusterFiringMode']}" required="#{false}" value="#{pageSession.valueMap['clusterFiringMode']}" labels={"One Per Data Grid","One Per Deployment Group","All Instances"} values={"OnePerCluster","OnePerDeploymentGroup","AllInstances"} >
-                </sun:dropDown>
-            </sun:property>            
+            </sun:property>
             <sun:property id="TimerDatasourceProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_ejb.ejbTimerSettings.timerDatasourceLabel}" helpText="$resource{i18n_ejb.ejbTimerSettings.timerDatasourceLabelHelp}">
                 <sun:textField id="TimerDatasource"  columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.ejbTimerSettings.timerDatasource']}" text="#{pageSession.valueMap['timerDatasource']}" />
             </sun:property>

--- a/appserver/admingui/ejb/src/main/resources/configuration/ejbContainerTimerService.jsf
+++ b/appserver/admingui/ejb/src/main/resources/configuration/ejbContainerTimerService.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
 
 <!-- configuration/ejbContainerTimerSettings.jsf -->
 
@@ -98,7 +99,7 @@
                 <sun:staticText id="msecs" style="padding: 8pt" text="$resource{i18n.common.Milliseconds}"/>
             </sun:property>
             <sun:property id="persistenceServiceProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_ejb.ejbTimerSettings.persistenceServiceLabel}"  helpText="$resource{i18n_ejb.ejbTimerSettings.persistenceServiceHelp}" visible="#{true}" >
-                <sun:dropDown id="EjbTimerService" selected="#{pageSession.valueMap['ejbTimerService']}" required="#{false}" value="#{pageSession.valueMap['ejbTimerService']}" labels={"Database","DataGrid"} values={"Database","DataGrid"} >
+                <sun:dropDown id="EjbTimerService" selected="#{pageSession.valueMap['ejbTimerService']}" required="#{false}" value="#{pageSession.valueMap['ejbTimerService']}" labels={"Database","DataGrid","None"} values={"Database","DataGrid","None"} >
                 </sun:dropDown>
             </sun:property>            
             <sun:property id="clusterFiringModeProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_ejb.ejbTimerSettings.clusterFiringModeLabel}"  helpText="$resource{i18n_ejb.ejbTimerSettings.clusterFiringModeHelp}" visible="#{true}" >

--- a/appserver/admingui/ejb/src/main/resources/org/glassfish/ejb/admingui/Strings.properties
+++ b/appserver/admingui/ejb/src/main/resources/org/glassfish/ejb/admingui/Strings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 
 ejb.NumBeans=Number of beans
@@ -65,7 +66,7 @@ ejbTimerSettings.redeliveryIntrHelp=Time between redelivery attempts
 ejbTimerSettings.timerDatasourceLabel=Timer Datasource:
 ejbTimerSettings.timerDatasourceLabelHelp=JNDI name of the JDBC resource that will be used as the timer datasource when Database is selected as the Persistence Service
 ejbTimerSettings.persistenceServiceLabel=Persistence Service
-ejbTimerSettings.persistenceServiceHelp=Persistence Service for storing Persistent EJB Timers. Database stores in the specified datasource, DataGrid stores timers in-memory in the Data Grid. In Data Grid mode if all Data Grid instances are shutdown persistent timers will be lost
+ejbTimerSettings.persistenceServiceHelp=Persistence Service for storing Persistent EJB Timers. Database stores in the specified datasource, DataGrid stores timers in-memory in the Data Grid. In Data Grid mode if all Data Grid instances are shutdown persistent timers will be lost. When mode is None, all timers are non-persistent.
 ejbTimerSettings.clusterFiringModeLabel=Clustered Timer Firing Mode
 ejbTimerSettings.clusterFiringModeHelp=Determines how clustered timers fire. One Per Data Grid - only one timer will be active in the data grid. One Per Deployment Group - only one timer will be active within the targeted deployment group. All Instances - Timer will be active on all instances where the application is deployed.
 

--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbTimerService.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbTimerService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation]
+// Portions Copyright [2016-2019] [Payara Foundation]
 
 package org.glassfish.ejb.config;
 
@@ -68,6 +68,8 @@ import javax.validation.constraints.Min;
 
 @Configured
 public interface EjbTimerService extends ConfigBeanProxy, PropertyBag {
+    static String TYPE_NONE = "None";
+    static String TYPE_DATABASE = "Database";
 
     /**
      * Gets the value of the minimumDeliveryIntervalInMillis property.
@@ -160,11 +162,16 @@ public interface EjbTimerService extends ConfigBeanProxy, PropertyBag {
      * Gets the value of the EJB Timer Service  property.
      *
      * The EJB Timer Service type to use in Payara.
+     * Supported values:
+     * <ul>
+     *     <li>{@value #TYPE_DATABASE} for database-backed persistence</li>
+     *     <li>"DataGrid" for DataGrid-backed persistence</li>
+     *     <li>{@value #TYPE_NONE} for non-persistent timer service</li>
+     * </ul>
      *
-     * @return possible object is
-     *         {@link String }
+     * @return One of the options above
      */
-    @Attribute (defaultValue="Database")
+    @Attribute (defaultValue=TYPE_DATABASE)
     String getEjbTimerService();
 
     /**

--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbTimerService.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/EjbTimerService.java
@@ -68,8 +68,8 @@ import javax.validation.constraints.Min;
 
 @Configured
 public interface EjbTimerService extends ConfigBeanProxy, PropertyBag {
-    static String TYPE_NONE = "None";
-    static String TYPE_DATABASE = "Database";
+    String TYPE_NONE = "None";
+    String TYPE_DATABASE = "Database";
 
     /**
      * Gets the value of the minimumDeliveryIntervalInMillis property.

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerService.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 package com.sun.ejb.containers;
 
 import java.io.Serializable;
@@ -391,9 +391,11 @@ public abstract class EJBTimerService {
 
     private static synchronized void initPersistentTimerService(String target, boolean force) {
         if (persistentTimerService == null) {
+            EjbContainerUtil ejbContainerUtil = EjbContainerUtilImpl.getInstance();
+            String serviceType = ejbContainerUtil.getEjbContainer().getEjbTimerService().getEjbTimerService();
             List<PersistentTimerService> persistentTSList
                     = EjbContainerUtilImpl.getInstance().getServices().getAllServices(PersistentTimerService.class);
-            if (persistentTSList.isEmpty()) {
+            if (persistentTSList.isEmpty() || EjbTimerService.TYPE_NONE.equals(serviceType)) {
                 try {
                     persistentTimerService = new NonPersistentEJBTimerService();
                     persistentTimerServiceVerified = true;
@@ -403,8 +405,6 @@ public abstract class EJBTimerService {
             } else {
                 synchronized (LOCK) {
                     // choose service based on the configuration setting
-                    EjbContainerUtil ejbContainerUtil = EjbContainerUtilImpl.getInstance();
-                    String serviceType = ejbContainerUtil.getEjbContainer().getEjbTimerService().getEjbTimerService();
                     PersistentTimerService persistentTS = null;
                     for (PersistentTimerService pts : persistentTSList) {
                         if (pts.getClass().getSimpleName().startsWith(serviceType)) {

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
@@ -469,11 +469,15 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
             }
 
             boolean createTimers = true;
-            if (!(opsparams.origin.isDeploy() || opsparams.origin.isCreateAppRef()) || env.getInstanceName().equals(dcp.target)) {
-                // Do real work only on deploy for a cluster or create-application-ref (the latter will
+            boolean isDeploymentGroup = domain.getDeploymentGroupNamed(dcp.target) != null;
+            boolean isDeployment = opsparams.origin.isDeploy() || opsparams.origin.isCreateAppRef();
+            boolean isDirectTarget = env.getInstanceName().equals(dcp.target);
+            // Create timers on DAS only if this condition is not met
+            if (!isDeployment || isDirectTarget || isDeploymentGroup) {
+                // Create them on deploy for a cluster or create-application-ref (the latter will
                 // check if it's the 1st ref being added or a subsequent one (timers with this unique id are present
                 // or not)
-                // Timers will be created by the BaseContainer if it's a single instance deploy
+                // Otherwise, timers will be created by the BaseContainer if it's a single instance deploy
                 if (_logger.isLoggable(Level.FINE)) {
                     _logger.log(Level.FINE, "EjbDeployer ... will only set the timeout application flag if any");
                 }


### PR DESCRIPTION
`asadmin deploy` no longer fails when application with timers are deployed to a deployment group.

EJB Timer Service offers option of persistence type None, where all timers are treated like non-persistent (as in Web Profile / EJB Lite).