### PR TITLE
[PAYARA-3909] - Can't Use Any of the Variable Types in JDBC Connection Pool Settings

### DIFF
--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.jdbc.config;
 

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -187,7 +187,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
     /**
      * Gets the value of the maxPoolSize property.
      *
-     * Maximum number of conections that can be created
+     * Maximum number of connections that can be created
      * 
      * @return possible object is
      *         {@link String }
@@ -251,7 +251,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * maximum time in seconds, that a connection can remain idle in the pool.
      * After this time, the pool implementation can close this connection.
      * Note that this does not control connection timeouts enforced at the
-     * database server side. Adminsitrators are advised to keep this timeout
+     * database server side. Administrators are advised to keep this timeout
      * shorter than the database server side timeout (if such timeouts are
      * configured on the specific vendor's database), to prevent accumulation of
      * unusable connection in Application Server.
@@ -798,7 +798,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *
      * Init sql is executed whenever a connection created from the pool. 
      * This is mostly useful when the state of a
-     * connection is to be initialized
+     * connection is to be initialised
      * 
      * @return possible object is
      *         {@link String }

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -58,7 +58,6 @@ import org.jvnet.hk2.config.*;
 import org.jvnet.hk2.config.types.Property;
 import org.jvnet.hk2.config.types.PropertyBag;
 
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import java.beans.PropertyVetoException;
@@ -175,8 +174,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="8")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getSteadyPoolSize();
 
     /**
@@ -196,8 +193,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="32")
-    @Min(value=1)
-    @Max(value=Integer.MAX_VALUE)
     String getMaxPoolSize();
 
     /**
@@ -218,8 +213,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="60000")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getMaxWaitTimeInMillis();
 
     /**
@@ -242,8 +235,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="2")
-    @Min(value=1)
-    @Max(value=Integer.MAX_VALUE)
     String getPoolResizeQuantity();
 
     /**
@@ -269,8 +260,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="300")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getIdleTimeoutInSeconds();
 
     /**
@@ -507,8 +496,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="0")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getValidateAtmostOncePeriodInSeconds();
 
     /**
@@ -535,8 +522,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="0")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getConnectionLeakTimeoutInSeconds();
 
     /**
@@ -577,8 +562,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="0")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getConnectionCreationRetryAttempts();
 
     /**
@@ -600,8 +583,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="10")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getConnectionCreationRetryIntervalInSeconds();
 
     /**
@@ -753,8 +734,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="0")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getStatementCacheSize();
 
     /**
@@ -792,8 +771,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="0")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getStatementLeakTimeoutInSeconds();
 
     /**
@@ -871,8 +848,6 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      *         {@link String }
      */
     @Attribute (defaultValue="0")
