### PR TITLE
PAYARA-3729 Added missing runtime dependencies

### DIFF
--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -114,10 +114,22 @@
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-binding</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.json.bind</groupId>
+                    <artifactId>jakarta.json.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -46,16 +46,16 @@
         <artifactId>ejb-http-remoting</artifactId>
         <version>5.192-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>ejb-http-client</artifactId>
-    
+
     <name>EJB - HTTP Client</name>
     <description>
         Module providing support for the EJB HTTP Client. This contains an InitialContext based lookup mechanism that uses HTTP calls back
         to Payara to lookup EJB beans, as well as a proxy mechanism to invoke methods on an EJB, which will be sent via HTTP all well
         to Payara.
     </description>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -69,6 +69,31 @@
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <!--<version>1.1.0</version> -->
+                <configuration>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -92,7 +117,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
+            <artifactId>jersey-media-json-binding</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -86,5 +86,13 @@
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <!--<version>1.1.0</version> -->
+                <version>1.1.0</version>
                 <configuration>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Adds the missing runtime dependencies to the client and used the maven flatten plugin that will make the distributed artefact appear as if it is the top most  stand-alone module which makes it cleaner to use the client.

Tested this with both our jersey patched version `2.27.payara-p15`  and `2.28`. 

I attached a maven project with test application to the jira issue. This can be used to deploy (make a jar without the `Client` class) and verify (run `Client` class) the EJB over HTTP.