### PR TITLE
PAYARA-3911 Fix domain.xml java-home is not honored in version-specific jvm-options (#4025)

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.launcher;
 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -73,7 +73,7 @@ import java.util.stream.Collectors;
  */
 public abstract class GFLauncher {
 
-    private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile(".* version \"([^\"]+)\".*");
+    private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile(".* version \"([^\"\\-]+)(-.*)?\".*");
     private final List<String> commandLine = new ArrayList<String>();
     private final List<String> jvmOptionsList = new ArrayList<String>();
     private final GFLauncherInfo info;

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -60,6 +60,8 @@ import static com.sun.enterprise.util.SystemPropertyConstants.*;
 import static com.sun.enterprise.admin.launcher.GFLauncherConstants.*;
 import com.sun.enterprise.util.JDK;
 import fish.payara.admin.launcher.PayaraDefaultJvmOptions;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -70,7 +72,8 @@ import java.util.stream.Collectors;
  * @author bnevins
  */
 public abstract class GFLauncher {
-    
+
+    private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("java version \"([^\"]+)\".*");
     private final List<String> commandLine = new ArrayList<String>();
     private final List<String> jvmOptionsList = new ArrayList<String>();
     private final GFLauncherInfo info;
@@ -187,6 +190,14 @@ public abstract class GFLauncher {
         }
         info.setAdminAddresses(parser.getAdminAddresses());
         javaConfig = new JavaConfig(parser.getJavaConfig());
+        // Set the config java-home value as the Java home for the environment,
+        // unless it is empty or it is already refering to a substitution of
+        // the environment variable.
+        String jhome = javaConfig.getJavaHome();
+        if (GFLauncherUtils.ok(jhome) && !jhome.trim().equals("${" + JAVA_ROOT_PROPERTY + "}")) {
+            asenvProps.put(JAVA_ROOT_PROPERTY, jhome);
+        }
+        setJavaExecutable();
         setupProfilerAndJvmOptions(parser);
         setupUpgradeSecurity();
 
@@ -206,13 +217,6 @@ public abstract class GFLauncher {
         sysPropsFromXml = parser.getSystemProperties();
         asenvProps.put(INSTANCE_ROOT_PROPERTY, getInfo().getInstanceRootDir().getPath());
 
-        // Set the config java-home value as the Java home for the environment,
-        // unless it is empty or it is already refering to a substitution of
-        // the environment variable.
-        String jhome = javaConfig.getJavaHome();
-        if (GFLauncherUtils.ok(jhome) && !jhome.trim().equals("${" + JAVA_ROOT_PROPERTY + "}")) {
-            asenvProps.put(JAVA_ROOT_PROPERTY, jhome);
-        }
         debugOptions = getDebug();
         parseDebug();
         parser.setupConfigDir(getInfo().getConfigDir(), getInfo().getInstallDir());
@@ -220,7 +224,6 @@ public abstract class GFLauncher {
         resolveAllTokens();
         fixLogFilename();
         GFLauncherLogger.addLogFileHandler(logFilename);
-        setJavaExecutable();
         setClasspath();
         setCommandLine();
         setJvmOptions();
@@ -867,9 +870,10 @@ public abstract class GFLauncher {
                 parser.getProfilerJvmOptions(),
                 parser.getProfilerSystemProperties());
 
+        Optional<JDK.Version> jdkVersion = getConfiguredJdkVersion(javaExe);
         List<String> rawJvmOptions = parser.getJvmOptions()
                 .stream()
-                .filter(fullOption -> JDK.isCorrectJDK(fullOption.minVersion, fullOption.maxVersion))
+                .filter(fullOption -> JDK.isCorrectJDK(jdkVersion, fullOption.minVersion, fullOption.maxVersion))
                 .map(option -> option.option)
                 .collect(Collectors.toList());
         rawJvmOptions.addAll(getSpecialSystemProperties());
@@ -884,7 +888,35 @@ public abstract class GFLauncher {
         // PAYARA-1681 - Add default Payara JVM options if an override isn't in place
         addDefaultJvmOptions();
     }
-    
+
+    /**
+     * Get the Java version from the given path to a Java executable.
+     *
+     * @param javaExePath The full path to the executable java command.
+     * @return The Java version as a JDK.Version object, if successful.
+     * @throws GFLauncherException
+     */
+    private Optional<JDK.Version> getConfiguredJdkVersion(String javaExePath) throws GFLauncherException {
+        try {
+            Runtime r = Runtime.getRuntime();
+            Process p = r.exec(javaExePath + " -version");
+            p.waitFor();
+            try (BufferedReader b = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+                String line = b.readLine();
+                if (line == null) {
+                    return Optional.empty();
+                }
+                Matcher m = JAVA_VERSION_PATTERN.matcher(line);
+                if (m.matches()) {
+                    return Optional.ofNullable(JDK.getVersion(m.group(1)));
+                }
+            }
+            return Optional.empty();
+        } catch (IOException | InterruptedException ex) {
+            throw new GFLauncherException("nojvm");
+        }
+    }
+
     private void addDefaultJvmOptions() {
         if (!jvmOptions.getCombinedMap().containsKey(PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY)) {
             jvmOptions.sysProps.put(PayaraDefaultJvmOptions.GRIZZLY_DEFAULT_MEMORY_MANAGER_PROPERTY, 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -73,7 +73,7 @@ import java.util.stream.Collectors;
  */
 public abstract class GFLauncher {
 
-    private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("java version \"([^\"]+)\".*");
+    private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile(".* version \"([^\"]+)\".*");
     private final List<String> commandLine = new ArrayList<String>();
     private final List<String> jvmOptionsList = new ArrayList<String>();
     private final GFLauncherInfo info;

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.util;
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
@@ -240,12 +240,25 @@ public final class JDK {
     }
 
     public static boolean isCorrectJDK(Optional<Version> minVersion, Optional<Version> maxVersion) {
+        return isCorrectJDK(Optional.of(JDK_VERSION), minVersion, maxVersion);
+    }
+
+    /**
+     * Check if the reference version falls between the minVersion and maxVersion.
+     *
+     * @param reference The version to compare; falls back to the current JDK version if empty.
+     * @param minVersion The inclusive minimum version.
+     * @param maxVersion The inclusive maximum version.
+     * @return true if within the version range, false otherwise
+     */
+    public static boolean isCorrectJDK(Optional<Version> reference, Optional<Version> minVersion, Optional<Version> maxVersion) {
+        Version version = reference.orElse(JDK_VERSION);
         boolean correctJDK = true;
         if (minVersion.isPresent()) {
-            correctJDK = JDK_VERSION.newerOrEquals(minVersion.get());
+            correctJDK = version.newerOrEquals(minVersion.get());
         }
         if (correctJDK && maxVersion.isPresent()) {
-            correctJDK = JDK_VERSION.olderOrEquals(maxVersion.get());
+            correctJDK = version.olderOrEquals(maxVersion.get());
         }
         return correctJDK;
     }


### PR DESCRIPTION
Fix GFLauncher to use the correct JDK when determining the JVM options.

Using the javaExe already set for launching the domain, run it first with the -version parameter, and use the version parsed from its output (if available and matching) when setting the JVM options instead of the JVM currently running.

In case of non-fatal errors, the functionality falls back on the current JVM version (like before). On fatal errors a GFLauncherException will be thrown.

Fixes #4025