### PR TITLE
PAYARA-3780 fix http and https ports in generated openapi

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -330,7 +330,7 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
 
                     // Check if this listener is using HTTP or HTTPS
                     boolean securityEnabled = Boolean.parseBoolean(networkListener.findProtocol().getSecurityEnabled());
-                    List<Integer> ports = securityEnabled ? httpPorts : httpsPorts;
+                    List<Integer> ports = securityEnabled ? httpsPorts : httpPorts;
 
                     // If this listener isn't the admin listener, it must be an HTTP/HTTPS listener
                     if (!networkListener.getName().equals(adminListener)) {


### PR DESCRIPTION
Documentation of REST API on the /openapi url had switched ports in http and https addresses. This commit fixes it.