### PR TITLE
SonarQube - Replacing raw Collections EMPTY_... fields with generic methods empty…()

### DIFF
--- a/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/ACCAgentClassLoader.java
+++ b/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/ACCAgentClassLoader.java
@@ -194,7 +194,7 @@ public class ACCAgentClassLoader extends URLClassLoader {
 
     private static List<URL> classPathToURLs(final String classPath) {
         if (classPath == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         final List<URL> result = new ArrayList<URL>();
         try {

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCClassLoader.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCClassLoader.java
@@ -163,7 +163,7 @@ public class ACCClassLoader extends URLClassLoader {
 
     private static List<URL> classPathToURLs(final String classPath) {
         if (classPath == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         final List<URL> result = new ArrayList<URL>();
         try {

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientDeployerHelper.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientDeployerHelper.java
@@ -318,7 +318,7 @@ public abstract class AppClientDeployerHelper {
             throws IOException;
     
     public Map<String,Map<URI,StaticContent>> signingAliasToJar() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     public final DeploymentContext dc() {

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/StandaloneAppClientDeployerHelper.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/StandaloneAppClientDeployerHelper.java
@@ -330,7 +330,7 @@ public class StandaloneAppClientDeployerHelper extends AppClientDeployerHelper {
 
     @Override
     public Set<FullAndPartURIs> earLevelDownloads() throws IOException {
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
 
     @Override

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/BundleDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/BundleDescriptor.java
@@ -690,7 +690,7 @@ public abstract class BundleDescriptor extends RootDeploymentDescriptor implemen
      * @return persistence units that are referenced by this module
      */
     public Collection<? extends PersistenceUnitDescriptor> findReferencedPUs() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraClusteredCDIEventImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraClusteredCDIEventImpl.java
@@ -180,7 +180,7 @@ public class PayaraClusteredCDIEventImpl implements PayaraClusteredCDIEvent {
             }
             return result;
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     } 
 

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/acl/RoleMapper.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/acl/RoleMapper.java
@@ -352,7 +352,7 @@ public class RoleMapper implements Serializable, SecurityRoleMapper {
         assert roleToGroup != null;
         Set<Group> s = roleToGroup.get(r.getName());
         if (s == null) {
-            return Collections.enumeration(Collections.EMPTY_SET);
+            return Collections.enumeration(Collections.emptySet());
         }
         return Collections.enumeration(s);
     }
@@ -367,7 +367,7 @@ public class RoleMapper implements Serializable, SecurityRoleMapper {
         assert roleToPrincipal != null;
         Set<Principal> s = roleToPrincipal.get(r.getName());
         if (s == null) {
-            return Collections.enumeration(Collections.EMPTY_SET);
+            return Collections.enumeration(Collections.emptySet());
         }
         return Collections.enumeration(s);
     }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/SecureAdmin.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/SecureAdmin.java
@@ -193,7 +193,7 @@ public interface SecureAdmin extends ConfigBeanProxy {
                 
         
         public static List<SecureAdminInternalUser> secureAdminInternalUsers(final SecureAdmin secureAdmin) {
-            return (secureAdmin == null) ? Collections.EMPTY_LIST : secureAdmin.getSecureAdminInternalUser();
+            return (secureAdmin == null) ? Collections.emptyList() : secureAdmin.getSecureAdminInternalUser();
         }
         
         public static SecureAdminInternalUser secureAdminInternalUser(final SecureAdmin secureAdmin) {

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
@@ -418,7 +418,7 @@ public class CompositeUtil {
 
         Set<ConstraintViolation<T>> constraintViolations = beanValidator.validate(model);
         if (constraintViolations == null || constraintViolations.isEmpty()) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         return constraintViolations;

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
@@ -602,7 +602,7 @@ public abstract class PayloadFilesManager {
             final Payload.Inbound inboundPayload) throws Exception {
 
         if (inboundPayload == null) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
 
         final Map<File,Properties> result = new LinkedHashMap<File,Properties>();

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
@@ -338,7 +338,7 @@ public abstract class GenericSniffer implements Sniffer {
      * archive entries might exist
      */
     protected List<String> getDeploymentConfigurationPaths() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -645,7 +645,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         if (Boolean.valueOf(skipScanExternalLibProp)) {
             // if we skip scanning external libraries, we should just
             // return an empty list here
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         List<URI> externalLibs = DeploymentUtils.getExternalLibraries(context.getSource());
@@ -699,7 +699,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     @Override
     public Collection<? extends Sniffer> getSniffers(final ArchiveHandler handler, Collection<? extends Sniffer> sniffers, DeploymentContext context) {
         if (handler == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         if (sniffers==null) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
@@ -215,7 +215,7 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
         }
         if (!derbyLib.exists()) {
             logger.info(KernelLoggerInfo.cantFindDerby);
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         return Arrays.asList(derbyLib.listFiles(new FilenameFilter(){
@@ -252,7 +252,7 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
 
         if (h2Lib==null || !h2Lib.exists()) {
             logger.info(KernelLoggerInfo.cantFindH2);
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         return Arrays.asList(h2Lib.listFiles((dir, name) -> name.startsWith("h2") && name.endsWith(".jar")));

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/versioning/VersioningService.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/versioning/VersioningService.java
@@ -233,7 +233,7 @@ public class VersioningService {
                         "Application {0} has no version registered",
                         untagged));  
             }
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         return VersioningUtils.matchExpression(allVersions, name);

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/versioning/VersioningUtils.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/versioning/VersioningUtils.java
@@ -211,7 +211,7 @@ public class VersioningUtils {
             throws VersioningException {
 
         if (listVersion.size() == 0) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         String expressionVersion = getExpression(appName);
 

--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigModel.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigModel.java
@@ -982,7 +982,7 @@ public final class ConfigModel {
         return ( dv );        
     }
     private static List<String> getMetadataFromDescription(Map<String, List<String>> map, String key) {
-        return map.get(key) == null ? Collections.emptyList() : map.get(key);
+        return map.getOrDefault(key, Collections.emptyList());
     }
     
     private static class SafeHk2Loader implements HK2Loader {

--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigModel.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigModel.java
@@ -982,7 +982,7 @@ public final class ConfigModel {
         return ( dv );        
     }
     private static List<String> getMetadataFromDescription(Map<String, List<String>> map, String key) {
-        return map.get(key) == null ? Collections.EMPTY_LIST : map.get(key);
+        return map.get(key) == null ? Collections.emptyList() : map.get(key);
     }
     
     private static class SafeHk2Loader implements HK2Loader {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryService.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryService.java
@@ -205,7 +205,7 @@ public class DomainDiscoveryService implements DiscoveryService {
 
     @Override
     public Map<String, Object> discoverLocalMetadata() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
     
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
@@ -72,7 +72,7 @@ public class JNDIConfigSource extends PayaraConfigSource implements ConfigSource
 
     @Override
     public Map<String, String> getProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     @Override


### PR DESCRIPTION
This PR solves some cases of the SonarQube rule: ["Collections.EMPTY_LIST", "EMPTY_MAP", and "EMPTY_SET" should not be used](https://rules.sonarsource.com/java/RSPEC-1596).

I only replaced cases where a method returns with a typed Collection return type.