### PR TITLE
PAYARA-3864: Make flattened pom match released pom

### DIFF
--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -49,15 +49,14 @@
         <version>5.193-SNAPSHOT</version>
     </parent>
 
+    <groupId>fish.payara.extras</groupId>
     <artifactId>ejb-http-client</artifactId>
 
     <name>EJB - HTTP Client</name>
     <description>
         Module providing support for the EJB HTTP Client. This contains an InitialContext based lookup mechanism that
-        uses HTTP calls back
-        to Payara to lookup EJB beans, as well as a proxy mechanism to invoke methods on an EJB, which will be sent via
-        HTTP all well
-        to Payara.
+        uses HTTP calls back to Payara to lookup EJB beans, as well as a proxy mechanism to invoke methods on an EJB,
+        which will be sent via HTTP to Payara.
     </description>
 
     <build>
@@ -90,6 +89,11 @@
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.1.0</version>
                 <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                    <pomElements>
+                        <developers>resolve</developers>
+                        <build>remove</build>
+                    </pomElements>
                 </configuration>
                 <executions>
                     <!-- enable flattening -->

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -58,15 +58,6 @@
     <packaging>pom</packaging>
     <name>Payara Appserver Parent Project</name>
 
-
-    <scm>
-        <connection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</connection>
-        <developerConnection>scm:svn:https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</developerConnection>
-        <url>https://svn.java.net/svn/glassfish~svn/tags/4.1/main/appserver</url>
-        <tag>payara-server-5.193-SNAPSHOT</tag>
-    </scm>
-
-
     <properties>
 
         <!-- Java EE -->

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -57,10 +57,11 @@
     <version>5.193-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Payara Nucleus Parent Project</name>
+    <url>https://github.com/payara/Payara</url>
 
     <scm>
         <connection>scm:git:git@github.com:payara/payara.git</connection>
-        <url>scm:git:git@github.com:payara/payara.git</url>
+        <url>https://github.com/payara/Payara/tree/master</url>
         <developerConnection>scm:git:git@github.com:payara/payara.git</developerConnection>
         <tag>payara-server-5.193-SNAPSHOT</tag>
     </scm>
@@ -79,6 +80,15 @@
       </license>
     </licenses>
 
+
+    <developers>
+        <developer>
+            <name>Payara Team</name>
+            <email>info@payara.fish</email>
+            <organization>Payara Foundation</organization>
+            <organizationUrl>http://www.payara.fish</organizationUrl>
+        </developer>
+    </developers>
 
     <repositories>
         <!-- Try Maven central first, not last, which happens when omitted here -->


### PR DESCRIPTION
* groupId now matches release artifact
* developers are included
* outdated misleading scm section removed

Also relates to PAYARA-3646

Javadoc and sources are generated when built using maven's `release-profile`