### PR TITLE
PAYARA-3919 SonarQube - Iterating on entrySet() instead of keySet() when key and value are needed

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpan.java
+++ b/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpan.java
@@ -225,8 +225,8 @@ public class RequestTraceSpan implements Serializable, Comparable<RequestTraceSp
         
         if (spanTags != null && !spanTags.isEmpty()) {
             result.append(",\"spanTags\":[");
-            for (String key : spanTags.keySet()) {
-                result.append("{\"").append(key).append("\": \"").append(spanTags.get(key)).append("\"},");
+            for (Entry<String, String> entry : spanTags.entrySet()) {
+                result.append("{\"").append(entry.getKey()).append("\": \"").append(entry.getValue()).append("\"},");
             }
             result.deleteCharAt(result.length() - 1);
             result.append("]");

--- a/appserver/admingui/common/src/main/java/fish/payara/admingui/common/handlers/PayaraPropertiesHandlers.java
+++ b/appserver/admingui/common/src/main/java/fish/payara/admingui/common/handlers/PayaraPropertiesHandlers.java
@@ -46,6 +46,7 @@ import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  *
@@ -126,10 +127,10 @@ public class PayaraPropertiesHandlers {
 
         if (props != null) {
             for (Map<String, String> prop : props) {
-                for (String key : prop.keySet()) {
-                    if (key.equals("name")) {
-                        if (prop.get(key).toString().contains("payara.microprofile")) {
-                            prop.put(key, prop.get(key).toString().replaceAll("payara.microprofile.", ""));
+                for (Entry<String, String> entry : prop.entrySet()) {
+                    if (entry.getKey().equals("name")) {
+                        if (entry.getValue().toString().contains("payara.microprofile")) {
+                            prop.put(entry.getKey(), entry.getValue().toString().replaceAll("payara.microprofile.", ""));
                             convertedProps.add(prop);
                         }
                     }
@@ -159,10 +160,10 @@ public class PayaraPropertiesHandlers {
 
         if (props != null) {
             for (Map<String, String> prop : props) {
-                for (String key : prop.keySet()) {
-                    if (key.equals("name")) {
-                        if (!prop.get(key).toString().contains("payara.microprofile.")) {
-                            prop.put(key, "payara.microprofile." + prop.get(key).toString().replaceAll("\\s+", ""));
+                for (Entry<String, String> entry : prop.entrySet()) {
+                    if (entry.getKey().equals("name")) {
+                        if (!entry.getValue().toString().contains("payara.microprofile.")) {
+                            prop.put(entry.getKey(), "payara.microprofile." + entry.getValue().toString().replaceAll("\\s+", ""));
                         }
                     }
                 }

--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/NamedNamingObjectManager.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/NamedNamingObjectManager.java
@@ -50,6 +50,7 @@ import javax.naming.NamingException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -145,9 +146,10 @@ public class NamedNamingObjectManager {
     private static NamedNamingObjectProxy getCachedProxy(String name) {
         rwLock.readLock().lock();
         try {
-            for (String proxyPrefix : proxies.keySet()) {
+            for (Entry<String, NamedNamingObjectProxy> entry : proxies.entrySet()) {
+                String proxyPrefix = entry.getKey();
                 if (name.startsWith(proxyPrefix)) {
-                    return proxies.get(proxyPrefix);
+                    return entry.getValue();
                 }
             }
         } finally {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
@@ -621,8 +621,8 @@ public class ApplicationValidator extends ComponentValidator
         Vector appVectorName = validNameSpaceDetails.get(APP_KEYS);
         Vector ebdVectorName = validNameSpaceDetails.get(EJBBUNDLE_KEYS);
 
-        for (String key : allResourceDescriptors.keySet()) {
-            CommonResourceValidator commonResourceValidator = allResourceDescriptors.get(key);
+        for (Map.Entry<String, CommonResourceValidator> entry : allResourceDescriptors.entrySet()) {
+            CommonResourceValidator commonResourceValidator = entry.getValue();
             Vector scopeVector = commonResourceValidator.getScope();
             String jndiName = commonResourceValidator.getJndiName();
 

--- a/appserver/deployment/javaee-core/src/main/java/org/glassfish/javaee/core/deployment/ListSubComponentsCommand.java
+++ b/appserver/deployment/javaee-core/src/main/java/org/glassfish/javaee/core/deployment/ListSubComponentsCommand.java
@@ -219,11 +219,11 @@ public class ListSubComponentsCommand implements AdminCommand {
             part.setMessage(localStrings.getLocalString("listsubcomponents.no.elements.to.list", "Nothing to List."));
         }
         int i=0;
-        for (String key : subComponents.keySet()) {
+        for (Map.Entry<String, String> entry : subComponents.entrySet()) {
             ActionReport.MessagePart childPart = part.addChild();
             childPart.setMessage(
                     String.format(formattedLine,
-                    new Object[]{key, subComponents.get(key)} ));
+                    new Object[]{entry.getKey(), entry.getValue()} ));
             if (appname == null && !app.isVirtual()) {
                 // we use the property mechanism to provide
                 // support for JSR88 client
@@ -233,7 +233,7 @@ public class ListSubComponentsCommand implements AdminCommand {
                 }
             }
             if (resources) {
-                Module module = application.getModule(key);
+                Module module = application.getModule(entry.getKey());
                 if (module != null) {
                     ActionReport subReport = report.addSubActionsReport();
                     CommandRunner.CommandInvocation inv = commandRunner.getCommandInvocation("_list-resources", subReport, context.getSubject());

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbDescriptor.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbDescriptor.java
@@ -983,9 +983,10 @@ public abstract class EjbDescriptor extends CommonResourceDescriptor implements 
 
         List<EjbInterceptor> classOrMethodInterceptors = null;
 
-        for (MethodDescriptor methodDesc : methodInterceptorsMap.keySet()) {
+        for (Map.Entry<MethodDescriptor, List<EjbInterceptor>> entry : methodInterceptorsMap.entrySet()) {
+            MethodDescriptor methodDesc = entry.getKey();
             if (methodDesc.implies(businessMethod)) {
-                classOrMethodInterceptors = methodInterceptorsMap.get(methodDesc);
+                classOrMethodInterceptors = entry.getValue();
             }
         }
 

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbSessionDescriptor.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbSessionDescriptor.java
@@ -350,16 +350,18 @@ public class EjbSessionDescriptor extends EjbDescriptor
      */
     public EjbRemovalInfo getRemovalInfo(MethodDescriptor method) {
         // first try to find the exact match
-        for (MethodDescriptor methodDesc : removeMethods.keySet()) {
+        for (Map.Entry<MethodDescriptor, EjbRemovalInfo> entry : removeMethods.entrySet()) {
+            MethodDescriptor methodDesc = entry.getKey();
             if (methodDesc.equals(method)) {
-                return removeMethods.get(methodDesc);
+                return entry.getValue();
             }
         }
 
         // if nothing is found, try to find the loose match
-        for (MethodDescriptor methodDesc : removeMethods.keySet()) {
+        for (Map.Entry<MethodDescriptor, EjbRemovalInfo> entry : removeMethods.entrySet()) {
+            MethodDescriptor methodDesc = entry.getKey();
             if (methodDesc.implies(method)) {
-                return removeMethods.get(methodDesc);
+                return entry.getValue();
             }
         }
 

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/util/InterceptorBindingTranslator.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/util/InterceptorBindingTranslator.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import com.sun.enterprise.deployment.EjbInterceptor;
@@ -290,10 +291,11 @@ public class InterceptorBindingTranslator {
             }
         }
 
-        for(MethodDescriptor nextMethod : methodInterceptorsMap.keySet()) {
+        for (Entry<MethodDescriptor, LinkedList<String>> entry : methodInterceptorsMap.entrySet()) {
+            MethodDescriptor nextMethod = entry.getKey();
 
             List<String> interceptorClassChain = (List<String>)
-                methodInterceptorsMap.get(nextMethod);
+                entry.getValue();
             
             List<EjbInterceptor> interceptorChain = 
                 new LinkedList<EjbInterceptor>();

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroRuntimeImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroRuntimeImpl.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -141,10 +142,11 @@ public class PayaraMicroRuntimeImpl implements PayaraMicroRuntime  {
         
         Map<String,Future<ClusterCommandResult>> commandResult = instanceService.executeClusteredASAdmin(command, args);
         Map<InstanceDescriptor, Future<? extends ClusterCommandResult>> result = new HashMap<>(commandResult.size());
-        for (String uuid : commandResult.keySet()) {
+        for (Entry<String,Future<ClusterCommandResult>> entry : commandResult.entrySet()) {
+            String uuid = entry.getKey();
             InstanceDescriptor id = instanceService.getDescriptor(uuid);
             if (id != null) {
-                result.put(id, commandResult.get(uuid));
+                result.put(id, entry.getValue());
             }
         }
         return result;
@@ -169,10 +171,11 @@ public class PayaraMicroRuntimeImpl implements PayaraMicroRuntime  {
         
         Map<String,Future<ClusterCommandResult>> commandResult = instanceService.executeClusteredASAdmin(memberUUIDs,command, args);
         Map<InstanceDescriptor, Future<? extends ClusterCommandResult>> result = new HashMap<>(commandResult.size());
-        for (String uuid : commandResult.keySet()) {
+        for (Entry<String,Future<ClusterCommandResult>> entry : commandResult.entrySet()) {
+            String uuid = entry.getKey();
             InstanceDescriptor id = instanceService.getDescriptor(uuid);
             if (id != null) {
-                result.put(id, commandResult.get(uuid));
+                result.put(id, entry.getValue());
             }
         }
         return result;
@@ -193,10 +196,11 @@ public class PayaraMicroRuntimeImpl implements PayaraMicroRuntime  {
         
         Map<String, Future<T>> runCallable = instanceService.runCallable(callable);
         Map<InstanceDescriptor, Future<T>> result = new HashMap<>(runCallable.size());
-        for (String uuid : runCallable.keySet()) {
+        for (Entry<String, Future<T>> entry : runCallable.entrySet()) {
+            String uuid = entry.getKey();
             InstanceDescriptor id = instanceService.getDescriptor(uuid);
             if (id != null) {
-                result.put(id, runCallable.get(uuid));
+                result.put(id, entry.getValue());
             }
         }
         return result;
@@ -221,10 +225,11 @@ public class PayaraMicroRuntimeImpl implements PayaraMicroRuntime  {
         
         Map<String, Future<T>> runCallable = instanceService.runCallable(memberUUIDs,callable);
         Map<InstanceDescriptor, Future<T>> result = new HashMap<>(runCallable.size());
-        for (String uuid : runCallable.keySet()) {
+        for (Entry<String, Future<T>> entry : runCallable.entrySet()) {
+            String uuid = entry.getKey();
             InstanceDescriptor id = instanceService.getDescriptor(uuid);
             if (id != null) {
-                result.put(id, runCallable.get(uuid));
+                result.put(id, entry.getValue());
             }
         }
         return result;

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
@@ -59,6 +59,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -530,8 +531,8 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
             }
         }
 
-        for (String pk : toRestore.keySet()) {
-            pkCache.put(pk, toRestore.get(pk));
+        for (Entry<String, HZTimer> entry : toRestore.entrySet()) {
+            pkCache.put(entry.getKey(), entry.getValue());
             totalTimersMigrated++;
         }
 

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JwtTokenParser.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JwtTokenParser.java
@@ -51,6 +51,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -151,8 +152,9 @@ public class JwtTokenParser {
         if(this.enableNamespacedClaims){
             final String namespace = customNamespace.orElse(DEFAULT_NAMESPACE);
             Map<String, JsonValue> processedClaims = new HashMap<>(currentClaims.size());
-            for(String claimName : currentClaims.keySet()){
-                JsonValue value = currentClaims.get(claimName);
+            for (Entry<String, JsonValue> entry : currentClaims.entrySet()) {
+                String claimName = entry.getKey();
+                JsonValue value = entry.getValue();
                 if(claimName.startsWith(namespace)){
                     claimName = claimName.substring(namespace.length());
                 }

--- a/appserver/payara-appserver-modules/payara-rest-endpoints/src/main/java/fish/payara/appserver/rest/endpoints/config/admin/ListRestEndpointsCommand.java
+++ b/appserver/payara-appserver-modules/payara-rest-endpoints/src/main/java/fish/payara/appserver/rest/endpoints/config/admin/ListRestEndpointsCommand.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -208,9 +209,10 @@ public class ListRestEndpointsCommand implements AdminCommand {
 
         // loop through jersey components
         boolean hasEndpoints = false;
-        for (ServletContainer jerseyApplication : jerseyApplicationMap.keySet()) {
+        for (Entry<ServletContainer, String> entry : jerseyApplicationMap.entrySet()) {
+            ServletContainer jerseyApplication = entry.getKey();
             String appRoot = jerseyApplication.getServletContext().getContextPath();
-            String jerseyAppRoot = jerseyApplicationMap.get(jerseyApplication);
+            String jerseyAppRoot = entry.getValue();
 
             List<Class<?>> containedClasses = getClasses(jerseyApplication);
 

--- a/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/BaseAuthConfigFactory.java
+++ b/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/BaseAuthConfigFactory.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -230,9 +231,10 @@ public abstract class BaseAuthConfigFactory extends AuthConfigFactory {
         String registrationId = getRegistrationID(layer, appContext);
 
         doWriteLocked(() -> {
-            for (String targetID : idToRegistrationListenersMap.keySet()) {
+            for (Entry<String, List<RegistrationListener>> entry : idToRegistrationListenersMap.entrySet()) {
+                String targetID = entry.getKey();
                 if (regIdImplies(registrationId, targetID)) {
-                    List<RegistrationListener> listeners = idToRegistrationListenersMap.get(targetID);
+                    List<RegistrationListener> listeners = entry.getValue();
                     if (listeners != null && listeners.remove(listener)) {
                         removedListenerIds.add(targetID);
                     }

--- a/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/webservices/ClientPipeCloser.java
+++ b/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/webservices/ClientPipeCloser.java
@@ -43,6 +43,7 @@ package com.sun.enterprise.security.webservices;
 import static java.util.Collections.synchronizedMap;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.WeakHashMap;
 
 import com.sun.enterprise.deployment.ServiceReferenceDescriptor;
@@ -72,8 +73,9 @@ public class ClientPipeCloser {
     public void removeListenerWrapper(AuthConfigRegistrationWrapper wrapper) {
         ServiceReferenceDescriptor entryToRemove = null;
 
-        for (ServiceReferenceDescriptor svc : svcRefListenerMap.keySet()) {
-            AuthConfigRegistrationWrapper wrp = svcRefListenerMap.get(svc);
+        for (Entry<ServiceReferenceDescriptor, AuthConfigRegistrationWrapper> entry : svcRefListenerMap.entrySet()) {
+            ServiceReferenceDescriptor svc = entry.getKey();
+            AuthConfigRegistrationWrapper wrp = entry.getValue();
             if (wrp == wrapper) {
                 entryToRemove = svc;
                 break;

--- a/appserver/tests/quicklook/amx/src/test/amx/AMXConfigProxyTests.java
+++ b/appserver/tests/quicklook/amx/src/test/amx/AMXConfigProxyTests.java
@@ -51,6 +51,7 @@ import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.List;
 import java.util.HashMap;
 import java.util.ArrayList;
@@ -120,11 +121,12 @@ public final class AMXConfigProxyTests extends AMXTestBase
 
         // test the Map keyed by XML attribute name
         final Map<String, String> defaultValuesXML = amxConfig.getDefaultValues(false);
-        for (final String attrName : defaultValuesXML.keySet())
+        for (final Entry<String, String> entry : defaultValuesXML.entrySet())
         {
+            String attrName = entry.getKey();
             // no default value should ever be null
 
-            assert defaultValuesXML.get(attrName) != null :
+            assert entry.getValue() != null :
             "null value for attribute " + attrName + " in " + objectName;
         }
 
@@ -132,11 +134,12 @@ public final class AMXConfigProxyTests extends AMXTestBase
         final Map<String, String> defaultValuesAMX = amxConfig.getDefaultValues(true);
 
         assert defaultValuesXML.size() == defaultValuesAMX.size();
-        for (final String attrName : defaultValuesAMX.keySet())
+        for (final Entry<String, String> entry : defaultValuesAMX.entrySet())
         {
+            String attrName = entry.getKey();
             // no default value should ever be null
 
-            assert defaultValuesAMX.get(attrName) != null :
+            assert entry.getValue() != null :
             "null value for attribute " + attrName + " in " + objectName;
         }
     }

--- a/appserver/web/jsf-connector/src/main/java/org/glassfish/faces/integration/GlassFishTldProvider.java
+++ b/appserver/web/jsf-connector/src/main/java/org/glassfish/faces/integration/GlassFishTldProvider.java
@@ -102,12 +102,13 @@ public class GlassFishTldProvider implements TldProvider, PostConstruct {
     public synchronized Map<URI, List<String>> getTldListenerMap() {
         if (tldListenerMap == null) {
             tldListenerMap = new HashMap<URI, List<String>>();
-            for (URI uri : tldMap.keySet()) {
+            for (Map.Entry<URI, List<String>> entry : tldMap.entrySet()) {
+                URI uri = entry.getKey();
                 /*
                  * In the case of JSF, the only TLD that declares any listener is META-INF/jsf_core.tld
                  */
-                if (tldMap.get(uri).contains("META-INF/jsf_core.tld")) {
-                    tldListenerMap.put(uri, tldMap.get(uri));
+                if (entry.getValue().contains("META-INF/jsf_core.tld")) {
+                    tldListenerMap.put(uri, entry.getValue());
                     break;
                 }
             }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -90,6 +90,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
@@ -5083,14 +5084,15 @@ public class StandardContext
         boolean ok = true;
         synchronized (filterConfigs) {
             filterConfigs.clear();
-            for (String name : filterDefs.keySet()) {
+            for (Entry<String, FilterDef> entry : filterDefs.entrySet()) {
+                String name = entry.getKey();
                 if(log.isLoggable(Level.FINE)) {
                     log.log(Level.FINE, " Starting filter '" + name + "'");
                 }
                 try {
                     filterConfigs.put(name,
                         new ApplicationFilterConfig(this,
-                                                    filterDefs.get(name)));
+                                                    entry.getValue()));
                 } catch(Throwable t) {
                     String msg = MessageFormat.format(rb.getString(LogFacade.STARTING_FILTER_EXCEPTION), name);
                     getServletContext().log(msg, t);
@@ -5115,11 +5117,12 @@ public class StandardContext
 
         // Release all Filter and FilterConfig instances
         synchronized (filterConfigs) {
-            for (String filterName : filterConfigs.keySet()) {
+            for (Entry<String, FilterConfig> entry : filterConfigs.entrySet()) {
+                String filterName = entry.getKey();
                 if(log.isLoggable(Level.FINE)) {
                     log.log(Level.FINE, " Stopping filter '" + filterName + "'");
                 }
-                ApplicationFilterConfig filterConfig = (ApplicationFilterConfig)filterConfigs.get(filterName);
+                ApplicationFilterConfig filterConfig = (ApplicationFilterConfig)entry.getValue();
                 filterConfig.release();
             }
             filterConfigs.clear();

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -75,6 +75,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -962,9 +963,10 @@ public class WebModule extends PwcWebModule implements Context {
 
         // Check if given path starts with any of the ad-hoc subtree paths
         if (servletInfo == null && path != null && hasAdHocSubtrees()) {
-            for(String adHocSubtree : adHocSubtrees.keySet()) {
+            for (Entry<String,AdHocServletInfo> entry : adHocSubtrees.entrySet()) {
+                String adHocSubtree = entry.getKey();
                 if(path.startsWith(adHocSubtree)) {
-                    servletInfo = adHocSubtrees.get(adHocSubtree);
+                    servletInfo = entry.getValue();
                     break;
                 }
             }

--- a/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/RestartMonitoring.java
+++ b/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/RestartMonitoring.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Inject;
@@ -133,8 +134,9 @@ public class RestartMonitoring implements AdminCommand {
     *to change the value of the monitoring modules config. The changes take affect immedietly after a succesful transaction.
     */
     private void setModules(Map<String, String> modules){
-        for (String module : modules.keySet()) {
-            String moduleLevel = modules.get(module);
+        for (Entry<String, String> entry : modules.entrySet()) {
+            String module = entry.getKey();
+            String moduleLevel = entry.getValue();
             try {
                 ConfigSupport.apply((final MonitoringService monitoringServiceProxy) -> {
                     monitoringServiceProxy.setMonitoringLevel(module, moduleLevel);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/StatusGenerator.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/StatusGenerator.java
@@ -238,18 +238,18 @@ public class StatusGenerator extends AbstractResource {
                 .append("<table border=\"1\" style=\"border-collapse: collapse\">\n")
                 .append("<tr><th>Command</th><th>Target</th><th>Resource</th></tr>\n");
 
-        for (String ss : commandsToResources.keySet()) {
-            status.append("<tr><td>").append(ss).append(TABLE_CELL_DIVIDER)
-                    .append(hasTargetParam(ss) ? "target" : "").append(TABLE_CELL_DIVIDER)
-                    .append(commandsToResources.get(ss)).append("</td></tr>\n");
+        for (Entry<String, String> entry : commandsToResources.entrySet()) {
+            status.append("<tr><td>").append(entry.getKey()).append(TABLE_CELL_DIVIDER)
+                    .append(hasTargetParam(entry.getKey()) ? "target" : "").append(TABLE_CELL_DIVIDER)
+                    .append(entry.getValue()).append("</td></tr>\n");
         }
         status.append("</table>\n<hr/>\n")
                 .append("<h4>Resources with Delete Commands in REST Admin (not counting RESTREDIRECT)</h4>\n")
                 .append("<table border=\"1\" style=\"border-collapse: collapse\">\n")
                 .append("<tr><th>Resource</th><th>Delete Command</th></tr>\n");
-        for (String ss : resourcesToDeleteCommands.keySet()) {
-            status.append("<tr><td>").append(ss)
-                    .append(TABLE_CELL_DIVIDER).append(resourcesToDeleteCommands.get(ss)).append("</td></tr>\n");
+        for (Entry<String, String> entry : resourcesToDeleteCommands.entrySet()) {
+            status.append("<tr><td>").append(entry.getKey())
+                    .append(TABLE_CELL_DIVIDER).append(entry.getValue()).append("</td></tr>\n");
         }
         status.append("</table>");
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
@@ -48,6 +48,7 @@ import com.sun.enterprise.universal.process.ProcessUtils;
 import com.sun.enterprise.util.io.FileUtils;
 import java.io.File;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import javax.inject.Inject;
 import org.glassfish.api.Param;
@@ -172,8 +173,9 @@ public class StopDomainCommand extends LocalDomainCommand {
             StringBuilder runningDomains = new StringBuilder();
             try {
                 Map<String, Boolean> domains = listDomains.getDomains();
-                for (String domain : domains.keySet()) {
-                    if (domains.get(domain)) {
+                for (Entry<String, Boolean> entry : domains.entrySet()) {
+                    String domain = entry.getKey();
+                    if (entry.getValue()) {
                         runningDomains.append("\n").append(domain);
                     }
                 }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigImpl.java
@@ -423,9 +423,10 @@ public class AMXConfigImpl extends AMXImplBase
             if ( values == null ) return null;
             
             final List<AttributeChanges> changes = ListUtil.newList();
-            for (final String xmlName : mAttrs.keySet() )
+            for (final Map.Entry<String,Object> entry : mAttrs.entrySet())
             {
-                final Object value = mAttrs.get(xmlName);
+                String xmlName = entry.getKey();
+                final Object value = entry.getValue();
 
                 if ( value instanceof String )
                 {
@@ -1362,9 +1363,10 @@ public class AMXConfigImpl extends AMXImplBase
         protected void makeChanges()
                 throws TransactionFailure
         {
-            for (final String xmlName : mChanges.keySet())
+            for (final Map.Entry<String, Object> entry : mChanges.entrySet())
             {
-                final Object value = mChanges.get(xmlName);
+                String xmlName = entry.getKey();
+                final Object value = entry.getValue();
                 final ConfigModel.Property prop = getConfigModel_Property(xmlName);
 
                 if (prop.isCollection())

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/ConfigBeanJMXSupport.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/ConfigBeanJMXSupport.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import javax.management.Descriptor;
 import javax.management.MBeanAttributeInfo;
@@ -1158,11 +1159,11 @@ class ConfigBeanJMXSupport
             if (Number.class.isAssignableFrom(inferDataType()))
             {
                 final String attrName = attrName();
-                for (final String key : UNITS_SUFFIXES.keySet())
+                for (final Entry<String, String> entry : UNITS_SUFFIXES.entrySet())
                 {
-                    if (attrName.endsWith(key))
+                    if (attrName.endsWith(entry.getKey()))
                     {
-                        return UNITS_SUFFIXES.get(key);
+                        return entry.getValue();
                     }
                 }
                 return Units.COUNT;

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/SampleImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/SampleImpl.java
@@ -51,6 +51,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -107,8 +108,9 @@ public final class SampleImpl extends AMXImplBase {
     private synchronized MBeanInfo createMBeanInfo(final MBeanInfo baseMBeanInfo) {
         final MBeanAttributeInfo[] dynamicAttrInfos = new MBeanAttributeInfo[mAttributes.keySet().size()];
         int i = 0;
-        for (final String name : mAttributes.keySet()) {
-            final Object value = mAttributes.get(name);
+        for (final Entry<String, Serializable> entry : mAttributes.entrySet()) {
+            String name = entry.getKey();
+            final Object value = entry.getValue();
             final String type = value == null ? String.class.getName() : value.getClass().getName();
 
             dynamicAttrInfos[i] = new MBeanAttributeInfo(name, type, "dynamically-added Attribute",

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ModuleInfo.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ModuleInfo.java
@@ -55,6 +55,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
@@ -147,9 +148,9 @@ public class ModuleInfo {
     }
 
     public Object getMetaData(String className) {
-        for (Class c : metaData.keySet()) {
-            if (c.getName().equals(className)) {
-                return metaData.get(c);
+        for (Entry<Class<? extends Object>, Object> entry : metaData.entrySet()) {
+            if (entry.getKey().getName().equals(className)) {
+                return entry.getValue();
             }
         }
         return null;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GrizzlyService.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -372,13 +373,14 @@ public class GrizzlyService implements RequestDispatcher, PostConstruct, PreDest
                 GrizzlyProxy grizzlyProxy = (GrizzlyProxy)newNetworkProxy;
                 GenericGrizzlyListener grizzlyListener = (GenericGrizzlyListener)grizzlyProxy.getUnderlyingListener();
                 if (!filterToProbeMapping.isEmpty()) {
-                    for (Class<? extends HttpCodecFilter> aClass : filterToProbeMapping.keySet()) {
+                    for (Entry<Class<? extends HttpCodecFilter>, List<HttpProbe>> entry : filterToProbeMapping.entrySet()) {
+                        Class<? extends HttpCodecFilter> aClass = entry.getKey();
                         List<? extends HttpCodecFilter> filters = grizzlyListener.getFilters(aClass);
                         if (filters != null && !filters.isEmpty()) {
                             if (filters.size() != 1) {
                                 throw new IllegalStateException();
                             }
-                            final List<HttpProbe> probes = filterToProbeMapping.get(aClass);
+                            final List<HttpProbe> probes = entry.getValue();
                             filters.get(0).getMonitoringConfig().addProbes(probes.toArray(new HttpProbe[probes.size()]));
                         }
                     }

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/monitor/DeploymentLifecycleStatsProvider.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/monitor/DeploymentLifecycleStatsProvider.java
@@ -57,6 +57,7 @@ import org.glassfish.gmbal.ManagedObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -125,11 +126,12 @@ public class DeploymentLifecycleStatsProvider {
             // Set the headings for the tabular output
             int appNameLength = COLUMN_LENGTH;
             int moduleTypeLength = COLUMN_LENGTH;
-            for (String appName : appsInfoMap.keySet()) {
+            for (Entry<String, Map<String, String>> entry : appsInfoMap.entrySet()) {
+                String appName = entry.getKey();
                 if (appName.length() > appNameLength) {
                     appNameLength = appName.length() + 1;
                 }
-                String moduleType = appsInfoMap.get(appName).get(MODULE_TYPE);
+                String moduleType = entry.getValue().get(MODULE_TYPE);
                 if (moduleType.length() > moduleTypeLength) {
                     moduleTypeLength = moduleType.length() + 1;
                 }
@@ -141,9 +143,10 @@ public class DeploymentLifecycleStatsProvider {
             appendColumn(strBuf, "Loading_Time(ms)", COLUMN_LENGTH);
             strBuf.append(LINE_BREAK);
 
-            for (String appName : appsInfoMap.keySet()) {
+            for (Entry<String, Map<String, String>> entry : appsInfoMap.entrySet()) {
+                String appName = entry.getKey();
                 appendColumn(strBuf, appName, appNameLength);
-                Map<String, String> appInfoMap = appsInfoMap.get(appName);
+                Map<String, String> appInfoMap = entry.getValue();
                 String moduleType = appInfoMap.get(MODULE_TYPE);
                 String loadingTime = appInfoMap.get(LOADING_TIME);
 		appendColumn(strBuf, moduleType, COLUMN_LENGTH);

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/exec/ClusterExecutionService.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/exec/ClusterExecutionService.java
@@ -50,6 +50,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -128,8 +129,9 @@ public class ClusterExecutionService implements EventListener {
 
             Set<Member> membersToSubmit = selectMembers(memberUUIDS);
             Map<Member, Future<T>> results = hzCore.getInstance().getExecutorService(HazelcastCore.CLUSTER_EXECUTOR_SERVICE_NAME).submitToMembers(callable, membersToSubmit);
-            for (Member member : results.keySet()) {
-                result.put(member.getUuid(), results.get(member));
+            for (Entry<Member, Future<T>> entry : results.entrySet()) {
+                Member member = entry.getKey();
+                result.put(member.getUuid(), entry.getValue());
             }
         }
         return result;
@@ -147,8 +149,9 @@ public class ClusterExecutionService implements EventListener {
             // work out which members correspond to cluster UUIDS.
             HazelcastInstance instance = hzCore.getInstance();
             Map<Member, Future<T>> results = hzCore.getInstance().getExecutorService(HazelcastCore.CLUSTER_EXECUTOR_SERVICE_NAME).submitToAllMembers(callable);
-            for (Member member : results.keySet()) {
-                result.put(member.getUuid(), results.get(member));
+            for (Entry<Member, Future<T>> entry : results.entrySet()) {
+                Member member = entry.getKey();
+                result.put(member.getUuid(), entry.getValue());
             }
         }
         return result;
@@ -209,8 +212,9 @@ public class ClusterExecutionService implements EventListener {
             Collection<Member> toSubmitTo = selectMembers(memberUUIDs);
             IScheduledExecutorService scheduledExecutorService = hzCore.getInstance().getScheduledExecutorService(HazelcastCore.SCHEDULED_CLUSTER_EXECUTOR_SERVICE_NAME);
             Map<Member, IScheduledFuture<V>> schedule = scheduledExecutorService.scheduleOnMembers(callable, toSubmitTo, delay, unit);
-            for (Member member : schedule.keySet()) {
-                result.put(member.getUuid(), new ScheduledTaskFuture<>(schedule.get(member)));
+            for (Entry<Member, IScheduledFuture<V>> entry : schedule.entrySet()) {
+                Member member = entry.getKey();
+                result.put(member.getUuid(), new ScheduledTaskFuture<>(entry.getValue()));
             }
         }
         return result;
@@ -271,8 +275,9 @@ public class ClusterExecutionService implements EventListener {
             Collection<Member> toSubmitTo = selectMembers(memberUUIDs);
             IScheduledExecutorService scheduledExecutorService = hzCore.getInstance().getScheduledExecutorService(HazelcastCore.SCHEDULED_CLUSTER_EXECUTOR_SERVICE_NAME);
             Map<Member, IScheduledFuture<?>> schedule = scheduledExecutorService.scheduleOnMembersAtFixedRate(runnable, toSubmitTo, delay, period, unit);
-            for (Member member : schedule.keySet()) {
-                result.put(member.getUuid(), new ScheduledTaskFuture<>(schedule.get(member)));
+            for (Entry<Member, IScheduledFuture<?>> entry : schedule.entrySet()) {
+                Member member = entry.getKey();
+                result.put(member.getUuid(), new ScheduledTaskFuture<>(entry.getValue()));
             }
         }
         return result;

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/NameGenerator.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/NameGenerator.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -117,10 +118,11 @@ public class NameGenerator
         }
         
         // Find a name not in use
-        for (String adjective : names.keySet()) {
+        for (Entry<String, List<String>> entry : names.entrySet()) {
+            String adjective = entry.getKey();
             // If a name has been found, exit the loop
             if (name.equals("")) {
-                for (String fish : names.get(adjective)) {
+                for (String fish : entry.getValue()) {
                     String potentialName = adjective + "-" + fish;
                     if (!takenNames.contains(potentialName)) {
                         name = potentialName;

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ClusterConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ClusterConfigSource.java
@@ -43,6 +43,7 @@ import fish.payara.nucleus.store.ClusteredStore;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.glassfish.internal.api.Globals;
 
@@ -63,8 +64,8 @@ public class ClusterConfigSource extends PayaraConfigSource implements ConfigSou
     public Map<String, String> getProperties() {
         Map<Serializable, Serializable> map = clusterStore.getMap(CLUSTERED_CONFIG_STORE);
         HashMap<String, String> result = new HashMap<>();
-        for (Serializable key : map.keySet()) {
-            result.put((String) key, (String) map.get(key));
+        for (Entry<Serializable, Serializable> entry : map.entrySet()) {
+            result.put((String) entry.getKey(), (String) entry.getValue());
         }
         return result;
     }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -52,6 +52,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -193,11 +194,12 @@ public class PayaraConfig implements Config {
             
         if (converter == null) {
             // search for a matching raw type
-            for (Type type1 : converters.keySet()) {
+            for (Entry<Type, Converter> entry : converters.entrySet()) {
+                Type type1 = entry.getKey();
                 if (type1 instanceof ParameterizedType) {
                     ParameterizedType ptype = (ParameterizedType)type1;
                     if (ptype.getRawType().equals(propertyType)) {
-                        converter = converters.get(type1);
+                        converter = entry.getValue();
                         break;
                     }
                 }


### PR DESCRIPTION
This PR comprises only _nucleus_ classes.

Iterating on a Map using `entrySet()`, when both key and value are needed, is more performant.

Fix a SonarQube violation of the rule: ["entrySet()" should be iterated when both the key and value are needed](https://rules.sonarsource.com/java/RSPEC-2864) 