### PR TITLE
PAYARA-3939 Remove Google Guava

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
@@ -41,7 +41,6 @@
 
 package org.glassfish.admingui.common.handlers;
 
-import com.google.common.collect.ImmutableMap;
 import com.sun.enterprise.universal.xml.MiniXmlParser.JvmOption;
 import com.sun.jsftemplating.annotation.Handler;  
 import com.sun.jsftemplating.annotation.HandlerInput; 
@@ -792,15 +791,17 @@ public class SecurityHandler {
                 for (Map<String, String> origOption : list){
                     newOptions.add(origOption);
                 }
-                newOptions.add(ImmutableMap.of(JVM_OPTION, JVM_OPTION_SECURITY_MANAGER));
+                newOptions.add(Collections.singletonMap(JVM_OPTION, JVM_OPTION_SECURITY_MANAGER));
             } else {
                 for (Map<String, String> origOption : list){
                     String str = origOption.get(JVM_OPTION);
                     if (! (str.trim().equals(JVM_OPTION_SECURITY_MANAGER) ||
                             str.trim().startsWith(JVM_OPTION_SECURITY_MANAGER_WITH_EQUAL))){
-                       newOptions.add(ImmutableMap.of(JVM_OPTION, str,
-                               MIN_VERSION, origOption.get(MIN_VERSION),
-                               MAX_VERSION, origOption.get(MAX_VERSION)));
+                        Map<String, String> jvmOptions = new HashMap<>(3);
+                        jvmOptions.put(JVM_OPTION, str);
+                        jvmOptions.put(MIN_VERSION, origOption.get(MIN_VERSION));
+                        jvmOptions.put(MAX_VERSION, origOption.get(MAX_VERSION));
+                        newOptions.add(Collections.unmodifiableMap(jvmOptions));
                     }
                 }
             }

--- a/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/BaseSeleniumTestClass.java
+++ b/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/BaseSeleniumTestClass.java
@@ -37,11 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates] 
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] 
 
 package org.glassfish.admingui.devtests;
 
-import com.google.common.base.Function;
 import com.thoughtworks.selenium.Selenium;
 import com.thoughtworks.selenium.SeleniumException;
 import org.junit.*;
@@ -53,9 +52,9 @@ import java.net.URL;
 import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.glassfish.admingui.common.util.RestUtil;
 import org.glassfish.admingui.devtests.util.ElementFinder;
 import org.glassfish.admingui.devtests.util.SeleniumHelper;
 import org.openqa.selenium.support.ui.ExpectedCondition;

--- a/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/util/ElementFinder.java
+++ b/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/util/ElementFinder.java
@@ -37,10 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] Payara Foundation and/or affiliates
+
 package org.glassfish.admingui.devtests.util;
 
-import com.google.common.base.Function;
-import com.thoughtworks.selenium.Wait;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openqa.selenium.By;

--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -253,6 +253,12 @@
             <groupId>org.glassfish.main.security</groupId>
             <artifactId>webservices.security</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>hk2-metadata-generator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -272,7 +278,7 @@
             <artifactId>connectors-inbound-runtime</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        
         
         <dependency>
             <groupId>org.glassfish.main.orb</groupId>

--- a/appserver/deployment/dol/pom.xml
+++ b/appserver/deployment/dol/pom.xml
@@ -168,10 +168,6 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.api</groupId>
             <artifactId>payara-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -79,9 +79,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.security.common.Role;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableSet;
 import com.sun.enterprise.deployment.node.ApplicationNode;
 import com.sun.enterprise.deployment.runtime.application.wls.ApplicationParam;
 import com.sun.enterprise.deployment.runtime.common.SecurityRoleMapping;
