### PR TITLE
PAYARA-3660: Supply Common Classloader as locator

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassloaderResourceLocatorAdapter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassloaderResourceLocatorAdapter.java
@@ -1,0 +1,72 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package com.sun.enterprise.v3.server;
+
+import org.glassfish.hk2.classmodel.reflect.util.ResourceLocator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.stream.Stream;
+
+class ClassloaderResourceLocatorAdapter implements ResourceLocator {
+    private static String[] BLACKLIST = {"java/","com/sun"};
+
+    private ClassLoader delegate;
+
+    ClassloaderResourceLocatorAdapter(ClassLoader delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public InputStream openResourceStream(String name) throws IOException {
+        return isAllowed(name) ? delegate.getResourceAsStream(name) : null;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        return isAllowed(name) ? delegate.getResource(name) : null;
+    }
+
+    private static boolean isAllowed(String name) {
+        return Stream.of(BLACKLIST).noneMatch(p -> name.startsWith(p));
+    }
+}


### PR DESCRIPTION
 when CommonModelRegistry is unavailable. Fixes e. g. CDI deployment in Payara Micro, where the definition of annotations are relevant.

The bug workaround mentioned refers to eclipse-ee4j/glassfish-hk2#446