### PR TITLE
PAYARA-3738 OpenIdState: properly implement equals and hashcode method

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/security/openid/api/OpenIdState.java
+++ b/api/payara-api/src/main/java/fish/payara/security/openid/api/OpenIdState.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -46,7 +46,7 @@ import java.util.UUID;
 /**
  * Class to hold state of OpenId
  * <p>
- * This is used in the authentication mechanism to both help prevent CSRF and to 
+ * This is used in the authentication mechanism to both help prevent CSRF and to
  * pass data to the callback page.
  *
  * @author Gaurav Gupta
@@ -54,16 +54,17 @@ import java.util.UUID;
  */
 public class OpenIdState implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final String state;
-    
 
     /**
-     * Creates a new instance with a random UUID as the state. 
+     * Creates a new instance with a random UUID as the state.
      */
     public OpenIdState(){
         state = UUID.randomUUID().toString();
     }
-    
+
     /**
      * Creates a new instance set the state to what is in the constructor.
      * <p>
@@ -72,23 +73,34 @@ public class OpenIdState implements Serializable {
      * {@link fish.payara.security.openid.OpenIdAuthenticationMechanism} by
      * default
      *
-     * @param state 
+     * @param state the state to encapsulate
      */
     public OpenIdState(String state){
         this.state = state;
     }
-    
+
     /**
      * Gets the state
      *
-     * @return
+     * @return the state
      */
     public String getValue() {
         return state;
     }
 
-    public boolean equals(String expectedStateValue) {
-        return Objects.equals(this.state, expectedStateValue);
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof String) {
+            return Objects.equals(this.state, obj);
+        } else if (obj instanceof OpenIdState) {
+            return Objects.equals(this.state, ((OpenIdState)obj).state);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.state);
     }
 
 }


### PR DESCRIPTION
Picked up from sonarcloud.io finding: https://sonarcloud.io/project/issues?id=org.glassfish.main%3Aglassfish-main-aggregator&open=AWVeB8Tq33vkQKHpI6h-&resolved=false&types=BUG

If allowing a String with the same value as the contained state property to qualify as an equal object is IMHO questionable. Should I correct it?