### PR TITLE
PAYARA-3825 Validity check and auto-refresh for OpenID connect tokens.

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
+++ b/api/payara-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -218,4 +218,22 @@ public @interface AzureAuthenticationDefinition {
      * @return
      */
     int jwksReadTimeout() default 500;
+    
+    /**
+     * Optional. Enables or disables the automatically performed refresh of
+     * Access and Refresh Token.
+     *
+     * @return {@code true}, if Access and Refresh Token shall be refreshed
+     * automatically when they are expired.
+     */
+    boolean tokenAutoRefresh() default true;
+
+    /**
+     * Optional.Sets the minimum validity time in milliseconds the Access Token
+     * must be valid before it is considered expired. Value must not be negative
+     * and if value is zero then infinite timeout.
+     *
+     * @return
+     */
+    int tokenMinValidity() default 10 * 1000;
 }

--- a/api/payara-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
+++ b/api/payara-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -205,4 +205,22 @@ public @interface GoogleAuthenticationDefinition {
      * @return
      */
     int jwksReadTimeout() default 500;
+
+    /**
+     * Optional. Enables or disables the automatically performed refresh of
+     * Access and Refresh Token.
+     *
+     * @return {@code true}, if Access and Refresh Token shall be refreshed
+     * automatically when they are expired.
+     */
+    boolean tokenAutoRefresh() default true;
+
+    /**
+     * Optional.Sets the minimum validity time in milliseconds the Access Token
+     * must be valid before it is considered expired. Value must not be negative
+     * and if value is zero then infinite timeout.
+     *
+     * @return
+     */
+    int tokenMinValidity() default 10 * 1000;
 }

--- a/api/payara-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/api/payara-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -320,4 +320,32 @@ public @interface OpenIdAuthenticationDefinition {
      * <code>{@value}</code>.
      */
     public static final String OPENID_MP_CLIENT_ENC_JWKS = "payara.security.openid.client.encryption.jwks";
+    
+    /**
+     * The Microprofile Config key for the Access Token auto refresh is
+     * <code>{@value}</code>.
+     */
+    public static final String OPENID_MP_TOKEN_AUTO_REFRESH = "payara.security.openid.token.auto-refresh";
+
+    /**
+     * The Microprofile Config key for the minimum validity in secondes of
+     * Access Tokens is <code>{@value}</code>.
+     */
+    public static final String OPENID_MP_TOKEN_MIN_VALIDITY = "payara.security.openid.token.min-validity";
+
+    /**
+     * Optional. Enables or disables the automatically performed refresh of
+     * Access and Refresh Token.
+     *
+     * @return {@code true}, if Access and Refresh Token shall be refreshed
+     * automatically when they are expired.
+     */
+    boolean tokenAutoRefresh() default true;
+
+    /**
+     * Optional. Sets the minimum validity time in milliseconds the Access Token
+     * must be valid before it is considered expired. Value must not be negative
+     * and if value is zero then infinite timeout.
+     */
+    int tokenMinValidity() default 10 * 1000;
 }

--- a/api/payara-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/api/payara-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -346,6 +346,8 @@ public @interface OpenIdAuthenticationDefinition {
      * Optional. Sets the minimum validity time in milliseconds the Access Token
      * must be valid before it is considered expired. Value must not be negative
      * and if value is zero then infinite timeout.
+     *
+     * @return
      */
     int tokenMinValidity() default 10 * 1000;
 }

