### PR TITLE
PAYARA-3815: Preserve configured properties when looking up administe…

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/naming/AdministeredObjectFactory.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/naming/AdministeredObjectFactory.java
@@ -92,7 +92,7 @@ public class AdministeredObjectFactory implements ObjectFactory {
         if (runtime.isACCRuntime() || runtime.isNonACCRuntime()) {
             ConnectorDescriptor connectorDescriptor = null;
             try {
-                Context ic = new InitialContext();
+                Context ic = new InitialContext(env);
                 String descriptorJNDIName = ConnectorAdminServiceUtils.
                         getReservePrefixedJNDINameForDescriptor(moduleName);
                 connectorDescriptor = (ConnectorDescriptor) ic.lookup(descriptorJNDIName);


### PR DESCRIPTION
…red object

Ignoring env resulted in properties defined in jndi.properties taking over the values
configured in the naming context the lookup was done in.