### PR TITLE
PAYARA-3487 Race condition in ConnectionPool

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceState.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceState.java
@@ -41,11 +41,19 @@
 
 package com.sun.enterprise.resource;
 
+import com.sun.enterprise.resource.pool.ConnectionPool;
+import com.sun.logging.LogDomains;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class ResourceState {
     private boolean enlisted;
     private boolean busy;
     private long timestamp;
     private TwiceBusyException busyException;
+    
+    //This is the same logger as in ConnectionPool, used to check the log level
+    private Logger LOGGER = LogDomains.getLogger(ConnectionPool.class,LogDomains.RSR_LOGGER);
 
     public boolean isEnlisted() {
         return enlisted;
@@ -69,7 +77,7 @@ public class ResourceState {
 
     public void setBusy(boolean busy) {
         this.busy = busy;
-        if (!busy) {
+        if (!busy && LOGGER.isLoggable(Level.FINE)) {
             busyException = new TwiceBusyException();
         }
     }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceState.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceState.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.resource;
 
@@ -44,6 +45,7 @@ public class ResourceState {
     private boolean enlisted;
     private boolean busy;
     private long timestamp;
+    private TwiceBusyException busyException;
 
     public boolean isEnlisted() {
         return enlisted;
@@ -67,6 +69,20 @@ public class ResourceState {
 
     public void setBusy(boolean busy) {
         this.busy = busy;
+        if (!busy) {
+            busyException = new TwiceBusyException();
+        }
+    }
+    
+    /**
+     * Gets an exception with a stack trace of when the resource was previously
+     * set to not busy.
+     * @return a TwiceBusyException used to create a MultiException when setBusy
+     * is set to false twice
+     * @see com.sun.enterprise.resource.pool.ConnectionPool#resourceClosed(com.sun.enterprise.resource.ResourceHandle) 
+     */
+    public TwiceBusyException getBusyStackException(){
+        return busyException;
     }
 
     public long getTimestamp() {
@@ -81,7 +97,11 @@ public class ResourceState {
         touchTimestamp();
     }
 
+    @Override
     public String toString() {
         return "Enlisted :" + enlisted + " Busy :" + busy;
     }
+    
+    public class TwiceBusyException extends Exception {}
+    
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -1020,11 +1020,14 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
 
         if (!state.isBusy()) {
             //throw new IllegalStateException("state.isBusy() : false");
-            MultiException noBusyException = new MultiException(state.getBusyStackException());
-            noBusyException.addError(new IllegalStateException("state.isBusy() : false"));
-            _logger.log(Level.WARNING, "state.isBusy already set to false for " + h.getName() + "#" + h.getId(), noBusyException);
+            _logger.log(Level.WARNING, "state.isBusy already set to false for {0}#{1}", new Object[]{h.getName(), h.getId()});
+            if (_logger.isLoggable(Level.FINE)) {
+                MultiException noBusyException = new MultiException(state.getBusyStackException());
+                noBusyException.addError(new IllegalStateException("state.isBusy() : false"));
+                _logger.log(Level.WARNING, null, noBusyException);
+            }
         }
-
+            
         setResourceStateToFree(h);  // mark as not busy
         state.touchTimestamp();
 

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -71,6 +71,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.internal.api.Globals;
+import org.glassfish.hk2.api.MultiException;
 
 /**
  * Connection Pool for Connector & JDBC resources<br>
@@ -1005,6 +1006,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
      * this method is called to indicate that the resource is
      * not used by a bean/application anymore
      */
+    @Override
     public void resourceClosed(ResourceHandle h)
             throws IllegalStateException {
         if (_logger.isLoggable(Level.FINE)) {
@@ -1017,7 +1019,10 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
         }
 
         if (!state.isBusy()) {
-            throw new IllegalStateException("state.isBusy() : false");
+            //throw new IllegalStateException("state.isBusy() : false");
+            MultiException noBusyException = new MultiException(state.getBusyStackException());
+            noBusyException.addError(new IllegalStateException("state.isBusy() : false"));
+            _logger.log(Level.WARNING, "state.isBusy already set to false for " + h.getName() + "#" + h.getId(), noBusyException);
         }
 
         setResourceStateToFree(h);  // mark as not busy


### PR DESCRIPTION
When a connectionpool is closed it now logs an error rather than throwing an exception.

A multiexception is printed, showing both the current stack trace and the trace of where
the resource was previously closed.