### PR TITLE
Ensure that the TimerWrapper references correct EJBTimerService

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerServiceWrapper.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerServiceWrapper.java
@@ -273,7 +273,7 @@ public class EJBTimerServiceWrapper implements TimerService {
             Collection<TimerPrimaryKey> timerIds
                     = timerService_.getTimerIds(containerIds);
             for (TimerPrimaryKey timerId : timerIds) {
-                timerWrappers.add(new TimerWrapper(timerId, persistentTimerService_));
+                timerWrappers.add(new TimerWrapper(timerId, timerService_));
             }
         }
 


### PR DESCRIPTION
Non-persistent timers are incorrectly wrapped and thus will generate NoSuchObjectLocalException
exceptions when invoking methods such as Timer.getInfo() on returned timers.

Fixes #3884