### PR TITLE
PAYARA-3729 EJB HTTP Endpoint improvments

### DIFF
--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -46,16 +46,16 @@
         <artifactId>ejb-http-remoting</artifactId>
         <version>5.192-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>ejb-http-client</artifactId>
-    
+
     <name>EJB - HTTP Client</name>
     <description>
         Module providing support for the EJB HTTP Client. This contains an InitialContext based lookup mechanism that uses HTTP calls back
         to Payara to lookup EJB beans, as well as a proxy mechanism to invoke methods on an EJB, which will be sent via HTTP all well
         to Payara.
     </description>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -69,6 +69,31 @@
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <!--<version>1.1.0</version> -->
+                <configuration>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -92,7 +117,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
+            <artifactId>jersey-media-json-binding</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -86,5 +86,13 @@
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
+++ b/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
@@ -47,11 +47,16 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Base64;
-import java.util.List;
-import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.json.*;
 import javax.json.bind.Jsonb;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 import javax.json.bind.JsonbBuilder;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -72,111 +77,112 @@ import com.sun.enterprise.security.ee.auth.login.ProgrammaticLogin;
 public class InvokeEJBServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
 
+    private static final Logger logger = Logger.getLogger(InvokeEJBServlet.class.getName());
+
+    @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         response.getWriter().append("Served at: ").append(request.getContextPath());
     }
 
+    @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        JsonObject requestPayload = readJsonObject(request.getReader());
 
-        final JsonObject requestPayload = readJsonObject(request.getReader());
-
+        String beanName = requestPayload.getString("lookup");
         if (request.getRequestURI().endsWith("lookup")) {
-            boolean success = excuteInAppContext(() -> {
-
-                try {
-                    response.getWriter().print(
-                            new InitialContext().lookup(requestPayload.getString("lookup"))
-                                                .getClass()
-                                                .getInterfaces()[0]
-                                                .getName());
-                    return true;
-                } catch (IOException | NamingException e) {
-                    // Ignore for now
-                }
-
-                return false;
-            });
-
-            if (!success) {
-                response.sendError(SC_INTERNAL_SERVER_ERROR, "Name " + requestPayload.getString("lookup") + " not found when doing initial lookup");
-            }
-
-            return;
-        }
-
-        // Convert JSON encoded method parameter type names to actually Class instances
-        Class<?>[] argTypes =
-            requestPayload.getJsonArray("argTypes").stream()
-                          .map(e -> toClass(e))
-                          .toArray(Class[]::new);
-
-        // Convert JSON encoded method parameter values to their object instances
-        List<JsonValue> jsonArgValues = requestPayload.getJsonArray("argValues");
-        Object[] argValues = new Object[argTypes.length];
-        for (int i = 0; i < jsonArgValues.size(); i++) {
-            argValues[i] =  toObject(jsonArgValues.get(i), argTypes[i]);
-        }
-
-        boolean success = excuteInAppContext(() -> {
             try {
-                // Obtain the target EJB that we're going to invoke
-                Object bean = new InitialContext().lookup(requestPayload.getString("lookup"));
-
-                // Authenticates the caller and if successful sets the security context
-                // *for the outgoing EJB call*. In other words, the security context for this
-                // Servlet will not be changed.
-                if (requestPayload.containsKey(SECURITY_PRINCIPAL)) {
-                    ProgrammaticLogin login = new ProgrammaticLogin();
-                    login.login(
-                        base64Decode(requestPayload.getString(SECURITY_PRINCIPAL)),
-                        base64Decode(requestPayload.getString(SECURITY_CREDENTIALS)),
-                        null, true);
-                }
-
-                // Actually invoke the target EJB
-                Object result =
-                    bean.getClass()
-                        .getMethod(requestPayload.getString("method"), argTypes)
-                        .invoke(bean, argValues);
-
+                response.getWriter().print(lookupBeanInterface(beanName));
+            } catch (NamingException ex) {
+                response.sendError(SC_INTERNAL_SERVER_ERROR,
+                        "Name " + beanName + " not found when doing initial lookup.");
+            } catch (Exception ex) {
+                logger.log(Level.WARNING, "EJB bean lookup failed.", ex);
+                response.sendError(SC_INTERNAL_SERVER_ERROR,
+                        "Error while looking up EJB with name " + beanName + ": " + ex.getMessage());
+            }
+        } else {
+            String methodName = requestPayload.getString("method");
+            Class<?>[] argTypes = toClasses(requestPayload.getJsonArray("argTypes"));
+            Object[] argValues = toObjects(argTypes, requestPayload.getJsonArray("argValues"));
+            String principal = requestPayload.getString(SECURITY_PRINCIPAL, "");
+            String credentials = requestPayload.getString(SECURITY_CREDENTIALS, "");
+            try {
+                Object result = invokeBeanMethod(beanName, methodName, argTypes, argValues, principal, credentials);
                 response.setContentType(APPLICATION_JSON);
                 response.getWriter().print(result instanceof String? result : JsonbBuilder.create().toJson(result));
-
-                return true;
-
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (NamingException ex) {
+                response.sendError(SC_INTERNAL_SERVER_ERROR,
+                        "Name " + beanName + " not found when invoking method " + methodName);
+            } catch (Exception ex) {
+                logger.log(Level.WARNING, "EJB bean method invocation failed.", ex);
+                response.sendError(SC_INTERNAL_SERVER_ERROR,
+                        "Error while invoking invoking method " + methodName + " on EJB with name " + beanName + ": "
+                                + ex.getMessage());
             }
-
-            return false;
-        });
-
-        if (!success) {
-            response.sendError(SC_INTERNAL_SERVER_ERROR, "Name " + requestPayload.getString("lookup") + " not found when invoking");
         }
     }
 
