### PR TITLE
PAYARA-3964 Allow configuration of MDB bean pool size with ActivationConfigProperty

### DIFF
--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/deployment/annotation/handlers/MessageDrivenHandler.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/deployment/annotation/handlers/MessageDrivenHandler.java
@@ -160,7 +160,7 @@ public class MessageDrivenHandler extends AbstractEjbHandler {
             } else if (acProp.propertyName().equals("PoolIdleTimeoutInSeconds")) {
                 initialiseBeanPoolDescriptor(ejbMsgBeanDesc);
                 ejbMsgBeanDesc.getIASEjbExtraDescriptors().getBeanPool().setPoolIdleTimeoutInSeconds(Integer.valueOf(envProp.getValue()));
-            }else if (acProp.propertyName().equals("SingletonBeanPool")) {
+            } else if (acProp.propertyName().equals("SingletonBeanPool")) {
                 NameValuePairDescriptor singletonProperty = new NameValuePairDescriptor();
                 singletonProperty.setName("singleton-bean-pool");
                 singletonProperty.setValue(envProp.getValue());


### PR DESCRIPTION
Added support for singleton-bean-pool and bean-pool MDB deployment descriptor elements as ActivationConfigProperty values in MDB annotations