### PR TITLE
PAYARA-3798 Create zip file system when processing nested archives

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExecutableArchiveLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExecutableArchiveLauncher.java
@@ -17,7 +17,10 @@
 
 package fish.payara.micro.boot.loader;
 
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.Manifest;
@@ -69,6 +72,7 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 
 	@Override
 	protected List<Archive> getClassPathArchives() throws Exception {
+		FileSystems.newFileSystem(this.archive.getUrl().toURI(), Collections.emptyMap());
 		List<Archive> archives = new ArrayList<Archive>(
 				this.archive.getNestedArchives(new EntryFilter() {
 

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExecutableArchiveLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExecutableArchiveLauncher.java
@@ -18,6 +18,7 @@
 package fish.payara.micro.boot.loader;
 
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,7 +73,11 @@ public abstract class ExecutableArchiveLauncher extends Launcher {
 
 	@Override
 	protected List<Archive> getClassPathArchives() throws Exception {
-		FileSystems.newFileSystem(this.archive.getUrl().toURI(), Collections.emptyMap());
+	    try {
+	        FileSystems.newFileSystem(this.archive.getUrl().toURI(), Collections.emptyMap());
+	    } catch (FileSystemAlreadyExistsException e) {
+	        // fine
+	    }
 		List<Archive> archives = new ArrayList<Archive>(
 				this.archive.getNestedArchives(new EntryFilter() {
 


### PR DESCRIPTION
**Description**
The issue seems to be that we use the nested jar file without ever creating the `FileSystem` for it as one should according to https://docs.oracle.com/javase/7/docs/technotes/guides/io/fsp/zipfilesystemprovider.html and similar problems reported on SO. 

**Reviewer notes**
I can't say why this would work prior to Java 11. I am also unsure where best to create the `FileSystems.newFileSystem`. In the launcher where I put it it ensures that we do it just for the payara jar  and the method effectively isn't called multiple times but it does feel quite right place.

**Testing performed**
I first ran the reproducer 
```bash
java -jar payara-micro.jar --deploy <some.war> --nested
```
getting the error, added the fix and rebuild the jar and ran the reproducer again without getting the error.

I also tested that the code does not run when not using `--nested`.