### PR TITLE
PAYARA-4026 Fault Tolerance 2.0.1 fix for failing TCK

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FaultTolerancePolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FaultTolerancePolicy.java
@@ -453,9 +453,11 @@ public final class FaultTolerancePolicy implements Serializable {
                 resultValue = processTimeoutStage(invocation, asyncAttempt);
                 state.recordClosedOutcome(true);
             } catch (Exception ex) {
-                invocation.metrics.incrementCircuitbreakerCallsFailedTotal();
                 if (circuitBreaker.failOn(ex)) {
                     state.recordClosedOutcome(false);
+                    invocation.metrics.incrementCircuitbreakerCallsFailedTotal();
+                } else {
+                    invocation.metrics.incrementCircuitbreakerCallsSucceededTotal();
                 }
                 failedOn = ex;
             }


### PR DESCRIPTION
Circuit Breaker should be considered success if exception thrown is not
marked as failOn