--- a/api/payara-api/src/main/java/fish/payara/security/openid/api/OpenIdConstant.java
+++ b/api/payara-api/src/main/java/fish/payara/security/openid/api/OpenIdConstant.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -82,7 +82,10 @@ public interface OpenIdConstant {
     public static final String ERROR_DESCRIPTION_PARAM = "error_description";
 
     //claims
+    public static final String ISSUER_IDENTIFIER = "iss";
     public static final String SUBJECT_IDENTIFIER = "sub";
+    public static final String EXPIRATION_IDENTIFIER = "exp";
+    public static final String AUDIENCE = "aud";
     public static final String AUTHORIZED_PARTY = "azp";
     public static final String ACCESS_TOKEN_HASH = "at_hash";
 

--- a/api/payara-api/src/main/java/fish/payara/security/openid/api/Scope.java
+++ b/api/payara-api/src/main/java/fish/payara/security/openid/api/Scope.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -39,70 +39,44 @@
  */
 package fish.payara.security.openid.api;
 
-import java.util.Map;
+import static java.util.Arrays.asList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import static java.util.Objects.isNull;
 
 /**
- * The Access Token is used by an application to access protected resources.
  *
- * @author jGauravGupta
+ * @author Gaurav Gupta
  */
-public interface AccessToken {
+public class Scope extends LinkedHashSet<String> {
 
-    /**
-     * The access token
-     *
-     * @return
-     */
-    public String getToken();
-
-    /**
-     * Gets the access token's claims that was received from the OpenId Connect
-     * provider
-     *
-     * @return
-     */
-    Map<String, Object> getClaims();
-
-    /**
-     * Gets the identity token's claim based on requested key type.
-     *
-     * @param key
-     * @return
-     */
-    Object getClaim(String key);
-
-    /**
-     * Optional. Expiration time of the Access Token in seconds since the
-     * response was generated.
-     *
-     * @return
-     */
-    Long getExpirationTime();
-
-    /**
-     * Checks if the Access Token is expired, taking into account the min
-     * validity time configured by the user.
-     *
-     * @return {@code true}, if access token is expired or it will be expired in
-     * the next X milliseconds configured by user.
-     */
-    boolean isExpired();
-
-    /**
-     * Optional. Scope of the Access Token.
-     *
-     * @return
-     */
-    Scope getScope();
-
-    /**
-     * Type of the Access Token.
-     * @return
-     */
-    public Type getType();
-
-    enum Type {
-        BEARER, // Json Web Token (JWT) format
-        MAC; // Message Authentication Code format
+    public Scope() {
     }
+
+    public Scope(final List<String> values) {
+        addAll(values);
+    }
+
+    public static Scope parse(final String scopeValue) {
+
+        if (isNull(scopeValue)) {
+            return null;
+        }
+
+        Scope scope = new Scope();
+
+        if (scopeValue.trim().isEmpty()) {
+            return scope;
+        }
+
+        // Multiple scope values may be used by creating a space delimited
+        scope.addAll(asList(scopeValue.split(" ")));
+        return scope;
+    }
+
+    @Override
+    public String toString() {
+        return String.join(" ", this);
+    }
+
 }

--- a/appserver/payara-appserver-modules/security-openid/pom.xml
+++ b/appserver/payara-appserver-modules/security-openid/pom.xml
@@ -102,6 +102,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <version>${microprofile-config.version}</version>

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -299,7 +299,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
             HttpServletResponse response,
             HttpMessageContext httpContext) throws AuthenticationException {
 
-        if (isAccessTokenExpired()) {
+        if (this.context.getAccessToken().isExpired()) {
             // Access Token expired
             LOGGER.fine("Access Token is expired. Request new Access Token with Refresh Token.");
 
@@ -321,20 +321,6 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         return SUCCESS;
 
-    }
-
-    /**
-     * Checks if the Access Token is expired, taking into account the min
-     * validity time configured by the user.
-     *
-     * @see OpenIdAuthenticationDefinition2#tokenMinValidity()
-     * @see OpenIdAuthenticationDefinition2#OPENID_MP_TOKEN_MIN_VALIDITY
-     * @return {@code true}, if token is expired or it will be expired in the
-     * next X millisecondes configured by user.
-     */
-    private boolean isAccessTokenExpired() {
-        Date exp = (Date) this.context.getAccessToken().getClaim("exp");
-        return System.currentTimeMillis() + configuration.getTokenMinValidity() > exp.getTime();
     }
 
     private AuthenticationStatus refreshTokens(HttpMessageContext httpContext, RefreshToken refreshToken) {

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -71,8 +71,14 @@ public class OpenIdCredential implements Credential {
 
         this.identityToken = new IdentityTokenImpl(tokensObject.getString(IDENTITY_TOKEN));
         String accessTokenString = tokensObject.getString(ACCESS_TOKEN, null);
+        Long expiresIn = null;
+        if(nonNull(tokensObject.getJsonNumber("expires_in"))){
+            expiresIn = tokensObject.getJsonNumber("expires_in").longValue();
+        }
+        String tokenType = tokensObject.getString("token_type", null);
+        String scopeString = tokensObject.getString("scope", null);
         if (nonNull(accessTokenString)) {
-            accessToken = new AccessTokenImpl(accessTokenString);
+            accessToken = new AccessTokenImpl(configuration, tokenType, accessTokenString, expiresIn, scopeString);
         }
     }
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/azure/AzureOpenIdAuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/azure/AzureOpenIdAuthenticationMechanism.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -43,7 +43,6 @@ import fish.payara.security.annotations.AzureAuthenticationDefinition;
 import fish.payara.security.openid.OpenIdAuthenticationMechanism;
 import static fish.payara.security.openid.azure.AzureOpenIdExtension.toOpenIdAuthDefinition;
 import javax.enterprise.inject.Typed;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
 
 /**
  * The Azure AD AuthenticationMechanism used to authenticate users using the
@@ -51,7 +50,6 @@ import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
  *
  * @author Gaurav Gupta
  */
-@AutoApplySession
 @Typed(AzureOpenIdAuthenticationMechanism.class)
 public class AzureOpenIdAuthenticationMechanism extends OpenIdAuthenticationMechanism {
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/azure/AzureOpenIdExtension.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/azure/AzureOpenIdExtension.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -216,12 +216,12 @@ public class AzureOpenIdExtension extends OpenIdExtension {
 
             @Override
             public boolean tokenAutoRefresh() {
-                return false; // TODO check if "true" is working with Azure
+                return azureDefinition.tokenAutoRefresh();
             }
 
             @Override
             public int tokenMinValidity() {
-                return 0;
+                return azureDefinition.tokenMinValidity();
             }
         };
     }

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/azure/AzureOpenIdExtension.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/azure/AzureOpenIdExtension.java
@@ -213,6 +213,16 @@ public class AzureOpenIdExtension extends OpenIdExtension {
             public int jwksReadTimeout() {
                 return azureDefinition.jwksReadTimeout();
             }
+
+            @Override
+            public boolean tokenAutoRefresh() {
+                return false; // TODO check if "true" is working with Azure
+            }
+
+            @Override
+            public int tokenMinValidity() {
+                return 0;
+            }
         };
     }
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -70,6 +70,7 @@ import static fish.payara.security.openid.api.OpenIdConstant.AUTHORIZATION_ENDPO
 import static fish.payara.security.openid.api.OpenIdConstant.HYBRID_FLOW_TYPES;
 import static fish.payara.security.openid.api.OpenIdConstant.IMPLICIT_FLOW_TYPES;
 import static fish.payara.security.openid.api.OpenIdConstant.JWKS_URI;
+import static fish.payara.security.openid.api.OpenIdConstant.OFFLINE_ACCESS_SCOPE;
 import static fish.payara.security.openid.api.OpenIdConstant.OPENID_SCOPE;
 import static fish.payara.security.openid.api.OpenIdConstant.TOKEN_ENDPOINT;
 import static fish.payara.security.openid.api.OpenIdConstant.USERINFO_ENDPOINT;

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -56,6 +56,8 @@ import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OP
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_RESPONSE_MODE;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_RESPONSE_TYPE;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_SCOPE;
+import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_AUTO_REFRESH;
+import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_MIN_VALIDITY;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION;
 import static fish.payara.security.annotations.OpenIdProviderMetadata.OPENID_MP_AUTHORIZATION_ENDPOINT;
@@ -205,6 +207,9 @@ public class ConfigurationController {
         String callerNameClaim = getConfiguredValue(String.class, definition.claimsDefinition().callerNameClaim(), provider, OPENID_MP_CALLER_NAME_CLAIM);
         String callerGroupsClaim = getConfiguredValue(String.class, definition.claimsDefinition().callerGroupsClaim(), provider, OPENID_MP_CALLER_GROUP_CLAIM);
 
+        boolean tokenAutoRefresh = getConfiguredValue(Boolean.class, definition.tokenAutoRefresh(), provider, OPENID_MP_TOKEN_AUTO_REFRESH);
+        int tokenMinValidity = getConfiguredValue(Integer.class, definition.tokenMinValidity(), provider, OPENID_MP_TOKEN_MIN_VALIDITY);
+        
         OpenIdConfiguration configuration = new OpenIdConfiguration()
                 .setProviderMetadata(
                         new OpenIdProviderMetadata(providerDocument)
@@ -236,7 +241,9 @@ public class ConfigurationController {
                 .setUseNonce(nonce)
                 .setUseSession(session)
                 .setJwksConnectTimeout(jwksConnectTimeout)
-                .setJwksReadTimeout(jwksReadTimeout);
+                .setJwksReadTimeout(jwksReadTimeout)
+                .setTokenAutoRefresh(tokenAutoRefresh)
+                .setTokenMinValidity(tokenMinValidity);
 
         validateConfiguration(configuration);
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/RefreshedIdTokenClaimsSetVerifier.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/RefreshedIdTokenClaimsSetVerifier.java
@@ -1,0 +1,107 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.openid.controller;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
+import fish.payara.security.openid.api.IdentityToken;
+import static fish.payara.security.openid.api.OpenIdConstant.ISSUER_IDENTIFIER;
+import static fish.payara.security.openid.api.OpenIdConstant.SUBJECT_IDENTIFIER;
+import static fish.payara.security.openid.api.OpenIdConstant.AUDIENCE;
+import static fish.payara.security.openid.api.OpenIdConstant.AUTHORIZED_PARTY;
+import fish.payara.security.openid.domain.OpenIdConfiguration;
+import java.util.List;
+import static java.util.Objects.isNull;
+
+/**
+ * Validates the ID token received from the Refresh token response
+ *
+ * @author Gaurav Gupta
+ */
+public class RefreshedIdTokenClaimsSetVerifier extends TokenClaimsSetVerifier {
+
+    private final IdentityToken previousIdToken;
+
+    public RefreshedIdTokenClaimsSetVerifier(IdentityToken previousIdToken, OpenIdConfiguration configuration) {
+        super(configuration);
+        this.previousIdToken = previousIdToken;
+    }
+
+    /**
+     * Validate ID Token's claims received from the Refresh token response
+     *
+     * @param claims
+     * @throws com.nimbusds.jwt.proc.BadJWTException
+     */
+    @Override
+    public void verify(JWTClaimsSet claims) throws BadJWTException {
+
+        String previousIssuer = (String) previousIdToken.getClaim(ISSUER_IDENTIFIER);
+        String newIssuer = (String) claims.getIssuer();
+        if (newIssuer == null || !newIssuer.equals(previousIssuer)) {
+            throw new IllegalStateException("iss Claim Value MUST be the same as in the ID Token issued when the original authentication occurred.");
+        }
+
+        String previousSubject = (String) previousIdToken.getClaim(SUBJECT_IDENTIFIER);
+        String newSubject = (String) claims.getSubject();
+        if (newSubject == null || !newSubject.equals(previousSubject)) {
+            throw new IllegalStateException("sub Claim Value MUST be the same as in the ID Token issued when the original authentication occurred.");
+        }
+
+        List<String> previousAudience = (List<String>) previousIdToken.getClaim(AUDIENCE);
+        List<String> newAudience = claims.getAudience();
+        if (newAudience == null || !newAudience.equals(previousAudience)) {
+            throw new IllegalStateException("aud Claim Value MUST be the same as in the ID Token issued when the original authentication occurred.");
+        }
+
+        if(isNull(claims.getIssueTime())) {
+            throw new IllegalStateException("iat Claim Value must not be null.");
+        }
+
+        String previousAzp = (String) previousIdToken.getClaim(AUTHORIZED_PARTY);
+        String newAzp = (String) claims.getClaim(AUTHORIZED_PARTY);
+        if (previousAzp == null ? newAzp != null : !previousAzp.equals(newAzp)) {
+            throw new IllegalStateException("azp Claim Value MUST be the same as in the ID Token issued when the original authentication occurred.");
+        }
+
+        // if the ID Token contains an auth_time Claim, its value MUST represent the time of the original authentication - not the time that the new ID token is issued,
+    }
+
+}

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -66,6 +66,7 @@ import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier;
 import static fish.payara.security.openid.OpenIdUtil.DEFAULT_JWT_SIGNED_ALGORITHM;
+import fish.payara.security.openid.api.IdentityToken;
 import static fish.payara.security.openid.api.OpenIdConstant.AUTHORIZATION_CODE;
 import static fish.payara.security.openid.api.OpenIdConstant.CLIENT_ID;
 import static fish.payara.security.openid.api.OpenIdConstant.CLIENT_SECRET;
@@ -173,6 +174,21 @@ public class TokenController {
             nonceController.remove(configuration, httpContext);
         }
 
+        return claimsSet.getClaims();
+    }
+
+    /**
+     * Validate Id Token received from Successful Refresh Response.
+     *
+     * @param previousIdToken
+     * @param newIdToken
+     * @param httpContext
+     * @param configuration
+     * @return JWT Claims
+     */
+    public Map<String, Object> validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
+        JWTClaimsSetVerifier jwtVerifier = new RefreshedIdTokenClaimsSetVerifier(previousIdToken, configuration);
+        JWTClaimsSet claimsSet = validateBearerToken(newIdToken.getTokenJWT(), jwtVerifier, configuration);
         return claimsSet.getClaims();
     }
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
@@ -72,6 +72,8 @@ import static fish.payara.security.openid.api.OpenIdConstant.CLIENT_SECRET;
 import static fish.payara.security.openid.api.OpenIdConstant.CODE;
 import static fish.payara.security.openid.api.OpenIdConstant.GRANT_TYPE;
 import static fish.payara.security.openid.api.OpenIdConstant.REDIRECT_URI;
+import static fish.payara.security.openid.api.OpenIdConstant.REFRESH_TOKEN;
+import fish.payara.security.openid.api.RefreshToken;
 import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.IdentityTokenImpl;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
@@ -202,6 +204,31 @@ public class TokenController {
 //        }
 
         return claims;
+    }
+
+    /**
+     * Makes a refresh request to the token endpoint and the OpenId Provider
+     * responds with a new (updated) Access Token and Refreshs Token.
+     *
+     * @param configuration
+     * @param refreshToken Refresh Token received from previous token request.
+     * @return a JSON object representation of OpenID Connect token response
+     * from the Token endpoint.
+     */
+    public Response getTokens(OpenIdConfiguration configuration, RefreshToken refreshToken) {
+
+        Form form = new Form()
+                .param(CLIENT_ID, configuration.getClientId())
+                .param(CLIENT_SECRET, new String(configuration.getClientSecret()))
+                .param(GRANT_TYPE, REFRESH_TOKEN)
+                .param(REFRESH_TOKEN, refreshToken.getToken());
+
+        // Access Token and RefreshToken Request
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(configuration.getProviderMetadata().getTokenEndpoint());
+        return target.request()
+                .accept(APPLICATION_JSON)
+                .post(Entity.form(form));
     }
 
     private JWTClaimsSet validateBearerToken(JWT token, JWTClaimsSetVerifier jwtVerifier, OpenIdConfiguration configuration) {

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -66,6 +66,8 @@ public class OpenIdConfiguration {
     private OpenIdProviderMetadata providerMetadata;
     private OpenIdTokenEncryptionMetadata encryptionMetadata;
     private ClaimsConfiguration claimsConfiguration;
+    private boolean tokenAutoRefresh;
+    private int tokenMinValidity;
 
     private static final String BASE_URL_EXPRESSION = "${baseURL}";
 
@@ -222,6 +224,24 @@ public class OpenIdConfiguration {
         return this;
     }
 
+    public boolean isTokenAutoRefresh() {
+        return tokenAutoRefresh;
+    }
+
+    public OpenIdConfiguration setTokenAutoRefresh(boolean tokenAutoRefresh) {
+        this.tokenAutoRefresh = tokenAutoRefresh;
+        return this;
+    }
+
+    public int getTokenMinValidity() {
+        return tokenMinValidity;
+    }
+
+    public OpenIdConfiguration setTokenMinValidity(int tokenMinValidity) {
+        this.tokenMinValidity = tokenMinValidity;
+        return this;
+    }
+
     @Override
     public String toString() {
         return OpenIdConfiguration.class.getSimpleName()
@@ -240,6 +260,8 @@ public class OpenIdConfiguration {
                 + ", providerMetadata=" + providerMetadata
                 + ", claimsConfiguration=" + claimsConfiguration
                 + ", encryptionMetadata=" + encryptionMetadata
+                + ", tokenAutoRefresh=" + tokenAutoRefresh
+                + ", tokenMinValidity=" + tokenMinValidity
                 + '}';
     }
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/google/GoogleOpenIdAuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/google/GoogleOpenIdAuthenticationMechanism.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -43,7 +43,6 @@ import fish.payara.security.annotations.GoogleAuthenticationDefinition;
 import fish.payara.security.openid.OpenIdAuthenticationMechanism;
 import static fish.payara.security.openid.google.GoogleOpenIdExtension.toOpenIdAuthDefinition;
 import javax.enterprise.inject.Typed;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
 
 /**
  * The Google AuthenticationMechanism used to authenticate users using the
@@ -51,7 +50,6 @@ import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
  *
  * @author Gaurav Gupta
  */
-@AutoApplySession
 @Typed(GoogleOpenIdAuthenticationMechanism.class)
 public class GoogleOpenIdAuthenticationMechanism extends OpenIdAuthenticationMechanism {
 

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/google/GoogleOpenIdExtension.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/google/GoogleOpenIdExtension.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -205,12 +205,12 @@ public class GoogleOpenIdExtension extends OpenIdExtension {
 
             @Override
             public boolean tokenAutoRefresh() {
-                return false; // TODO check if "true" is working with Google
+                return googleDefinition.tokenAutoRefresh();
             }
 
             @Override
             public int tokenMinValidity() {
-                return 0;
+                return googleDefinition.tokenMinValidity();
             }
         };
     }

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/google/GoogleOpenIdExtension.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/google/GoogleOpenIdExtension.java
@@ -202,6 +202,16 @@ public class GoogleOpenIdExtension extends OpenIdExtension {
             public int jwksReadTimeout() {
                 return googleDefinition.jwksReadTimeout();
             }
+
+            @Override
+            public boolean tokenAutoRefresh() {
+                return false; // TODO check if "true" is working with Google
+            }
+
+            @Override
+            public int tokenMinValidity() {
+                return 0;
+            }
         };
     }
 


### PR DESCRIPTION
Added (optional) validity-check for Access Tokens and automated refresh of Access and Refresh tokens to OpenID connect authentication mechanism.

If auto-refresh is enabled but the Refresh Token is invalid (expired or user has logged out from OpenID connect provider), (s)he is logged out from the application (app-server) as well and redirected to the OpenID Connect provider. This allows the user to login again.