### PR TITLE
PAYARA-3980 Remove duplicated element 'description'

### DIFF
--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/glassfish-ejb-jar_3_1-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/glassfish-ejb-jar_3_1-1.dtd
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 -->
 
 <!--
@@ -1224,8 +1224,6 @@ Syntax for supplying properties as name value pairs
 <!ELEMENT property (description?)>
 <!ATTLIST property name  CDATA  #REQUIRED
                    value CDATA  #REQUIRED>
-
-<!ELEMENT description (#PCDATA)>
 
 <!--
 Optional Default authentication configuration for an EJB web service endpoint.


### PR DESCRIPTION
# Description

As reported in #4073, element `description` is declared more than one time in DTD file.

# Dependencies

none

# Reviewer notes

First element declaration is here:
https://github.com/payara/Payara/blob/d9d9bb5e4349c0fe63ffd2999c671855c0b23cf4/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/glassfish-ejb-jar_3_1-1.dtd#L667-L672

# Testing performed

After this change test referenced in #4073 complains only about `Element type "property" must not be declared more than once` .

# Test Environment

[Travis CI](https://travis-ci.org/pzrep/Payara/jobs/553747506)
