### PR TITLE
Cleanup sonar issues 7 - Locks not released

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/AdminCommandLock.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/AdminCommandLock.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2019] Payara Foundation and/or affiliates
  */
 
 package org.glassfish.api.admin;


### PR DESCRIPTION
Complexity of locks deserves a PR focused on the `AdminCommandLock` entirely. 

~~There are two cases of not releasing the lock on all paths that were corrected. I annotate them in context.~~

@pdudits provided a PR-PR that removes the full suspension feature as it is unused whereby the inconsistent lock handling fixed originally no longer exists.