### PR TITLE
PAYARA-3755: Improve JSON-B support in ejb-http-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ nb-configuration.xml
 appserver/extras/arquillian-containers/payara-common/dependency-reduced-pom.xml
 appserver/tests/quicklook/quicklook_summary.txt
 **/nbproject
+.flattened-pom.xml

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -143,5 +143,10 @@
             <groupId>javax.json.bind</groupId>
             <artifactId>javax.json.bind-api</artifactId>
         </dependency>
+       <dependency>
+           <groupId>org.eclipse</groupId>
+           <artifactId>yasson</artifactId>
+           <scope>runtime</scope>
+       </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-http-remoting/client/src/main/java/fish/payara/ejb/http/client/EjbHttpProxyHandler.java
+++ b/appserver/ejb/ejb-http-remoting/client/src/main/java/fish/payara/ejb/http/client/EjbHttpProxyHandler.java
@@ -8,6 +8,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -81,7 +82,7 @@ class EjbHttpProxyHandler implements InvocationHandler {
         Map<String, Object> payload = new HashMap<>();
         payload.put("lookup", lookup);
         payload.put("method", method.getName());
-        payload.put("argTypes", method.getParameterTypes());
+        payload.put("argTypes", Arrays.stream(method.getParameterTypes()).map(Class::getName).toArray());
         payload.put("argValues", argValues == null? new Object[0] : argValues);
         
         if (jndiOptions.containsKey(SECURITY_PRINCIPAL)) {

--- a/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
+++ b/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
@@ -188,7 +188,7 @@ public class InvokeEJBServlet extends HttpServlet {
                     // try further
                 }
             }
-            throw new NoSuchMethodException("No method matching "+methodName+"("+ Arrays.toString(argTypeClasses)+") found in business interface");
+            throw new NoSuchMethodException("No method matching " + methodName + "(" + Arrays.toString(argTypeClasses) + ") found in business interface");
         }
 
         void setArgs(JsonArray argValues) {

--- a/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
+++ b/appserver/ejb/ejb-http-remoting/endpoint/src/main/java/fish/payara/ejb/invoke/InvokeEJBServlet.java
@@ -39,24 +39,17 @@
  */
 package fish.payara.ejb.invoke;
 
-import static javax.naming.Context.SECURITY_CREDENTIALS;
-import static javax.naming.Context.SECURITY_PRINCIPAL;
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import com.sun.enterprise.security.ee.auth.login.ProgrammaticLogin;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.data.ApplicationRegistry;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.Base64;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.json.*;
-import javax.json.bind.Jsonb;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonReader;
 import javax.json.JsonString;
 import javax.json.JsonValue;
+import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -65,12 +58,20 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import com.sun.enterprise.admin.util.ClassUtil;
-import org.glassfish.internal.api.Globals;
-import org.glassfish.internal.data.ApplicationRegistry;
-
-import com.sun.enterprise.security.ee.auth.login.ProgrammaticLogin;
+import static javax.naming.Context.SECURITY_CREDENTIALS;
+import static javax.naming.Context.SECURITY_PRINCIPAL;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
  */
@@ -108,13 +109,14 @@ public class InvokeEJBServlet extends HttpServlet {
             String principal = requestPayload.getString(SECURITY_PRINCIPAL, "");
             String credentials = requestPayload.getString(SECURITY_CREDENTIALS, "");
             try {
-                Object result = invokeBeanMethod(beanName, methodName, argTypeNames, argValuesJson, principal, credentials);
+                Invocation invocation = invokeBeanMethod(beanName, methodName, argTypeNames, argValuesJson, principal, credentials);
                 response.setContentType(APPLICATION_JSON);
-                if (result == null) {
+                if (invocation.result == null) {
                     // JSON-B cannot marshall null
                     response.getWriter().print("null");
                 } else {
-                    response.getWriter().print(JsonbBuilder.create().toJson(result));
+                    Type resultType = invocation.method.getGenericReturnType();
+                    response.getWriter().print(JsonbBuilder.create().toJson(invocation.result, resultType));
                 }
             } catch (NamingException ex) {
                 response.sendError(SC_INTERNAL_SERVER_ERROR,
@@ -146,7 +148,7 @@ public class InvokeEJBServlet extends HttpServlet {
         });
     }
 
-    private static Object invokeBeanMethod(String beanName, String methodName, JsonArray argTypeNames,
+    private static Invocation invokeBeanMethod(String beanName, String methodName, JsonArray argTypeNames,
             JsonArray argValuesJson, String principal, String credentials) throws Exception {
         return excuteInAppContext(beanName, bean -> {
             // Authenticates the caller and if successful sets the security context
@@ -156,10 +158,46 @@ public class InvokeEJBServlet extends HttpServlet {
                 new ProgrammaticLogin().login(base64Decode(principal), base64Decode(credentials), null, true);
             }
             // Actually invoke the target EJB
-            Class<?>[] argTypes = toClasses(argTypeNames);
-            Object[] argValues = toObjects(argTypes, argValuesJson);
-            return bean.getClass().getMethod(methodName, argTypes).invoke(bean, argValues);
+            Invocation invocation = new Invocation(bean, methodName, argTypeNames);
+            invocation.setArgs(argValuesJson);
+            invocation.invoke();
+            return invocation;
         });
+    }
+
+    static class Invocation {
+        private final Object bean;
+        private Type[] argTypes;
+        private Method method;
+        private Object[] argValues;
+        private Object result;
+
+        Invocation(Object bean, String methodName, JsonArray argTypes) throws NoSuchMethodException {
+            this.bean = bean;
+            Class<?>[] argTypeClasses = toClasses(argTypes);
+            // we look up the method in the interfaces, because proxy classes do not retain generic information
+            this.method = findBusinessMethodDeclaration(methodName, argTypeClasses);
+            this.argTypes = method.getGenericParameterTypes();
+        }
+
+        private Method findBusinessMethodDeclaration(String methodName, Class<?>[] argTypeClasses) throws NoSuchMethodException {
+            for (Class<?> intf : bean.getClass().getInterfaces()) {
+                try {
+                    return intf.getMethod(methodName, argTypeClasses);
+                } catch (NoSuchMethodException e) {
+                    // try further
+                }
+            }
+            throw new NoSuchMethodException("No method matching "+methodName+"("+ Arrays.toString(argTypeClasses)+") found in business interface");
+        }
+
+        void setArgs(JsonArray argValues) {
+            this.argValues = toObjects(this.argTypes, argValues);
+        }
+
+        void invoke() throws InvocationTargetException, IllegalAccessException {
+            this.result = method.invoke(bean, argValues);
+        }
     }
 
     /**
@@ -204,7 +242,7 @@ public class InvokeEJBServlet extends HttpServlet {
     /**
      * Convert JSON encoded method parameter values to their object instances 
      */
-    private static Object[] toObjects(Class<?>[] argTypes, JsonArray jsonArgValues) {
+    private static Object[] toObjects(Type[] argTypes, JsonArray jsonArgValues) {
         Object[] argValues = new Object[argTypes.length];
         for (int i = 0; i < jsonArgValues.size(); i++) {
             argValues[i] =  toObject(jsonArgValues.get(i), argTypes[i]);
@@ -212,7 +250,7 @@ public class InvokeEJBServlet extends HttpServlet {
         return argValues;
     }
 
-    private static Object toObject(JsonValue objectValue, Class<?> type) {
+    private static Object toObject(JsonValue objectValue, Type type) {
         try (Jsonb jsonb = JsonbBuilder.create()) {
             return jsonb.fromJson(objectValue.toString(), type);
         } catch (Exception e) {

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,7 +99,8 @@
 
         <!-- JSON-B -->
         <json.bind-api.version>1.0</json.bind-api.version>
-        <yasson.version>1.0.4.payara-p1-SNAPSHOT</yasson.version>
+        <!--<yasson.version>1.0.4.payara-p1-SNAPSHOT</yasson.version>-->
+        <yasson.version>1.0.3-SNAPSHOT</yasson.version>
 
         <!-- JPA -->
         <javax-persistence-api.version>2.2.0</javax-persistence-api.version>
@@ -971,6 +972,16 @@
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${yasson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.json.bind</groupId>
+                        <artifactId>jakarta.json.bind-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish</groupId>
+                        <artifactId>jakarta.json</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- JSON-P -->

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,7 +99,7 @@
 
         <!-- JSON-B -->
         <json.bind-api.version>1.0</json.bind-api.version>
-        <yasson.version>1.0.2</yasson.version>
+        <yasson.version>1.0.4.payara-p1-SNAPSHOT</yasson.version>
 
         <!-- JPA -->
         <javax-persistence-api.version>2.2.0</javax-persistence-api.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,8 +99,7 @@
 
         <!-- JSON-B -->
         <json.bind-api.version>1.0</json.bind-api.version>
-        <!--<yasson.version>1.0.4.payara-p1-SNAPSHOT</yasson.version>-->
-        <yasson.version>1.0.3-SNAPSHOT</yasson.version>
+        <yasson.version>1.0.4.payara-p1</yasson.version>
 
         <!-- JPA -->
         <javax-persistence-api.version>2.2.0</javax-persistence-api.version>


### PR DESCRIPTION
This builds upon #3931 (and the diff will get simpler once that one is merged) and payara/patched-src-yasson#3 in order to handle all of the test cases present in payara/payara-samples#9. Needs payara/Payara_PatchedProjects#244 to build properly.

512fbc7  handles class names especially for primitive types and null
7148154 adds dependency of client to same version of Yasson as in server, because all public Yasson versions at this time have issues with handling primitive types (and null)
177d55b maintains proper generic type of method parameters, so that JSON-B can properly deserialize parameters of types `List<Pojo>`, instead of creating `List<Map<String,Object>>` instead.