### PR TITLE
TEST-204 Update Felix to version not throwing errors with JCE

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -327,15 +327,15 @@
 
 
         <!-- Apache Felix is an open source implementation of the OSGi Core Release 6 framework specification. -->
-        <org.apache.felix.main.version>6.0.1</org.apache.felix.main.version>
+        <org.apache.felix.main.version>6.0.2</org.apache.felix.main.version>
         <org.apache.felix.webconsole.version>4.3.8</org.apache.felix.webconsole.version>
         <org.apache.felix.eventadmin.version>1.5.0</org.apache.felix.eventadmin.version>
         <org.apache.felix.shell.version>1.4.3</org.apache.felix.shell.version>
-        <org.apache.felix.gogo.runtime.version>1.1.0</org.apache.felix.gogo.runtime.version>
-        <org.apache.felix.gogo.shell.version>1.1.0</org.apache.felix.gogo.shell.version>
-        <org.apache.felix.gogo.command.version>1.0.2</org.apache.felix.gogo.command.version>
+        <org.apache.felix.gogo.runtime.version>1.1.2</org.apache.felix.gogo.runtime.version>
+        <org.apache.felix.gogo.shell.version>1.1.2</org.apache.felix.gogo.shell.version>
+        <org.apache.felix.gogo.command.version>1.1.0</org.apache.felix.gogo.command.version>
         <org.apache.felix.fileinstall.version>3.6.4.payara-p1</org.apache.felix.fileinstall.version>
-        <org.apache.felix.configadmin.version>1.9.10</org.apache.felix.configadmin.version>
+        <org.apache.felix.configadmin.version>1.9.14</org.apache.felix.configadmin.version>
         <org.apache.felix.scr.version>2.1.14</org.apache.felix.scr.version>
         <org.apache.felix.bundlerepository.version>2.0.10</org.apache.felix.bundlerepository.version>
 


### PR DESCRIPTION
Felix 6.0.2 runs without throwing exceptions when using an external JCE
provider on OpenJDK 11.0.3.