### PR TITLE
PAYARA-3868: Check whether directory did not disappear in the meantime

### DIFF
--- a/nucleus/deployment/autodeploy/src/main/java/org/glassfish/deployment/autodeploy/AutoDeployDirectoryScanner.java
+++ b/nucleus/deployment/autodeploy/src/main/java/org/glassfish/deployment/autodeploy/AutoDeployDirectoryScanner.java
@@ -179,6 +179,9 @@ public class AutoDeployDirectoryScanner implements DirectoryScanner{
     static Set<File> getListOfFilesAsSet(File dir, boolean includeSubDir) {
         Set<File> result = new HashSet<File>();
         File[] dirFiles = dir.listFiles();
+        if (dirFiles == null) {
+            return null;
+        }
         for (File dirFile : dirFiles) {
             String name = dirFile.getName();
             String fileType = name.substring(name.lastIndexOf(".") + 1);


### PR DESCRIPTION
Fixes #2258

The autodeploy state folder tends to disappear in windows after running Payara Micro
for longer period of time.