### PR TITLE
SonarQube - Optimizing String.lastIndexOf() for single char in nucleus

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
@@ -111,7 +111,7 @@ public class DocClassVisitor extends ClassVisitor {
                 if (hasConfiguredAnnotation) {
                     if (signature != null) {
                         type = GenerateDomainSchema.toClassName(
-                            signature.substring(signature.indexOf("<") + 1, signature.lastIndexOf(">") - 1));
+                            signature.substring(signature.indexOf('<') + 1, signature.lastIndexOf('>') - 1));
                     } else {
                         type = GenerateDomainSchema.toClassName(desc);
                     }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/ConfigModularityUtils.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/ConfigModularityUtils.java
@@ -324,7 +324,7 @@ public final class ConfigModularityUtils {
             StringTokenizer tokenizer = new StringTokenizer(location, "/", false);
             //something directly inside the config itself
             if (tokenizer.countTokens() == 3) {
-                String expression = location.substring(location.lastIndexOf("[") + 1, location.length() - 1);
+                String expression = location.substring(location.lastIndexOf('[') + 1, location.length() - 1);
                 String configName = resolveExpression(expression);
                 return serviceLocator.<Domain>getService(Domain.class).getConfigNamed(configName);
             }
@@ -334,7 +334,7 @@ public final class ConfigModularityUtils {
             String curLevel = tokenizer.nextToken();
             String expression;
             if (curLevel.contains("[")) {
-                expression = curLevel.substring(curLevel.lastIndexOf("[") + 1, curLevel.length() - 1);
+                expression = curLevel.substring(curLevel.lastIndexOf('[') + 1, curLevel.length() - 1);
             } else {
                 expression = curLevel;
             }
@@ -368,8 +368,8 @@ public final class ConfigModularityUtils {
         if (childElement.endsWith("]")) {
             String componentName;
             String elementName;
-            elementName = childElement.substring(childElement.lastIndexOf("/") + 1, childElement.indexOf("["));
-            componentName = childElement.substring(childElement.lastIndexOf("[") + 1, childElement.indexOf("]"));
+            elementName = childElement.substring(childElement.lastIndexOf('/') + 1, childElement.indexOf('['));
+            componentName = childElement.substring(childElement.lastIndexOf('[') + 1, childElement.indexOf(']'));
             Class childClass = getClassFor(elementName);
             Class parentClass = getClassFor(parentElement);
             Method m = findSuitableCollectionGetter(parentClass, childClass);
@@ -686,7 +686,7 @@ public final class ConfigModularityUtils {
 
     public String getServiceTypeNameIfNamedComponent(String serviceName) {
         if (serviceName.endsWith("]")) {
-            serviceName = serviceName.substring(0, serviceName.indexOf("["));
+            serviceName = serviceName.substring(0, serviceName.indexOf('['));
         }
         return serviceName;
     }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
@@ -516,7 +516,7 @@ public class ASMClassWriter implements ClassWriter, Opcodes {
         // to decompile to figure out what is going on.  No need to make it even harder!
         clsName = clsName.replace('.', '/');
         clsName = clsName.replace('\\', '/'); // just in case Windows?  unlikely...
-        int index = clsName.lastIndexOf("/");
+        int index = clsName.lastIndexOf('/');
 
         if (index >= 0) {
             clsName = clsName.substring(index + 1);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/Util.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/Util.java
@@ -173,7 +173,7 @@ public class Util {
         String name = getParentName(url);
         // Find the : to skip past the protocal part of the URL, as that is causing
         // problems with resources named 'http'.
-        int nameIndex = url.indexOf(name, url.indexOf(":") + 1);
+        int nameIndex = url.indexOf(name, url.indexOf(':') + 1);
         return getName(url.substring(0, nameIndex - 1), '/');
     }
 

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/sftp/SFTPClient.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/sftp/SFTPClient.java
@@ -106,7 +106,7 @@ public class SFTPClient extends SFTPv3Client {
         if (atts!=null && atts.isDirectory())
             return;
 
-        int idx = path.lastIndexOf("/");
+        int idx = path.lastIndexOf('/');
         if (idx>0)
             mkdirs(path.substring(0,idx), posixPermission);
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/AMXValidator.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/AMXValidator.java
@@ -992,7 +992,7 @@ public final class AMXValidator
         private static boolean
     isLegalClassname( final String s )
     {
-        if ( s.length()== 0 || s.indexOf(" ") >= 0 )
+        if ( s.length()== 0 || s.indexOf(' ') >= 0 )
         {
             return false;   // detect totally bogus name
         }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/Util.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/Util.java
@@ -69,7 +69,7 @@ public final class Util {
     }
 
     public static String quoteIfNeeded(String name) {
-        if(name.indexOf(":") > 1) {
+        if(name.indexOf(':') > 1) {
            return ObjectName.quote(name);
         } else {
             return name;
@@ -458,12 +458,12 @@ public final class Util {
     Generate the default MBean type from a String, eg from a classname.
      */
     public static String typeFromName(final String s) {
-        if (s.indexOf("-") >= 0) {
+        if (s.indexOf('-') >= 0) {
             return s;   // if it already has dashes, leave unchanged
         }
 
         String simpleName = s;
-        final int idx = s.lastIndexOf(".");
+        final int idx = s.lastIndexOf('.');
         if (idx >= 0) {
             simpleName = s.substring(idx + 1);
         }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigImpl.java
@@ -663,7 +663,7 @@ public class AMXConfigImpl extends AMXImplBase
     public static String convertAttributeName(final String s )
     {
         // do not alter any name that is already all lower-case or that contains a "-" */
-        if ( s.equals( s.toLowerCase(Locale.getDefault()) ) || s.indexOf("-") >= 0 )
+        if ( s.equals( s.toLowerCase(Locale.getDefault()) ) || s.indexOf('-') >= 0 )
         {
             return(s);
         }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/ToolsImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/ToolsImpl.java
@@ -150,8 +150,8 @@ public class ToolsImpl extends AMXImplBase // implements Tools
         if (pattern == null) {
             String temp = searchStringIn;
 
-            final boolean hasProps = temp.indexOf("=") >= 0;
-            final boolean hasDomain = temp.indexOf(":") >= 0;
+            final boolean hasProps = temp.indexOf('=') >= 0;
+            final boolean hasDomain = temp.indexOf(':') >= 0;
             final boolean isPattern = temp.endsWith(WILD_SUFFIX);
 
             if (!(hasProps || hasDomain || isPattern)) {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/ClassUtil.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/ClassUtil.java
@@ -164,7 +164,7 @@ public final class ClassUtil
      */
     public static String stripPackageName(String classname)
     {
-        final int lastDot = classname.lastIndexOf(".");
+        final int lastDot = classname.lastIndexOf('.');
         if (lastDot < 0)
         {
             return (classname);
@@ -1194,7 +1194,7 @@ public final class ClassUtil
             throw new IllegalArgumentException("not an array of Object");
         }
 
-        final int innerNameBegin = 1 + arrayClassname.indexOf("L");
+        final int innerNameBegin = 1 + arrayClassname.indexOf('L');
 
         final String newClassName = arrayClassname.substring(0, innerNameBegin) + newInnerType.getName() + ";";
 
@@ -1266,7 +1266,7 @@ public final class ClassUtil
 
     public static String stripPackagePrefix(final String classname)
     {
-        final int index = classname.lastIndexOf(".");
+        final int index = classname.lastIndexOf('.');
 
         String result = classname;
         if (index > 0)
@@ -1281,7 +1281,7 @@ public final class ClassUtil
 
     public static String getPackagePrefix(final String classname)
     {
-        final int index = classname.lastIndexOf(".");
+        final int index = classname.lastIndexOf('.');
 
         String result = classname;
         if (index > 0)

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/JMXUtil.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/JMXUtil.java
@@ -1618,8 +1618,8 @@ public final class JMXUtil
         {
             final String patternProps = pattern.getCanonicalKeyPropertyListString();
             final String candidateProps = candidate.getCanonicalKeyPropertyListString();
-            assert (patternProps.indexOf("*") < 0);
-            assert (candidateProps.indexOf("*") < 0);
+            assert (patternProps.indexOf('*') < 0);
+            assert (candidateProps.indexOf('*') < 0);
 
             // Since we used canonical form any match means the pattern props String
             // must be a substring of candidateProps

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/MBeanInterfaceGenerator.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/MBeanInterfaceGenerator.java
@@ -149,7 +149,7 @@ public class MBeanInterfaceGenerator
         String base = name;
         String extra = "";
 
-        final int idx = name.indexOf("[");
+        final int idx = name.indexOf('[');
         if ( idx > 0 )
         {
             base  = name.substring(0, idx);
@@ -202,7 +202,7 @@ public class MBeanInterfaceGenerator
 
     protected boolean isUnqualifiedType(String type)
     {
-        return (type.indexOf(".") < 0);
+        return (type.indexOf('.') < 0);
     }
 
     /**

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/stringifier/MBeanConstructorInfoStringifier.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/stringifier/MBeanConstructorInfoStringifier.java
@@ -64,7 +64,7 @@ public class MBeanConstructorInfoStringifier extends MBeanFeatureInfoStringifier
         final MBeanConstructorInfo constructor = (MBeanConstructorInfo) o;
 
         final String name = constructor.getName();
-        final int lastDot = name.lastIndexOf(".");
+        final int lastDot = name.lastIndexOf('.');
         final String abbreviatedName = name.substring(lastDot + 1, name.length());
 
         final String params = "(" +

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/PropertiesDecoder.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/PropertiesDecoder.java
@@ -92,7 +92,7 @@ public class PropertiesDecoder {
         if(!ok(element))
             return; // no harm, no foul
 
-        int index = element.indexOf("=");
+        int index = element.indexOf('=');
 
         // 1.
         if(index < 0)

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/glassfish/ASenvPropertyReader.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/glassfish/ASenvPropertyReader.java
@@ -275,7 +275,7 @@ public class ASenvPropertyReader {
          *
          */
         private void setProperty(String line) {
-            int pos = line.indexOf("=");
+            int pos = line.indexOf('=');
 
             if (pos > 0) {
                 String lhs = (line.substring(0, pos)).trim();

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadImpl.java
@@ -156,7 +156,7 @@ public class PayloadImpl implements Payload {
                 if (relativeURIPath.endsWith("/")) {
                     relativeURIPath = relativeURIPath.substring(0, relativeURIPath.length() - 1);
                 }
-                relativeURIPath = relativeURIPath.substring(0, relativeURIPath.lastIndexOf("/") + 1);
+                relativeURIPath = relativeURIPath.substring(0, relativeURIPath.lastIndexOf('/') + 1);
 
                 attachFilesRecursively(
                         file.getParentFile().toURI(),

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/embedded/ScatteredArchive.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/embedded/ScatteredArchive.java
@@ -485,7 +485,7 @@ public class ScatteredArchive extends ReadableArchiveAdapter {
         if (metadata.containsKey(name)) {
             return metadata.get(name);
         }
-        String shortName = (name.indexOf("/") != -1 ? name.substring(name.indexOf("/") + 1) : name);
+        String shortName = (name.indexOf('/') != -1 ? name.substring(name.indexOf('/') + 1) : name);
         if (metadata.containsKey(shortName)) {
             return metadata.get(shortName);
         }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -170,7 +170,7 @@ public class GlassFishMain {
                             continue;
                         }
                         Deployer deployer = gf.getService(Deployer.class, null);
-                        String name = command.substring(command.indexOf(" ")).trim();
+                        String name = command.substring(command.indexOf(' ')).trim();
                         deployer.undeploy(name);
                         System.out.println("Undeployed = " + name);
                     } else if ("quit".equalsIgnoreCase(command)) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
@@ -621,10 +621,10 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
         StringTokenizer stoken = new StringTokenizer(requestString == null ? "" : requestString, QUERY_STRING_SEPARATOR);
         while (stoken.hasMoreTokens()) {
             String token = stoken.nextToken();
-            if (token.indexOf("=") == -1)
+            if (token.indexOf('=') == -1)
                 continue;
-            String paramName = token.substring(0, token.indexOf("="));
-            String value = token.substring(token.indexOf("=") + 1);
+            String paramName = token.substring(0, token.indexOf('='));
+            String value = token.substring(token.indexOf('=') + 1);
 
             try {
                 value = URLDecoder.decode(value, "UTF-8");
@@ -658,10 +658,10 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
         StringTokenizer stoken = new StringTokenizer(requestString == null ? "" : requestString, QUERY_STRING_SEPARATOR);
         while (stoken.hasMoreTokens()) {
             String token = stoken.nextToken();
-            if (token.indexOf("=") == -1)
+            if (token.indexOf('=') == -1)
                 continue;
-            String paramName = token.substring(0, token.indexOf("="));
-            String value = token.substring(token.indexOf("=") + 1);
+            String paramName = token.substring(0, token.indexOf('='));
+            String value = token.substring(token.indexOf('=') + 1);
             try {
                 value = URLDecoder.decode(value, "UTF-8");
             } catch (UnsupportedEncodingException e) {
@@ -733,7 +733,7 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
      * @return the scope for a command
      */
     private String getScope(String command) {
-        int ci = command.indexOf("/");
+        int ci = command.indexOf('/');
         return (ci != -1) ? command.substring(0, ci + 1) : null;
     }
 
@@ -746,7 +746,7 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
      * for the above example
      */
     private String getCommandAfterScope(String command) {
-        int ci = command.indexOf("/");
+        int ci = command.indexOf('/');
         return (ci != -1) ? command = command.substring(ci + 1) : command;
 
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/DynamicInterceptor.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/DynamicInterceptor.java
@@ -841,8 +841,8 @@ public class DynamicInterceptor implements MBeanServer
     }
 
     private String getName(String oName) {
-        if(oName.indexOf("[") != -1 ) {
-          return oName.substring(oName.indexOf("[") + 1, oName.indexOf("]"));
+        if(oName.indexOf('[') != -1 ) {
+          return oName.substring(oName.indexOf('[') + 1, oName.indexOf(']'));
         } else {
             return null;
         }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobManagerService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobManagerService.java
@@ -277,14 +277,14 @@ public class JobManagerService implements JobManager, PostConstruct, EventListen
         Long timeInterval = new Long(period);
         String s = input.toLowerCase(Locale.US);
         long milliseconds = 86400000;
-        if (s.indexOf("s") > 0 ) {
+        if (s.indexOf('s') > 0 ) {
             milliseconds = timeInterval*1000;
         }
-        else if (s.indexOf("h") > 0 ) {
+        else if (s.indexOf('h') > 0 ) {
             milliseconds = timeInterval*3600*1000;
 
         }
-        else if (s.indexOf("m") > 0 ) {
+        else if (s.indexOf('m') > 0 ) {
             milliseconds = timeInterval*60*1000;
         }
         return milliseconds;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/ListCommandsCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/ListCommandsCommand.java
@@ -112,7 +112,7 @@ public class ListCommandsCommand implements AdminCommand {
                 
                 // limit list to commands for current scope
             if (name != null) {
-                int ci = name.indexOf("/");
+                int ci = name.indexOf('/');
                 if (ci != -1) {
                     String cmdScope = name.substring(0, ci + 1);
                     if (scope == null || !cmdScope.equals(scope)) continue;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/MonitoringReporter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/MonitoringReporter.java
@@ -218,9 +218,9 @@ public class MonitoringReporter extends V2DottedNameSupport {
         String key = null;
         String value = null;
         if (str != null) {
-            key = str.substring(0, str.lastIndexOf("="));
+            key = str.substring(0, str.lastIndexOf('='));
             key = (key.substring(instanceName.length() + 1)).trim();
-            value = (str.substring(str.lastIndexOf("=") + 1, str.length())).trim();
+            value = (str.substring(str.lastIndexOf('=') + 1, str.length())).trim();
         }
         list.add(0, key);
         list.add(1, value);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/V2DottedNameSupport.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/V2DottedNameSupport.java
@@ -227,8 +227,8 @@ public class V2DottedNameSupport {
                 }
             } else {
                 String delim;
-                if (token.lastIndexOf("*")!=-1) {
-                    delim = token.substring(0, token.lastIndexOf("*"));
+                if (token.lastIndexOf('*')!=-1) {
+                    delim = token.substring(0, token.lastIndexOf('*'));
                 } else {
                     delim = token;
                 }
@@ -264,7 +264,7 @@ public class V2DottedNameSupport {
             return false;
         } else {
             // patter is exhausted, only elements one level down should be returned
-            return dottedName.indexOf(".")==-1;
+            return dottedName.indexOf('.')==-1;
         }
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/ContainerMapper.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/ContainerMapper.java
@@ -284,9 +284,9 @@ public class ContainerMapper extends ADBAwareHttpHandler {
             if (httpHandler == null || httpHandler instanceof ContainerMapper) {
                 String ext = decodedURI.toString();
                 String type = "";
-                if (ext.lastIndexOf(".") > 0) {
-                    ext = "*" + ext.substring(ext.lastIndexOf("."));
-                    type = ext.substring(ext.lastIndexOf(".") + 1);
+                if (ext.lastIndexOf('.') > 0) {
+                    ext = "*" + ext.substring(ext.lastIndexOf('.'));
+                    type = ext.substring(ext.lastIndexOf('.') + 1);
                 }
 
                 if (!MimeType.contains(type) && !"/".equals(ext)) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
@@ -1077,7 +1077,7 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
             synchronized (gfHandlers) {
                 rootLogger.addHandler(handler);
                 String handlerName = handler.toString();
-                gfHandlers.put(handlerName.substring(0, handlerName.indexOf("@")), handler);
+                gfHandlers.put(handlerName.substring(0, handlerName.indexOf('@')), handler);
             }
         }
     }

--- a/nucleus/deployment/autodeploy/src/main/java/org/glassfish/deployment/autodeploy/AutoDeployDirectoryScanner.java
+++ b/nucleus/deployment/autodeploy/src/main/java/org/glassfish/deployment/autodeploy/AutoDeployDirectoryScanner.java
@@ -184,7 +184,7 @@ public class AutoDeployDirectoryScanner implements DirectoryScanner{
         }
         for (File dirFile : dirFiles) {
             String name = dirFile.getName();
-            String fileType = name.substring(name.lastIndexOf(".") + 1);
+            String fileType = name.substring(name.lastIndexOf('.') + 1);
             if ( ! dirFile.isDirectory()) {
                 if (fileType != null && !fileType.equals("") &&
                         ! typeIsMarkerType(fileType)) {

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentUtils.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentUtils.java
@@ -241,9 +241,8 @@ public class DeploymentUtils {
         if (pathName.endsWith("/")) {
             pathName = pathName.substring(0, pathName.length() - 1);
         }
-        if (pathName.lastIndexOf("/") != -1) {
-            pathName = pathName.substring(pathName.lastIndexOf(
-                "/") + 1);
+        if (pathName.lastIndexOf('/') != -1) {
+            pathName = pathName.substring(pathName.lastIndexOf('/') + 1);
         }
         if (pathName.endsWith(".jar") || pathName.endsWith(".war")
             || pathName.endsWith(".rar") || pathName.endsWith(".ear")) {

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/Descriptor.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/Descriptor.java
@@ -517,7 +517,7 @@ public class Descriptor extends DynamicAttributesDescriptor {
     public static String createUniqueFilenameAmongst(String trialName, Vector<String> otherNames) {
 
         /* extract file.ext */
-        int p = trialName.lastIndexOf(".");
+        int p = trialName.lastIndexOf('.');
         if (p < 0) {
             return uniquifyString(trialName, otherNames, 0);
         }

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderImplGenerator.java
@@ -205,7 +205,7 @@ public class ProviderImplGenerator {
             // to decompile to figure out what is going on.  No need to make it even harder!
             clsName = clsName.replace('.', '/');
             clsName = clsName.replace('\\', '/'); // just in case Windows?  unlikely...
-            index = clsName.lastIndexOf("/");
+            index = clsName.lastIndexOf('/');
 
             if (index >= 0)
                 clsName = clsName.substring(index + 1);


### PR DESCRIPTION
This pull request contains fixes only for module _nucleus_.

Replacing `String.lastIndexOf("/")` with `String.lastIndexOf('/')` which can be more performant.

This fixes SonarQube violations of the rule: [String function use should be optimized for single characters](https://rules.sonarsource.com/java/RSPEC-3027)