@@ -98,6 +95,8 @@ import com.sun.enterprise.deployment.util.ComponentVisitor;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.StringUtils;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Objects of this type encapsulate the data and behaviour of a J2EE
@@ -796,8 +795,7 @@ public class Application extends CommonResourceBundleDescriptor
     }
 
     public void addScanningInclusions(List<String> inclusions, String libDir) {
-        this.scanningInclusions.addAll(FluentIterable.from(inclusions)
-                .transform(new WildcardToRegex(libDir)).toList());
+        this.scanningInclusions.addAll(inclusions.stream().map(new WildcardToRegex(libDir)).collect(Collectors.toList()));
     }
 
     public void addScanningExclusions(List<String> exclusions) {
@@ -805,8 +803,7 @@ public class Application extends CommonResourceBundleDescriptor
     }
 
     public void addScanningExclusions(List<String> exclusions, String libDir) {
-        this.scanningExclusions.addAll(FluentIterable.from(exclusions)
-                .transform(new WildcardToRegex(libDir)).toList());
+        this.scanningExclusions.addAll(exclusions.stream().map(new WildcardToRegex(libDir)).collect(Collectors.toList()));
     }
 
     public boolean isWhitelistEnabled() {
@@ -814,7 +811,7 @@ public class Application extends CommonResourceBundleDescriptor
     }
 
     public Set<String> getWhitelistPackages() {
-        return ImmutableSet.copyOf(whitelistPackages);
+        return Collections.unmodifiableSet(whitelistPackages);
     }
 
     public void addWhitelistPackage(String aPackage) {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/runtime/application/gf/ApplicationRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/runtime/application/gf/ApplicationRuntimeNode.java
@@ -37,11 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.deployment.node.runtime.application.gf;
 
-import com.google.common.collect.ImmutableList;
 import com.sun.enterprise.config.serverbeans.ConfigBeansUtilities;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.ResourcePropertyDescriptor;
@@ -56,6 +55,7 @@ import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.deployment.xml.DTDRegistry;
 import com.sun.enterprise.deployment.xml.RuntimeTagNames;
 import com.sun.enterprise.deployment.xml.WebServicesTagNames;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.glassfish.deployment.common.ModuleDescriptor;
@@ -193,10 +193,10 @@ public class ApplicationRuntimeNode extends RuntimeBundleNode<Application> {
             // ignore, handled in EarHandler.java
 	} else 
 	if (element.getQName().equals(RuntimeTagNames.PAYARA_SCANNING_EXCLUDE)) {
-            descriptor.addScanningExclusions(ImmutableList.of(value));
+            descriptor.addScanningExclusions(Collections.singletonList(value));
 	} else
 	if (element.getQName().equals(RuntimeTagNames.PAYARA_SCANNING_INCLUDE)) {
-            descriptor.addScanningInclusions(ImmutableList.of(value));
+            descriptor.addScanningInclusions(Collections.singletonList(value));
 	} else
 	if (element.getQName().equals(RuntimeTagNames.PAYARA_WHITELIST_PACKAGE)) {
             descriptor.addWhitelistPackage(value);

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
@@ -37,16 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.deployment.util;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -109,7 +103,10 @@ import com.sun.enterprise.deployment.io.DescriptorConstants;
 import com.sun.enterprise.deployment.node.XMLElement;
 import com.sun.enterprise.deployment.xml.TagNames;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.glassfish.logging.annotation.LogMessageInfo;
@@ -166,18 +163,9 @@ public class DOLUtils {
     private static final String IGNORE_WLSDD = "ignore.wlsdd";
 
     private static final String ID_SEPARATOR = "_";
-    private static final Set<String> SYSTEM_PACKAGES_ =
-            ImmutableSet.of("com.sun", "org.glassfish", "org.apache.jasper", "fish.payara", "com.ibm.jbatch",
-                            "org.hibernate.validator", "org.jboss.weld", "com.ctc.wstx",
-                            "java", "javax");
-    private static final Set<String> SYSTEM_PACKAGES = ImmutableSet.copyOf(Collections2.transform(SYSTEM_PACKAGES_,
-            new Function<String, String>() {
-        @Override
-        public String apply(String input) {
-            return input + ".";
-        }
-    }));
-
+    private static final String[] SYSTEM_PACKAGES = {"com.sun.", "org.glassfish.", "org.apache.jasper.", "fish.payara.", "com.ibm.jbatch.",
+                            "org.hibernate.validator.", "org.jboss.weld.", "com.ctc.wstx.", "java.", "javax."};
+    
     /** no need to creates new DOLUtils */
     private DOLUtils() {
     }
@@ -224,8 +212,9 @@ public class DOLUtils {
      * @return 
      */
     public static boolean isScanningAllowed(Application app, String entryName) {
-        boolean included = !FluentIterable.from(app.getScanningExclusions()).anyMatch(new MatchingPredicate(entryName));
-        return included |= FluentIterable.from(app.getScanningInclusions()).anyMatch(new MatchingPredicate(entryName));
+        
+        boolean included = !app.getScanningExclusions().stream().anyMatch(new MatchingPredicate(entryName));
+        return included |= app.getScanningInclusions().stream().anyMatch(new MatchingPredicate(entryName));
     }
 
     private static class MatchingPredicate implements Predicate<Pattern> {
@@ -236,7 +225,7 @@ public class DOLUtils {
         }
 
         @Override
-        public boolean apply(Pattern input) {
+        public boolean test(Pattern input) {
             return input.matcher(entryName).matches();
         }
     }
@@ -1009,7 +998,9 @@ public class DOLUtils {
      * @return true if the class is white-listed
      */
     public static boolean isWhiteListed(Application application, String className) {
-        for (String packageName : Iterables.concat(application.getWhitelistPackages(), SYSTEM_PACKAGES)) {
+        List<String> packages = Arrays.asList(SYSTEM_PACKAGES);
+        packages.addAll(application.getWhitelistPackages());
+        for (String packageName : packages) {
             if (className.startsWith(packageName)) {
                 return true;
             }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
@@ -998,9 +998,12 @@ public class DOLUtils {
      * @return true if the class is white-listed
      */
     public static boolean isWhiteListed(Application application, String className) {
-        List<String> packages = Arrays.asList(SYSTEM_PACKAGES);
-        packages.addAll(application.getWhitelistPackages());
-        for (String packageName : packages) {
+        for (String packageName : SYSTEM_PACKAGES) {
+            if (className.startsWith(packageName)) {
+                return true;
+            }
+        }
+        for (String packageName : application.getWhitelistPackages()) {
             if (className.startsWith(packageName)) {
                 return true;
             }

--- a/appserver/deployment/javaee-full/pom.xml
+++ b/appserver/deployment/javaee-full/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-   Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+   Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -159,10 +159,6 @@
             <groupId>org.glassfish.main.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
-        </dependency>        
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
    </dependencies>
 </project>

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
@@ -129,14 +129,7 @@ public class RuntimeOptions {
             }
         }
         if (invalidArgs.size() > 0) {
-            StringBuilder invalid = new StringBuilder();
-            for (String invalidArgument: invalidArgs) {
-                if (invalidArgument != null) {
-                    invalid.append(invalidArgument);
-                    invalid.append(',');
-                }
-            }
-            throw new ValidationException(MessageFormat.format(commandlogstrings.getString("notValidArguments"), invalid.toString()));
+            throw new ValidationException(MessageFormat.format(commandlogstrings.getString("notValidArguments"), String.join(",", invalidArgs)));
         }
     }
     

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
@@ -39,8 +39,6 @@
  */
 package fish.payara.micro.cmd.options;
 
-import com.google.common.base.Joiner;
-
 import java.text.MessageFormat;
 import java.util.*;
 
@@ -131,8 +129,14 @@ public class RuntimeOptions {
             }
         }
         if (invalidArgs.size() > 0) {
-            String argsStr = Joiner.on(",").skipNulls().join(invalidArgs);
-            throw new ValidationException(MessageFormat.format(commandlogstrings.getString("notValidArguments"), argsStr));
+            StringBuilder invalid = new StringBuilder();
+            for (String invalidArgument: invalidArgs) {
+                if (invalidArgument != null) {
+                    invalid.append(invalidArgument);
+                    invalid.append(',');
+                }
+            }
+            throw new ValidationException(MessageFormat.format(commandlogstrings.getString("notValidArguments"), invalid.toString()));
         }
     }
     

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,7 +39,6 @@
  */
 package fish.payara.micro.impl;
 
-import com.google.common.io.Files;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -48,6 +47,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -235,7 +235,7 @@ public class UberJarCreator {
                         }
                         libEntry.setCrc(check.getChecksum().getValue());
                         jos.putNextEntry(libEntry);
-                        Files.copy(lib, jos);
+                        Files.copy(lib.toPath(), jos);
                         jos.flush();
                         jos.closeEntry();
                     }
@@ -246,7 +246,7 @@ public class UberJarCreator {
                 for (File deployment : deployments) {
                     JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + deployment.getName());
                     jos.putNextEntry(deploymentEntry);
-                    Files.copy(deployment, jos);
+                    Files.copy(deployment.toPath(), jos);
                     jos.flush();
                     jos.closeEntry();
                 }
@@ -257,7 +257,7 @@ public class UberJarCreator {
                     if (deployment.isFile()) {
                         JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + deployment.getName());
                         jos.putNextEntry(deploymentEntry);
-                        Files.copy(deployment, jos);
+                        Files.copy(deployment.toPath(), jos);
                         jos.flush();
                         jos.closeEntry();
 
@@ -272,7 +272,7 @@ public class UberJarCreator {
 
                         JarEntry deploymentEntry = new JarEntry(file.getCanonicalPath().replace(basePath, ""));
                         jos.putNextEntry(deploymentEntry);
-                        Files.copy(file, jos);
+                        Files.copy(file.toPath(), jos);
                         jos.flush();
                         jos.closeEntry();
                 }
@@ -317,7 +317,7 @@ public class UberJarCreator {
             if (alternateHZConfigFile != null) {
                 JarEntry hzXml = new JarEntry("MICRO-INF/domain/hzconfig.xml");
                 jos.putNextEntry(hzXml);
-                Files.copy(alternateHZConfigFile, jos);
+                Files.copy(alternateHZConfigFile.toPath(), jos);
                 jos.flush();
                 jos.closeEntry();
 
@@ -342,7 +342,7 @@ public class UberJarCreator {
                         } else if (domainFile.getName().equals("logging.properties") && (loggingPropertiesFile != null)) {
                             domainFile = loggingPropertiesFile;
                         }
-                        Files.copy(domainFile, jos);
+                        Files.copy(domainFile.toPath(), jos);
                         jos.flush();
                         jos.closeEntry();
                     } else if (domainFile.isDirectory() && domainFile.getName().equals("branding")) {
@@ -351,7 +351,7 @@ public class UberJarCreator {
                         for (File brandingFile : domainFile.listFiles()) {
                             JarEntry brandingFileEntry = new JarEntry("MICRO-INF/domain/branding/" + brandingFile.getName());
                             jos.putNextEntry(brandingFileEntry);
-                            Files.copy(brandingFile, jos);
+                            Files.copy(brandingFile.toPath(), jos);
                             jos.flush();
                             jos.closeEntry();
                         }
@@ -373,7 +373,7 @@ public class UberJarCreator {
                                 }
                                 appEntry.setCrc(check.getChecksum().getValue());
                                 jos.putNextEntry(appEntry);
-                                Files.copy(app, jos);
+                                Files.copy(app.toPath(), jos);
                                 jos.flush();
                                 jos.closeEntry();
                             }

--- a/appserver/packager/glassfish-jcdi/pom.xml
+++ b/appserver/packager/glassfish-jcdi/pom.xml
@@ -149,8 +149,9 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.7.0</version>
         </dependency>
         
         <!-- CDI extension to activate Bean Validation -->

--- a/appserver/packager/glassfish-jcdi/pom.xml
+++ b/appserver/packager/glassfish-jcdi/pom.xml
@@ -148,11 +148,6 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-            <version>2.7.0</version>
-        </dependency>
         
         <!-- CDI extension to activate Bean Validation -->
         <dependency>

--- a/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE-WEB-PROFILE.txt
+++ b/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE-WEB-PROFILE.txt
@@ -37,7 +37,6 @@ Hibernate Validator 5.0
 Classmate 0.80
 IBM Batch
 Dependency Injection 1.0
-Google-collections guava 1.0
 JType 0.1.0
 IzPack 4.3.3
 ant-contrib 1.0b5

--- a/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
+++ b/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
@@ -37,7 +37,6 @@ Hibernate Validator 5.0
 Classmate 0.80
 IBM Batch
 Dependency Injection 1.0
-Google-collections guava 1.0
 JType 0.1.0
 IzPack 4.3.3
 ant-contrib 1.0b5

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/GetJMXMonitoringConfiguration.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/GetJMXMonitoringConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,8 +39,6 @@
  */
 package fish.payara.jmx.monitoring.admin;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.util.ColumnFormatter;
@@ -56,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
@@ -167,12 +166,9 @@ public class GetJMXMonitoringConfiguration implements AdminCommand {
         actionReport.setExtraProperties(extraProps);
 
         if (!monitoringConfig.getNotifierList().isEmpty()) {
-            List<Class<Notifier>> notifierClassList = Lists.transform(monitoringConfig.getNotifierList(), new Function<Notifier, Class<Notifier>>() {
-                @Override
-                public Class<Notifier> apply(Notifier input) {
-                    return resolveNotifierClass(input);
-                }
-            });
+            List<Class<Notifier>> notifierClassList = monitoringConfig.getNotifierList().stream().map((input) -> {
+                return resolveNotifierClass(input);
+            }).collect(Collectors.toList());
 
             Properties notifierProps = new Properties();
             for (ServiceHandle<BaseNotifierService> serviceHandle : allNotifierServiceHandles) {

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JwtTokenParser.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JwtTokenParser.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.nimbusds.jose.JWSAlgorithm.RS256;
 import static java.util.Arrays.asList;
 import static javax.json.Json.createObjectBuilder;
@@ -97,7 +96,9 @@ public class JwtTokenParser {
     }
     
     public JsonWebTokenImpl verify(String issuer, PublicKey publicKey) throws Exception {
-        checkState(signedJWT != null, "No parsed SignedJWT.");
+        if (signedJWT == null) {
+            throw new IllegalStateException("No parsed SignedJWT.");
+        }
         
         // 1.0 4.1 alg + MP-JWT 1.0 6.1 1
         if (!signedJWT.getHeader().getAlgorithm().equals(RS256)) {
@@ -144,7 +145,9 @@ public class JwtTokenParser {
     }
     
     public String getKeyID() {
-        checkState(signedJWT != null, "No parsed SignedJWT.");
+        if (signedJWT == null) {
+            throw new IllegalStateException("No parsed SignedJWT.");
+        }
         return signedJWT.getHeader().getKeyID();
     }
     

--- a/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotificationConfigurer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,8 +39,7 @@
  */
 package fish.payara.notification.datadog;
 
-import com.google.common.base.Strings;
-import fish.payara.notification.datadog.DatadogNotifierConfiguration;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -71,6 +70,7 @@ public class DatadogNotificationConfigurer extends BaseNotificationConfigurer<Da
     @Param(name = "key")
     private String key;
 
+    @Override
     protected void applyValues(DatadogNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -78,7 +78,7 @@ public class DatadogNotificationConfigurer extends BaseNotificationConfigurer<Da
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(key)) {
+        if(StringUtils.ok(key)) {
             configuration.setKey(key);
         }
     }

--- a/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotifierService.java
@@ -41,8 +41,10 @@ package fish.payara.notification.datadog;
 
 import fish.payara.nucleus.notification.configuration.DatadogNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
+import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.api.messaging.MessageReceiver;
 import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
@@ -52,6 +54,7 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service(name = "service-datadog")
 @RunLevel(StartupRunLevel.VAL)
+@MessageReceiver
 public class DatadogNotifierService extends QueueBasedNotifierService<DatadogNotificationEvent,
         DatadogNotifier,
         DatadogNotifierConfiguration,
@@ -64,10 +67,12 @@ public class DatadogNotifierService extends QueueBasedNotifierService<DatadogNot
 }
 
     @Override
-    public void handleNotification(@SubscribeTo DatadogNotificationEvent event) {
-        if (executionOptions != null && executionOptions.isEnabled()) {
-            DatadogMessage message = new DatadogMessage(event, event.getSubject(), event.getMessage());
-            queue.addMessage(message);
+    public void handleNotification(@SubscribeTo NotificationEvent event) {
+        if (event instanceof DatadogNotificationEvent) {
+            if (executionOptions != null && executionOptions.isEnabled()) {
+                DatadogMessage message = new DatadogMessage((DatadogNotificationEvent) event, event.getSubject(), event.getMessage());
+                queue.addMessage(message);
+            }
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotifierService.java
@@ -68,11 +68,9 @@ public class DatadogNotifierService extends QueueBasedNotifierService<DatadogNot
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof DatadogNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                DatadogMessage message = new DatadogMessage((DatadogNotificationEvent) event, event.getSubject(), event.getMessage());
-                queue.addMessage(message);
-            }
+        if (event instanceof DatadogNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            DatadogMessage message = new DatadogMessage((DatadogNotificationEvent) event, event.getSubject(), event.getMessage());
+            queue.addMessage(message);
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-datadog-core/src/main/java/fish/payara/notification/datadog/DatadogNotifierService.java
@@ -39,11 +39,11 @@
  */
 package fish.payara.notification.datadog;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.DatadogNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
@@ -64,8 +64,7 @@ public class DatadogNotifierService extends QueueBasedNotifierService<DatadogNot
 }
 
     @Override
-    @Subscribe
-    public void handleNotification(DatadogNotificationEvent event) {
+    public void handleNotification(@SubscribeTo DatadogNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             DatadogMessage message = new DatadogMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);
@@ -74,7 +73,7 @@ public class DatadogNotifierService extends QueueBasedNotifierService<DatadogNot
 
     @Override
     public void bootstrap() {
-        register(NotifierType.DATADOG, DatadogNotifier.class, DatadogNotifierConfiguration.class, this);
+        register(NotifierType.DATADOG, DatadogNotifier.class, DatadogNotifierConfiguration.class);
         executionOptions = (DatadogNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
         if (executionOptions != null && executionOptions.isEnabled()) {
             initializeExecutor();

--- a/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,11 +38,9 @@
  */
 package fish.payara.notification.email;
 
-import com.google.common.base.Strings;
-import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
-import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.*;
 import org.glassfish.config.support.CommandTarget;
@@ -76,6 +74,7 @@ public class EmailNotificationConfigurer extends BaseNotificationConfigurer<Emai
     @Pattern(regexp = "\\S+@\\S+")
     private String to;
 
+    @Override
     protected void applyValues(EmailNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -83,10 +82,10 @@ public class EmailNotificationConfigurer extends BaseNotificationConfigurer<Emai
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(jndiName)) {
+        if(StringUtils.ok(jndiName)) {
             configuration.setJndiName(jndiName);
         }
-        if(!Strings.isNullOrEmpty(to)) {
+        if(StringUtils.ok(to)) {
             configuration.setTo(to);
         }
     }

--- a/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotifierService.java
@@ -41,6 +41,7 @@ package fish.payara.notification.email;
 
 import fish.payara.nucleus.notification.configuration.EmailNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
+import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.hk2.runlevel.RunLevel;
@@ -51,6 +52,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.MessageReceiver;
 import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
@@ -58,6 +60,7 @@ import org.glassfish.hk2.api.messaging.SubscribeTo;
  */
 @Service(name = "service-email")
 @RunLevel(StartupRunLevel.VAL)
+@MessageReceiver
 public class EmailNotifierService extends QueueBasedNotifierService<EmailNotificationEvent,
         EmailNotifier,
         EmailNotifierConfiguration,
@@ -72,10 +75,12 @@ public class EmailNotifierService extends QueueBasedNotifierService<EmailNotific
     }
 
     @Override
-    public void handleNotification(@SubscribeTo EmailNotificationEvent event) {
-        if (executionOptions != null && executionOptions.isEnabled()) {
-            EmailMessage message = new EmailMessage(event, event.getSubject(), event.getMessage());
-            queue.addMessage(message);
+    public void handleNotification(@SubscribeTo NotificationEvent event) {
+        if (event instanceof EmailNotificationEvent) {
+            if (executionOptions != null && executionOptions.isEnabled()) {
+                EmailMessage message = new EmailMessage((EmailNotificationEvent) event, event.getSubject(), event.getMessage());
+                queue.addMessage(message);
+            }
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotifierService.java
@@ -76,11 +76,9 @@ public class EmailNotifierService extends QueueBasedNotifierService<EmailNotific
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof EmailNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                EmailMessage message = new EmailMessage((EmailNotificationEvent) event, event.getSubject(), event.getMessage());
-                queue.addMessage(message);
-            }
+        if (event instanceof EmailNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            EmailMessage message = new EmailMessage((EmailNotificationEvent) event, event.getSubject(), event.getMessage());
+            queue.addMessage(message);
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-email-core/src/main/java/fish/payara/notification/email/EmailNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,12 +39,10 @@
  */
 package fish.payara.notification.email;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.EmailNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
-import org.glassfish.api.event.EventTypes;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
@@ -53,6 +51,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
  * @author mertcaliskan
@@ -73,8 +72,7 @@ public class EmailNotifierService extends QueueBasedNotifierService<EmailNotific
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(EmailNotificationEvent event) {
+    public void handleNotification(@SubscribeTo EmailNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             EmailMessage message = new EmailMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);
@@ -83,7 +81,7 @@ public class EmailNotifierService extends QueueBasedNotifierService<EmailNotific
 
     @Override
     public void bootstrap() {
-        register(NotifierType.EMAIL, EmailNotifier.class, EmailNotifierConfiguration.class, this);
+        register(NotifierType.EMAIL, EmailNotifier.class, EmailNotifierConfiguration.class);
 
         executionOptions = (EmailNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
         if(executionOptions != null && executionOptions.isEnabled()) {

--- a/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotificationConfigurer.java
@@ -38,7 +38,7 @@
  */
 package fish.payara.notification.hipchat;
 
-import com.google.common.base.Strings;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -72,6 +72,7 @@ public class HipchatNotificationConfigurer extends BaseNotificationConfigurer<Hi
     @Param(name = "token")
     private String token;
 
+    @Override
     protected void applyValues(HipchatNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -79,11 +80,11 @@ public class HipchatNotificationConfigurer extends BaseNotificationConfigurer<Hi
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(roomName)) {
+        if(StringUtils.ok(roomName)) {
             configuration.setRoomName(roomName);
         }
 
-        if(!Strings.isNullOrEmpty(token)) {
+        if(StringUtils.ok(token)) {
             configuration.setToken(token);
         }
     }

--- a/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,11 +39,11 @@
  */
 package fish.payara.notification.hipchat;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.HipchatNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
@@ -64,8 +64,7 @@ public class HipchatNotifierService extends QueueBasedNotifierService<HipchatNot
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(HipchatNotificationEvent event) {
+    public void handleNotification(@SubscribeTo HipchatNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             HipchatMessage message = new HipchatMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);
@@ -74,7 +73,7 @@ public class HipchatNotifierService extends QueueBasedNotifierService<HipchatNot
 
     @Override
     public void bootstrap() {
-        register(NotifierType.HIPCHAT, HipchatNotifier.class, HipchatNotifierConfiguration.class, this);
+        register(NotifierType.HIPCHAT, HipchatNotifier.class, HipchatNotifierConfiguration.class);
         executionOptions = (HipchatNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
         if (executionOptions != null && executionOptions.isEnabled()){
             initializeExecutor();

--- a/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotifierService.java
@@ -68,11 +68,9 @@ public class HipchatNotifierService extends QueueBasedNotifierService<HipchatNot
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof HipchatNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                HipchatMessage message = new HipchatMessage((HipchatNotificationEvent) event, event.getSubject(), event.getMessage());
-                queue.addMessage(message);
-            }
+        if (event instanceof HipchatNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            HipchatMessage message = new HipchatMessage((HipchatNotificationEvent) event, event.getSubject(), event.getMessage());
+            queue.addMessage(message);
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-hipchat-core/src/main/java/fish/payara/notification/hipchat/HipchatNotifierService.java
@@ -41,8 +41,10 @@ package fish.payara.notification.hipchat;
 
 import fish.payara.nucleus.notification.configuration.HipchatNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
+import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.api.messaging.MessageReceiver;
 import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
@@ -52,6 +54,7 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service(name = "service-hipchat")
 @RunLevel(StartupRunLevel.VAL)
+@MessageReceiver
 public class HipchatNotifierService extends QueueBasedNotifierService<HipchatNotificationEvent,
         HipchatNotifier,
         HipchatNotifierConfiguration,
@@ -64,10 +67,12 @@ public class HipchatNotifierService extends QueueBasedNotifierService<HipchatNot
     }
 
     @Override
-    public void handleNotification(@SubscribeTo HipchatNotificationEvent event) {
-        if (executionOptions != null && executionOptions.isEnabled()) {
-            HipchatMessage message = new HipchatMessage(event, event.getSubject(), event.getMessage());
-            queue.addMessage(message);
+    public void handleNotification(@SubscribeTo NotificationEvent event) {
+        if (event instanceof HipchatNotificationEvent) {
+            if (executionOptions != null && executionOptions.isEnabled()) {
+                HipchatMessage message = new HipchatMessage((HipchatNotificationEvent) event, event.getSubject(), event.getMessage());
+                queue.addMessage(message);
+            }
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,7 @@
  */
 package fish.payara.notification.jms;
 
-import com.google.common.base.Strings;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -89,6 +89,7 @@ public class JmsNotificationConfigurer extends BaseNotificationConfigurer<JmsNot
         super.execute(context);
     }
 
+    @Override
     protected void applyValues(JmsNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -96,22 +97,22 @@ public class JmsNotificationConfigurer extends BaseNotificationConfigurer<JmsNot
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(contextFactoryClass )) {
+        if(StringUtils.ok(contextFactoryClass )) {
             configuration.setContextFactoryClass(contextFactoryClass);
         }
-        if(!Strings.isNullOrEmpty(connectionFactoryName)) {
+        if(StringUtils.ok(connectionFactoryName)) {
             configuration.setConnectionFactoryName(connectionFactoryName);
         }
-        if(!Strings.isNullOrEmpty(queueName)) {
+        if(StringUtils.ok(queueName)) {
             configuration.setQueueName(queueName);
         }
-        if(!Strings.isNullOrEmpty(url)) {
+        if(StringUtils.ok(url)) {
             configuration.setUrl(url);
         }
-        if(!Strings.isNullOrEmpty(username)) {
+        if(StringUtils.ok(username)) {
             configuration.setUsername(username);
         }
-        if(!Strings.isNullOrEmpty(password)) {
+        if(StringUtils.ok(password)) {
             configuration.setPassword(password);
         }
     }

--- a/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotifierService.java
@@ -38,8 +38,10 @@
  */
 package fish.payara.notification.jms;
 
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.configuration.JmsNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
+import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.hk2.runlevel.RunLevel;
@@ -55,12 +57,15 @@ import javax.naming.NoInitialContextException;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.MessageReceiver;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
  * @author mertcaliskan
  */
 @Service(name = "service-jms")
 @RunLevel(StartupRunLevel.VAL)
+@MessageReceiver
 public class JmsNotifierService extends QueueBasedNotifierService<JmsNotificationEvent,
         JmsNotifier,
         JmsNotifierConfiguration,
@@ -122,10 +127,12 @@ public class JmsNotifierService extends QueueBasedNotifierService<JmsNotificatio
     }
 
     @Override
-    public void handleNotification(@SubscribeTo JmsNotificationEvent event) {
-        if (executionOptions != null && executionOptions.isEnabled()) {
-            JmsMessage message = new JmsMessage(event, event.getSubject(), event.getMessage());
-            queue.addMessage(message);
+    public void handleNotification(@SubscribeTo NotificationEvent event) {
+        if (event instanceof JmsNotificationEvent) {
+            if (executionOptions != null && executionOptions.isEnabled()) {
+                JmsMessage message = new JmsMessage((JmsNotificationEvent) event, event.getSubject(), event.getMessage());
+                queue.addMessage(message);
+            }
         }
     }
 }

--- a/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotifierService.java
@@ -128,11 +128,9 @@ public class JmsNotifierService extends QueueBasedNotifierService<JmsNotificatio
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof JmsNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                JmsMessage message = new JmsMessage((JmsNotificationEvent) event, event.getSubject(), event.getMessage());
-                queue.addMessage(message);
-            }
+        if (event instanceof JmsNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            JmsMessage message = new JmsMessage((JmsNotificationEvent) event, event.getSubject(), event.getMessage());
+            queue.addMessage(message);
         }
     }
 }

--- a/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-jms-core/src/main/java/fish/payara/notification/jms/JmsNotifierService.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,8 +38,6 @@
  */
 package fish.payara.notification.jms;
 
-import com.google.common.base.Strings;
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.JmsNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
@@ -78,7 +76,7 @@ public class JmsNotifierService extends QueueBasedNotifierService<JmsNotificatio
 
     @Override
     public void bootstrap() {
-        register(NotifierType.JMS, JmsNotifier.class, JmsNotifierConfiguration.class, this);
+        register(NotifierType.JMS, JmsNotifier.class, JmsNotifierConfiguration.class);
 
         try {
             executionOptions = (JmsNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
@@ -87,19 +85,19 @@ public class JmsNotifierService extends QueueBasedNotifierService<JmsNotificatio
                 initializeExecutor();
 
                 final Properties env = new Properties();
-                if (!Strings.isNullOrEmpty(executionOptions.getContextFactoryClass())) {
+                if (StringUtils.ok(executionOptions.getContextFactoryClass())) {
                     env.put(Context.INITIAL_CONTEXT_FACTORY, executionOptions.getContextFactoryClass());
                 }
-                if (!Strings.isNullOrEmpty(executionOptions.getUrl())) {
+                if (StringUtils.ok(executionOptions.getUrl())) {
                     env.put(Context.PROVIDER_URL, executionOptions.getUrl());
                 }
-                if (!Strings.isNullOrEmpty(executionOptions.getUsername())) {
+                if (StringUtils.ok(executionOptions.getUsername())) {
                     env.put(Context.SECURITY_PRINCIPAL, executionOptions.getUsername());
                 }
-                if (!Strings.isNullOrEmpty(executionOptions.getPassword())) {
+                if (StringUtils.ok(executionOptions.getPassword())) {
                     env.put(Context.SECURITY_CREDENTIALS, executionOptions.getPassword());
                 }
-                if (!Strings.isNullOrEmpty(executionOptions.getConnectionFactoryName())) {
+                if (StringUtils.ok(executionOptions.getConnectionFactoryName())) {
                     try {
                         InitialContext ctx = new InitialContext(env);
                         ConnectionFactory connectionFactory =
@@ -124,8 +122,7 @@ public class JmsNotifierService extends QueueBasedNotifierService<JmsNotificatio
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(JmsNotificationEvent event) {
+    public void handleNotification(@SubscribeTo JmsNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             JmsMessage message = new JmsMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);

--- a/appserver/payara-appserver-modules/notification-newrelic-core/src/main/java/fish/payara/notification/newrelic/NewRelicNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-newrelic-core/src/main/java/fish/payara/notification/newrelic/NewRelicNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,7 @@
  */
 package fish.payara.notification.newrelic;
 
-import com.google.common.base.Strings;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -72,6 +72,7 @@ public class NewRelicNotificationConfigurer extends BaseNotificationConfigurer<N
     @Param(name = "accountId", alias = "accountid")
     private String accountId;
 
+    @Override
     protected void applyValues(NewRelicNotifierConfiguration configuration) throws PropertyVetoException {
         if (this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -79,10 +80,10 @@ public class NewRelicNotificationConfigurer extends BaseNotificationConfigurer<N
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if (!Strings.isNullOrEmpty(key)) {
+        if (StringUtils.ok(key)) {
             configuration.setKey(key);
         }
-        if (!Strings.isNullOrEmpty(accountId)) {
+        if (StringUtils.ok(accountId)) {
             configuration.setAccountId(accountId);
         }
     }

--- a/appserver/payara-appserver-modules/notification-newrelic-core/src/main/java/fish/payara/notification/newrelic/NewRelicNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-newrelic-core/src/main/java/fish/payara/notification/newrelic/NewRelicNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,11 +39,11 @@
  */
 package fish.payara.notification.newrelic;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.NewRelicNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
@@ -64,8 +64,7 @@ public class NewRelicNotifierService extends QueueBasedNotifierService<NewRelicN
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(NewRelicNotificationEvent event) {
+    public void handleNotification(@SubscribeTo NewRelicNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             NewRelicEventMessage message = new NewRelicEventMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);

--- a/appserver/payara-appserver-modules/notification-newrelic-core/src/main/java/fish/payara/notification/newrelic/NewRelicNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-newrelic-core/src/main/java/fish/payara/notification/newrelic/NewRelicNotifierService.java
@@ -68,11 +68,9 @@ public class NewRelicNotifierService extends QueueBasedNotifierService<NewRelicN
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof NewRelicNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                NewRelicEventMessage message = new NewRelicEventMessage((NewRelicNotificationEvent) event, event.getSubject(), event.getMessage());
-                queue.addMessage(message);
-            }
+        if (event instanceof NewRelicNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            NewRelicEventMessage message = new NewRelicEventMessage((NewRelicNotificationEvent) event, event.getSubject(), event.getMessage());
+            queue.addMessage(message);
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-slack-core/src/main/java/fish/payara/notification/slack/SlackNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-slack-core/src/main/java/fish/payara/notification/slack/SlackNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,7 @@
  */
 package fish.payara.notification.slack;
 
-import com.google.common.base.Strings;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -75,6 +75,7 @@ public class SlackNotificationConfigurer extends BaseNotificationConfigurer<Slac
     @Param(name = "token3")
     private String token3;
 
+    @Override
     protected void applyValues(SlackNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -82,13 +83,13 @@ public class SlackNotificationConfigurer extends BaseNotificationConfigurer<Slac
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(token1)) {
+        if(StringUtils.ok(token1)) {
             configuration.setToken1(token1);
         }
-        if(!Strings.isNullOrEmpty(token2)) {
+        if(StringUtils.ok(token2)) {
             configuration.setToken2(token2);
         }
-        if(!Strings.isNullOrEmpty(token3)) {
+        if(StringUtils.ok(token3)) {
             configuration.setToken3(token3);
         }
     }

--- a/appserver/payara-appserver-modules/notification-slack-core/src/main/java/fish/payara/notification/slack/SlackNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-slack-core/src/main/java/fish/payara/notification/slack/SlackNotifierService.java
@@ -68,11 +68,9 @@ public class SlackNotifierService extends QueueBasedNotifierService<SlackNotific
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof SlackNotificationEvent) {
-        if (executionOptions != null && executionOptions.isEnabled()) {
+        if (event instanceof SlackNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
             SlackMessage message = new SlackMessage((SlackNotificationEvent) event, event.getSubject(), event.getMessage());
             queue.addMessage(message);
-        }
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-slack-core/src/main/java/fish/payara/notification/slack/SlackNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-slack-core/src/main/java/fish/payara/notification/slack/SlackNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,12 +39,11 @@
  */
 package fish.payara.notification.slack;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.configuration.SlackNotifier;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
-import org.glassfish.api.event.EventTypes;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
@@ -65,8 +64,7 @@ public class SlackNotifierService extends QueueBasedNotifierService<SlackNotific
 }
 
     @Override
-    @Subscribe
-    public void handleNotification(SlackNotificationEvent event) {
+    public void handleNotification(@SubscribeTo SlackNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             SlackMessage message = new SlackMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);

--- a/appserver/payara-appserver-modules/notification-snmp-core/src/main/java/fish/payara/notification/snmp/SnmpNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-snmp-core/src/main/java/fish/payara/notification/snmp/SnmpNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,8 +38,7 @@
  */
 package fish.payara.notification.snmp;
 
-import com.google.common.base.Strings;
-import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -82,6 +81,7 @@ public class SnmpNotificationConfigurer extends BaseNotificationConfigurer<SnmpN
     @Param(name = "port", defaultValue = "162", optional = true)
     private Integer port;
 
+    @Override
     protected void applyValues(SnmpNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -89,16 +89,16 @@ public class SnmpNotificationConfigurer extends BaseNotificationConfigurer<SnmpN
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(community)) {
+        if(StringUtils.ok(community)) {
             configuration.setCommunity(community);
         }
-        if(!Strings.isNullOrEmpty(oid)) {
+        if(StringUtils.ok(oid)) {
             configuration.setOid(oid);
         }
-        if(!Strings.isNullOrEmpty(version)) {
+        if(StringUtils.ok(version)) {
             configuration.setVersion(version);
         }
-        if(!Strings.isNullOrEmpty(hostName)) {
+        if(StringUtils.ok(hostName)) {
             configuration.setHost(hostName);
         }
         if(port != null) {

--- a/appserver/payara-appserver-modules/notification-snmp-core/src/main/java/fish/payara/notification/snmp/SnmpNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-snmp-core/src/main/java/fish/payara/notification/snmp/SnmpNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2017] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,28 +39,24 @@
  */
 package fish.payara.notification.snmp;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.notification.snmp.exception.InvalidSnmpVersion;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.configuration.SnmpNotifier;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
-import org.glassfish.api.event.EventTypes;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 import org.snmp4j.CommunityTarget;
-import org.snmp4j.PDU;
 import org.snmp4j.Snmp;
 import org.snmp4j.TransportMapping;
 import org.snmp4j.mp.SnmpConstants;
 import org.snmp4j.smi.*;
 import org.snmp4j.transport.DefaultUdpTransportMapping;
-import org.snmp4j.util.DefaultPDUFactory;
 
 import java.io.IOException;
-import java.util.concurrent.ScheduledFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
  * @author mertcaliskan
@@ -85,8 +81,7 @@ public class SnmpNotifierService extends QueueBasedNotifierService<SnmpNotificat
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(SnmpNotificationEvent event) {
+    public void handleNotification(@SubscribeTo SnmpNotificationEvent event) {
         if (execOptions != null && execOptions.isEnabled()) {
             SnmpMessage message = new SnmpMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);

--- a/appserver/payara-appserver-modules/notification-snmp-core/src/main/java/fish/payara/notification/snmp/SnmpNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-snmp-core/src/main/java/fish/payara/notification/snmp/SnmpNotifierService.java
@@ -85,11 +85,9 @@ public class SnmpNotifierService extends QueueBasedNotifierService<SnmpNotificat
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof SnmpNotificationEvent) {
-        if (execOptions != null && execOptions.isEnabled()) {
+        if (event instanceof SnmpNotificationEvent && execOptions != null && execOptions.isEnabled()) {
             SnmpMessage message = new SnmpMessage((SnmpNotificationEvent) event, event.getSubject(), event.getMessage());
             queue.addMessage(message);
-        }
         }
     }
 

--- a/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/TestXmppNotifier.java
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/TestXmppNotifier.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2017] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -39,8 +39,8 @@
  */
 package fish.payara.notification.xmpp;
 
-import com.google.common.base.Strings;
 import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.BlockingQueueHandler;
 import fish.payara.nucleus.notification.TestNotifier;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
@@ -154,10 +154,10 @@ public class TestXmppNotifier extends TestNotifier {
         options.setHost(hostName);
         options.setPort(port);
         options.setServiceName(serviceName);
-        if (!Strings.isNullOrEmpty(username)){
+        if (StringUtils.ok(username)){
             options.setUsername(username);
         }
-        if (!Strings.isNullOrEmpty(password)){
+        if (StringUtils.ok(password)){
             options.setPassword(password);
         }
         options.setSecurityDisabled(securityDisabled);

--- a/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotificationConfigurer.java
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,7 @@
  */
 package fish.payara.notification.xmpp;
 
-import com.google.common.base.Strings;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;
@@ -87,6 +87,7 @@ public class XmppNotificationConfigurer extends BaseNotificationConfigurer<XmppN
     @Param(name = "roomId")
     private String roomId;
 
+    @Override
     protected void applyValues(XmppNotifierConfiguration configuration) throws PropertyVetoException {
         if(this.enabled != null) {
             configuration.enabled(this.enabled);
@@ -94,25 +95,25 @@ public class XmppNotificationConfigurer extends BaseNotificationConfigurer<XmppN
         if(this.noisy != null) {
             configuration.noisy(this.noisy);
         }
-        if(!Strings.isNullOrEmpty(hostName)) {
+        if(StringUtils.ok(hostName)) {
             configuration.host(hostName);
         }
         if(port != null) {
             configuration.port(String.valueOf(port));
         }
-        if(!Strings.isNullOrEmpty(serviceName)) {
+        if(StringUtils.ok(serviceName)) {
             configuration.serviceName(serviceName);
         }
-        if(!Strings.isNullOrEmpty(username)) {
+        if(StringUtils.ok(username)) {
             configuration.username(username);
         }
-        if(!Strings.isNullOrEmpty(password)) {
+        if(StringUtils.ok(password)) {
             configuration.password(password);
         }
         if(securityDisabled != null) {
             configuration.securityDisabled(String.valueOf(securityDisabled));
         }
-        if(!Strings.isNullOrEmpty(roomId)) {
+        if(StringUtils.ok(roomId)) {
             configuration.roomId(roomId);
         }
     }

--- a/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -126,11 +126,9 @@ public class XmppNotifierService extends QueueBasedNotifierService<XmppNotificat
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof XmppNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                XmppMessage message = new XmppMessage((XmppNotificationEvent) event, event.getSubject(), event.getMessage());
-                queue.addMessage(message);
-            }
+        if (event instanceof XmppNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            XmppMessage message = new XmppMessage((XmppNotificationEvent) event, event.getSubject(), event.getMessage());
+            queue.addMessage(message);
         }
     }
 }

--- a/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotifierService.java
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/src/main/java/fish/payara/notification/xmpp/XmppNotifierService.java
@@ -39,12 +39,10 @@
  */
 package fish.payara.notification.xmpp;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.configuration.XmppNotifier;
 import fish.payara.nucleus.notification.service.QueueBasedNotifierService;
 import org.glassfish.api.StartupRunLevel;
-import org.glassfish.api.event.EventTypes;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jivesoftware.smack.ConnectionConfiguration;
 import org.jivesoftware.smack.SmackException;
@@ -56,6 +54,7 @@ import org.jvnet.hk2.annotations.Service;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
  * @author mertcaliskan
@@ -123,8 +122,7 @@ public class XmppNotifierService extends QueueBasedNotifierService<XmppNotificat
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(XmppNotificationEvent event) {
+    public void handleNotification(@SubscribeTo XmppNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             XmppMessage message = new XmppMessage(event, event.getSubject(), event.getMessage());
             queue.addMessage(message);

--- a/appserver/payara-appserver-modules/payara-jsr107/pom.xml
+++ b/appserver/payara-appserver-modules/payara-jsr107/pom.xml
@@ -108,10 +108,5 @@
             <artifactId>payara-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/implementation/PayaraValueHolder.java
+++ b/appserver/payara-appserver-modules/payara-jsr107/src/main/java/fish/payara/cdi/jsr107/implementation/PayaraValueHolder.java
@@ -1,23 +1,44 @@
 /*
-
- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
- Copyright (c) 2016-2018 Payara Foundation. All rights reserved.
-
- The contents of this file are subject to the terms of the Common Development
- and Distribution License("CDDL") (collectively, the "License").  You
- may not use this file except in compliance with the License.  You can
- obtain a copy of the License at
- https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- or packager/legal/LICENSE.txt.  See the License for the specific
- language governing permissions and limitations under the License.
-
- When distributing the software, include this License Header Notice in each
- file and include the License file at packager/legal/LICENSE.txt.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.cdi.jsr107.implementation;
 
-import com.google.common.base.Strings;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Externalizable;
@@ -61,7 +82,10 @@ public class PayaraValueHolder<T> implements Externalizable {
         }
         catch (ClassNotFoundException ex) {
             String invocationComponentId = Globals.getDefaultHabitat().getService(JavaEEContextUtil.class).getInstanceComponentId();
-            if (!Strings.nullToEmpty(componentId).equals(invocationComponentId)) {
+            if (componentId == null){
+                componentId = "";
+            }
+            if (componentId.equals(invocationComponentId)) {
                 throw new ClassNotFoundException(String.format("Wrong application: expected %s bug got %s", componentId, invocationComponentId),
                         new IllegalStateException("Wrong Application"));
             } else {

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopeContext.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopeContext.java
@@ -48,7 +48,6 @@ import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 
-import com.google.common.base.Optional;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.util.DOLUtils;
 
@@ -57,6 +56,7 @@ import org.glassfish.soteria.cdi.CdiUtils;
 
 import fish.payara.cluster.Clustered;
 import fish.payara.micro.cdi.extension.cluster.annotations.ClusterScoped;
+import java.util.Optional;
 
 /**
  * @Clustered singleton CDI context implementation
@@ -102,7 +102,7 @@ class ClusterScopeContext implements Context {
         String beanName = getBeanName(bean, clusteredAnnotation);
         TT beanInstance = (TT)clusteredLookup.getClusteredSingletonMap().get(beanName);
         if (clusteredAnnotation.callPostConstructOnAttach() && beanInstance != null &&
-                getFromApplicationScoped(contextual, Optional.<CreationalContext<TT>>absent()) == null) {
+                getFromApplicationScoped(contextual, Optional.empty()) == null ) {
             beanManager.getContext(ApplicationScoped.class).get(contextual, beanManager.createCreationalContext(contextual));
         }
         return beanInstance;

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopedInterceptor.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopedInterceptor.java
@@ -39,7 +39,6 @@
  */
 package fish.payara.micro.cdi.extension.cluster;
 
-import com.google.common.collect.Iterables;
 import com.hazelcast.core.IAtomicLong;
 import fish.payara.cluster.Clustered;
 import fish.payara.cluster.DistributedLockType;
@@ -50,6 +49,7 @@ import fish.payara.micro.cdi.extension.cluster.annotations.ClusterScopedIntercep
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Priority;
@@ -132,7 +132,11 @@ public class ClusterScopedInterceptor implements Serializable {
     }
 
     private void refresh(Class<?> beanClass) {
-        Bean<?> bean = Iterables.getOnlyElement(beanManager.getBeans(beanClass));
+        Set<Bean<?>> managedBeans = beanManager.getBeans(beanClass);
+        if (managedBeans.size() > 1) {
+            throw new IllegalArgumentException();
+        }
+        Bean<?> bean = managedBeans.iterator().next();
         String beanName = getBeanName(bean, getAnnotation(beanManager, bean));
         Context ctx = beanManager.getContext(ClusterScoped.class);
         clusteredLookup.getClusteredSingletonMap().put(beanName, ctx.get(bean));

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopedInterceptor.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopedInterceptor.java
@@ -134,7 +134,7 @@ public class ClusterScopedInterceptor implements Serializable {
     private void refresh(Class<?> beanClass) {
         Set<Bean<?>> managedBeans = beanManager.getBeans(beanClass);
         if (managedBeans.size() > 1) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Multiple beans found for " + beanClass);
         }
         Bean<?> bean = managedBeans.iterator().next();
         String beanName = getBeanName(bean, getAnnotation(beanManager, bean));

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusteredSingletonLookupImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusteredSingletonLookupImpl.java
@@ -39,11 +39,11 @@
  */
 package fish.payara.micro.cdi.extension.cluster;
 
-import com.google.common.collect.Iterables;
 import com.sun.enterprise.container.common.impl.util.ClusteredSingletonLookupImplBase;
 import static com.sun.enterprise.container.common.spi.ClusteredSingletonLookup.SingletonType.CDI;
 import static fish.payara.micro.cdi.extension.cluster.ClusterScopeContext.getAnnotation;
 import static fish.payara.micro.cdi.extension.cluster.ClusterScopeContext.getBeanName;
+import java.util.Set;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 
@@ -68,8 +68,12 @@ public class ClusteredSingletonLookupImpl extends ClusteredSingletonLookupImplBa
     }
 
     void setClusteredSessionKey(Class<?> beanClass) {
-        Bean<?> bean = Iterables.getOnlyElement(beanManager.getBeans(beanClass), null);
-        if (bean != null) {
+        Set<Bean<?>> managedBeans = beanManager.getBeans(beanClass);
+        if (managedBeans.size() > 1) {
+            throw new IllegalArgumentException();
+        }
+        if (managedBeans.size() == 1) {
+            Bean<?> bean = managedBeans.iterator().next();
             sessionKey.set(getBeanName(bean, getAnnotation(beanManager, bean)));
             invalidateKeys();
         }

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusteredSingletonLookupImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusteredSingletonLookupImpl.java
@@ -70,7 +70,7 @@ public class ClusteredSingletonLookupImpl extends ClusteredSingletonLookupImplBa
     void setClusteredSessionKey(Class<?> beanClass) {
         Set<Bean<?>> managedBeans = beanManager.getBeans(beanClass);
         if (managedBeans.size() > 1) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Multiple beans found for " + beanClass);
         }
         if (managedBeans.size() == 1) {
             Bean<?> bean = managedBeans.iterator().next();

--- a/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/admin/SetZendeskSupportConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/zendesk-support/src/main/java/fish/payara/appserver/zendesk/admin/SetZendeskSupportConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,8 +39,8 @@
  */
 package fish.payara.appserver.zendesk.admin;
 
-import com.google.common.base.Strings;
 import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.util.StringUtils;
 import fish.payara.appserver.zendesk.ZendeskSupportService;
 import fish.payara.appserver.zendesk.config.ZendeskSupportConfiguration;
 import java.util.logging.Logger;
@@ -106,7 +106,7 @@ public class SetZendeskSupportConfigurationCommand implements AdminCommand {
                          if(enabled != null) {
                             config.setEnabled(Boolean.toString(enabled));
                         }
-                         if (!Strings.isNullOrEmpty(emailAddress)){
+                         if (StringUtils.ok(emailAddress)){
                              config.setEmailAddress(emailAddress);
                          }
                         

--- a/appserver/tests/hk2/cdi/jersey/war/pom.xml
+++ b/appserver/tests/hk2/cdi/jersey/war/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]" -->
+<!--"Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]" -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -119,12 +119,6 @@
           <version>${jersey.version}</version>
           <scope>test</scope>
         </dependency>
-         <dependency>
-             <groupId>com.google.guava</groupId>
-             <artifactId>guava</artifactId>
-             <version>18.0</version>
-             <scope>test</scope>
-         </dependency>
     </dependencies>
     <build>
         <finalName>jersey-cdi</finalName>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -175,10 +175,5 @@
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-            <version>2.7.0</version>
-        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -175,5 +175,10 @@
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.7.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -56,7 +56,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package org.apache.catalina.session;
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -60,8 +60,8 @@
 
 package org.apache.catalina.session;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import org.glassfish.jersey.internal.guava.Cache;
+import org.glassfish.jersey.internal.guava.CacheBuilder;
 import com.sun.enterprise.spi.io.BaseIndirectlySerializable;
 import org.apache.catalina.*;
 import org.apache.catalina.core.StandardContext;
@@ -2425,8 +2425,9 @@ public class StandardSession
     }
 
     private static Cache<Object, Boolean> buildSerializableCache() {
-        return Caffeine.newBuilder().softValues().
-                 maximumSize(Integer.getInteger(StandardSession.class.getName() + ".identityCacheSize", 100)).build();
+        return CacheBuilder.newBuilder()
+                .maximumSize(Integer.getInteger(StandardSession.class.getName() + ".identityCacheSize", 100))
+                .build();
     }
 }
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -60,8 +60,8 @@
 
 package org.apache.catalina.session;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.sun.enterprise.spi.io.BaseIndirectlySerializable;
 import org.apache.catalina.*;
 import org.apache.catalina.core.StandardContext;
@@ -2425,9 +2425,8 @@ public class StandardSession
     }
 
     private static Cache<Object, Boolean> buildSerializableCache() {
-        return CacheBuilder.newBuilder().softValues()
-                .maximumSize(Integer.getInteger(StandardSession.class.getName() + ".identityCacheSize", 100))
-                .build();
+        return Caffeine.newBuilder().softValues().
+                 maximumSize(Integer.getInteger(StandardSession.class.getName() + ".identityCacheSize", 100)).build();
     }
 }
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebDeployer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebDeployer.java
@@ -37,14 +37,14 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
-import com.google.common.base.Strings;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.ServerTags;
 import com.sun.enterprise.deployment.Application;
+import com.sun.enterprise.util.StringUtils;
 import org.glassfish.api.container.RequestDispatcher;
 import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
@@ -130,7 +130,7 @@ public class WebDeployer extends JavaEEDeployer<WebContainer, WebApplication>{
                 contextRoot = params.previousContextRoot;
             }
             // default should be application name, if available
-            if (contextRoot == null && !Strings.isNullOrEmpty(params.name())) {
+            if (contextRoot == null && StringUtils.ok(params.name())) {
                 contextRoot = params.name();
             }
             if (contextRoot == null)

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/WebBundleRuntimeNode.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/WebBundleRuntimeNode.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 package org.glassfish.web.deployment.node.runtime.gf;
 
 import static com.sun.enterprise.deployment.xml.RuntimeTagNames.PAYARA_JAXRS_ROLES_ALLOWED_ENABLED;
@@ -65,7 +65,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.Attributes;
 
-import com.google.common.collect.ImmutableList;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.ResourceEnvReferenceDescriptor;
 import com.sun.enterprise.deployment.ResourceReferenceDescriptor;
@@ -90,6 +89,7 @@ import com.sun.enterprise.deployment.types.EjbReference;
 import com.sun.enterprise.deployment.xml.DTDRegistry;
 import com.sun.enterprise.deployment.xml.RuntimeTagNames;
 import com.sun.enterprise.deployment.xml.WebServicesTagNames;
+import java.util.Collections;
 
 /**
  * This node is responsible for handling all runtime information for web bundle.
@@ -335,11 +335,11 @@ public class WebBundleRuntimeNode extends RuntimeBundleNode<WebBundleDescriptorI
         } else if (element.getQName().equals(RuntimeTagNames.VERSION_IDENTIFIER)) {
         } else if (element.getQName().equals(RuntimeTagNames.PAYARA_SCANNING_INCLUDE)) {
             if (descriptor.getApplication() != null) {
-                descriptor.getApplication().addScanningInclusions(ImmutableList.of(value), "WEB-INF/lib");
+                descriptor.getApplication().addScanningInclusions(Collections.singletonList(value), "WEB-INF/lib");
             }
         } else if (element.getQName().equals(RuntimeTagNames.PAYARA_SCANNING_EXCLUDE)) {
             if (descriptor.getApplication() != null) {
-                descriptor.getApplication().addScanningExclusions(ImmutableList.of(value), "WEB-INF/lib");
+                descriptor.getApplication().addScanningExclusions(Collections.singletonList(value), "WEB-INF/lib");
             }
         } else if (element.getQName().equals(PAYARA_JAXRS_ROLES_ALLOWED_ENABLED)) {
             descriptor.setJaxrsRolesAllowedEnabled(Boolean.parseBoolean(value));

--- a/nucleus/cluster/admin/pom.xml
+++ b/nucleus/cluster/admin/pom.xml
@@ -123,6 +123,10 @@
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
     </dependencies>
 </project>
 

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ServerSynchronizer.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ServerSynchronizer.java
@@ -73,7 +73,6 @@ import org.glassfish.hk2.api.PostConstruct;
 import org.jvnet.hk2.annotations.Optional;
 import org.jvnet.hk2.annotations.Service;
 
-import com.google.common.net.MediaType;
 import com.sun.enterprise.config.serverbeans.Application;
 import com.sun.enterprise.config.serverbeans.ApplicationRef;
 import com.sun.enterprise.config.serverbeans.Applications;
@@ -317,7 +316,7 @@ public final class ServerSynchronizer implements PostConstruct {
             if (logger.isLoggable(FINE))
                 logger.log(FINE, "ServerSynchronizer: sending file {0}{1}",
                         new Object[] { f, modTime.time == 0 ? " because it doesn't exist on the instance" : " because it was out of date" });
-            payload.requestFileReplacement(MediaType.OCTET_STREAM.toString(), root.relativize(f.toURI()), "configChange", null, f, true);
+            payload.requestFileReplacement("application/octet-stream", root.relativize(f.toURI()), "configChange", null, f, true);
         } catch (IOException ioex) {
             if (logger.isLoggable(FINE)) {
                 logger.log(FINE, "ServerSynchronizer: IOException attaching file: {0}", f);

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ServerSynchronizer.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ServerSynchronizer.java
@@ -63,6 +63,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
 
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.ActionReport.ExitCode;
@@ -316,7 +317,7 @@ public final class ServerSynchronizer implements PostConstruct {
             if (logger.isLoggable(FINE))
                 logger.log(FINE, "ServerSynchronizer: sending file {0}{1}",
                         new Object[] { f, modTime.time == 0 ? " because it doesn't exist on the instance" : " because it was out of date" });
-            payload.requestFileReplacement("application/octet-stream", root.relativize(f.toURI()), "configChange", null, f, true);
+            payload.requestFileReplacement(MediaType.APPLICATION_OCTET_STREAM, root.relativize(f.toURI()), "configChange", null, f, true);
         } catch (IOException ioex) {
             if (logger.isLoggable(FINE)) {
                 logger.log(FINE, "ServerSynchronizer: IOException attaching file: {0}", f);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -364,9 +364,8 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         final String appName = app.getName();
 
         // lifecycle modules are loaded separately
-        if (Boolean.valueOf(app.getDeployProperties().getProperty
-            (ServerTags.IS_LIFECYCLE))) {
-            return Collections.unmodifiableList(Collections.emptyList());
+        if (Boolean.valueOf(app.getDeployProperties().getProperty(ServerTags.IS_LIFECYCLE))) {
+            return Collections.emptyList();
         }
 
         URI uri;
@@ -374,7 +373,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
             uri = new URI(source);
         } catch (URISyntaxException e) {
             logger.log(Level.SEVERE, KernelLoggerInfo.cantDetermineLocation, e.getLocalizedMessage());
-            return Collections.unmodifiableList(Collections.emptyList());
+            return Collections.emptyList();
         }
         List<Deployment.ApplicationDeployment> appDeployments = new ArrayList<>();
         File sourceFile = new File(uri);
@@ -439,9 +438,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         } else {
             logger.log(Level.SEVERE, KernelLoggerInfo.notFoundInOriginalLocation, source);
         }
-        appDeployments.removeIf((t) -> {
-            return t == null;
-        });
+        appDeployments.removeIf(t -> t == null);
         return appDeployments;
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -41,9 +41,6 @@
 
 package com.sun.enterprise.v3.server;
 
-import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.sun.enterprise.config.serverbeans.*;
 import com.sun.enterprise.deploy.shared.ArchiveFactory;
 import com.sun.enterprise.util.io.FileUtils;
@@ -369,7 +366,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         // lifecycle modules are loaded separately
         if (Boolean.valueOf(app.getDeployProperties().getProperty
             (ServerTags.IS_LIFECYCLE))) {
-            return ImmutableList.of();
+            return Collections.unmodifiableList(Collections.emptyList());
         }
 
         URI uri;
@@ -377,7 +374,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
             uri = new URI(source);
         } catch (URISyntaxException e) {
             logger.log(Level.SEVERE, KernelLoggerInfo.cantDetermineLocation, e.getLocalizedMessage());
-            return ImmutableList.of();
+            return Collections.unmodifiableList(Collections.emptyList());
         }
         List<Deployment.ApplicationDeployment> appDeployments = new ArrayList<>();
         File sourceFile = new File(uri);
@@ -442,7 +439,10 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         } else {
             logger.log(Level.SEVERE, KernelLoggerInfo.notFoundInOriginalLocation, source);
         }
-        return FluentIterable.from(appDeployments).filter(Predicates.notNull()).toList();
+        appDeployments.removeIf((t) -> {
+            return t == null;
+        });
+        return appDeployments;
     }
 
 
@@ -557,7 +557,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
 
     private List<Deployment.ApplicationDeployment> loadApplicationForTenants(Application app, ApplicationRef appRef, ActionReport report) {
         if (app.getAppTenants() == null) {
-            return ImmutableList.of();
+            return Collections.unmodifiableList(Collections.emptyList());
         }
         List<Deployment.ApplicationDeployment> appDeployments = new ArrayList<>();
         for (AppTenant tenant : app.getAppTenants().getAppTenant()) {
@@ -603,7 +603,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
                 }
             }
         }
-        return ImmutableList.copyOf(appDeployments);
+        return Collections.unmodifiableList(appDeployments);
     }
 
     private boolean loadAppOnDAS(String appName) {

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -95,6 +95,10 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-extras</artifactId>
+        </dependency>
          <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>javax.inject</artifactId>

--- a/nucleus/payara-modules/asadmin-audit/src/main/java/fish/payara/audit/admin/GetAdminAuditServiceConfiguration.java
+++ b/nucleus/payara-modules/asadmin-audit/src/main/java/fish/payara/audit/admin/GetAdminAuditServiceConfiguration.java
@@ -42,8 +42,6 @@
  */
 package fish.payara.audit.admin;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.ColumnFormatter;
 import com.sun.enterprise.util.SystemPropertyConstants;
@@ -55,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.Param;
@@ -133,12 +132,9 @@ public class GetAdminAuditServiceConfiguration implements AdminCommand {
         
         Properties notifierProps = new Properties();
         if (!config.getNotifierList().isEmpty()) {
-            List<Class<Notifier>> notifierClassList = Lists.transform(config.getNotifierList(), new Function<Notifier, Class<Notifier>>() {
-                @Override
-                public Class<Notifier> apply(Notifier input) {
-                    return resolveNotifierClass(input);
-                }
-            });
+            List<Class<Notifier>> notifierClassList = config.getNotifierList().stream().map((input) -> {
+                return resolveNotifierClass(input);
+            }).collect(Collectors.toList());
 
             for (ServiceHandle<BaseNotifierService> serviceHandle : allNotifierServiceHandles) {
                 Notifier notifier = config.getNotifierByType(serviceHandle.getService().getNotifierType());

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/GetHealthCheckConfiguration.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/GetHealthCheckConfiguration.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,9 +38,6 @@
  */
 package fish.payara.nucleus.healthcheck.admin;
 
-import com.google.common.base.Function;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.ColumnFormatter;
 import com.sun.enterprise.util.StringUtils;
@@ -75,6 +72,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.ConfigView;
 
@@ -160,7 +158,7 @@ public class GetHealthCheckConfiguration implements AdminCommand, HealthCheckCon
                         + configuration.getHistoricalTraceStoreSize() + "\n");
             }
 
-            if (!Strings.isNullOrEmpty(configuration.getHistoricalTraceStoreTimeout())) {
+            if (StringUtils.ok(configuration.getHistoricalTraceStoreTimeout())) {
                 mainActionReport.appendMessage("Health Check Historical Tracing Store Timeout in Seconds: "
                         + configuration.getHistoricalTraceStoreTimeout() + "\n");
             }
@@ -179,12 +177,9 @@ public class GetHealthCheckConfiguration implements AdminCommand, HealthCheckCon
         mainActionReport.setExtraProperties(mainExtraProps);
 
         if (!configuration.getNotifierList().isEmpty()) {
-            List<Class<Notifier>> notifierClassList = Lists.transform(configuration.getNotifierList(), new Function<Notifier, Class<Notifier>>() {
-                @Override
-                public Class<Notifier> apply(Notifier input) {
-                    return resolveNotifierClass(input);
-                }
-            });
+            List<Class<Notifier>> notifierClassList = configuration.getNotifierList().stream().map((input) -> {
+                return resolveNotifierClass(input);
+            }).collect(Collectors.toList());
 
             Properties extraProps = new Properties();
             for (ServiceHandle<BaseNotifierService> serviceHandle : allNotifierServiceHandles) {

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/notifier/BaseHealthCheckNotifierConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/notifier/BaseHealthCheckNotifierConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,6 @@
  */
 package fish.payara.nucleus.healthcheck.admin.notifier;
 
-import com.google.common.collect.ObjectArrays;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import fish.payara.nucleus.healthcheck.HealthCheckService;
@@ -123,11 +122,10 @@ public abstract class BaseHealthCheckNotifierConfigurer<C extends Notifier> impl
         ParameterizedType genericSuperclass = (ParameterizedType) getClass().getGenericSuperclass();
         notifierClass = (Class<C>) genericSuperclass.getActualTypeArguments()[0];
 
-        C c = healthCheckServiceConfiguration.getNotifierByType(notifierClass);
-        final C[] config = ObjectArrays.newArray(notifierClass, 1);
+        C notifier = healthCheckServiceConfiguration.getNotifierByType(notifierClass);
 
         try {
-            if (c == null) {
+            if (notifier == null) {
                 ConfigSupport.apply(new SingleConfigCode<HealthCheckServiceConfiguration>() {
                     @Override
                     public Object run(final HealthCheckServiceConfiguration healthCheckServiceConfigurationProxy)
@@ -141,14 +139,13 @@ public abstract class BaseHealthCheckNotifierConfigurer<C extends Notifier> impl
                 }, healthCheckServiceConfiguration);
             }
             else {
-                config[0] = c;
                 ConfigSupport.apply(new SingleConfigCode<C>() {
                     public Object run(C cProxy) throws PropertyVetoException, TransactionFailure {
                         applyValues(cProxy);
                         actionReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
                         return cProxy;
                     }
-                }, c);
+                }, notifier);
             }
 
             if (dynamic) {

--- a/nucleus/payara-modules/notification-cdi-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/CDIEventbusNotifierService.java
+++ b/nucleus/payara-modules/notification-cdi-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/CDIEventbusNotifierService.java
@@ -74,8 +74,7 @@ public class CDIEventbusNotifierService extends BaseNotifierService<CDIEventbusN
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof CDIEventbusNotificationEvent) {
-        if (executionOptions != null && executionOptions.isEnabled()) {
+        if (event instanceof CDIEventbusNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
             CDIEventbusMessageImpl message = new CDIEventbusMessageImpl((CDIEventbusNotificationEvent) event, event.getSubject(), event.getMessage());
             for(String appName : appRegistry.getAllApplicationNames()) {
                 ClassLoader oldCL = null;
@@ -94,7 +93,6 @@ public class CDIEventbusNotifierService extends BaseNotifierService<CDIEventbusN
                     Utility.setContextClassLoader(oldCL);
                 }
             }
-        }
         }
     }
 

--- a/nucleus/payara-modules/notification-cdi-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/CDIEventbusNotifierService.java
+++ b/nucleus/payara-modules/notification-cdi-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/CDIEventbusNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,7 +39,6 @@
  */
 package fish.payara.notification.eventbus.core;
 
-import com.google.common.eventbus.Subscribe;
 import com.sun.enterprise.util.Utility;
 import fish.payara.micro.cdi.Outbound;
 import fish.payara.nucleus.notification.configuration.CDIEventbusNotifier;
@@ -54,6 +53,7 @@ import java.lang.annotation.Annotation;
 import java.util.logging.Logger;
 import javax.inject.Inject;
 import org.glassfish.api.logging.LogLevel;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 import org.glassfish.internal.data.ApplicationRegistry;
 
 /**
@@ -70,8 +70,7 @@ public class CDIEventbusNotifierService extends BaseNotifierService<CDIEventbusN
     private static final Logger log = Logger.getLogger(CDIEventbusNotifierService.class.getName());
 
     @Override
-    @Subscribe
-    public void handleNotification(CDIEventbusNotificationEvent event) {
+    public void handleNotification(@SubscribeTo CDIEventbusNotificationEvent event) {
         if (executionOptions != null && executionOptions.isEnabled()) {
             CDIEventbusMessageImpl message = new CDIEventbusMessageImpl(event, event.getSubject(), event.getMessage());
             for(String appName : appRegistry.getAllApplicationNames()) {
@@ -120,7 +119,7 @@ public class CDIEventbusNotifierService extends BaseNotifierService<CDIEventbusN
 
     @Override
     public void bootstrap() {
-        register(NotifierType.CDIEVENTBUS, CDIEventbusNotifier.class, CDIEventbusNotifierConfiguration.class, this);
+        register(NotifierType.CDIEVENTBUS, CDIEventbusNotifier.class, CDIEventbusNotifierConfiguration.class);
 
         executionOptions = (CDIEventbusNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
     }

--- a/nucleus/payara-modules/notification-core/pom.xml
+++ b/nucleus/payara-modules/notification-core/pom.xml
@@ -96,16 +96,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-extras</artifactId>
+            <version>${hk2.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
             <version>${javaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
@@ -62,7 +62,7 @@ import org.jvnet.hk2.annotations.Service;
 public class NotificationEventBus {
     
     @Inject
-    Topic<NotificationEvent> topiceventBus;
+    Topic<NotificationEvent> eventBus;
     
     public NotificationEventBus() {
         // done in constructor to ensure that topics are valid for injection
@@ -70,19 +70,19 @@ public class NotificationEventBus {
     }
 
     public void register(BaseNotifierService notifier) {
-        eventBus.register(notifier);
+        //eventBus.register(notifier);
     }
 
     public void unregister(BaseNotifierService notifier) {
-        try {
+        /*try {
             eventBus.unregister(notifier);
         } catch (IllegalArgumentException e){
             Logger.getLogger(NotificationEventBus.class.getCanonicalName()).log(Level.WARNING, "Tried to unregister" + notifier.toString() + ", it may not have been previously registered");
-        }
+        }*/
     }
 
     void postEvent(NotificationEvent event) {
-        eventBus.post(event);
-        topiceventBus.publish(event);
+        //eventBus.post(event);
+        eventBus.publish(event);
     }
 }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,13 +39,16 @@
  */
 package fish.payara.nucleus.notification;
 
-import com.google.common.eventbus.EventBus;
 import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.BaseNotifierService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.inject.Inject;
 import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.api.messaging.Topic;
+import org.glassfish.hk2.extras.ExtrasUtilities;
 import org.glassfish.hk2.runlevel.RunLevel;
+import org.glassfish.internal.api.Globals;
 import org.jvnet.hk2.annotations.Service;
 
 /**
@@ -57,8 +60,14 @@ import org.jvnet.hk2.annotations.Service;
 @Service(name = "notification-eventbus")
 @RunLevel(StartupRunLevel.VAL)
 public class NotificationEventBus {
-
-    private EventBus eventBus = new EventBus();
+    
+    @Inject
+    Topic<NotificationEvent> topiceventBus;
+    
+    public NotificationEventBus() {
+        // done in constructor to ensure that topics are valid for injection
+        ExtrasUtilities.enableTopicDistribution(Globals.getDefaultHabitat());
+    }
 
     public void register(BaseNotifierService notifier) {
         eventBus.register(notifier);
@@ -74,5 +83,6 @@ public class NotificationEventBus {
 
     void postEvent(NotificationEvent event) {
         eventBus.post(event);
+        topiceventBus.publish(event);
     }
 }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
@@ -41,8 +41,6 @@ package fish.payara.nucleus.notification;
 
 import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.BaseNotifierService;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.inject.Inject;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.hk2.api.messaging.Topic;

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/NotificationEventBus.java
@@ -67,20 +67,15 @@ public class NotificationEventBus {
         ExtrasUtilities.enableTopicDistribution(Globals.getDefaultHabitat());
     }
 
+    @Deprecated
     public void register(BaseNotifierService notifier) {
-        //eventBus.register(notifier);
     }
 
+    @Deprecated
     public void unregister(BaseNotifierService notifier) {
-        /*try {
-            eventBus.unregister(notifier);
-        } catch (IllegalArgumentException e){
-            Logger.getLogger(NotificationEventBus.class.getCanonicalName()).log(Level.WARNING, "Tried to unregister" + notifier.toString() + ", it may not have been previously registered");
-        }*/
     }
 
     void postEvent(NotificationEvent event) {
-        //eventBus.post(event);
         eventBus.publish(event);
     }
 }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/admin/BaseNotificationConfigurer.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/admin/BaseNotificationConfigurer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,19 +38,16 @@
  */
 package fish.payara.nucleus.notification.admin;
 
-import com.google.common.collect.ObjectArrays;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import fish.payara.nucleus.notification.NotificationService;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
-import fish.payara.nucleus.notification.configuration.Notifier;
 import fish.payara.nucleus.notification.configuration.NotifierConfiguration;
 import fish.payara.nucleus.notification.service.BaseNotifierService;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.*;
 import org.glassfish.internal.api.Target;
-import org.jvnet.hk2.annotations.Contract;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.SingleConfigCode;
 import org.jvnet.hk2.config.TransactionFailure;

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/admin/GetNotificationConfiguration.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/admin/GetNotificationConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,12 +39,11 @@
  */
 package fish.payara.nucleus.notification.admin;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.ColumnFormatter;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
+import fish.payara.nucleus.notification.configuration.Notifier;
 import fish.payara.nucleus.notification.configuration.NotifierConfiguration;
 import fish.payara.nucleus.notification.configuration.NotifierConfigurationType;
 import fish.payara.nucleus.notification.configuration.NotifierType;
@@ -69,6 +68,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Admin command to list Notification Configuration
@@ -118,12 +118,9 @@ public class GetNotificationConfiguration implements AdminCommand {
             mainActionReport.setMessage("No notifier defined");
         }
         else {
-            List<Class<NotifierConfiguration>> notifierConfigurationClassList = Lists.transform(configuration.getNotifierConfigurationList(), new Function<NotifierConfiguration, Class<NotifierConfiguration>>() {
-                @Override
-                public Class<NotifierConfiguration> apply(NotifierConfiguration input) {
-                    return resolveNotifierConfigurationClass(input);
-                }
-            });
+            List<Class<NotifierConfiguration>> notifierConfigurationClassList = configuration.getNotifierConfigurationList().stream().map((input) -> {
+                return resolveNotifierConfigurationClass(input);
+            }).collect(Collectors.toList());
 
             Properties extraProps = new Properties();
             for (ServiceHandle<BaseNotifierService> serviceHandle : allServiceHandles) {

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/log/LogNotifierService.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/log/LogNotifierService.java
@@ -41,6 +41,7 @@ package fish.payara.nucleus.notification.log;
 
 import fish.payara.enterprise.server.logging.PayaraNotificationFileHandler;
 import fish.payara.nucleus.notification.configuration.NotifierType;
+import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.BaseNotifierService;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -52,6 +53,7 @@ import javax.inject.Inject;
 import java.text.MessageFormat;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.MessageReceiver;
 import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
@@ -59,6 +61,7 @@ import org.glassfish.hk2.api.messaging.SubscribeTo;
  */
 @Service(name = "service-log")
 @RunLevel(StartupRunLevel.VAL)
+@MessageReceiver
 public class LogNotifierService extends BaseNotifierService<LogNotificationEvent, LogNotifier, LogNotifierConfiguration> {
 
     @Inject
@@ -108,16 +111,20 @@ public class LogNotifierService extends BaseNotifierService<LogNotificationEvent
         handler = null;
     }
 
+    //@Override
     @Override
-    public void handleNotification(@SubscribeTo LogNotificationEvent event) {
-        if (execOptions != null && execOptions.isEnabled()) {
-            if (event.getParameters() != null && event.getParameters().length > 0) {
-                String formattedText = MessageFormat.format(event.getMessage(), event.getParameters());
-                logger.log(event.getLevel(), event.getSubject() != null ?
-                        event.getSubject() + " - " + formattedText : formattedText);
-            } else {
-                logger.log(event.getLevel(), event.getSubject() != null ?
-                        event.getSubject() + " - " + event.getMessage() : event.getMessage());
+    public void handleNotification(@SubscribeTo NotificationEvent event) {
+        if (event instanceof LogNotificationEvent) {
+            LogNotificationEvent logEvent = (LogNotificationEvent) event;
+            if (execOptions != null && execOptions.isEnabled()) {
+                if (logEvent.getParameters() != null && logEvent.getParameters().length > 0) {
+                    String formattedText = MessageFormat.format(logEvent.getMessage(), logEvent.getParameters());
+                    logger.log(logEvent.getLevel(), logEvent.getSubject() != null
+                            ? logEvent.getSubject() + " - " + formattedText : formattedText);
+                } else {
+                    logger.log(logEvent.getLevel(), logEvent.getSubject() != null
+                            ? logEvent.getSubject() + " - " + logEvent.getMessage() : logEvent.getMessage());
+                }
             }
         }
     }

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/log/LogNotifierService.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/log/LogNotifierService.java
@@ -111,7 +111,6 @@ public class LogNotifierService extends BaseNotifierService<LogNotificationEvent
         handler = null;
     }
 
-    //@Override
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
         if (event instanceof LogNotificationEvent) {

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/log/LogNotifierService.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/log/LogNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,8 +39,6 @@
  */
 package fish.payara.nucleus.notification.log;
 
-import com.google.common.base.Strings;
-import com.google.common.eventbus.Subscribe;
 import fish.payara.enterprise.server.logging.PayaraNotificationFileHandler;
 import fish.payara.nucleus.notification.configuration.NotifierType;
 import fish.payara.nucleus.notification.service.BaseNotifierService;
@@ -51,10 +49,10 @@ import org.jvnet.hk2.annotations.Service;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import java.text.MessageFormat;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
  * @author mertcaliskan
@@ -73,7 +71,7 @@ public class LogNotifierService extends BaseNotifierService<LogNotificationEvent
 
     @Override
     public void bootstrap() {
-        register(NotifierType.LOG, LogNotifier.class, LogNotifierConfiguration.class, this);
+        register(NotifierType.LOG, LogNotifier.class, LogNotifierConfiguration.class);
 
         execOptions = (LogNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
 
@@ -111,8 +109,7 @@ public class LogNotifierService extends BaseNotifierService<LogNotificationEvent
     }
 
     @Override
-    @Subscribe
-    public void handleNotification(LogNotificationEvent event) {
+    public void handleNotification(@SubscribeTo LogNotificationEvent event) {
         if (execOptions != null && execOptions.isEnabled()) {
             if (event.getParameters() != null && event.getParameters().length > 0) {
                 String formattedText = MessageFormat.format(event.getMessage(), event.getParameters());

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/service/BaseNotifierService.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/service/BaseNotifierService.java
@@ -106,7 +106,7 @@ public abstract class BaseNotifierService<E extends NotificationEvent,
         this.notifierConfigType = notifierConfigType;
     }
 
-    public abstract void handleNotification(E event);
+    public abstract void handleNotification(NotificationEvent event);
 
     public Class<C> getNotifierType() {
         return notifierType;

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/service/BaseNotifierService.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/service/BaseNotifierService.java
@@ -95,11 +95,15 @@ public abstract class BaseNotifierService<E extends NotificationEvent,
         events.register(this);
     }
 
+    @Deprecated
     protected void register(NotifierType type, Class<C> notifierType, Class<NC> notifierConfigType, BaseNotifierService service) {
+        register(type, notifierType, notifierConfigType);
+    }
+    
+    protected void register(NotifierType type, Class<C> notifierType, Class<NC> notifierConfigType) {
         this.type = type;
         this.notifierType = notifierType;
         this.notifierConfigType = notifierConfigType;
-        eventBus.register(service);
     }
 
     public abstract void handleNotification(E event);

--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/service/MessageQueue.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/service/MessageQueue.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,12 +38,12 @@
  */
 package fish.payara.nucleus.notification.service;
 
-import com.google.common.collect.EvictingQueue;
 import fish.payara.nucleus.notification.NotificationService;
 import org.jvnet.hk2.annotations.Contract;
 
 import javax.inject.Inject;
 import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * @author mertcaliskan
@@ -53,10 +53,15 @@ public abstract class MessageQueue<M extends Message> {
 
     @Inject
     private NotificationService notificationService;
-
-    private Queue<M> messageQueue = EvictingQueue.create(200);
+    
+    
+    private static final int QUEUE_SIZE = 200;
+    private final Queue<M> messageQueue = new LinkedBlockingQueue(QUEUE_SIZE);
 
     public synchronized void addMessage(M message) {
+        if (messageQueue.size() == QUEUE_SIZE) {
+            messageQueue.poll();
+        }
         messageQueue.add(message);
     }
 

--- a/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotificationConfigurer.java
+++ b/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotificationConfigurer.java
@@ -38,7 +38,6 @@
  */
 package fish.payara.notification.eventbus.core;
 
-import com.google.common.base.Strings;
 import fish.payara.nucleus.notification.admin.BaseNotificationConfigurer;
 import fish.payara.nucleus.notification.configuration.NotificationServiceConfiguration;
 import org.glassfish.api.Param;

--- a/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotifierService.java
+++ b/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotifierService.java
@@ -39,7 +39,6 @@
  */
 package fish.payara.notification.eventbus.core;
 
-import com.google.common.eventbus.Subscribe;
 import fish.payara.nucleus.eventbus.ClusterMessage;
 import fish.payara.nucleus.eventbus.EventBus;
 import fish.payara.nucleus.notification.configuration.EventbusNotifier;
@@ -50,6 +49,7 @@ import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.inject.Inject;
+import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
  * @author mertcaliskan
@@ -66,8 +66,7 @@ public class EventbusNotifierService extends BaseNotifierService<EventbusNotific
     private EventbusNotifierConfigurationExecutionOptions executionOptions;
 
     @Override
-    @Subscribe
-    public void handleNotification(EventbusNotificationEvent event) {
+    public void handleNotification(@SubscribeTo EventbusNotificationEvent event) {
         if(executionOptions != null && executionOptions.isEnabled()) {
             EventbusMessageImpl message = new EventbusMessageImpl(event, event.getSubject(), event.getMessage());
             eventBus.publish(executionOptions.getTopicName(), new ClusterMessage<>(message));
@@ -76,7 +75,7 @@ public class EventbusNotifierService extends BaseNotifierService<EventbusNotific
 
     @Override
     public void bootstrap() {
-        register(NotifierType.EVENTBUS, EventbusNotifier.class, EventbusNotifierConfiguration.class, this);
+        register(NotifierType.EVENTBUS, EventbusNotifier.class, EventbusNotifierConfiguration.class);
 
         executionOptions = (EventbusNotifierConfigurationExecutionOptions) getNotifierConfigurationExecutionOptions();
     }

--- a/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotifierService.java
+++ b/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotifierService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -43,12 +43,14 @@ import fish.payara.nucleus.eventbus.ClusterMessage;
 import fish.payara.nucleus.eventbus.EventBus;
 import fish.payara.nucleus.notification.configuration.EventbusNotifier;
 import fish.payara.nucleus.notification.configuration.NotifierType;
+import fish.payara.nucleus.notification.domain.NotificationEvent;
 import fish.payara.nucleus.notification.service.BaseNotifierService;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.inject.Inject;
+import org.glassfish.hk2.api.messaging.MessageReceiver;
 import org.glassfish.hk2.api.messaging.SubscribeTo;
 
 /**
@@ -56,6 +58,7 @@ import org.glassfish.hk2.api.messaging.SubscribeTo;
  */
 @Service(name = "service-eventbus")
 @RunLevel(StartupRunLevel.VAL)
+@MessageReceiver
 public class EventbusNotifierService extends BaseNotifierService<EventbusNotificationEvent,
         EventbusNotifier,
         EventbusNotifierConfiguration> {
@@ -66,10 +69,12 @@ public class EventbusNotifierService extends BaseNotifierService<EventbusNotific
     private EventbusNotifierConfigurationExecutionOptions executionOptions;
 
     @Override
-    public void handleNotification(@SubscribeTo EventbusNotificationEvent event) {
-        if(executionOptions != null && executionOptions.isEnabled()) {
-            EventbusMessageImpl message = new EventbusMessageImpl(event, event.getSubject(), event.getMessage());
-            eventBus.publish(executionOptions.getTopicName(), new ClusterMessage<>(message));
+    public void handleNotification(@SubscribeTo NotificationEvent event) {
+        if (event instanceof EventbusNotificationEvent) {
+            if (executionOptions != null && executionOptions.isEnabled()) {
+                EventbusMessageImpl message = new EventbusMessageImpl((EventbusNotificationEvent) event, event.getSubject(), event.getMessage());
+                eventBus.publish(executionOptions.getTopicName(), new ClusterMessage<>(message));
+            }
         }
     }
 

--- a/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotifierService.java
+++ b/nucleus/payara-modules/notification-eventbus-core/src/main/java/fish/payara/notification/eventbus/core/EventbusNotifierService.java
@@ -70,11 +70,9 @@ public class EventbusNotifierService extends BaseNotifierService<EventbusNotific
 
     @Override
     public void handleNotification(@SubscribeTo NotificationEvent event) {
-        if (event instanceof EventbusNotificationEvent) {
-            if (executionOptions != null && executionOptions.isEnabled()) {
-                EventbusMessageImpl message = new EventbusMessageImpl((EventbusNotificationEvent) event, event.getSubject(), event.getMessage());
-                eventBus.publish(executionOptions.getTopicName(), new ClusterMessage<>(message));
-            }
+        if (event instanceof EventbusNotificationEvent && executionOptions != null && executionOptions.isEnabled()) {
+            EventbusMessageImpl message = new EventbusMessageImpl((EventbusNotificationEvent) event, event.getSubject(), event.getMessage());
+            eventBus.publish(executionOptions.getTopicName(), new ClusterMessage<>(message));
         }
     }
 

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/GetRequestTracingConfiguration.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/GetRequestTracingConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -40,9 +40,6 @@
 
 package fish.payara.nucleus.requesttracing.admin;
 
-import com.google.common.base.Function;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.ColumnFormatter;
 import com.sun.enterprise.util.StringUtils;
@@ -70,6 +67,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Admin command to list Request Tracing Configuration
@@ -136,7 +134,7 @@ public class GetRequestTracingConfiguration implements AdminCommand {
             // Print trace store details
             writeVariableToActionReport(mainActionReport, "Reservoir Sampling Enabled?", configuration.getReservoirSamplingEnabled());
             writeVariableToActionReport(mainActionReport, "Trace Store Size", configuration.getTraceStoreSize());
-            if (!Strings.isNullOrEmpty(configuration.getTraceStoreTimeout())) {
+            if (StringUtils.ok(configuration.getTraceStoreTimeout())) {
                 writeVariableToActionReport(mainActionReport, "Trace Store Timeout (secs)", configuration.getTraceStoreTimeout());
             }
 
@@ -144,7 +142,7 @@ public class GetRequestTracingConfiguration implements AdminCommand {
             writeVariableToActionReport(mainActionReport, "Historic Trace Store Enabled?", configuration.getHistoricTraceStoreEnabled());
             if (Boolean.parseBoolean(configuration.getHistoricTraceStoreEnabled())) {
                 writeVariableToActionReport(mainActionReport, "Historic Trace Store Size", configuration.getHistoricTraceStoreSize());
-                if (!Strings.isNullOrEmpty(configuration.getHistoricTraceStoreTimeout())) {
+                if (StringUtils.ok(configuration.getHistoricTraceStoreTimeout())) {
                     writeVariableToActionReport(mainActionReport, "Historic Trace Store Timeout (secs)", configuration.getHistoricTraceStoreTimeout());
                 }
             }
@@ -188,12 +186,9 @@ public class GetRequestTracingConfiguration implements AdminCommand {
             String headers[] = {"Notifier Name", "Notifier Enabled"};
             ColumnFormatter columnFormatter = new ColumnFormatter(headers);
             
-            List<Class<Notifier>> notifierClassList = Lists.transform(configuration.getNotifierList(), new Function<Notifier, Class<Notifier>>() {
-                @Override
-                public Class<Notifier> apply(Notifier input) {
-                    return resolveNotifierClass(input);
-                }
-            });
+            List<Class<Notifier>> notifierClassList = configuration.getNotifierList().stream().map((input) -> {
+                return resolveNotifierClass(input);
+            }).collect(Collectors.toList());
 
             Properties notifierExtraProps = new Properties();
             for (ServiceHandle<BaseNotifierService> serviceHandle : allServiceHandles) {

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -367,7 +367,6 @@
         <xpp3.version>1.1.4c_7</xpp3.version>
         <snmp4j.version>2.5.3-payara.p1</snmp4j.version>
         <mockito.version>2.2.6</mockito.version>
-        <guava.version>19.0</guava.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>
         <jaxb-impl.version>2.3.2</jaxb-impl.version>
 
@@ -1386,11 +1385,6 @@ Parent is ${project.parent}</echo>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
                 <version>${javassist.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.cache</groupId>


### PR DESCRIPTION
Versions post-19.0 rely on JSR 305 which is not published by Oracle and can't be used by us. The functionality that Payara uses from Guava is available elsewhere in Payara or the standard Java library.