### PR TITLE
SPEC-259: Correctly identify if timer service relates to managed entity

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerServiceWrapper.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerServiceWrapper.java
@@ -82,19 +82,8 @@ public class EJBTimerServiceWrapper implements TimerService {
         ejbContext_   = ejbContext;
         BaseContainer container = (BaseContainer) ejbContext.getContainer();
         ejbDescriptor_ = container.getEjbDescriptor();
-        entity_       = false;
+        entity_       = ejbContext instanceof EntityContext;
         timedObjectPrimaryKey_   = null;
-    }
-
-    public EJBTimerServiceWrapper(
-            EJBTimerService persistentTimerService,
-            EJBTimerService nonPersistentTimerService,
-            EntityContext entityContext) {
-        this(persistentTimerService, nonPersistentTimerService, ((EJBContextImpl) entityContext));
-        entity_ = true;
-        // Delay access of primary key since this might have been called 
-        // from ejbCreate
-        timedObjectPrimaryKey_ = null;
     }
 
     @Override


### PR DESCRIPTION
In some previous refactorings the invocation of the second constructor
disappeared, replacing with runtime instance check.

Fixes all 35 failures in `ejb/ee/timer`, and thus entire `ejb` suite