### PR TITLE
PAYARA-3922 Updated jersey.version to 2.29.payara-p4

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -273,7 +273,7 @@
         <!-- JAX-RS -->
         <jax-rs-api.spec.version>2.1.5</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
-        <jersey.version>2.29.payara-p3</jersey.version>
+        <jersey.version>2.29.payara-p4</jersey.version>
 
         <!-- Bean Validation -->
         <javax.validation.version>2.0.1.Final</javax.validation.version>


### PR DESCRIPTION
- fixes PAYARA-3922:
  - support for Stateless(name = "xxx")
  - support for implicit Local interface