-    private JsonObject readJsonObject(Reader reader) {
+    private static JsonObject readJsonObject(Reader reader) {
         try (JsonReader jsonReader = Json.createReader(reader)) {
             return jsonReader.readObject();
         }
     }
 
-    private Class<?> toClass(JsonValue classNameValue) {
-        try {
-            String className = null;
-            if (classNameValue instanceof JsonString) {
-                className = ((JsonString) classNameValue).getString();
-            } else {
-                className = classNameValue.toString().replace("\"", "");
+    private static String lookupBeanInterface(String beanName) throws Exception {
+        return excuteInAppContext(beanName, bean -> {
+            int bangIndex = beanName.indexOf('!');
+            if (bangIndex > 0) {
+                return beanName.substring(bangIndex + 1);
             }
-            return Class.forName(className);
+            // there should only be one interface otherwise plain name would not be allowed (portable names at least)
+            return bean.getClass().getInterfaces()[0].getName();
+        });
+    }
+
+    private static Object invokeBeanMethod(String beanName, String methodName, Class<?>[] argTypes, Object[] argValues,
+            String principal, String credentials) throws Exception {
+        return excuteInAppContext(beanName, bean -> {
+            // Authenticates the caller and if successful sets the security context
+            // *for the outgoing EJB call*. In other words, the security context for this
+            // Servlet will not be changed.
+            if (!principal.isEmpty()) {
+                new ProgrammaticLogin().login(base64Decode(principal), base64Decode(credentials), null, true);
+            }
+            // Actually invoke the target EJB
+            return bean.getClass().getMethod(methodName, argTypes).invoke(bean, argValues);
+        });
+    }
+
+    /**
+     * Convert JSON encoded method parameter type names to actually Class instances 
+     */
+    private static Class<?>[] toClasses(JsonArray classNames) {
+        return classNames.stream().map(e -> toClass(e)).toArray(Class[]::new);
+    }
+
+    private static Class<?> toClass(JsonValue classNameValue) {
+        try {
+            if (classNameValue instanceof JsonString) {
+                return Class.forName(((JsonString) classNameValue).getString());
+            }
+            return Class.forName(classNameValue.toString().replace("\"", ""));
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException(e);
         }
     }
 
-    private Object toObject(JsonValue objectValue, Class<?> type) {
+    /**
+     * Convert JSON encoded method parameter values to their object instances 
+     */
+    private static Object[] toObjects(Class<?>[] argTypes, JsonArray jsonArgValues) {
+        Object[] argValues = new Object[argTypes.length];
+        for (int i = 0; i < jsonArgValues.size(); i++) {
+            argValues[i] =  toObject(jsonArgValues.get(i), argTypes[i]);
+        }
+        return argValues;
+    }
+
+    private static Object toObject(JsonValue objectValue, Class<?> type) {
         try (Jsonb jsonb = JsonbBuilder.create()) {
             return jsonb.fromJson(objectValue.toString(), type);
         } catch (Exception e) {
@@ -185,36 +191,56 @@ public class InvokeEJBServlet extends HttpServlet {
         }
     }
 
-    private boolean excuteInAppContext(Supplier<Boolean> body) {
+    private static <T> T excuteInAppContext(String beanName, EjbOperation<T> operation) throws Exception {
         ApplicationRegistry registry = Globals.get(ApplicationRegistry.class);
-
-        for (String applicationName : registry.getAllApplicationNames()) {
-            ClassLoader existingContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread currentThread = Thread.currentThread();
+        if (beanName.startsWith("java:global/")) {
+            String applicationName = beanName.substring(12, beanName.indexOf('/', 12));
+            ClassLoader existingContextClassLoader = currentThread.getContextClassLoader();
             try {
-
-                Thread.currentThread().setContextClassLoader(registry.get(applicationName).getAppClassLoader());
-
-                try {
-                    if (body.get()) {
-                        return true;
-                    }
-                } catch (Exception e) {
-                    // ignore
-                }
-
+                currentThread.setContextClassLoader(registry.get(applicationName).getAppClassLoader());
+                Object bean = new InitialContext().lookup(beanName);
+                return operation.execute(bean);
             } finally {
                 if (existingContextClassLoader != null) {
-                    Thread.currentThread().setContextClassLoader(existingContextClassLoader);
+                    currentThread.setContextClassLoader(existingContextClassLoader);
+                }
+            }
+        }
+        NamingException lastLookupError = null;
+        for (String applicationName : registry.getAllApplicationNames()) {
+            ClassLoader existingContextClassLoader = currentThread.getContextClassLoader();
+            try {
+                currentThread.setContextClassLoader(registry.get(applicationName).getAppClassLoader());
+                try {
+                    Object bean = new InitialContext().lookup(beanName);
+                    return operation.execute(bean);
+                } catch (NamingException ex) {
+                    lastLookupError = ex;
+                    // try next app
+                }
+            } finally {
+                if (existingContextClassLoader != null) {
+                    currentThread.setContextClassLoader(existingContextClassLoader);
                 }
             }
 
         }
-
-        return false;
+        if (lastLookupError != null) {
+            throw lastLookupError;
+        }
+        return null;
     }
 
     private static String base64Decode(String input) {
         return new String(Base64.getDecoder().decode(input));
     }
 
+    /**
+     * Needed because of the {@link Exception} thrown.
+     */
+    interface EjbOperation<T> {
+
+        T execute(Object bean) throws Exception;
+    }
 }

--- a/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
+++ b/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
@@ -164,10 +164,10 @@ public class InvokeEJBServlet extends HttpServlet {
 
     private static Class<?> toClass(JsonValue classNameValue) {
         try {
-            if (classNameValue instanceof JsonString) {
-                return Class.forName(((JsonString) classNameValue).getString());
-            }
-            return Class.forName(classNameValue.toString().replace("\"", ""));
+            String className = classNameValue instanceof JsonString 
+                    ? ((JsonString) classNameValue).getString() 
+                    : classNameValue.toString().replace("\"", "");
+            return Class.forName(className, true, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
While testing #3925 I looked into several kinds of errors. Some where user errors due to limitations I wasn't aware of. This PR contains the improvements I made to understand the errors I dealt with.

* Added logging
* Error responses are less likely to mislead as different error causes are distinguished
* Separated concerns on method level into: unpack JSON, process request, create response + helpers
* For the interface we now don't simply use the first interface returned by `getClass().getInterfaces()` but make use of the EJB bean name in case it does contain the interface name
* For application name we do use the name given in the EJB bean name if it contains the application name (portable names) - otherwise we do fallback on the existing strategy to try each application and use the first that succeeds. This does however now only continue trying if the problem was looking up the bean. If the operation done with the bean fails this is considered the final error and no further applications are tried. 
* uses thread's context classloader to load parameter classes

Ignore the changes to the pom as those are part of #3925. This PR just branched from that branch as I did both at the same time.

Test app can be found here https://github.com/payara/payara-samples/pull/8