### PR TITLE
PAYARA-4081 Merge 'property' elements

### DIFF
--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/glassfish-ejb-jar_3_1-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/glassfish-ejb-jar_3_1-1.dtd
@@ -701,11 +701,6 @@ for delivering messages to the message-driven bean.
 -->
 <!ELEMENT resource-adapter-mid ( #PCDATA ) >
 
-<!-- 
-Generic name-value pairs property
--->
-<!ELEMENT property ( name, value ) >
-
 <!--
 This text nodes holds a value string.
 -->
@@ -1221,9 +1216,9 @@ The version-identifier element contains the version information. The value is
 <!-- 
 Syntax for supplying properties as name value pairs 
 -->
-<!ELEMENT property (description?)>
-<!ATTLIST property name  CDATA  #REQUIRED
-                   value CDATA  #REQUIRED>
+<!ELEMENT property (description?, name?, value?)>
+<!ATTLIST property name  CDATA  #IMPLIED
+                   value CDATA  #IMPLIED>
 
 <!--
 Optional Default authentication configuration for an EJB web service endpoint.


### PR DESCRIPTION
Closes #4073

With two ways of providing property, as elements and as attributes
the REQUIRED constraints for attributes have to be relaxed,
and name/value elements have to be optional as well.