-    @Min(value=0)
-    @Max(value=Integer.MAX_VALUE)
     String getMaxConnectionUsageCount();
 
     /**

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
@@ -118,7 +118,7 @@ public class JdbcConnectionPoolValidator
                     }
                 }
                 
-                //By this point is should be the case that the value is castable
+                //By this point it should be the case that the value is always castable
                 //to an integer
                 maxPoolSizeValue = Integer.parseInt(maxPoolSize);
                 steadyPoolSizeValue = Integer.parseInt(steadyPoolSize);
@@ -193,7 +193,7 @@ public class JdbcConnectionPoolValidator
                 String dsClassName = jdbcPool.getDatasourceClassname();
                 String driverClassName = jdbcPool.getDriverClassname();
                 if (resType == null) {
-                    //One of datasource/driver classnames must be provided.
+                    //One of each datasource/driver classnames must be provided.
                     if ((dsClassName == null || dsClassName.equals("")) &&
                             (driverClassName == null || driverClassName.equals(""))) {
                         return false;

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
@@ -80,9 +80,6 @@ public class JdbcConnectionPoolValidator
                     return System.getenv(variableReference[1]);
                 }
                 break;
-            case "ALIAS":
-                //Check alias references for requested value
-                break;
             case "MPCONFIG":
                 //Check microprofile config for requested value
                 Config config = ConfigProvider.getConfig();

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 package org.glassfish.jdbc.config.validators;
 
 import com.sun.enterprise.config.serverbeans.ResourcePool;

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
@@ -69,8 +69,7 @@ public class JdbcConnectionPoolValidator
     }
 
     public String getParsedVariable(String variableToRetrieve) {
-        
-        Properties systemProps = System.getProperties();
+
         String[] variableReference = variableToRetrieve.split("=");
         
         switch(variableReference[0]) {
@@ -89,8 +88,8 @@ public class JdbcConnectionPoolValidator
                 break;
             default:
                 //We got a system variable as no split occured
-                if (systemProps.getProperty(variableReference[0]) != null && !systemProps.getProperty(variableReference[0]).isEmpty()) {
-                    return systemProps.getProperty(variableReference[0]);
+                if (System.getProperty(variableReference[0]) != null && !System.getProperty(variableReference[0]).isEmpty()) {
+                    return System.getProperty(variableReference[0]);
                 }
                 break;
         }
@@ -129,8 +128,13 @@ public class JdbcConnectionPoolValidator
                 
                 //By this point it should be the case that the value is always castable
                 //to an integer
-                maxPoolSizeValue = Integer.parseInt(maxPoolSize);
-                steadyPoolSizeValue = Integer.parseInt(steadyPoolSize);
+                try {
+                    maxPoolSizeValue = Integer.parseInt(maxPoolSize);
+                    steadyPoolSizeValue = Integer.parseInt(steadyPoolSize);
+                } catch(NumberFormatException nfe) {
+                    System.out.println("Exception occured whilst parsing value to int: \n - " + nfe.getMessage());
+                    return false;
+                }
                 
                 if (maxPoolSizeValue < steadyPoolSizeValue) {
                     //max pool size fault

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.jdbc.deployer;
 

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -642,7 +642,9 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public String getSteadyPoolSize() {
             int minPoolSize = desc.getMinPoolSize();
-            if (minPoolSize == -1) {
+            if (minPoolSize <= -1) {
+                _logger.log(Level.WARNING, "Value of steadyPoolSize Given, {0}, was outside the bounds"
+                        + ", default value of 8 will be used - PLEASE UPDATE YPUR VALUE", minPoolSize);
                 minPoolSize = 8;
             }
             return String.valueOf(minPoolSize);
@@ -656,7 +658,9 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public String getMaxPoolSize() {
             int maxPoolSize = desc.getMaxPoolSize();
-            if (maxPoolSize == -1) {
+            if (maxPoolSize <= -1) {
+                _logger.log(Level.WARNING, "Value of maxPoolSize Given, {0}, was outside the bounds"
+                        + ", default value of 32 will be used - PLEASE UPDATE YPUR VALUE", maxPoolSize);
                 maxPoolSize = 32;
             }
             return String.valueOf(maxPoolSize);

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -642,9 +642,9 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public String getSteadyPoolSize() {
             int minPoolSize = desc.getMinPoolSize();
-            if (minPoolSize <= -1) {
+            if (minPoolSize <= 0) {
                 _logger.log(Level.WARNING, "Value of steadyPoolSize Given, {0}, was outside the bounds"
-                        + ", default value of 8 will be used - PLEASE UPDATE YPUR VALUE", minPoolSize);
+                        + ", default value of 8 will be used - PLEASE UPDATE YOUR VALUE", minPoolSize);
                 minPoolSize = 8;
             }
             return String.valueOf(minPoolSize);
@@ -658,9 +658,9 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public String getMaxPoolSize() {
             int maxPoolSize = desc.getMaxPoolSize();
-            if (maxPoolSize <= -1) {
+            if (maxPoolSize <= 0) {
                 _logger.log(Level.WARNING, "Value of maxPoolSize Given, {0}, was outside the bounds"
-                        + ", default value of 32 will be used - PLEASE UPDATE YPUR VALUE", maxPoolSize);
+                        + ", default value of 32 will be used - PLEASE UPDATE YOUR VALUE", maxPoolSize);
                 maxPoolSize = 32;
             }
             return String.valueOf(maxPoolSize);


### PR DESCRIPTION
It is desired that variable types can be used in place of set values in JDBC connection pool settings (i.e. set maxPoolSize = ${MAX_POOL_SIZE_PROPERTY}) - this was previously not possible due to the validation process of JDBC connection pool properties (results in a NumberFormatException trying to parse an incorrect format string to an Integer) - the changes in this PR get around that