### PR TITLE
SonarQube - Using Wrapper.parseWrapper() when converting String to primitive

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -304,7 +304,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
             String contextInfoEnabled,
             boolean cleanupTransaction) {
 
-        boolean isContextInfoEnabled = Boolean.valueOf(contextInfoEnabled);
+        boolean isContextInfoEnabled = Boolean.parseBoolean(contextInfoEnabled);
 
         ContextSetupProviderImpl.CONTEXT_TYPE[] contextTypes
                 = parseContextInfo(contextInfo, isContextInfoEnabled);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/RAWriterAdapter.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/RAWriterAdapter.java
@@ -63,7 +63,7 @@ public class RAWriterAdapter extends Writer {
 
     private void initializeAutoFlush() {
         String autoFlushValue = System.getProperty("com.sun.enterprise.connectors.LogWriterAutoFlush", "true");
-        autoFlush = Boolean.valueOf(autoFlushValue);
+        autoFlush = Boolean.parseBoolean(autoFlushValue);
     }
 
     public void write(char cbuf[], int off, int len) {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/BundleDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/BundleDescriptor.java
@@ -1017,7 +1017,7 @@ public abstract class BundleDescriptor extends RootDeploymentDescriptor implemen
      * @param value the full attribute
      */
     public void setFullAttribute(String value) {
-        fullAttribute = Boolean.valueOf(value);
+        fullAttribute = Boolean.parseBoolean(value);
     }
 
     /**

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/EjbIORConfigurationDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/EjbIORConfigurationDescriptor.java
@@ -279,7 +279,7 @@ public class EjbIORConfigurationDescriptor implements Serializable {
      * @param val the value (true or false).
      */
     public void setAuthMethodRequired(String val) {
-	required = Boolean.valueOf(val).booleanValue();
+	required = Boolean.parseBoolean(val);
     }
 
     /**

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -1283,7 +1283,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             } else {
                 String disableInServer = ejbContainerUtilImpl.getEjbContainer().
                         getPropertyValue(RuntimeTagNames.DISABLE_NONPORTABLE_JNDI_NAMES);
-                disableNonPortableJndiName = Boolean.valueOf(disableInServer);
+                disableNonPortableJndiName = Boolean.parseBoolean(disableInServer);
             }
 
             String glassfishSpecificJndiName = null;

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/persistent/timer/PersistentEJBTimerService.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/persistent/timer/PersistentEJBTimerService.java
@@ -337,7 +337,7 @@ public class PersistentEJBTimerService extends NonPersistentEJBTimerService {
         try{
             String str=System.getProperty( strDBReadBeforeTimeout );
             if( null != str) {
-                performDBReadBeforeTimeout = Boolean.valueOf(str).booleanValue();
+                performDBReadBeforeTimeout = Boolean.parseBoolean(str);
 
                 if( logger.isLoggable(Level.FINE) ) {
                     logger.log(Level.FINE, "EJB Timer Service property : " +

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
@@ -1202,7 +1202,7 @@ public abstract class ManagedConnectionFactoryImpl implements javax.resource.spi
     
     public void setSlowQueryThresholdInSeconds(String seconds) {
         spec.setDetail(DataSourceSpec.SLOWSQLLOGTHRESHOLD, seconds);
-        double threshold = Double.valueOf(seconds);
+        double threshold = Double.parseDouble(seconds);
         if (threshold > 0) {
             if (sqlTraceDelegator == null) {
                 sqlTraceDelegator = new SQLTraceDelegator(getPoolName(), getApplicationName(), getModuleName());
@@ -1434,7 +1434,7 @@ public abstract class ManagedConnectionFactoryImpl implements javax.resource.spi
         boolean poolProperty = false;
         String statementWrappingString = getStatementWrapping();
         if (statementWrappingString != null)
-            poolProperty = Boolean.valueOf(statementWrappingString);
+            poolProperty = Boolean.parseBoolean(statementWrappingString);
 
         if (wrapStatement == JVM_OPTION_STATEMENT_WRAPPING_ON ||
                 (wrapStatement == JVM_OPTION_STATEMENT_WRAPPING_NOT_SET && poolProperty)) {
@@ -1565,7 +1565,7 @@ public abstract class ManagedConnectionFactoryImpl implements javax.resource.spi
         String stmtLeakReclaim = getStatementLeakReclaim();
         if (stmtLeakTimeout != null) {
             statementLeakTimeout = Integer.parseInt(stmtLeakTimeout) * 1000L;
-            statementLeakReclaim = Boolean.valueOf(stmtLeakReclaim);
+            statementLeakReclaim = Boolean.parseBoolean(stmtLeakReclaim);
             if (_logger.isLoggable(Level.FINE)) {
                 _logger.log(Level.FINE, "StatementLeakTimeout in seconds: "
                         + statementLeakTimeout + " & StatementLeakReclaim: "

--- a/appserver/persistence/cmp/generator-database/src/main/java/com/sun/jdo/spi/persistence/generator/database/MappingPolicy.java
+++ b/appserver/persistence/cmp/generator-database/src/main/java/com/sun/jdo/spi/persistence/generator/database/MappingPolicy.java
@@ -700,8 +700,7 @@ public class MappingPolicy implements Cloneable {
 
                 if (name.equals(USE_UNIQUE_TABLE_NAMES)) {
                     if (! StringHelper.isEmpty(value)) {
-                        uniqueTableName =
-                            Boolean.valueOf(value).booleanValue();
+                        uniqueTableName = Boolean.parseBoolean(value);
                     }
                     continue;
                 }
@@ -749,7 +748,7 @@ public class MappingPolicy implements Cloneable {
 
         // The name is in sqlInfo if it was loaded from one of our
         // vendor-specific properties files.
-        Object o = sqlInfo.get(new Integer(jdbcType));
+        Object o = sqlInfo.get(Integer.valueOf(jdbcType));
         if (null != o) {
             rc = (String) o;
         } else {
@@ -977,7 +976,7 @@ public class MappingPolicy implements Cloneable {
      */
     public static String getJdbcTypeName(int type) throws
             IllegalArgumentException {
-        String rc = (String) jdbcTypeNames.get(new Integer(type));
+        String rc = (String) jdbcTypeNames.get(Integer.valueOf(type));
         if (null == rc) {
             throw new IllegalArgumentException();
         }

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/ejb/DeploymentHelper.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/ejb/DeploymentHelper.java
@@ -107,7 +107,7 @@ public class DeploymentHelper
             if (! StringHelper.isEmpty(value)) {
                  if (logger.isLoggable(Logger.FINE))
                      logger.fine(DatabaseConstants.JAVA_TO_DB_FLAG + " property is set."); // NOI18N
-                 return Boolean.valueOf(value).booleanValue();
+                 return Boolean.parseBoolean(value);
             }
         }
         return false;

--- a/appserver/persistence/cmp/utility/src/main/java/com/sun/jdo/spi/persistence/utility/logging/LoggerFactoryJDK14.java
+++ b/appserver/persistence/cmp/utility/src/main/java/com/sun/jdo/spi/persistence/utility/logging/LoggerFactoryJDK14.java
@@ -187,7 +187,7 @@ public class LoggerFactoryJDK14 extends AbstractLoggerFactory {
             boolean defaultAppend = false;
             String append = logManager.getProperty(baseName + ".append"); //NOI18N
             if(append != null) {
-                defaultAppend = Boolean.valueOf(append).booleanValue();
+                defaultAppend = Boolean.parseBoolean(append);
             }
             
             FileHandler fileHandler = null;

--- a/appserver/security/jacc.provider.inmemory/src/main/java/com/sun/enterprise/security/jacc/provider/SimplePolicyProvider.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/com/sun/enterprise/security/jacc/provider/SimplePolicyProvider.java
@@ -203,7 +203,7 @@ public class SimplePolicyProvider extends Policy {
             // Will enable permission caching of container, unless REUSE
             // property is set, and its value is not "true".
             String propValue = System.getProperty(REUSE);
-            boolean supportsReuse = propValue == null ? true : Boolean.valueOf(propValue);
+            boolean supportsReuse = propValue == null ? true : Boolean.parseBoolean(propValue);
             if (supportsReuse) {
                 if (PolicyContext.getHandlerKeys().contains(REUSE)) {
                     PolicyContext.getContext(REUSE);

--- a/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
+++ b/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
@@ -580,7 +580,7 @@ public class WarHandler extends AbstractArchiveHandler {
                         }
 
                         if ("ignoreHiddenJarFiles".equals(propName)) {
-                            ignoreHiddenJarFiles = Boolean.valueOf(value);
+                            ignoreHiddenJarFiles = Boolean.parseBoolean(value);
                         } else {
                             Object[] params = { propName, value };
                             if (logger.isLoggable(Level.WARNING)) {
@@ -607,9 +607,9 @@ public class WarHandler extends AbstractArchiveHandler {
                         }
 
                         if("useMyFaces".equalsIgnoreCase(propName)) {
-                            useBundledJSF = Boolean.valueOf(value);
+                            useBundledJSF = Boolean.parseBoolean(value);
                         } else if("useBundledJsf".equalsIgnoreCase(propName)) {
-                            useBundledJSF = Boolean.valueOf(value);
+                            useBundledJSF = Boolean.parseBoolean(value);
                         }
                     } else if ("version-identifier".equals(name)) {
                         versionIdentifier = parser.getElementText();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1625,7 +1625,7 @@ public class Connector
 
         String prop = getProperty("clientauth");
         if (prop != null) {
-            ret = Boolean.valueOf(prop).booleanValue();
+            ret = Boolean.parseBoolean(prop);
         } else {	
             ServerSocketFactory factory = this.getFactory();
             if (factory instanceof CoyoteServerSocketFactory) {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/proxy/ProxyFactory.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/proxy/ProxyFactory.java
@@ -365,7 +365,7 @@ public final class ProxyFactory implements NotificationListener {
         final Descriptor d = info.getDescriptor();
 
         final String value = "" + d.getFieldValue(DESC_STD_IMMUTABLE_INFO);
-        return Boolean.valueOf(value);
+        return Boolean.parseBoolean(value);
     }
 
     /**

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/RuntimeRootImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/RuntimeRootImpl.java
@@ -317,7 +317,7 @@ public final class RuntimeRootImpl extends AMXImplBase
                 {
                     final String value = opt.substring( prefix.length() ).toLowerCase(Locale.ENGLISH);
                     //System.out.println( "RuntimeRootImpl.isRunningInDebugMode(): found: " + prefix + value );
-                    inDebugMode = Boolean.valueOf(value );
+                    inDebugMode = Boolean.parseBoolean(value);
                     break;
                 }
             }

--- a/nucleus/resources/src/main/java/org/glassfish/resourcebase/resources/admin/cli/ResourceUtil.java
+++ b/nucleus/resources/src/main/java/org/glassfish/resourcebase/resources/admin/cli/ResourceUtil.java
@@ -123,7 +123,7 @@ public class ResourceUtil {
      */
     public String computeEnabledValueForResourceBasedOnTarget(String enabledValue, String target) {
         String result = enabledValue;
-        boolean enabled = Boolean.valueOf(enabledValue);
+        boolean enabled = Boolean.parseBoolean(enabledValue);
         if(!isNonResourceRefTarget(target) && !enabled ){
             result = Boolean.toString(!enabled);
         }


### PR DESCRIPTION
parseWrapper() avoids creating a boxed primitive, and this is more performant when just the primitive is desired.

This fixes SonarQube violations of the rule: [Parsing should be used to convert "Strings" to primitives](https://rules.sonarsource.com/java/RSPEC-2130)