### PR TITLE
PAYARA-4013 Increase Microprofile Fault Tolerance version to 2.0.1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -208,7 +208,7 @@
         <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
 
         <!-- Microprofile version properties -->
-        <microprofile-fault-tolerance.version>2.0</microprofile-fault-tolerance.version>
+        <microprofile-fault-tolerance.version>2.0.1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
         <microprofile-healthcheck.version>1.0.payara-p1</microprofile-healthcheck.version>
         <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>


### PR DESCRIPTION
This allows MP Metrics 2.0 to work