### PR TITLE
PAYARA-3884 Payara Micro adds JDK 11 warning when exploded application deployed

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -209,6 +209,8 @@
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="fish.payara.micro.PayaraMicro"/>
                 <attribute name="Start-Class" value="fish.payara.micro.impl.PayaraMicroImpl"/>
+                <attribute name="Add-Exports" value="java.base/jdk.internal.ref"/>
+                <attribute name="Add-Opens" value="java.base/jdk.internal.loader java.base/java.lang java.base/java.nio java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt"/>
         </manifest>
         </jar>    
     </target> 

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2018] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
 
 <project name="payara-micro" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>


### PR DESCRIPTION
`jvm-options` in `domain.xml` is not used by Payara Micro and not applicable as Payara Micro is not executing in a separate JVM. 
```
        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
```

Hence either the end-user should pass the `--add-opens` and/or `--add-exports` command-line flag when running the JAR or these flags can be added to Payara Micro `META-INF/MANIFEST.MF` file:

```
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.6.5
Created-By: 25.172-b11 (Oracle Corporation)
Bundle-SymbolicName: fish.payara.micro
Main-Class: fish.payara.micro.PayaraMicro
Start-Class: fish.payara.micro.impl.PayaraMicroImpl
Add-Exports: java.base/jdk.internal.ref
Add-Opens: java.base/jdk.internal.loader java.base/java.lang java.base
 /java.nio java.base/sun.nio.ch java.management/sun.management jdk.man
 agement/com.sun.management.internal java.base/sun.net.www.protocol.jrt
```
** These flgas are ignored when runnging on JDK 8 (or less).