### PR TITLE
SonarQube - Instantiating wrappers - from 'new Wrapper(arg)' to 'Wrapper.valueOf(arg)'

### DIFF
--- a/appserver/persistence/cmp/ejb-mapping/src/main/java/com/sun/jdo/api/persistence/mapping/ejb/MappingFile.java
+++ b/appserver/persistence/cmp/ejb-mapping/src/main/java/com/sun/jdo/api/persistence/mapping/ejb/MappingFile.java
@@ -1762,7 +1762,7 @@ public class MappingFile {
 
             // Type numeric=2
             fakeKeyCol.setType(2);
-            fakeKeyCol.setPrecision(new Integer(MINIMUM_PRECISION));
+            fakeKeyCol.setPrecision(Integer.valueOf(MINIMUM_PRECISION));
             tkey.setPrimaryKey(true);
             tkey.addColumn(fakeKeyCol);
             retVal.addColumn(fakeKeyCol);

--- a/appserver/persistence/cmp/ejb-mapping/src/main/java/com/sun/jdo/api/persistence/mapping/ejb/MappingGenerator.java
+++ b/appserver/persistence/cmp/ejb-mapping/src/main/java/com/sun/jdo/api/persistence/mapping/ejb/MappingGenerator.java
@@ -573,7 +573,7 @@ public class MappingGenerator {
         }
 
         private static boolean checkType(int jdbcType, Map jdbcTypes) {
-            return jdbcTypes.containsKey(new Integer(jdbcType));
+            return jdbcTypes.containsKey(Integer.valueOf(jdbcType));
         }
 
         /** Returns a collection of compatible jdbc types.
@@ -636,16 +636,16 @@ public class MappingGenerator {
 
         private static String getAttribute(int jdbcType) {
             if (isNumeric(jdbcType)) {
-                return (String)numericMap.get(new Integer(jdbcType));
+                return (String)numericMap.get(Integer.valueOf(jdbcType));
             }
             else if (isCharacter(jdbcType)) {
-                return (String)characterMap.get(new Integer(jdbcType));
+                return (String)characterMap.get(Integer.valueOf(jdbcType));
             }
             else if (isBlob(jdbcType)) {
-                return (String)blobMap.get(new Integer(jdbcType));
+                return (String)blobMap.get(Integer.valueOf(jdbcType));
             }
             else if (isTime(jdbcType)) {
-                return (String)timeMap.get(new Integer(jdbcType));
+                return (String)timeMap.get(Integer.valueOf(jdbcType));
             }
             return NONE_ATTRIBUTE;
         }

--- a/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/classfile/CodeEnv.java
+++ b/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/classfile/CodeEnv.java
@@ -58,7 +58,7 @@ class CodeEnv {
   }
 
   final InsnTarget getTarget(int offset) {
-    Integer off = new Integer(offset);
+    Integer off = Integer.valueOf(offset);
     InsnTarget targ = (InsnTarget)targets.get(off);
     if (targ == null) {
       targ = new InsnTarget(offset);
@@ -68,7 +68,7 @@ class CodeEnv {
   }
 
   final InsnTarget findTarget(int offset) {
-    Integer off = new Integer(offset);
+    Integer off = Integer.valueOf(offset);
     return (InsnTarget)targets.get(off);
   }
 

--- a/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/classfile/ConstantPool.java
+++ b/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/classfile/ConstantPool.java
@@ -166,7 +166,7 @@ public class ConstantPool implements VMConstants {
    */
   public ConstInteger addInteger (int i) {
     hashConstants();
-    Integer io = new Integer(i);
+    Integer io = Integer.valueOf(i);
     ConstInteger ci = (ConstInteger) intTable.get(io);
     if (ci == null) {
       ci = new ConstInteger(i);
@@ -180,7 +180,7 @@ public class ConstantPool implements VMConstants {
    */
   public ConstFloat addFloat (float f) {
     hashConstants();
-    Float fo = new Float(f);
+    Float fo = Float.valueOf(f);
     ConstFloat cf = (ConstFloat) floatTable.get(fo);
     if (cf == null) {
       cf = new ConstFloat(f);
@@ -194,7 +194,7 @@ public class ConstantPool implements VMConstants {
    */
   public ConstLong addLong (long l) {
     hashConstants();
-    Long lo = new Long(l);
+    Long lo = Long.valueOf(l);
     ConstLong cl = (ConstLong) longTable.get(lo);
     if (cl == null) {
       cl = new ConstLong(l);
@@ -209,7 +209,7 @@ public class ConstantPool implements VMConstants {
    */
   public ConstDouble addDouble (double d) {
     hashConstants();
-    Double dobj = new Double(d);
+    Double dobj = Double.valueOf(d);
     ConstDouble cd = (ConstDouble) doubleTable.get(dobj);
     if (cd == null) {
       cd = new ConstDouble(d);

--- a/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/impl/MethodAnnotater.java
+++ b/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/impl/MethodAnnotater.java
@@ -2247,7 +2247,7 @@ class MethodAnnotater
         while (tmpDoubleRegisters.size() <= idx) {
             final CodeAttribute codeAttr = method.codeAttribute();
             final int reg = codeAttr.localsUsed();
-            tmpDoubleRegisters.addElement(new Integer(reg));
+            tmpDoubleRegisters.addElement(Integer.valueOf(reg));
             codeAttr.setLocalsUsed(reg+2);
         }
 
@@ -2268,7 +2268,7 @@ class MethodAnnotater
         while (tmpRegisters.size() <= idx) {
             final CodeAttribute codeAttr = method.codeAttribute();
             final int reg = codeAttr.localsUsed();
-            tmpRegisters.addElement(new Integer(reg));
+            tmpRegisters.addElement(Integer.valueOf(reg));
             codeAttr.setLocalsUsed(reg+1);
         }
         return ((Integer)tmpRegisters.elementAt(idx)).intValue();

--- a/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/util/Support.java
+++ b/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/util/Support.java
@@ -119,7 +119,7 @@ public class Support
                                           int arg1,
                                           String arg2) {
         return I18NHelper.getMessage(MESSAGES, key,
-                                     new Object[]{new Integer(arg1), arg2});
+                                     new Object[]{Integer.valueOf(arg1), arg2});
     }
 
     /**

--- a/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/util/Support.java
+++ b/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/util/Support.java
@@ -119,7 +119,7 @@ public class Support
                                           int arg1,
                                           String arg2) {
         return I18NHelper.getMessage(MESSAGES, key,
-                                     new Object[]{Integer.valueOf(arg1), arg2});
+                                     new Object[]{arg1, arg2});
     }
 
     /**

--- a/appserver/persistence/cmp/generator-database/src/main/java/com/sun/jdo/spi/persistence/generator/database/MappingPolicy.java
+++ b/appserver/persistence/cmp/generator-database/src/main/java/com/sun/jdo/spi/persistence/generator/database/MappingPolicy.java
@@ -749,7 +749,7 @@ public class MappingPolicy implements Cloneable {
 
         // The name is in sqlInfo if it was loaded from one of our
         // vendor-specific properties files.
-        Object o = sqlInfo.get(new Integer(jdbcType));
+        Object o = sqlInfo.get(Integer.valueOf(jdbcType));
         if (null != o) {
             rc = (String) o;
         } else {
@@ -977,7 +977,7 @@ public class MappingPolicy implements Cloneable {
      */
     public static String getJdbcTypeName(int type) throws
             IllegalArgumentException {
-        String rc = (String) jdbcTypeNames.get(new Integer(type));
+        String rc = (String) jdbcTypeNames.get(Integer.valueOf(type));
         if (null == rc) {
             throw new IllegalArgumentException();
         }

--- a/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/jdo/impl/PersistenceClassElementImpl.java
+++ b/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/jdo/impl/PersistenceClassElementImpl.java
@@ -189,7 +189,7 @@ public class PersistenceClassElementImpl extends PersistenceElementImpl
 	public void setObjectIdentityType (int type) throws ModelException
 	{
 		Integer old = new Integer(getObjectIdentityType());
-		Integer newType = new Integer(type);
+		Integer newType = Integer.valueOf(type);
 
 		try
 		{

--- a/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/jdo/impl/PersistenceFieldElementImpl.java
+++ b/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/jdo/impl/PersistenceFieldElementImpl.java
@@ -109,7 +109,7 @@ public class PersistenceFieldElementImpl extends PersistenceMemberElementImpl
 	public void setPersistenceType (int type) throws ModelException
 	{
 		Integer old = new Integer(getPersistenceType());
-		Integer newType = new Integer(type);
+		Integer newType = Integer.valueOf(type);
 		
 		try
 		{

--- a/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/jdo/impl/RelationshipElementImpl.java
+++ b/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/jdo/impl/RelationshipElementImpl.java
@@ -143,7 +143,7 @@ public class RelationshipElementImpl extends PersistenceFieldElementImpl
 	public void setUpdateAction (int action) throws ModelException
 	{
 		Integer old = new Integer(getUpdateAction());
-		Integer newAction = new Integer(action);
+		Integer newAction = Integer.valueOf(action);
 
 		try
 		{
@@ -180,7 +180,7 @@ public class RelationshipElementImpl extends PersistenceFieldElementImpl
 	public void setDeleteAction (int action) throws ModelException
 	{
 		Integer old = new Integer(getDeleteAction());
-		Integer newAction = new Integer(action);
+		Integer newAction = Integer.valueOf(action);
 
 		try
 		{
@@ -235,7 +235,7 @@ public class RelationshipElementImpl extends PersistenceFieldElementImpl
 	public void setLowerBound (int lowerBound) throws ModelException
 	{
 		Integer old = new Integer(getLowerBound());
-		Integer newBound = new Integer(lowerBound);
+		Integer newBound = Integer.valueOf(lowerBound);
 
 		try
 		{
@@ -264,7 +264,7 @@ public class RelationshipElementImpl extends PersistenceFieldElementImpl
 	public void setUpperBound (int upperBound) throws ModelException
 	{
 		Integer old = new Integer(getUpperBound());
-		Integer newBound = new Integer(upperBound);
+		Integer newBound = Integer.valueOf(upperBound);
 
 		try
 		{

--- a/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/mapping/impl/MappingClassElementImpl.java
+++ b/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/mapping/impl/MappingClassElementImpl.java
@@ -298,7 +298,7 @@ public class MappingClassElementImpl extends MappingElementImpl
 	public void setConsistencyLevel (int level)  throws ModelException
 	{
 		Integer old = new Integer(getConsistencyLevel());
-		Integer newLevel = new Integer(level);
+		Integer newLevel = Integer.valueOf(level);
 
 		try
 		{

--- a/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/mapping/impl/MappingFieldElementImpl.java
+++ b/appserver/persistence/cmp/model/src/main/java/com/sun/jdo/api/persistence/model/mapping/impl/MappingFieldElementImpl.java
@@ -234,7 +234,7 @@ public class MappingFieldElementImpl extends MappingMemberElementImpl
 	public void setFetchGroup (int group) throws ModelException
 	{
 		Integer old = new Integer(getFetchGroup());
-		Integer newGroup = new Integer(group);
+		Integer newGroup = Integer.valueOf(group);
 
 		try
 		{

--- a/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbc/CMPProcessor.java
+++ b/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbc/CMPProcessor.java
@@ -100,7 +100,7 @@ public class CMPProcessor {
 
         if (logger.isLoggable(logger.FINE)) {                
             logger.fine("ejb.CMPProcessor.createanddroptables", //NOI18N
-                new Object[] {Boolean.valueOf(createTables), Boolean.valueOf(userDropTables)});
+                new Object[] {createTables, userDropTables});
         }
 
         if (!createTables && !userDropTables) {

--- a/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbc/CMPProcessor.java
+++ b/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbc/CMPProcessor.java
@@ -100,7 +100,7 @@ public class CMPProcessor {
 
         if (logger.isLoggable(logger.FINE)) {                
             logger.fine("ejb.CMPProcessor.createanddroptables", //NOI18N
-                new Object[] {new Boolean(createTables), new Boolean(userDropTables)});
+                new Object[] {Boolean.valueOf(createTables), Boolean.valueOf(userDropTables)});
         }
 
         if (!createTables && !userDropTables) {

--- a/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbqlc/ErrorMsg.java
+++ b/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbqlc/ErrorMsg.java
@@ -77,13 +77,13 @@ public class ErrorMsg
         EJBQLException ex = null;
         if (line > 1) {
             // include line and column info
-            Object args[] = {Integer.valueOf(line), Integer.valueOf(col), text};
+            Object args[] = {line, col, text};
             ex = new EJBQLException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgLineColumn", args)); //NOI18N
         }
         else if (col > 0) {
             // include column info
-            Object args[] = {Integer.valueOf(col), text};
+            Object args[] = {col, text};
             ex = new EJBQLException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgColumn", args)); //NOI18N
         }
@@ -133,13 +133,13 @@ public class ErrorMsg
         if (line > 1)
         {
             // include line and column info
-            Object args[] = {Integer.valueOf(line), Integer.valueOf(col), text};
+            Object args[] = {line, col, text};
             ex = new UnsupportedOperationException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgLineColumn", args)); //NOI18N
         }
         else if (col > 0) {
             // include column info
-            Object args[] = {Integer.valueOf(col), text};
+            Object args[] = {col, text};
             ex = new UnsupportedOperationException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgColumn", args)); //NOI18N
         }

--- a/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbqlc/ErrorMsg.java
+++ b/appserver/persistence/cmp/support-ejb/src/main/java/com/sun/jdo/spi/persistence/support/ejb/ejbqlc/ErrorMsg.java
@@ -77,13 +77,13 @@ public class ErrorMsg
         EJBQLException ex = null;
         if (line > 1) {
             // include line and column info
-            Object args[] = {new Integer(line), new Integer(col), text};
+            Object args[] = {Integer.valueOf(line), Integer.valueOf(col), text};
             ex = new EJBQLException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgLineColumn", args)); //NOI18N
         }
         else if (col > 0) {
             // include column info
-            Object args[] = {new Integer(col), text};
+            Object args[] = {Integer.valueOf(col), text};
             ex = new EJBQLException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgColumn", args)); //NOI18N
         }
@@ -133,13 +133,13 @@ public class ErrorMsg
         if (line > 1)
         {
             // include line and column info
-            Object args[] = {new Integer(line), new Integer(col), text};
+            Object args[] = {Integer.valueOf(line), Integer.valueOf(col), text};
             ex = new UnsupportedOperationException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgLineColumn", args)); //NOI18N
         }
         else if (col > 0) {
             // include column info
-            Object args[] = {new Integer(col), text};
+            Object args[] = {Integer.valueOf(col), text};
             ex = new UnsupportedOperationException(I18NHelper.getMessage(
                 msgs, "EXC_PositionInfoMsgColumn", args)); //NOI18N
         }

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/SQLStateManager.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/SQLStateManager.java
@@ -4398,7 +4398,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public boolean setBooleanField(int fieldNumber, boolean value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Boolean(value));
+        prepareSetField(fieldNumber, Boolean.valueOf(value));
         return value;
     }
 
@@ -4409,7 +4409,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public byte setByteField(int fieldNumber, byte value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Byte(value));
+        prepareSetField(fieldNumber, Byte.valueOf(value));
         return value;
     }
 
@@ -4420,7 +4420,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public short setShortField(int fieldNumber, short value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Short(value));
+        prepareSetField(fieldNumber, Short.valueOf(value));
         return value;
     }
 
@@ -4431,7 +4431,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public int setIntField(int fieldNumber, int value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Integer(value));
+        prepareSetField(fieldNumber, Integer.valueOf(value));
         return value;
     }
 
@@ -4442,7 +4442,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public long setLongField(int fieldNumber, long value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Long(value));
+        prepareSetField(fieldNumber, Long.valueOf(value));
         return value;
     }
 
@@ -4453,7 +4453,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public char setCharField(int fieldNumber, char value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Character(value));
+        prepareSetField(fieldNumber, Character.valueOf(value));
         return value;
     }
 
@@ -4464,7 +4464,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public float setFloatField(int fieldNumber, float value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Float(value));
+        prepareSetField(fieldNumber, Float.valueOf(value));
         return value;
     }
 
@@ -4475,7 +4475,7 @@ public class SQLStateManager implements Cloneable, StateManager, TestStateManage
 
     public double setDoubleField(int fieldNumber, double value) {
         assertNotPK(fieldNumber);
-        prepareSetField(fieldNumber, new Double(value));
+        prepareSetField(fieldNumber, Double.valueOf(value));
         return value;
     }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/SQLStoreManager.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/SQLStoreManager.java
@@ -238,7 +238,7 @@ public class SQLStoreManager implements PersistenceStore {
 
         if (debug) {
             logger.fine("sqlstore.sqlstoremanager.executeupdate.exit", // NOI18N
-                    new Integer(affectedRows));
+                    Integer.valueOf(affectedRows));
         }
     }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/database/oracle/OracleSpecialDBOperation.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/database/oracle/OracleSpecialDBOperation.java
@@ -368,7 +368,7 @@ public class OracleSpecialDBOperation extends BaseSpecialDBOperation {
             ps.setString(index, padSpaceChar(strVal, length) );
             if (logger.isLoggable(Logger.FINE) ) {
                 logger.log(Logger.FINE, "sqlstore.database.oracle.fixedcharpadded",
-                           strVal, new Integer(length) );
+                           strVal, Integer.valueOf(length) );
             }
         }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/impl/TransactionImpl.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/impl/TransactionImpl.java
@@ -1363,7 +1363,7 @@ public class TransactionImpl
 
         if (debug) {
             Object[] items = new Object[] {_connection, Boolean.valueOf(optimistic),
-                new Integer(_connectionReferenceCount) , persistenceManager};
+                Integer.valueOf(_connectionReferenceCount) , persistenceManager};
             logger.finest("sqlstore.transactionimpl.getconnection",items); // NOI18N
         }
 
@@ -1420,7 +1420,7 @@ public class TransactionImpl
         if (debug) {
             Object[] items = new Object[] {Boolean.valueOf(optimistic),
                 Boolean.valueOf(startedCommit),
-                new Integer(_connectionReferenceCount) , persistenceManager};
+                Integer.valueOf(_connectionReferenceCount) , persistenceManager};
             logger.finest("sqlstore.transactionimpl.releaseconnection",items); // NOI18N
         }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/model/FieldDesc.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/model/FieldDesc.java
@@ -327,7 +327,7 @@ public abstract class FieldDesc implements java.io.Serializable {
         if (absoluteID < 0) {
             // Hidden field nothing to convert
             if (debug)
-                logger.finest("sqlstore.model.fielddesc.convertvalue.hidden",new Integer(absoluteID)); // NOI18N
+                logger.finest("sqlstore.model.fielddesc.convertvalue.hidden",Integer.valueOf(absoluteID)); // NOI18N
             return value;
         }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/model/LocalFieldDesc.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/model/LocalFieldDesc.java
@@ -92,7 +92,7 @@ public class LocalFieldDesc extends FieldDesc {
                 ColumnElement c = (ColumnElement) iter.next();
                 rc = c.isNullable();
             }
-            primitiveMappedToNullableColumn = new Boolean(rc);
+            primitiveMappedToNullableColumn = Boolean.valueOf(rc);
         }
 
         return primitiveMappedToNullableColumn.booleanValue();

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/query/jqlc/ErrorMsg.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/query/jqlc/ErrorMsg.java
@@ -104,14 +104,14 @@ public class ErrorMsg
         if (line > 1)
         {
             // include line and column info
-            Object args[] = {context, Integer.valueOf(line), Integer.valueOf(col), msg};
+            Object args[] = {context, line, col, msg};
             ex = new JDOQueryException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msglinecolumn", args)); //NOI18N
         }
         else if (col > 0)
         {
             // include column info
-            Object args[] = {context, Integer.valueOf(col), msg};
+            Object args[] = {context, col, msg};
             ex = new JDOQueryException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msgcolumn", args)); //NOI18N
         }
@@ -138,14 +138,14 @@ public class ErrorMsg
         if (line > 1)
         {
             // include line and column info
-            Object args[] = {context, Integer.valueOf(line), Integer.valueOf(col), msg};
+            Object args[] = {context, line, col, msg};
             ex = new JDOUnsupportedOptionException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msglinecolumn", args)); //NOI18N
         }
         else if (col > 0)
         {
             // include column info
-            Object args[] = {context, Integer.valueOf(col), msg};
+            Object args[] = {context, col, msg};
             ex = new JDOUnsupportedOptionException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msgcolumn", args)); //NOI18N
                                                                          

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/query/jqlc/ErrorMsg.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/query/jqlc/ErrorMsg.java
@@ -104,14 +104,14 @@ public class ErrorMsg
         if (line > 1)
         {
             // include line and column info
-            Object args[] = {context, new Integer(line), new Integer(col), msg};
+            Object args[] = {context, Integer.valueOf(line), Integer.valueOf(col), msg};
             ex = new JDOQueryException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msglinecolumn", args)); //NOI18N
         }
         else if (col > 0)
         {
             // include column info
-            Object args[] = {context, new Integer(col), msg};
+            Object args[] = {context, Integer.valueOf(col), msg};
             ex = new JDOQueryException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msgcolumn", args)); //NOI18N
         }
@@ -138,14 +138,14 @@ public class ErrorMsg
         if (line > 1)
         {
             // include line and column info
-            Object args[] = {context, new Integer(line), new Integer(col), msg};
+            Object args[] = {context, Integer.valueOf(line), Integer.valueOf(col), msg};
             ex = new JDOUnsupportedOptionException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msglinecolumn", args)); //NOI18N
         }
         else if (col > 0)
         {
             // include column info
-            Object args[] = {context, new Integer(col), msg};
+            Object args[] = {context, Integer.valueOf(col), msg};
             ex = new JDOUnsupportedOptionException(I18NHelper.getMessage(
                 messages, "jqlc.errormsg.generic.msgcolumn", args)); //NOI18N
                                                                          

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/ResultDesc.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/ResultDesc.java
@@ -263,7 +263,7 @@ public class ResultDesc {
                 case FieldTypeEnumeration.BOOLEAN  :
                         boolean booleanValue = resultData.getBoolean(index);
                         if(!resultData.wasNull() )
-                            retVal = new Boolean(booleanValue);
+                            retVal = Boolean.valueOf(booleanValue);
                         break;
                 case FieldTypeEnumeration.CHARACTER_PRIMITIVE :
                 case FieldTypeEnumeration.CHARACTER  :
@@ -275,37 +275,37 @@ public class ResultDesc {
                 case FieldTypeEnumeration.BYTE  :
                         byte byteValue = resultData.getByte(index);
                         if(!resultData.wasNull() )
-                            retVal = new Byte(byteValue);
+                            retVal = Byte.valueOf(byteValue);
                         break;
                 case FieldTypeEnumeration.SHORT_PRIMITIVE :
                 case FieldTypeEnumeration.SHORT  :
                         short shortValue = resultData.getShort(index);
                         if(!resultData.wasNull() )
-                            retVal = new Short(shortValue);
+                            retVal = Short.valueOf(shortValue);
                         break;
                 case FieldTypeEnumeration.INTEGER_PRIMITIVE :
                 case FieldTypeEnumeration.INTEGER  :
                         int intValue = resultData.getInt(index);
                         if(!resultData.wasNull() )
-                            retVal = new Integer(intValue);
+                            retVal = Integer.valueOf(intValue);
                         break;
                 case FieldTypeEnumeration.LONG_PRIMITIVE :
                 case FieldTypeEnumeration.LONG  :
                         long longValue = resultData.getLong(index);
                         if(!resultData.wasNull() )
-                            retVal = new Long(longValue);
+                            retVal = Long.valueOf(longValue);
                         break;
                 case FieldTypeEnumeration.FLOAT_PRIMITIVE :
                 case FieldTypeEnumeration.FLOAT  :
                         float floatValue = resultData.getFloat(index);
                         if(!resultData.wasNull() )
-                            retVal = new Float(floatValue);
+                            retVal = Float.valueOf(floatValue);
                         break;
                 case FieldTypeEnumeration.DOUBLE_PRIMITIVE :
                 case FieldTypeEnumeration.DOUBLE  :
                         double doubleValue = resultData.getDouble(index);
                         if(!resultData.wasNull() )
-                            retVal = new Double(doubleValue);
+                            retVal = Double.valueOf(doubleValue);
                         break;
                 case FieldTypeEnumeration.BIGDECIMAL :
                 case FieldTypeEnumeration.BIGINTEGER :
@@ -363,7 +363,7 @@ public class ResultDesc {
         } catch (SQLException e) {
             if(logger.isLoggable(Logger.WARNING) ) {
                 Object items[] =
-                    { new Integer(index), new Integer(resultType), new Integer(columnType), e};
+                    { Integer.valueOf(index), Integer.valueOf(resultType), Integer.valueOf(columnType), e};
                 logger.log(Logger.WARNING,"sqlstore.resultdesc.errorgettingvalefromresulset",items);
             }
             throw e;

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/ResultDesc.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/ResultDesc.java
@@ -363,7 +363,7 @@ public class ResultDesc {
         } catch (SQLException e) {
             if(logger.isLoggable(Logger.WARNING) ) {
                 Object items[] =
-                    { Integer.valueOf(index), Integer.valueOf(resultType), Integer.valueOf(columnType), e};
+                    { index, resultType, columnType, e};
                 logger.log(Logger.WARNING,"sqlstore.resultdesc.errorgettingvalefromresulset",items);
             }
             throw e;

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/generator/DBStatement.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/generator/DBStatement.java
@@ -211,7 +211,7 @@ public class DBStatement extends Object {
     {
         int sqlType = getSqlType(columnElement);
         if (logger.isLoggable(Logger.FINER)) {
-            Object[] items = {Integer.valueOf(index),val,Integer.valueOf(sqlType)};
+            Object[] items = {index, val, sqlType};
             logger.finer("sqlstore.sql.generator.dbstatement.bindinputcolumn", items); // NOI18N
         }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/generator/DBStatement.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/sql/generator/DBStatement.java
@@ -138,7 +138,7 @@ public class DBStatement extends Object {
         batchCounter++;
         if (logger.isLoggable(Logger.FINER)) {
             logger.finer("sqlstore.sql.generator.dbstatement.addbatch", // NOI18N
-                         new Integer(batchCounter));
+                         Integer.valueOf(batchCounter));
         }
         preparedStmt.addBatch();
     }
@@ -152,7 +152,7 @@ public class DBStatement extends Object {
     {
         if (logger.isLoggable(Logger.FINER)) {
             logger.finer("sqlstore.sql.generator.dbstatement.executebatch", // NOI18N
-                         new Integer(batchCounter));
+                         Integer.valueOf(batchCounter));
         }
         batchCounter = 0;
         return preparedStmt.executeBatch();
@@ -211,7 +211,7 @@ public class DBStatement extends Object {
     {
         int sqlType = getSqlType(columnElement);
         if (logger.isLoggable(Logger.FINER)) {
-            Object[] items = {new Integer(index),val,new Integer(sqlType)};
+            Object[] items = {Integer.valueOf(index),val,Integer.valueOf(sqlType)};
             logger.finer("sqlstore.sql.generator.dbstatement.bindinputcolumn", items); // NOI18N
         }
 

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/utility/StringScanner.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/utility/StringScanner.java
@@ -528,7 +528,7 @@ public class StringScanner
 		case 6:
 			return "                       "; // NOI18N
 		default:
-			str = new String("                       "); // NOI18N
+			str = "                       "; // NOI18N
 			for (i = 6; i < level; i++)
 				str = str.concat("    "); // NOI18N
 			return str;

--- a/appserver/persistence/cmp/utility/src/main/java/com/sun/jdo/spi/persistence/utility/SemaphoreImpl.java
+++ b/appserver/persistence/cmp/utility/src/main/java/com/sun/jdo/spi/persistence/utility/SemaphoreImpl.java
@@ -90,7 +90,7 @@ public class SemaphoreImpl implements Semaphore {
         boolean debug = _logger.isLoggable(Logger.FINEST);
 
         if (debug) {
-            Object[] items = new Object[] {_owner, Thread.currentThread(),Integer.valueOf(_counter)};
+            Object[] items = new Object[] {_owner, Thread.currentThread(), _counter};
             _logger.finest("utility.semaphoreimpl.acquire",items); // NOI18N
         }
 
@@ -114,7 +114,7 @@ public class SemaphoreImpl implements Semaphore {
                 _counter++;
                 
                 if (debug) {
-                    Object[] items = new Object[] {_owner, Thread.currentThread(),Integer.valueOf(_counter)};
+                    Object[] items = new Object[] {_owner, Thread.currentThread(), _counter};
                     _logger.finest("utility.semaphoreimpl.gotlock",items); // NOI18N
                 }
             }
@@ -127,7 +127,7 @@ public class SemaphoreImpl implements Semaphore {
         boolean debug = _logger.isLoggable(Logger.FINEST);
         
         if (debug) {
-            Object[] items = new Object[] {_owner, Thread.currentThread(),Integer.valueOf(_counter)};
+            Object[] items = new Object[] {_owner, Thread.currentThread(), _counter};
             _logger.finest("utility.semaphoreimpl.release",items); // NOI18N
         }
         

--- a/appserver/persistence/cmp/utility/src/main/java/com/sun/jdo/spi/persistence/utility/SemaphoreImpl.java
+++ b/appserver/persistence/cmp/utility/src/main/java/com/sun/jdo/spi/persistence/utility/SemaphoreImpl.java
@@ -90,7 +90,7 @@ public class SemaphoreImpl implements Semaphore {
         boolean debug = _logger.isLoggable(Logger.FINEST);
 
         if (debug) {
-            Object[] items = new Object[] {_owner, Thread.currentThread(),new Integer(_counter)};
+            Object[] items = new Object[] {_owner, Thread.currentThread(),Integer.valueOf(_counter)};
             _logger.finest("utility.semaphoreimpl.acquire",items); // NOI18N
         }
 
@@ -114,7 +114,7 @@ public class SemaphoreImpl implements Semaphore {
                 _counter++;
                 
                 if (debug) {
-                    Object[] items = new Object[] {_owner, Thread.currentThread(),new Integer(_counter)};
+                    Object[] items = new Object[] {_owner, Thread.currentThread(),Integer.valueOf(_counter)};
                     _logger.finest("utility.semaphoreimpl.gotlock",items); // NOI18N
                 }
             }
@@ -127,7 +127,7 @@ public class SemaphoreImpl implements Semaphore {
         boolean debug = _logger.isLoggable(Logger.FINEST);
         
         if (debug) {
-            Object[] items = new Object[] {_owner, Thread.currentThread(),new Integer(_counter)};
+            Object[] items = new Object[] {_owner, Thread.currentThread(),Integer.valueOf(_counter)};
             _logger.finest("utility.semaphoreimpl.release",items); // NOI18N
         }
         


### PR DESCRIPTION
This PR fixes multiple SonarQube violations of the rule: [Constructors should not be used to instantiate "String", "BigInteger", "BigDecimal" and primitive-wrapper classes](https://rules.sonarsource.com/java/RSPEC-2129)

The rule says: 

> Constructors for String, BigInteger, BigDecimal and the objects used to wrap primitives should never be used. Doing so is less clear and uses more memory than simply using the desired value in the case of strings, and using valueOf for everything else.