### PR TITLE
PAYARA-3468 Added a config property to set alternative @Asynchronous annotations

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceConfig.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceConfig.java
@@ -43,6 +43,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.time.temporal.ChronoUnit;
 
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
@@ -61,6 +62,15 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
  */
 @FunctionalInterface
 public interface FaultToleranceConfig {
+
+    /**
+     * A payara specific feature that allows to specify a list of annotation classes that have a similar effect as
+     * {@link Asynchronous}.
+     */
+    String ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY = "MP_Fault_Tolerance_Alternative_Asynchronous_Annotations";
+
+    @SuppressWarnings("unchecked")
+    Class<? extends Annotation>[] NO_ALTERNATIVE_ANNOTATIONS = new Class[0];
 
     /**
      * @return A {@link FaultToleranceConfig} that behaves as stated by the present FT annotations. {@link Method}
@@ -122,6 +132,10 @@ public interface FaultToleranceConfig {
      */
     default boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
         return getAnnotation(annotationType) != null;
+    }
+
+    default boolean isAlternativeAsynchronousAnnoationPresent() {
+        return false;
     }
 
 

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceExtension.java
@@ -96,7 +96,7 @@ public class FaultToleranceExtension implements Extension {
      */
     <T> void processAnnotatedType(@Observes @WithAnnotations({ Asynchronous.class, Bulkhead.class, CircuitBreaker.class,
         Fallback.class, Retry.class, Timeout.class }) ProcessAnnotatedType<T> processAnnotatedType) throws Exception {
-        Class<? extends Annotation>[] alternativeAsynchronousAnnotations =getAlternativeAsynchronousAnnotations();
+        Class<? extends Annotation>[] alternativeAsynchronousAnnotations = getAlternativeAsynchronousAnnotations();
         AnnotatedType<T> type = processAnnotatedType.getAnnotatedType();
         boolean markAllMethods = FaultToleranceUtils.isAnnotatedWithFaultToleranceAnnotations(type)
                 || isAnyAnnotationPresent(type, alternativeAsynchronousAnnotations);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceExtension.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.faulttolerance.cdi;
 
+import fish.payara.microprofile.faulttolerance.FaultToleranceConfig;
 import fish.payara.microprofile.faulttolerance.policy.FaultTolerancePolicy;
 import fish.payara.microprofile.faulttolerance.service.FaultToleranceUtils;
 
@@ -48,6 +49,9 @@ import java.util.Optional;
 
 import javax.annotation.Priority;
 import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
@@ -92,16 +96,38 @@ public class FaultToleranceExtension implements Extension {
      */
     <T> void processAnnotatedType(@Observes @WithAnnotations({ Asynchronous.class, Bulkhead.class, CircuitBreaker.class,
         Fallback.class, Retry.class, Timeout.class }) ProcessAnnotatedType<T> processAnnotatedType) throws Exception {
-        boolean markAllMethods = FaultToleranceUtils
-                .isAnnotatedWithFaultToleranceAnnotations(processAnnotatedType.getAnnotatedType());
-        Class<?> targetClass = processAnnotatedType.getAnnotatedType().getJavaClass();
+        Class<? extends Annotation>[] alternativeAsynchronousAnnotations =getAlternativeAsynchronousAnnotations();
+        AnnotatedType<T> type = processAnnotatedType.getAnnotatedType();
+        boolean markAllMethods = FaultToleranceUtils.isAnnotatedWithFaultToleranceAnnotations(type)
+                || isAnyAnnotationPresent(type, alternativeAsynchronousAnnotations);
+        Class<?> targetClass = type.getJavaClass();
         for (AnnotatedMethodConfigurator<?> methodConfigurator : processAnnotatedType.configureAnnotatedType().methods()) {
-            if (markAllMethods || FaultToleranceUtils
-                    .isAnnotatedWithFaultToleranceAnnotations(methodConfigurator.getAnnotated())) {
-                FaultTolerancePolicy.asAnnotated(targetClass, methodConfigurator.getAnnotated().getJavaMember());
+            AnnotatedMethod<?> method = methodConfigurator.getAnnotated();
+            if (markAllMethods || FaultToleranceUtils.isAnnotatedWithFaultToleranceAnnotations(method)
+                    || isAnyAnnotationPresent(method, alternativeAsynchronousAnnotations)) {
+                FaultTolerancePolicy.asAnnotated(targetClass, method.getJavaMember());
                 methodConfigurator.add(MARKER);
             }
         }
+    }
+
+    private static boolean isAnyAnnotationPresent(Annotated element, Class<? extends Annotation>[] annotationTypes) {
+        for (Class<? extends Annotation> annotationType : annotationTypes) {
+            if (element.isAnnotationPresent(annotationType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Class<? extends Annotation>[] getAlternativeAsynchronousAnnotations() {
+        Optional<String> alternativeAsynchronousAnnotationNames = ConfigProvider.getConfig().getOptionalValue(
+                FaultToleranceConfig.ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY, String.class);
+        return alternativeAsynchronousAnnotationNames.isPresent()
+                ? FaultToleranceUtils.toClassArray(alternativeAsynchronousAnnotationNames.get(),
+                        FaultToleranceConfig.ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY,
+                        FaultToleranceConfig.NO_ALTERNATIVE_ANNOTATIONS)
+                : FaultToleranceConfig.NO_ALTERNATIVE_ANNOTATIONS;
     }
 
     void changeInterceptorPriority(@Observes ProcessAnnotatedType<FaultToleranceInterceptor> interceptorType) {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/AsynchronousPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/AsynchronousPolicy.java
@@ -65,7 +65,8 @@ public final class AsynchronousPolicy extends Policy {
     }
 
     public static AsynchronousPolicy create(InvocationContext context, FaultToleranceConfig config) {
-        if (config.isAnnotationPresent(Asynchronous.class) && config.isEnabled(Asynchronous.class)) {
+        if ((config.isAnnotationPresent(Asynchronous.class) || config.isAlternativeAsynchronousAnnoationPresent())
+                && config.isEnabled(Asynchronous.class)) {
             checkReturnsFutureOrCompletionStage(context.getMethod());
             return context.getMethod().getReturnType() == Future.class ? FUTURE : COMPLETION_STAGE;
         }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceUtils.java
@@ -40,6 +40,8 @@
 package fish.payara.microprofile.faulttolerance.service;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -216,5 +218,25 @@ public class FaultToleranceUtils {
                 || element.isAnnotationPresent(Fallback.class)
                 || element.isAnnotationPresent(Retry.class)
                 || element.isAnnotationPresent(Timeout.class);
+    }
+
+    public static <T> Class<? extends T>[] toClassArray(String classNames, String attributeName,
+            Class<? extends T>[] defaultValue) {
+        if (classNames == null) {
+            return defaultValue;
+        }
+        try {
+            List<Class<?>> classList = new ArrayList<>();
+            // Remove any curly or square brackets from the string, as well as any spaces and ".class"es
+            for (String className : classNames.replaceAll("[\\{\\[ \\]\\}]", "").replaceAll("\\.class", "")
+                    .split(",")) {
+                classList.add(Class.forName(className));
+            }
+            return classList.toArray(defaultValue);
+        } catch (ClassNotFoundException cnfe) {
+            logger.log(Level.INFO, "Could not find class from " + attributeName + " config, defaulting to annotation. "
+                    + "Make sure you give the full canonical class name.", cnfe);
+            return defaultValue;
+        }
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/ConfigAlternativeAsynchronousAnnotationsTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/ConfigAlternativeAsynchronousAnnotationsTest.java
@@ -1,0 +1,138 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.faulttolerance.service;
+
+import static fish.payara.microprofile.faulttolerance.FaultToleranceConfig.ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.junit.Test;
+
+import fish.payara.microprofile.faulttolerance.FaultToleranceConfig;
+import fish.payara.microprofile.faulttolerance.policy.FaultTolerancePolicy;
+import fish.payara.microprofile.faulttolerance.policy.StaticAnalysisContext;
+import fish.payara.microprofile.faulttolerance.test.ConfigOverrides;
+import fish.payara.microprofile.faulttolerance.test.TestUtils;
+
+/**
+ * Tests that {@link FaultToleranceConfig#ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY} can be used to configure
+ * alternative annotations that can be used to get the {@link Asynchronous} behaviour.
+ * 
+ * @author Jan Bernitt
+ */
+public class ConfigAlternativeAsynchronousAnnotationsTest {
+
+    @Target({METHOD, TYPE})
+    @Retention(RUNTIME)
+    @interface OurAsynchronous {
+        // a user defined alternative Asynchronous annotation
+    }
+
+    private ConfigOverrides config = new ConfigOverrides();
+    private BindableFaultToleranceConfig configFactory = new BindableFaultToleranceConfig(config, null);
+
+    /**
+     * Test with a single alternative annotation of type {@link javax.ejb.Asynchronous} set.
+     */
+    @Test
+    public void javaxEjbAsynchronous() {
+        config.override(ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY, javax.ejb.Asynchronous.class.getName());
+        FaultTolerancePolicy policy = getPolicy();
+        assertNotNull(policy.asynchronous);
+        assertTrue("Should be FUTURE", policy.asynchronous.isSuccessWhenCompletedExceptionally());
+    }
+
+    @javax.ejb.Asynchronous
+    public Future<String> javaxEjbAsynchronous_Method() {
+        return null;
+    }
+
+    /**
+     * Tests with two alternative annotations, one of which is a user defined one {@link OurAsynchronous}.
+     */
+    @Test
+    public void userDefinedAsynchronousAnnotation() {
+        config.override(ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY, 
+                javax.ejb.Asynchronous.class.getName() + "," + OurAsynchronous.class.getName());
+        FaultTolerancePolicy policy = getPolicy();
+        assertNotNull(policy.asynchronous);
+        assertFalse("Should be COMPLETION_STAGE", policy.asynchronous.isSuccessWhenCompletedExceptionally());
+    }
+
+    @OurAsynchronous
+    public CompletionStage<String> userDefinedAsynchronousAnnotation_Method() {
+        return null;
+    }
+
+    /**
+     * Again two alternative annotations are set but the FT {@link Asynchronous} annotation is used and should still
+     * work (even when not in the list configured).
+     */
+    @Test
+    public void asynchronousStillRecognisedWhenSettingAlternativeAnnotations() {
+        config.override(ALTERNATIVE_ASYNCHRONOUS_ANNNOTATIONS_PROPERTY, 
+                javax.ejb.Asynchronous.class.getName() + "," + OurAsynchronous.class.getName());
+        FaultTolerancePolicy policy = getPolicy();
+        assertNotNull(policy.asynchronous);
+        assertTrue("Should be FUTURE", policy.asynchronous.isSuccessWhenCompletedExceptionally());
+    }
+
+    @Asynchronous
+    public Future<String> asynchronousStillRecognisedWhenSettingAlternativeAnnotations_Method() {
+        return null;
+    }
+
+    private FaultTolerancePolicy getPolicy() {
+        Method annotatedMethod = TestUtils.getAnnotatedMethod();
+        StaticAnalysisContext context = new StaticAnalysisContext(getClass(), annotatedMethod);
+        return FaultTolerancePolicy.get(context, () -> configFactory.bindTo(context));
+    }
+}


### PR DESCRIPTION
@arjantijms pointed out that projects might want to use other `@Asynchronous` annotations. As this is specific a fixed list of supported annotations seemed less feasible. Also some customers might not want to have such a feature enabled by default. Therefore I think the best solution is to allow to configure alternative annotation classes that should have the same effect as FT's `@Asynchronous`.

With this PR user can do so by defining the classes for the added key `MP_Fault_Tolerance_Alternative_Asynchronous_Annotations` as a comma separated list beside other FT configurations.

Implementation wise a bit of duplication cannot be avoided since the marking has to recognise the alternative annotations as well as the `FaultTolceranceConfig` which is not available at that stage.

I added tests that make sure one or two (many) alternatives can be set while FT's own `@Asynchronous` is still be recognised as well.