### PR TITLE
SPEC-104 Address security permission exception preventing TCK running

### DIFF
--- a/appserver/packager/external/javadb/pom.xml
+++ b/appserver/packager/external/javadb/pom.xml
@@ -40,17 +40,40 @@
     holder.
 
 -->
+<!--
+    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
     <parent>
         <groupId>org.glassfish.main.external</groupId>
         <artifactId>external</artifactId>
         <version>5.193-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    
     <artifactId>javadb</artifactId>
     <packaging>distribution-fragment</packaging>
+    
     <name>JavaDB to be bundled into GlassFish</name>
+    
+    <developers>
+        <developer>
+            <id>kohsuke</id>
+            <name>Kohsuke Kawaguchi</name>
+            <organization>Oracle, Inc.</organization>
+        </developer>
+    </developers>
+    
+    <dependencies>
+        <dependency>
+            <groupId>javadb</groupId>
+            <artifactId>javadb</artifactId>
+            <version>${javadb.version}</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -68,7 +91,7 @@
                                 <resolveArtifact artifactId="javadb" property="javadb.zip" />
 
                                 <mkdir dir="target/classes/glassfish/javadb" />
-				<unzip src="${javadb.zip}" dest="target/classes/glassfish/javadb">
+                                <unzip src="${javadb.zip}" dest="target/classes/glassfish/javadb">
                                     <patternset>
                                         <exclude name="demo/**" />
                                         <exclude name="docs/**" />
@@ -86,20 +109,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <developers>
-        <developer>
-            <id>kohsuke</id>
-            <name>Kohsuke Kawaguchi</name>
-            <organization>Oracle, Inc.</organization>
-        </developer>
-    </developers>
-    <dependencies>
-        <dependency>
-            <groupId>javadb</groupId>
-            <artifactId>javadb</artifactId>
-            <version>${javadb.version}</version>
-	    <type>zip</type>
-        </dependency>
-    </dependencies>
+    
 </project>

--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+ // Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 // classes in lib get all permissions by default
 grant codeBase "file:${com.sun.aas.installRoot}/lib/-" {
@@ -62,6 +63,7 @@ grant codeBase "file:${com.sun.aas.imqLib}/-" {
 grant codeBase "file:${com.sun.aas.derbyRoot}/lib/-" {
     permission java.lang.RuntimePermission "createClassLoader";
     permission java.io.FilePermission       "<<ALL FILES>>", "read,write";
+    permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";
 }; 
 
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
@@ -900,7 +900,11 @@ public class ASURLClassLoader
          */
         protected void finalize() throws IOException {
             reallyClose();
-            super.finalize();
+            try {
+                super.finalize();
+            } catch (Throwable t ) {
+                throw new IOException(t);
+            }
         }
     }
 

--- a/nucleus/security/core/src/main/resources/config/server.policy
+++ b/nucleus/security/core/src/main/resources/config/server.policy
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+ // Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 // classes in lib get all permissions by default
 grant codeBase "file:${com.sun.aas.installRoot}/lib/-" {
@@ -62,6 +63,7 @@ grant codeBase "file:${com.sun.aas.imqLib}/-" {
 grant codeBase "file:${com.sun.aas.derbyRoot}/lib/-" {
     permission java.lang.RuntimePermission "createClassLoader";
     permission java.io.FilePermission       "<<ALL FILES>>", "read,write";
+    permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";
 }; 
 
 


### PR DESCRIPTION
The TCK barks about an exception, and about security permissions not being set. This should have been done when integrating the updated JavaDB/Derby as per its release notes: https://db.apache.org/derby/releases/release-10.12.1.1.html (Note for DERBY-6648)

Signed-off-by: arjantijms <arjan.tijms@gmail.com>