### PR TITLE
SonarQube - Optimizing String.lastIndexOf() for single char in appserver

### DIFF
--- a/appserver/admin/runtime/mgmt-infra/src/main/java/org/glassfish/admin/runtime/mgmtinfra/RuntimeMBeanCageBuilder.java
+++ b/appserver/admin/runtime/mgmt-infra/src/main/java/org/glassfish/admin/runtime/mgmtinfra/RuntimeMBeanCageBuilder.java
@@ -74,7 +74,7 @@ public class RuntimeMBeanCageBuilder implements CageBuilder {
         }
         try {
             String className = o.getClass().getName();
-            String serName = className.substring(className.lastIndexOf(".") + 1);
+            String serName = className.substring(className.lastIndexOf('.') + 1);
             if (dbg) {
                 System.out.println("RuntimeMBeanCageBuilder: createMBean: " + 
                     " className = " + className +

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/gadget/GadgetHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/gadget/GadgetHandlers.java
@@ -253,7 +253,7 @@ public class GadgetHandlers {
         for (String str : strs) {
             str = str.trim();
             int end = str.length();
-            int index = str.indexOf("=");
+            int index = str.indexOf('=');
             newMap.put(str.substring(0, index), str.substring(index+1, end));
         }
         return newMap;

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/CommonHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/CommonHandlers.java
@@ -884,14 +884,14 @@ public class CommonHandlers {
         String sep = "?";
         // If a query string exists (i.e., the url already has "?foo=bar", then we
         // want to append to that string rather than starting a new one
-        if (url.indexOf("?") > -1) {
+        if (url.indexOf('?') > -1) {
             sep = "&";
         }
         String insert = sep + name + "=" + value; // TODO: HTML encode this
 
         // Should the url have a hash in it, we need the query string (addition) to
         // be inserted before that.
-        int hash = url.indexOf("#");
+        int hash = url.indexOf('#');
         if (hash > -1) {
             url = url.substring(0, hash-1) + insert + url.substring(hash);
         } else {

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/DeploymentHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/DeploymentHandler.java
@@ -369,7 +369,7 @@ public class DeploymentHandler {
                         if (GuiUtil.isEmpty(defWebModule)){
                             continue;
                         }
-                        int index = defWebModule.indexOf("#");
+                        int index = defWebModule.indexOf('#');
                         if (index != -1){
                             defWebModule = defWebModule.substring(0, index);
                         }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/InstanceHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/InstanceHandler.java
@@ -193,12 +193,12 @@ public class InstanceHandler {
 
     public static ArrayList getKeyValuePair(String str) {
         ArrayList list = new ArrayList(2);
-        int index = str.indexOf("=");
+        int index = str.indexOf('=');
         String key = "";
         String value = "";
         if (index != -1) {
-            key = str.substring(0,str.indexOf("="));
-            value = str.substring(str.indexOf("=")+1,str.length());
+            key = str.substring(0,str.indexOf('='));
+            value = str.substring(str.indexOf('=')+1,str.length());
         } else {
             key = str;
         }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/RestUtilHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/RestUtilHandlers.java
@@ -169,7 +169,7 @@ public class RestUtilHandlers {
                 //Once fixed, this condition will be removed.
                 if (oneProp.get(id).contains("=")) {
                     String key = oneProp.get(id);
-                    propsMap.put(key.substring(0, key.indexOf("=")), key.substring(key.indexOf("=") + 1));
+                    propsMap.put(key.substring(0, key.indexOf('=')), key.substring(key.indexOf('=') + 1));
                 } else {
                     propsMap.put(oneProp.get(id), oneProp.get("value"));
                 }
@@ -209,7 +209,7 @@ public class RestUtilHandlers {
                 //Once fixed, this condition will be removed.
                 if (oneProp.get(id).contains("=")) {
                     String key = oneProp.get(id);
-                    propsMap.put(key.substring(0, key.indexOf("=")), key.substring(key.indexOf("=") + 1));
+                    propsMap.put(key.substring(0, key.indexOf('=')), key.substring(key.indexOf('=') + 1));
                 } else {
                     propsMap.put(oneProp.get(id), oneProp.get("value"));
                 }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/WebAppHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/WebAppHandlers.java
@@ -97,7 +97,7 @@ public class WebAppHandlers {
         if (GuiUtil.isEmpty(webModule))
             return;
         String appName = webModule;
-        int index = webModule.indexOf("#");
+        int index = webModule.indexOf('#');
         if (index != -1){
             appName=webModule.substring(0, index);
         }

--- a/appserver/admingui/core/src/main/java/org/glassfish/admingui/handlers/WoodstockHandler.java
+++ b/appserver/admingui/core/src/main/java/org/glassfish/admingui/handlers/WoodstockHandler.java
@@ -164,7 +164,7 @@ public class WoodstockHandler {
             if (lastIndex != -1) {
                 name = name.substring(lastIndex + 1, name.length());
             }
-            int index = name.indexOf(".");
+            int index = name.indexOf('.');
             if (index <= 0) {
                 logger.info("name=" + name + ",index=" + index);
                 String mesg = GuiUtil.getMessage("msg.deploy.nullArchiveError");

--- a/appserver/admingui/jca/src/main/java/org/glassfish/jca/admingui/handlers/ConnectorsHandlers.java
+++ b/appserver/admingui/jca/src/main/java/org/glassfish/jca/admingui/handlers/ConnectorsHandlers.java
@@ -220,7 +220,7 @@ public class ConnectorsHandlers {
         List<String> inList = (List) handlerCtx.getInputValue("inList");
         List<String> convertedList = new ArrayList();
         for(String one: inList){
-            if( (one.indexOf("#") != -1) && one.endsWith(".rar")){
+            if( (one.indexOf('#') != -1) && one.endsWith(".rar")){
                 convertedList.add( one.substring(0, one.length() - 4));
             }else{
                 convertedList.add(one);

--- a/appserver/admingui/payara-console-extras/src/main/java/fish/payara/admingui/extras/rest/PayaraRestApiHandlers.java
+++ b/appserver/admingui/payara-console-extras/src/main/java/fish/payara/admingui/extras/rest/PayaraRestApiHandlers.java
@@ -732,7 +732,7 @@ public class PayaraRestApiHandlers {
                 for (String instance : instances) {
                     String configRef = (String) RestUtil.getAttributesMap(instance).get("configRef");
                     if (configRef.equals(configName)) {
-                        serverName = instance.substring(instance.lastIndexOf("/") + 1);
+                        serverName = instance.substring(instance.lastIndexOf('/') + 1);
                     }
                 }
                 String deployedApplicationsEndpoint = sessionScopeRestURL + "servers/server/" + serverName 
@@ -743,7 +743,7 @@ public class PayaraRestApiHandlers {
                 List<String> applications = RestUtil.getChildList(sessionScopeRestURL + "applications/application");
 
                 for (String virtualServer : virtualServers) {         
-                    String virtualServerName = virtualServer.substring(virtualServer.lastIndexOf("/") + 1);
+                    String virtualServerName = virtualServer.substring(virtualServer.lastIndexOf('/') + 1);
 
                     for (int i = 0; i < deployedApplications.size(); i++) {
                         deployedApplications.set(i, deployedApplications.get(i)
@@ -753,7 +753,7 @@ public class PayaraRestApiHandlers {
                     String contextRoots = "";
 
                     for (String application : applications) {
-                        String applicationName = application.substring(application.lastIndexOf("/") + 1);
+                        String applicationName = application.substring(application.lastIndexOf('/') + 1);
                         String[] deployedVirtualServers; 
                         if (RestUtil.get(deployedApplicationsEndpoint + "/" + applicationName).isSuccess()) {
                             String deployedVirtualServersString = ((String) RestUtil.getAttributesMap(

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/JWSACCMaskingClassLoader.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/JWSACCMaskingClassLoader.java
@@ -89,7 +89,7 @@ class JWSACCMaskingClassLoader extends MaskingClassLoader {
             return true;
         }
         
-        final String packageName = name.substring(0, name.lastIndexOf("."));
+        final String packageName = name.substring(0, name.lastIndexOf('.'));
         if (endorsedPackagesToMask.contains(packageName)) {
             /*
              * The requested name is one to be masked, so do not let the caller

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/MaskingClassLoader.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/MaskingClassLoader.java
@@ -137,7 +137,7 @@ public class MaskingClassLoader extends ClassLoader {
         if (!(name.startsWith("javax.") || name.startsWith("org."))) {
             return true;
         }
-        final String packageName = name.substring(0, name.lastIndexOf("."));
+        final String packageName = name.substring(0, name.lastIndexOf('.'));
         if (punchins.contains(packageName)) {
             return true;
         }

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/StandaloneAppClientDeployerHelper.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/StandaloneAppClientDeployerHelper.java
@@ -288,7 +288,7 @@ public class StandaloneAppClientDeployerHelper extends AppClientDeployerHelper {
         String uriText = appClientDesc().getModuleDescriptor().getArchiveUri();
         String uriRoot = "";
         String archiveName = uriText;
-        int lastIndex = uriText.lastIndexOf("/");
+        int lastIndex = uriText.lastIndexOf('/');
         if(lastIndex > -1) {
             uriRoot = uriText.substring(0, lastIndex);
             archiveName = uriText.substring(lastIndex);

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/AppClientHTTPAdapter.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/AppClientHTTPAdapter.java
@@ -530,7 +530,7 @@ public class AppClientHTTPAdapter extends RestrictedContentAdapter {
 
         public boolean processParameter(String param) {
             boolean result = false;
-            final int equalsSign = param.indexOf("=");
+            final int equalsSign = param.indexOf('=');
             String value = "";
             String paramPrefix;
             if (equalsSign != -1) {

--- a/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/ConnectorMessageBeanClient.java
+++ b/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/ConnectorMessageBeanClient.java
@@ -473,7 +473,7 @@ public final class ConnectorMessageBeanClient
         
         String appName = descriptor_.getApplication().getName();
         String moduleID = descriptor_.getEjbBundleDescriptor().getModuleID();
-        int pound = moduleID.indexOf("#");
+        int pound = moduleID.indexOf('#');
         if(pound>=0){
             // the module ID is in the format: appName#ejbName.jar
             // remove the appName part since it is duplicated

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/AdministeredObjectDefinitionHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/AdministeredObjectDefinitionHandler.java
@@ -238,7 +238,7 @@ public class AdministeredObjectDefinitionHandler extends AbstractResourceHandler
 
                 if (defnProperties.length > 0) {
                     for (String property : defnProperties) {
-                        int index = property.indexOf("=");
+                        int index = property.indexOf('=');
                         // found "=" and not at start or end of string
                         if (index > 0 && index < property.length() - 1) {
                             String name = property.substring(0, index).trim();
@@ -276,7 +276,7 @@ public class AdministeredObjectDefinitionHandler extends AbstractResourceHandler
             String[] defnProperties = defn.properties();
             if (defnProperties.length > 0) {
                 for (String property : defnProperties) {
-                    int index = property.indexOf("=");
+                    int index = property.indexOf('=');
                     // found "=" and not at start or end of string
                     if (index > 0 && index < property.length() - 1) {
                         String name = property.substring(0, index).trim();

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionHandler.java
@@ -250,7 +250,7 @@ public class ConnectionFactoryDefinitionHandler extends AbstractResourceHandler 
 
                 if (defnProperties.length > 0) {
                     for (String property : defnProperties) {
-                        int index = property.indexOf("=");
+                        int index = property.indexOf('=');
                         // found "=" and not at start or end of string
                         if (index > 0 && index < property.length() - 1) {
                             String name = property.substring(0, index);
@@ -290,7 +290,7 @@ public class ConnectionFactoryDefinitionHandler extends AbstractResourceHandler 
             String[] defnProperties = defn.properties();
             if (defnProperties.length > 0) {
                 for (String property : defnProperties) {
-                    int index = property.indexOf("=");
+                    int index = property.indexOf('=');
                     // found "=" and not at start or end of string
                     if (index > 0 && index < property.length() - 1) {
                         String name = property.substring(0, index);

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/AbstractDeploymentFacility.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/AbstractDeploymentFacility.java
@@ -1162,7 +1162,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         if (result == null) {
             return null;
         }
-        int index = result.lastIndexOf("=");
+        int index = result.lastIndexOf('=');
         return result.substring(index+1);
     }
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/AdministeredObjectDefinitionNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/AdministeredObjectDefinitionNode.java
@@ -94,7 +94,7 @@ public class AdministeredObjectDefinitionNode extends DeploymentDescriptorNode<A
         
         // change the resource adapter name from internal format to standard format
         String resourceAdapterName = desc.getResourceAdapter();
-        int poundIndex = resourceAdapterName.indexOf("#");
+        int poundIndex = resourceAdapterName.indexOf('#');
         if(poundIndex > 0){
             // the internal format of resource adapter name is "appName#raName", remove the appName part
             resourceAdapterName =  resourceAdapterName.substring(poundIndex);

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/ConnectionFactoryDefinitionNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/ConnectionFactoryDefinitionNode.java
@@ -88,7 +88,7 @@ public class ConnectionFactoryDefinitionNode extends DeploymentDescriptorNode<Co
 
         // change the resource adapter name from internal format to standard format
         String resourceAdapterName = desc.getResourceAdapter();
-        int poundIndex = resourceAdapterName.indexOf("#");
+        int poundIndex = resourceAdapterName.indexOf('#');
         if(poundIndex > 0){
             // the internal format of resource adapter name is "appName#raName", remove the appName part
             resourceAdapterName =  resourceAdapterName.substring(poundIndex);

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/JMSConnectionFactoryDefinitionNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/JMSConnectionFactoryDefinitionNode.java
@@ -98,7 +98,7 @@ public class JMSConnectionFactoryDefinitionNode extends DeploymentDescriptorNode
         // change the resource adapter name from internal format to standard format
         String resourceAdapter = desc.getResourceAdapter();
         if (resourceAdapter != null) {
-            int poundIndex = resourceAdapter.indexOf("#");
+            int poundIndex = resourceAdapter.indexOf('#');
             if (poundIndex > 0) {
                 // the internal format of resource adapter name is "appName#raName", remove the appName part
                 resourceAdapter =  resourceAdapter.substring(poundIndex);

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/JMSDestinationDefinitionNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/JMSDestinationDefinitionNode.java
@@ -92,7 +92,7 @@ public class JMSDestinationDefinitionNode extends DeploymentDescriptorNode<JMSDe
         // change the resource adapter name from internal format to standard format
         String resourceAdapter = desc.getResourceAdapter();
         if (resourceAdapter != null) {
-            int poundIndex = resourceAdapter.indexOf("#");
+            int poundIndex = resourceAdapter.indexOf('#');
             if (poundIndex > 0) {
                 // the internal format of resource adapter name is "appName#raName", remove the appName part
                 resourceAdapter =  resourceAdapter.substring(poundIndex);

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/SaxParserHandler.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/SaxParserHandler.java
@@ -618,8 +618,8 @@ public class SaxParserHandler extends DefaultHandler {
         } catch (EmptyStackException ex) {
         }
         if (lastElement != null) {
-            if (lastElement.lastIndexOf("/") >= 0) {
-                lastElement = lastElement.substring(0, lastElement.lastIndexOf("/"));
+            if (lastElement.lastIndexOf('/') >= 0) {
+                lastElement = lastElement.substring(0, lastElement.lastIndexOf('/'));
                 elementStack.push(lastElement);
             }
         }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/SaxParserHandlerBundled.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/SaxParserHandlerBundled.java
@@ -168,7 +168,7 @@ public class SaxParserHandlerBundled extends SaxParserHandler {
     }
 
     private InputSource openInputSource(final String localRoot, final String systemID) {
-        String targetID = localRoot + "/" + systemID.substring(systemID.lastIndexOf("/") + 1);
+        String targetID = localRoot + "/" + systemID.substring(systemID.lastIndexOf('/') + 1);
         URL url = this.getClass().getResource(targetID);
         InputStream stream;
         try {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/ws/WLWebServiceEndpointNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/ws/WLWebServiceEndpointNode.java
@@ -300,8 +300,8 @@ public class WLWebServiceEndpointNode extends DeploymentDescriptorNode {
             String serviceUri;
             String endpointAddressUri = descriptor.getEndpointAddressUri();
             if (descriptor.implementedByEjbComponent()) {
-                ctxtPath = endpointAddressUri.substring(0, endpointAddressUri.lastIndexOf("/") - 1);
-                serviceUri = endpointAddressUri.substring(endpointAddressUri.lastIndexOf("/"));
+                ctxtPath = endpointAddressUri.substring(0, endpointAddressUri.lastIndexOf('/') - 1);
+                serviceUri = endpointAddressUri.substring(endpointAddressUri.lastIndexOf('/'));
             } else {
                 //for servlet endpoint, use web application context root
                 ctxtPath = descriptor.getWebComponentImpl().getWebBundleDescriptor().getContextRoot();

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
@@ -709,12 +709,12 @@ public class ApplicationValidator extends ComponentValidator
         for (int j = 0; j < myVector.size(); j++) {
             String firstElement = (String) myVector.get(j);
             if (firstElement.contains("#")) {
-                firstElement = firstElement.substring(0, firstElement.indexOf("#"));
+                firstElement = firstElement.substring(0, firstElement.indexOf('#'));
             }
             for (int i = j+1; i < myVector.size(); i++) {
                 String otherElements = (String) myVector.get(i);
                 if (otherElements.contains("#")) {
-                    otherElements = otherElements.substring(0, otherElements.indexOf("#"));
+                    otherElements = otherElements.substring(0, otherElements.indexOf('#'));
                 }
                 if (firstElement.equals(otherElements)) {
                     boolean fail = !firstElement.startsWith(EJB_LEVEL);
@@ -744,18 +744,18 @@ public class ApplicationValidator extends ComponentValidator
         for (int j = 0; j < myVector.size(); j++) {
             String firstElement = (String) myVector.firstElement();
             if (firstElement.contains("#")) {
-                firstElement = firstElement.substring(firstElement.indexOf("#") + 1, firstElement.length());
+                firstElement = firstElement.substring(firstElement.indexOf('#') + 1, firstElement.length());
             }
             if (firstElement.contains("#")) {
-                firstElement = firstElement.substring(0, firstElement.indexOf("#"));
+                firstElement = firstElement.substring(0, firstElement.indexOf('#'));
             }
             for (int i = j+1; i < myVector.size(); i++) {
                 String otherElements = (String) myVector.get(i);
                 if (otherElements.contains("#")) {
-                    otherElements = otherElements.substring(otherElements.indexOf("#") + 1, otherElements.length());
+                    otherElements = otherElements.substring(otherElements.indexOf('#') + 1, otherElements.length());
                 }
                 if (otherElements.contains("#")) {
-                    otherElements = otherElements.substring(0, otherElements.indexOf("#"));
+                    otherElements = otherElements.substring(0, otherElements.indexOf('#'));
                 }
                 if (firstElement.equals(otherElements)) {
                     inValidJndiName = jndiName;
@@ -781,18 +781,18 @@ public class ApplicationValidator extends ComponentValidator
         for (int j = 0; j < myVector.size(); j++) {
             String firstElement = (String) myVector.firstElement();
             if (firstElement.contains("#")) {
-                firstElement = firstElement.substring(firstElement.lastIndexOf("#") + 1, firstElement.length());
+                firstElement = firstElement.substring(firstElement.lastIndexOf('#') + 1, firstElement.length());
             }
             if (firstElement.contains("#")) {
-                firstElement = firstElement.substring(firstElement.lastIndexOf("#") + 1, firstElement.length());
+                firstElement = firstElement.substring(firstElement.lastIndexOf('#') + 1, firstElement.length());
             }
             for (int i = j+1; i < myVector.size(); i++) {
                 String otherElements = (String) myVector.get(i);
                 if (otherElements.contains("#")) {
-                    otherElements = otherElements.substring(otherElements.lastIndexOf("#") + 1, otherElements.length());
+                    otherElements = otherElements.substring(otherElements.lastIndexOf('#') + 1, otherElements.length());
                 }
                 if (otherElements.contains("#")) {
-                    otherElements = otherElements.substring(otherElements.lastIndexOf("#") + 1, otherElements.length());
+                    otherElements = otherElements.substring(otherElements.lastIndexOf('#') + 1, otherElements.length());
                 }
                 if (firstElement.equals(otherElements)) {
                     inValidJndiName = jndiName;

--- a/appserver/docker/src/main/java/fish/payara/docker/instance/JsonRequestConstructor.java
+++ b/appserver/docker/src/main/java/fish/payara/docker/instance/JsonRequestConstructor.java
@@ -165,7 +165,7 @@ public class JsonRequestConstructor {
     private static void addNestedProperties(JsonObjectBuilder rootObjectBuilder, Properties containerConfig,
             List<String> processedProperties, String originalProperty) {
         JsonObjectBuilder topLevelObjectBuilder = Json.createObjectBuilder();
-        String topLevelProperty = originalProperty.substring(0, originalProperty.indexOf("."));
+        String topLevelProperty = originalProperty.substring(0, originalProperty.indexOf('.'));
 
         // Loop over nested properties and add to Json
         loopOverNestedProperties(rootObjectBuilder, containerConfig, processedProperties, topLevelProperty,

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
@@ -297,7 +297,7 @@ public class EJBUtils {
                 // Separate <jndi-name> portion from "corbaname:iiop:...#<jndi-name>
                 // We need to do this since we also use "#" in some glassfish-specific
                 // JNDI names
-                int indexOfCorbaNameSep = jndiName.indexOf("#");
+                int indexOfCorbaNameSep = jndiName.indexOf('#');
                 String jndiNameMinusCorbaNamePortion = jndiName.substring(indexOfCorbaNameSep + 1);
 
                 // Make sure any of the resulting jndi names still have corbaname: prefix intact

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/util/EjbBundleValidator.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/util/EjbBundleValidator.java
@@ -591,7 +591,7 @@ public class EjbBundleValidator extends ComponentValidator implements EjbBundleV
 
                     if( fullyQualified ) {
 
-                        int indexOfHash = next.indexOf("#");
+                        int indexOfHash = next.indexOf('#');
                         String ejbName = next.substring(indexOfHash+1);
                         String relativeJarPath = next.substring(0, indexOfHash);
 

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/SingletonLifeCycleManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/SingletonLifeCycleManager.java
@@ -127,7 +127,7 @@ public class SingletonLifeCycleManager {
 
         Application app = sessionDesc.getEjbBundleDescriptor().getApplication();
         if (fullyQualified) {
-            int indexOfHash = origName.indexOf("#");
+            int indexOfHash = origName.indexOf('#');
             String ejbName = origName.substring(indexOfHash + 1);
             String relativeJarPath = origName.substring(0, indexOfHash);
 

--- a/appserver/extras/embedded/common/bootstrap/src/main/java/org/glassfish/uberjar/bootstrap/Util.java
+++ b/appserver/extras/embedded/common/bootstrap/src/main/java/org/glassfish/uberjar/bootstrap/Util.java
@@ -110,7 +110,7 @@ public class Util {
 
     public static boolean isUber(URI uri) {
         String uriString = uri.toString();
-        String jarFileName = uriString.substring(uriString.lastIndexOf("/") + 1);
+        String jarFileName = uriString.substring(uriString.lastIndexOf('/') + 1);
         return jarFileName.indexOf("glassfish-embedded") != -1 ? true : false;
     }
 

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/archive/JarFileArchive.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/archive/JarFileArchive.java
@@ -106,8 +106,8 @@ public class JarFileArchive implements Archive {
 
 	private Archive getUnpackedNestedArchive(JarEntry jarEntry) throws IOException {
 		String name = jarEntry.getName();
-		if (name.lastIndexOf("/") != -1) {
-			name = name.substring(name.lastIndexOf("/") + 1);
+		if (name.lastIndexOf('/') != -1) {
+			name = name.substring(name.lastIndexOf('/') + 1);
 		}
 		File file = new File(getTempUnpackFolder(), name);
 		if (!file.exists() || file.length() != jarEntry.getSize()) {

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
@@ -350,7 +350,7 @@ public class DataSourceDefinitionHandler extends AbstractResourceHandler {
 
                 if (defnProperties.length > 0) {
                     for (String property : defnProperties) {
-                        int index = property.indexOf("=");
+                        int index = property.indexOf('=');
                         // found "=" and not at start or end of string
                         if (index > -1 && index != 0 && index < property.length() - 1) {
                             String name = property.substring(0, index);
@@ -449,7 +449,7 @@ public class DataSourceDefinitionHandler extends AbstractResourceHandler {
             String[] defnProperties = defn.properties();
             if (defnProperties.length > 0) {
                 for (String property : defnProperties) {
-                    int index = property.indexOf("=");
+                    int index = property.indexOf('=');
                     // found "=" and not at start or end of string
                     if (index > -1 && index != 0 && index < property.length() - 1) {
                         String name = property.substring(0, index);

--- a/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/CreateJMSResource.java
+++ b/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/CreateJMSResource.java
@@ -254,7 +254,7 @@ public class CreateJMSResource implements AdminCommand {
                         builder.append(prop.getKey()).append("=").append(prop.getValue()).append(":");
                     }
                     String propString = builder.toString();
-                    int lastColonIndex = propString.lastIndexOf(":");
+                    int lastColonIndex = propString.lastIndexOf(':');
                     if (lastColonIndex >= 0) {
                         propString = propString.substring(0, lastColonIndex);
                     }
@@ -394,7 +394,7 @@ public class CreateJMSResource implements AdminCommand {
                         builder.append(prop.getKey()).append("=").append(prop.getValue()).append(":");
                     }
                     String propString = builder.toString();
-                    int lastColonIndex = propString.lastIndexOf(":");
+                    int lastColonIndex = propString.lastIndexOf(':');
                     if (lastColonIndex >= 0) {
                         propString = propString.substring(0, lastColonIndex);
                     }

--- a/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/JMSPing.java
+++ b/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/JMSPing.java
@@ -226,7 +226,7 @@ public class JMSPing implements AdminCommand {
             builder.append(prop.getKey()).append("=").append(prop.getValue()).append(":");
         }
         String propString = builder.toString();
-        int lastColonIndex = propString.lastIndexOf(":");
+        int lastColonIndex = propString.lastIndexOf(':');
         if (lastColonIndex >= 0) {
             propString = propString.substring(0, lastColonIndex);
         }

--- a/appserver/jms/jms-handlers/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSConnectionFactoryDefinitionHandler.java
+++ b/appserver/jms/jms-handlers/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSConnectionFactoryDefinitionHandler.java
@@ -285,7 +285,7 @@ public class JMSConnectionFactoryDefinitionHandler extends AbstractResourceHandl
     
                     if (defnProperties.length > 0) {
                         for (String property : defnProperties) {
-                            int index = property.indexOf("=");
+                            int index = property.indexOf('=');
                             // found "=" and not at start or end of string
                             if (index > 0 && index < property.length() - 1) {
                                 String name = property.substring(0, index).trim();
@@ -351,7 +351,7 @@ public class JMSConnectionFactoryDefinitionHandler extends AbstractResourceHandl
             String[] defnProperties = defn.properties();
             if (defnProperties.length > 0) {
                 for (String property : defnProperties) {
-                    int index = property.indexOf("=");
+                    int index = property.indexOf('=');
                     // found "=" and not at start or end of string
                     if (index > 0 && index < property.length() - 1) {
                         String name = property.substring(0, index).trim();

--- a/appserver/jms/jms-handlers/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSDestinationDefinitionHandler.java
+++ b/appserver/jms/jms-handlers/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSDestinationDefinitionHandler.java
@@ -245,7 +245,7 @@ public class JMSDestinationDefinitionHandler extends AbstractResourceHandler {
     
                     if (defnProperties.length > 0) {
                         for (String property : defnProperties) {
-                            int index = property.indexOf("=");
+                            int index = property.indexOf('=');
                             // found "=" and not at start or end of string
                             if (index > 0 && index < property.length() - 1) {
                                 String name = property.substring(0, index).trim();
@@ -294,7 +294,7 @@ public class JMSDestinationDefinitionHandler extends AbstractResourceHandler {
             String[] defnProperties = defn.properties();
             if (defnProperties.length > 0) {
                 for (String property : defnProperties) {
-                    int index = property.indexOf("=");
+                    int index = property.indexOf('=');
                     // found "=" and not at start or end of string
                     if (index > 0 && index < property.length() - 1) {
                         String name = property.substring(0, index).trim();

--- a/appserver/load-balancer/admin/src/main/java/org/glassfish/loadbalancer/admin/cli/LBCommandsBase.java
+++ b/appserver/load-balancer/admin/src/main/java/org/glassfish/loadbalancer/admin/cli/LBCommandsBase.java
@@ -78,8 +78,8 @@ public class LBCommandsBase {
             String token = st.nextToken();
             String insName = null;
             String value = null;
-            insName = token.substring(0, token.indexOf("="));
-            value = token.substring(token.indexOf("=") + 1);
+            insName = token.substring(0, token.indexOf('='));
+            value = token.substring(token.indexOf('=') + 1);
             Integer weightInt;
             try
             {

--- a/appserver/load-balancer/admin/src/main/java/org/glassfish/loadbalancer/admin/cli/helper/LbConfigHelper.java
+++ b/appserver/load-balancer/admin/src/main/java/org/glassfish/loadbalancer/admin/cli/helper/LbConfigHelper.java
@@ -190,8 +190,8 @@ public class LbConfigHelper {
                 while (st.hasMoreElements()) {
                     String listener = st.nextToken();
                     if (listener.contains("ajp://")) {
-                        listenerHost = listener.substring(listener.lastIndexOf("/") + 1, listener.lastIndexOf(":"));
-                        listenerPort = listener.substring(listener.lastIndexOf(":") + 1, listener.length());
+                        listenerHost = listener.substring(listener.lastIndexOf('/') + 1, listener.lastIndexOf(':'));
+                        listenerPort = listener.substring(listener.lastIndexOf(':') + 1, listener.length());
                         break;
                     }
                 }
@@ -276,8 +276,8 @@ public class LbConfigHelper {
                 while (st.hasMoreElements()) {
                     String listener = st.nextToken();
                     if (listener.contains("http://")) {
-                        listenerHost = listener.substring(listener.lastIndexOf("/") + 1, listener.lastIndexOf(":"));
-                        listenerPort = listener.substring(listener.lastIndexOf(":") + 1, listener.length());
+                        listenerHost = listener.substring(listener.lastIndexOf('/') + 1, listener.lastIndexOf(':'));
+                        listenerPort = listener.substring(listener.lastIndexOf(':') + 1, listener.length());
                         break;
                     }
                 }

--- a/appserver/registration/registration-impl/src/main/java/com/sun/enterprise/registration/impl/environment/SolarisSystemEnvironment.java
+++ b/appserver/registration/registration-impl/src/main/java/com/sun/enterprise/registration/impl/environment/SolarisSystemEnvironment.java
@@ -153,8 +153,8 @@ class SolarisSystemEnvironment extends SystemEnvironment {
             String line = lines[i].trim();
             if (line.startsWith(token)) {
                 line = line.substring(line.indexOf(token) + token.length()).trim();
-                if (line.indexOf(" ") != -1) {
-                    return line.substring(0, line.indexOf(" ")).trim();
+                if (line.indexOf(' ') != -1) {
+                    return line.substring(0, line.indexOf(' ')).trim();
                 }
             }
         }

--- a/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/annotation/handler/MailSessionDefinitionHandler.java
+++ b/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/annotation/handler/MailSessionDefinitionHandler.java
@@ -236,7 +236,7 @@ public class MailSessionDefinitionHandler extends AbstractResourceHandler {
             String[] defnProperties = defn.properties();
             if (defnProperties.length > 0) {
                 for (String property : defnProperties) {
-                    int index = property.indexOf("=");
+                    int index = property.indexOf('=');
                     // found "=" and not at start or end of string
                     if (index > -1 && index != 0 && index < property.length() - 1) {
                         String name = property.substring(0, index);
@@ -307,7 +307,7 @@ public class MailSessionDefinitionHandler extends AbstractResourceHandler {
 
                 if (defnProperties.length > 0) {
                     for (String property : defnProperties) {
-                        int index = property.indexOf("=");
+                        int index = property.indexOf('=');
                         // found "=" and not at start or end of string
                         if (index > -1 && index != 0 && index < property.length() - 1) {
                             String name = property.substring(0, index);

--- a/appserver/tests/amx/src/org/glassfish/admin/amxtest/TestMain.java
+++ b/appserver/tests/amx/src/org/glassfish/admin/amxtest/TestMain.java
@@ -149,7 +149,7 @@ public final class TestMain
 
         for (int i = 1; i < args.length; ++i) {
             final String pair = args[i];
-            final int delimIndex = pair.indexOf("=");
+            final int delimIndex = pair.indexOf('=');
             String name = null;
             String value = null;
             if (delimIndex < 0) {

--- a/appserver/tests/logmonitor/Filter.java
+++ b/appserver/tests/logmonitor/Filter.java
@@ -107,7 +107,7 @@ public class Filter {
                         st.nextToken();
                         String tempString = st.nextToken().trim();
                         if (tempString.contains(":")) {
-                            String id = tempString.substring(0, tempString.indexOf(":")).trim();
+                            String id = tempString.substring(0, tempString.indexOf(':')).trim();
                             //System.out.println("Ids=" + id);
                             if (id.length() < 10 && !id.contains(" ") && id.matches("[a-zA-Z0-9]*")) {
                                 myMessageIds.add(id);
@@ -149,7 +149,7 @@ public class Filter {
                         st.nextToken();
                         String tempString = st.nextToken().trim();
                         if (tempString.contains(":")) {
-                            String id = tempString.substring(0, tempString.indexOf(":")).trim();
+                            String id = tempString.substring(0, tempString.indexOf(':')).trim();
                             //System.out.println("Ids=" + id);
                             if (id.length() < 10 && !id.contains(" ") && id.matches("[a-zA-Z0-9]*")) {
                                 myMissingMessageIds.add(id);

--- a/appserver/tests/quicklook/amx/src/test/amx/Demo.java
+++ b/appserver/tests/quicklook/amx/src/test/amx/Demo.java
@@ -133,7 +133,7 @@ public final class Demo {
             
             if ( arg.startsWith(name) || arg.startsWith("--" + name) )
             {
-                final int idx = arg.indexOf("=");
+                final int idx = arg.indexOf('=');
                 value = arg.substring(idx+1);
                 break;
             }

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/util/IntrospectionUtils.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/util/IntrospectionUtils.java
@@ -512,7 +512,7 @@ public final class IntrospectionUtils {
      */
     public static String replaceProperties(String value,
             Hashtable<Object,Object> staticProp, PropertySource dynamicProp[]) {
-        if (value.indexOf("$") < 0) {
+        if (value.indexOf('$') < 0) {
             return value;
         }
         StringBuilder sb = new StringBuilder();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -2190,7 +2190,7 @@ public class Request
             // We can't use StandardContext.getJvmRoute() to determine whether
             // jvmRoute has been enabled, because this CoyoteRequest may not
             // have been associated with any context yet.
-            int index = id.indexOf(".");
+            int index = id.indexOf('.');
             if (index > 0) {
                 requestedSessionId = id.substring(0, index);
             }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
@@ -897,7 +897,7 @@ public class Response
         // Ignore charset if getWriter() has already been called
         if (usingWriter) {
             if (type != null) {
-                int index = type.indexOf(";");
+                int index = type.indexOf(';');
                 if (index != -1) {
                     type = type.substring(0, index);
                 }
@@ -908,7 +908,7 @@ public class Response
 
         // Check to see if content type contains charset
         if (type != null) {
-            int index = type.indexOf(";");
+            int index = type.indexOf(';');
             if (index != -1) {
                 int len = type.length();
                 index++;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
@@ -1604,7 +1604,7 @@ public abstract class ContainerBase
     protected String logName() {
 
         String className = this.getClass().getName();
-        int period = className.lastIndexOf(".");
+        int period = className.lastIndexOf('.');
         if (period >= 0)
             className = className.substring(period + 1);
         return (className + "[" + getName() + "]");

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/NamingContextListener.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/NamingContextListener.java
@@ -1118,7 +1118,7 @@ public class NamingContextListener
     protected String logName() {
 
         String className = this.getClass().getName();
-        int period = className.lastIndexOf(".");
+        int period = className.lastIndexOf('.');
         if (period >= 0)
             className = className.substring(period + 1);
         return (className + "[" + getName() + "]");

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -6840,7 +6840,7 @@ public class StandardContext
             log.log(Level.SEVERE, LogFacade.MALFORMED_NAME, getName());
         }
         path=path.substring(2);
-        int delim=path.indexOf( "/" );
+        int delim=path.indexOf('/');
         hostName="localhost"; // Should be default...
         if( delim > 0 ) {
             hostName=path.substring(0, delim);
@@ -7094,7 +7094,7 @@ public class StandardContext
 
         if (file == null)
             return (null);
-        int period = file.lastIndexOf(".");
+        int period = file.lastIndexOf('.');
         if (period < 0)
             return (null);
         String extension = file.substring(period + 1);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/realm/RealmBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/realm/RealmBase.java
@@ -705,8 +705,8 @@ public abstract class RealmBase implements Lifecycle, Realm {
                     String pattern = caseSensitiveMapping ? patterns[k] : patterns[k].toLowerCase(Locale.ENGLISH);
                     // END SJSWS 6324431
                     if (uri != null && pattern.startsWith("*.")) {
-                        int slash = uri.lastIndexOf("/");
-                        int dot = uri.lastIndexOf(".");
+                        int slash = uri.lastIndexOf('/');
+                        int dot = uri.lastIndexOf('.');
                         if (slash >= 0 && dot > slash && dot != uri.length() - 1 && uri.length() - dot == pattern.length() - 1) {
                             if (pattern.regionMatches(1, uri, dot, uri.length() - dot)) {
                                 matched = true;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/servlets/CGIServlet.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/servlets/CGIServlet.java
@@ -821,7 +821,7 @@ public final class CGIServlet extends HttpServlet {
                 } else {
                     qs = req.getQueryString();
                 }
-                if (qs != null && qs.indexOf("=") == -1) {
+                if (qs != null && qs.indexOf('=') == -1) {
                     StringTokenizer qsTokens = new StringTokenizer(qs, "+");
                     while ( qsTokens.hasMoreTokens() ) {
                         cmdLineParameters.add(URLDecoder.decode(qsTokens.nextToken(),

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/servlets/WebdavServlet.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/servlets/WebdavServlet.java
@@ -1569,13 +1569,13 @@ public class WebdavServlet
                 destinationPath = destinationPath.substring(hostName.length());
             }
 
-            int portIndex = destinationPath.indexOf(":");
+            int portIndex = destinationPath.indexOf(':');
             if (portIndex >= 0) {
                 destinationPath = destinationPath.substring(portIndex);
             }
 
             if (destinationPath.startsWith(":")) {
-                int firstSeparator = destinationPath.indexOf("/");
+                int firstSeparator = destinationPath.indexOf('/');
                 if (firstSeparator < 0) {
                     destinationPath = "/";
                 } else {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/startup/HostConfig.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/startup/HostConfig.java
@@ -537,7 +537,7 @@ public class HostConfig
 
                 // Calculate the context path and make sure it is unique
                 String contextPath = "/" + files[i];
-                int period = contextPath.lastIndexOf(".");
+                int period = contextPath.lastIndexOf('.');
                 if (period >= 0)
                     contextPath = contextPath.substring(0, period);
 
@@ -879,7 +879,7 @@ public class HostConfig
                     } else if (dirLastModified > lastModified.longValue()) {
                         // The WAR has been modified: redeploy
                         String expandedDir = files[i];
-                        int period = expandedDir.lastIndexOf(".");
+                        int period = expandedDir.lastIndexOf('.');
                         if (period >= 0)
                             expandedDir = expandedDir.substring(0, period);
                         File expanded = new File(appBase, expandedDir);

--- a/appserver/web/web-core/src/main/java/org/apache/tomcat/util/digester/XercesParser.java
+++ b/appserver/web/web-core/src/main/java/org/apache/tomcat/util/digester/XercesParser.java
@@ -144,7 +144,7 @@ public class XercesParser{
                 versionClass.getMethod("getVersion", (Class[]) null); 
             String version = (String)method.invoke(null, (Object[]) null);
             versionNumber = version.substring( "Xerces-J".length() , 
-                                               version.lastIndexOf(".") ); 
+                                               version.lastIndexOf('.') ); 
         } catch (Exception ex){
             // Do nothing.
         }

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -3005,14 +3005,14 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         String jvmRoute = null;
         if (jvmOption.contains("{") && jvmOption.contains("}")) {
             // Look up system-property
-            jvmOption = jvmOption.substring(jvmOption.indexOf("{") + 1, jvmOption.indexOf("}"));
+            jvmOption = jvmOption.substring(jvmOption.indexOf('{') + 1, jvmOption.indexOf('}'));
             jvmRoute = server.getSystemPropertyValue(jvmOption);
             if (jvmRoute == null) {
                 // Try to get it from System property if it exists
                 jvmRoute = System.getProperty(jvmOption);
             }
         } else if (jvmOption.contains("=")) {
-            jvmRoute = jvmOption.substring(jvmOption.indexOf("=") + 1);
+            jvmRoute = jvmOption.substring(jvmOption.indexOf('=') + 1);
         }
         engine.setJvmRoute(jvmRoute);
         for (com.sun.enterprise.config.serverbeans.VirtualServer vsBean : httpService.getVirtualServer()) {

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/MapperListener.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/MapperListener.java
@@ -399,7 +399,7 @@ public class MapperListener implements NotificationListener, NotificationFilter{
         if (name.startsWith("//")) {
             name = name.substring(2);
         }
-        int slash = name.indexOf("/");
+        int slash = name.indexOf('/');
         if (slash != -1) {
             hostName = name.substring(0, slash);
             contextName = name.substring(slash);
@@ -437,7 +437,7 @@ public class MapperListener implements NotificationListener, NotificationFilter{
         if (name.startsWith("//")) {
             name = name.substring(2);
         }
-        int slash = name.indexOf("/");
+        int slash = name.indexOf('/');
         if (slash != -1) {
             hostName = name.substring(0, slash);
             contextName = name.substring(slash);
@@ -490,7 +490,7 @@ public class MapperListener implements NotificationListener, NotificationFilter{
         if (name.startsWith("//")) {
             name = name.substring(2);
         }
-        int slash = name.indexOf("/");
+        int slash = name.indexOf('/');
         if (slash != -1) {
             hostName = name.substring(0, slash);
             contextName = name.substring(slash);
@@ -539,7 +539,7 @@ public class MapperListener implements NotificationListener, NotificationFilter{
         if (name.startsWith("//")) {
             name = name.substring(2);
         }
-        int slash = name.indexOf("/");
+        int slash = name.indexOf('/');
         if (slash != -1) {
             hostName = name.substring(0, slash);
             contextName = name.substring(slash);

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -811,7 +811,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     private static String makeBdaId(String friendlyId, BDAType bdaType, String jarArchiveName) {
         // Use war-name.war/WEB-INF/lib/jarName as BDA Id
         StringBuilder sb = new StringBuilder();
-        int delimiterIndex = friendlyId.lastIndexOf(":");
+        int delimiterIndex = friendlyId.lastIndexOf(':');
         if(delimiterIndex == -1) {
             sb.append(friendlyId);
         }

--- a/appserver/webservices/connector/src/main/java/org/glassfish/webservices/connector/annotation/handlers/HandlerChainHandler.java
+++ b/appserver/webservices/connector/src/main/java/org/glassfish/webservices/connector/annotation/handlers/HandlerChainHandler.java
@@ -379,7 +379,7 @@ public class HandlerChainHandler extends AbstractHandler {
     
     private String getAsQName(Node n) {
         String nodeValue = n.getTextContent();
-        int index = nodeValue.indexOf(":");
+        int index = nodeValue.indexOf(':');
         if(index <= 0) {
             return nodeValue;
         }

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesDeployer.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesDeployer.java
@@ -341,7 +341,7 @@ public class WebServicesDeployer extends JavaEEDeployer<WebServicesContainer, We
                 // For entries with relative paths, Entity resolver always
                 // return file://<absolute path
                 if (mappedEntry.startsWith("file:")) {
-                    File f = new File(mappedEntry.substring(mappedEntry.indexOf(":") + 1));
+                    File f = new File(mappedEntry.substring(mappedEntry.indexOf(':') + 1));
                     if (!f.exists()) {
                         throw new DeploymentException(format(resourceBundle.getString(LogUtils.CATALOG_RESOLVER_ERROR), mappedEntry));
                     }

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WsCompile.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WsCompile.java
@@ -313,7 +313,7 @@ public final class WsCompile extends CompileToolDelegate {
                 String msg = "Endpoint address uri must be set for endpoint " +
                     next.getEndpointName();
                 throw new IllegalStateException(msg);
-            } else if( endpointAddressUri.indexOf("*") >= 0 ) {
+            } else if( endpointAddressUri.indexOf('*') >= 0 ) {
                 String msg = "Endpoint address uri " + endpointAddressUri + 
                     " for endpoint " + next.getEndpointName() + 
                     " is invalid. It must not contain the '*' character";


### PR DESCRIPTION
This pull request contains fixes only for module _appserver_.

Replacing `String.lastIndexOf("/")` with `String.lastIndexOf('/')` which can be more performant.

This fixes SonarQube violations of the rule: [String function use should be optimized for single characters](https://rules.sonarsource.com/java/RSPEC-3027)