### PR TITLE
PAYARA-3805 Cannot edit, add, or delete JVM options from Admin Console

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
@@ -352,10 +352,10 @@ public abstract class CollectionLeafResource extends AbstractResource {
                 results.put(key, entry.getValue());
             } else {
                 options.append(sep).append(removeVersioning ? new JvmOption(key).option : key);
-
+                
                 String value = entry.getValue();
                 
-                if (key != null && !key.trim().isEmpty() && key.startsWith("-D")) {    
+                if (key != null && !key.trim().isEmpty() && (key.startsWith("-D") || key.startsWith("-X"))) {    
                     if (value == null) {
                         value = "";
                     } else if(value.contains("=")) {

--- a/nucleus/admin/rest/rest-service/src/test/java/fish/payara/admin/rest/resources/CollectionLeafResourceTest.java
+++ b/nucleus/admin/rest/rest-service/src/test/java/fish/payara/admin/rest/resources/CollectionLeafResourceTest.java
@@ -122,4 +122,29 @@ public class CollectionLeafResourceTest {
         data8.put("-client", null);
         assertEquals(wrapper.getProcessedData(data8).get("id"), "-client");
     } 
+    
+    @Test
+    public void when_property_is_Xproperty_with_value_expect_add_to_map(){
+        Wrapper wrapper = new Wrapper();
+        Map<String, String> data9 = new HashMap<>();
+        data9.put("-XX:NewRatio=", "2");
+        assertEquals(wrapper.getProcessedData(data9).get("id"), "-XX:NewRatio=2");
+    }
+    
+    @Test
+    public void when_property_is_Xproperty_with_null_value_expect_add_to_map(){
+        Wrapper wrapper = new Wrapper();
+        Map<String, String> data9 = new HashMap<>();
+        data9.put("-XX:NewRatio=", null);
+        assertEquals(wrapper.getProcessedData(data9).get("id"), "-XX:NewRatio=");
+    }
+    
+    @Test
+    public void when_property_is_Xproperty_with_empty_value_expect_add_to_map(){
+        Wrapper wrapper = new Wrapper();
+        Map<String, String> data9 = new HashMap<>();
+        data9.put("-XX:NewRatio=", "");
+        assertEquals(wrapper.getProcessedData(data9).get("id"), "-XX:NewRatio=");
+    }
+    
 }


### PR DESCRIPTION
The problem was caused by '-XX:NewRatio=2' as previously it was assumed -X command-line options didn't require a value like in -D command-line options. 