### PR TITLE
PAYARA-3736: Let HazelcastConfigSpecificConfiguration register itself

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -131,7 +131,6 @@ public class HazelcastCore implements EventListener, ConfigListener {
     HazelcastRuntimeConfiguration configuration;
     
     @Inject
-    @Named(ServerEnvironment.DEFAULT_INSTANCE_NAME)
     HazelcastConfigSpecificConfiguration nodeConfig;
 
     @Inject


### PR DESCRIPTION
After HK2 upgrade, the `@Named` annotation prevents the config object to be
added into config automatically.

To test, backup a Payara4 domain, and restore it into Payara5. Before it failed because of this injection not being satisfied, now it will only compain about missing Grizzly ALPN classes (but will start).