### PR TITLE
[PAYARA-3860] - Added synchronization block double check to avoid race condition

### DIFF
--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
@@ -152,7 +152,7 @@ public class PayaraInstanceImpl implements EventListener, MessageReceiver, Payar
     private PayaraExecutorService executor;
     
     private synchronized InstanceDescriptorImpl getMyInstanceDescriptor() {
-        if(me == null) {
+        if (me == null) {
             initialiseInstanceDescriptor();
         }
         return me;
@@ -243,7 +243,6 @@ public class PayaraInstanceImpl implements EventListener, MessageReceiver, Payar
     @SuppressWarnings({"unchecked"})
     public void event(Event event) {
         if (event.is(EventTypes.SERVER_READY)) {
-            //initialiseInstanceDescriptor();
             PayaraInternalEvent pie = new PayaraInternalEvent(PayaraInternalEvent.MESSAGE.ADDED, getMyInstanceDescriptor());
             ClusterMessage<PayaraInternalEvent> message = new ClusterMessage<>(pie);
             this.cluster.getEventBus().publish(INTERNAL_EVENTS_NAME, message);

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
@@ -263,14 +263,6 @@ public class PayaraInstanceImpl implements EventListener, MessageReceiver, Payar
         else if (event.is(Deployment.APPLICATION_STARTED)) {
             if (event.hook() != null && event.hook() instanceof ApplicationInfo) {
                 ApplicationInfo applicationInfo = (ApplicationInfo) event.hook();
-                //Race condition double check
-                //if (me == null) {
-                //    synchronized (this) {
-                //        if (me == null) {
-                //            initialiseInstanceDescriptor();
-                //        }
-                //    }
-                //}
                 getMyInstanceDescriptor().addApplication(new ApplicationDescriptorImpl(applicationInfo));
                 logger.log(Level.FINE, "App Loaded: {2}, Enabled: {0}, my ID: {1}", new Object[] { hazelcast.isEnabled(),
                     myCurrentID, applicationInfo.getName() });
@@ -364,7 +356,7 @@ public class PayaraInstanceImpl implements EventListener, MessageReceiver, Payar
         return result;
     }
 
-    private synchronized void initialiseInstanceDescriptor() {
+    private void initialiseInstanceDescriptor() {
         boolean liteMember = false;
         int hazelcastPort = 5900;
         InetAddress hostname = null;


### PR DESCRIPTION
Added a synchronized double check in PayaraInstanceImpl to avoid race condition - tested through sheer brute forcing of Thread.sleep() and spamming of functionality and problem no longer appears to be present