### PR TITLE
PAYARA-3708 Implemented fixes for JLine Logging

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -133,7 +133,10 @@ public abstract class CLICommand implements PostConstruct {
     };
     private String manpageTokenValues[] = new String[manpageTokens.length];
 
-
+    static{
+        checkToDisableJLineLogging();
+    }
+    
     /**
      * The name of the command.
      * Initialized in the constructor.
@@ -1386,6 +1389,19 @@ public abstract class CLICommand implements PostConstruct {
             }
         } catch (IOException e) {
             e.printStackTrace();
+        }
+    }
+    
+    private static void checkToDisableJLineLogging(){
+        if (Boolean.getBoolean("fish.payara.admin.command.jline.log.disable")) {
+            System.setProperty("jline.log.jul", "false");
+            final OutputStream noOpOutputStream = new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    //NO-OP
+                }
+            };
+            jline.internal.Log.setOutput(new PrintStream(noOpOutputStream));
         }
     }
 }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -137,8 +137,7 @@ public class MultimodeCommand extends CLICommand {
     protected int executeCommand() throws CommandException, CommandValidationException {
         ConsoleReader reader = null;
         programOpts.setEcho(echo);       // restore echo flag, saved in validate
-        try {
-            checkToDisableJLineLogging();
+        try {            
             if (file == null) {
                 System.out.println(strings.get("multimodeIntro"));
                 reader = new ConsoleReader(ASADMIN, System.in, System.out, null, encoding);
@@ -183,19 +182,6 @@ public class MultimodeCommand extends CLICommand {
             catch (Exception e) {
                 // ignore it
             }
-        }
-    }
-    
-    private static void checkToDisableJLineLogging(){
-        if (Boolean.getBoolean("fish.payara.admin.command.jline.log.disable")) {
-            System.setProperty("jline.log.jul", "false");
-            final OutputStream noOpOutputStream = new OutputStream() {
-                @Override
-                public void write(int b) throws IOException {
-                    //NO-OP
-                }
-            };
-            jline.internal.Log.setOutput(new PrintStream(noOpOutputStream));
         }
     }
 


### PR DESCRIPTION
This request is made to complement the changes made by #3757. In particular, the following 2 cases were not considered:

* Running any `asadmin` command outside of multimode
* Running multimode without any domains running.

The gist of the changes was to move the `checkToDisableJLineLogging` method to the `CLICommand` class first and then allow an static initializer to disable the JLine logging before any interaction with a JLine reader is made.