### PR TITLE
PAYARA-3850 Data collection API and sources

### DIFF
--- a/appserver/payara-appserver-modules/healthcheck-checker/src/main/java/fish/payara/healthcheck/mphealth/MicroProfileHealthChecker.java
+++ b/appserver/payara-appserver-modules/healthcheck-checker/src/main/java/fish/payara/healthcheck/mphealth/MicroProfileHealthChecker.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -43,9 +43,12 @@
 package fish.payara.healthcheck.mphealth;
 
 import com.sun.enterprise.config.serverbeans.Domain;
+
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.inject.Inject;
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -59,6 +62,8 @@ import fish.payara.micro.ClusterCommandResult;
 import fish.payara.micro.data.InstanceDescriptor;
 import fish.payara.nucleus.healthcheck.configuration.MicroProfileHealthCheckerConfiguration;
 import fish.payara.microprofile.healthcheck.config.MetricsHealthCheckConfiguration;
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.notification.healthcheck.HealthCheckResultEntry;
 import fish.payara.notification.healthcheck.HealthCheckResultStatus;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
@@ -67,6 +72,8 @@ import fish.payara.nucleus.healthcheck.preliminary.BaseHealthCheck;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +87,6 @@ import org.glassfish.config.support.TranslatedConfigView;
 import org.glassfish.grizzly.config.dom.NetworkListener;
 import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.hk2.runlevel.RunLevel;
-import org.glassfish.internal.api.Target;
 import org.jvnet.hk2.annotations.Service;
 
 /**
@@ -92,13 +98,12 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service(name = "healthcheck-mp")
 @RunLevel(10)
-public class MicroProfileHealthChecker extends BaseHealthCheck<HealthCheckTimeoutExecutionOptions, MicroProfileHealthCheckerConfiguration> implements PostConstruct {
+public class MicroProfileHealthChecker
+        extends BaseHealthCheck<HealthCheckTimeoutExecutionOptions, MicroProfileHealthCheckerConfiguration>
+        implements PostConstruct, MonitoringDataSource {
 
     private static final Logger LOGGER = Logger.getLogger(MicroProfileHealthChecker.class.getPackage().getName());
     private static final String GET_MP_CONFIG_STRING = "get-microprofile-healthcheck-configuration";
-
-    @Inject
-    private Target targetUtil;
 
     @Inject
     private PayaraExecutorService payaraExecutorService;
@@ -115,28 +120,45 @@ public class MicroProfileHealthChecker extends BaseHealthCheck<HealthCheckTimeou
     @Inject
     private PayaraInstanceImpl payaraMicro;
 
+    private final Map<String, Integer> serverHttpStatus = new ConcurrentHashMap<>();
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        if (isReady()) {
+            MonitoringDataCollector statusCollector = collector.in("health-check").type("checker").entity("MP")
+                    .collect("checksDone", getChecksDone())
+                    .collectNonZero("checksFailed", getChecksFailed());
+            for (Entry<String, Integer> status : serverHttpStatus.entrySet()) {
+                statusCollector.tag("server", status.getKey()).collect("statusCode", status.getValue());
+            }
+        }
+    }
+
     @Override
     public void postConstruct() {
         postConstruct(this, MicroProfileHealthCheckerConfiguration.class);
     }
 
     @Override
-    public HealthCheckResult doCheck() {
+    protected HealthCheckResult doCheckInternal() {
         HealthCheckResult result = new HealthCheckResult();
 
         if (!envrionment.isDas()) {
             //currrently this should only run on DAS
             return result;
         }
+        serverHttpStatus.clear();
 
         Map<String, Future<ClusterCommandResult>> configs = payaraMicro.executeClusteredASAdmin(GET_MP_CONFIG_STRING, new String[0]);
 
-        HashSet<String> usedInstances = new HashSet<String>();
-        
+        HashSet<String> usedInstances = new HashSet<>();
+
         //get all instances that this server knows about
         for (Server server : domain.getServers().getServer()) {
-            
-            usedInstances.add(server.getName());
+
+            @Pattern(regexp = "[A-Za-z0-9_][A-Za-z0-9\\-_\\.;]*", message = "{server.invalid.name}", payload = Server.class)
+            String instanceName = server.getName();
+            usedInstances.add(instanceName);
 
             Future taskResult = payaraExecutorService.submit(() -> {
 
@@ -144,15 +166,12 @@ public class MicroProfileHealthChecker extends BaseHealthCheck<HealthCheckTimeou
                 MetricsHealthCheckConfiguration metricsConfig = server.getConfig().getExtensionByType(MetricsHealthCheckConfiguration.class);
                 if (metricsConfig != null && Boolean.valueOf(metricsConfig.getEnabled())) {
                     try {
-                        String endpoint = metricsConfig.getEndpoint();
-
-                        URI remote = buildURI(server, endpoint);
-
-                        result.add(pingHealthEndpoint(remote));
-
+                        result.add(pingHealthEndpoint(instanceName,  buildURI(server, metricsConfig.getEndpoint())));
                     } catch (URISyntaxException ex) {
+                        serverHttpStatus.put(instanceName, 420);
                         result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR, "INVALID ENDPOINT: " + ex.getInput()));
                     } catch (ProcessingException ex) {
+                        serverHttpStatus.put(instanceName, 420);
                         LOGGER.log(Level.FINE, "Error sending JAX-RS Request", ex);
                         result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "UNABLE TO CONNECT - " + ex.getMessage()));
                     }
@@ -162,39 +181,43 @@ public class MicroProfileHealthChecker extends BaseHealthCheck<HealthCheckTimeou
             try {
                 taskResult.get(options.getTimeout(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+                serverHttpStatus.put(server.getName(), HttpURLConnection.HTTP_CLIENT_TIMEOUT);
                 LOGGER.log(Level.FINE, "Error processing MP Healthcheck checker", ex);
                 result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "UNABLE TO CONNECT - " + ex.toString()));
             }
         }
-        
+
         for (InstanceDescriptor instance : payaraMicro.getClusteredPayaras()) {
-            
-            if (usedInstances.contains(instance.getInstanceName())) {
+            String instanceName = instance.getInstanceName();
+            if (usedInstances.contains(instanceName)) {
                 continue;
             }
 
             Future taskResult = payaraExecutorService.submit(() -> {
                 try {
-                    
+
                     ClusterCommandResult mpHealthConfigResult = configs.get(instance.getMemberUUID()).get();
                     String values = mpHealthConfigResult.getOutput().split("\n")[1];
                     Boolean enabled = Boolean.parseBoolean(values.split(" ")[0]);
                     if (enabled) {
-                        
+
                         String endpoint = values.split(" ", 2)[1].trim();
 
                         URL usedURL = instance.getApplicationURLS().get(0);
                         URI remote = new URI(usedURL.getProtocol(), usedURL.getUserInfo(), usedURL.getHost(), usedURL.getPort(), "/" + endpoint, null, null);
 
-                        result.add(pingHealthEndpoint(remote));
+                        result.add(pingHealthEndpoint(instanceName, remote));
 
                     }
                 } catch (InterruptedException | ExecutionException ex) {
+                    serverHttpStatus.put(instanceName, HttpURLConnection.HTTP_CLIENT_TIMEOUT);
                     LOGGER.log(Level.FINE, "Error processing MP Healthcheck checker", ex);
-                result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "UNABLE TO CONNECT - " + ex.toString()));
+                    result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "UNABLE TO CONNECT - " + ex.toString()));
                 } catch (URISyntaxException ex) {
+                    serverHttpStatus.put(instanceName, 420);
                     result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR, "INVALID ENDPOINT: " + ex.getInput()));
                 } catch (ProcessingException ex) {
+                    serverHttpStatus.put(instanceName, 420);
                     LOGGER.log(Level.FINE, "Error sending JAX-RS Request", ex);
                     result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "UNABLE TO CONNECT - " + ex.getMessage()));
                 }
@@ -240,12 +263,13 @@ public class MicroProfileHealthChecker extends BaseHealthCheck<HealthCheckTimeou
     }
 
     //send request to remote healthcheck endpoint to get the status
-    private HealthCheckResultEntry pingHealthEndpoint(URI remote) {
+    private HealthCheckResultEntry pingHealthEndpoint(String instanceName, URI remote) {
         Client jaxrsClient = ClientBuilder.newClient();
         WebTarget target = jaxrsClient.target(remote);
 
-        Response metricsResponse = target.request().accept(MediaType.APPLICATION_JSON).get();
-        switch (metricsResponse.getStatus()) {
+        try (Response metricsResponse = target.request().accept(MediaType.APPLICATION_JSON).get()) {
+            serverHttpStatus.put(instanceName, metricsResponse.getStatus());
+            switch (metricsResponse.getStatus()) {
             case 200:
                 return new HealthCheckResultEntry(HealthCheckResultStatus.GOOD, "UP");
             case 503:
@@ -254,6 +278,7 @@ public class MicroProfileHealthChecker extends BaseHealthCheck<HealthCheckTimeou
                 return new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "FAILURE");
             default:
                 return new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR, "UNKNOWN RESPONSE");
+            }
         }
     }
 

--- a/appserver/payara-appserver-modules/healthcheck-checker/src/main/java/fish/payara/healthcheck/mphealth/MicroProfileHealthChecker.java
+++ b/appserver/payara-appserver-modules/healthcheck-checker/src/main/java/fish/payara/healthcheck/mphealth/MicroProfileHealthChecker.java
@@ -168,10 +168,10 @@ public class MicroProfileHealthChecker
                     try {
                         result.add(pingHealthEndpoint(instanceName,  buildURI(server, metricsConfig.getEndpoint())));
                     } catch (URISyntaxException ex) {
-                        serverHttpStatus.put(instanceName, 420);
+                        serverHttpStatus.put(instanceName, HttpURLConnection.HTTP_INTERNAL_ERROR);
                         result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CHECK_ERROR, "INVALID ENDPOINT: " + ex.getInput()));
                     } catch (ProcessingException ex) {
-                        serverHttpStatus.put(instanceName, 420);
+                        serverHttpStatus.put(instanceName, HttpURLConnection.HTTP_INTERNAL_ERROR);
                         LOGGER.log(Level.FINE, "Error sending JAX-RS Request", ex);
                         result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL, "UNABLE TO CONNECT - " + ex.getMessage()));
                     }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -142,13 +142,9 @@ public class MetricsService implements EventListener, MonitoringDataSource {
 
     @Override
     public void collect(MonitoringDataCollector rootCollector) {
-        MonitoringDataCollector metricsCollector = rootCollector.in("metric");
-        if (metricsEnabled != null) {
-            metricsCollector.collect("enabled", metricsEnabled);
-        }
-        if (metricsSecure != null) {
-            metricsCollector.collect("secure", metricsSecure);
-        }
+        MonitoringDataCollector metricsCollector = rootCollector.in("metric")
+                .collect("enabled", metricsEnabled)
+                .collect("secure", isSecurityEnabled());
         for (Entry<String, MetricRegistry> registry : REGISTRIES.entrySet()) {
             MonitoringDataCollector appCollector = metricsCollector.app(registry.getKey());
 

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -47,10 +47,23 @@ import fish.payara.microprofile.metrics.impl.MetricRegistryImpl;
 import fish.payara.microprofile.metrics.jmx.MBeanMetadata;
 import fish.payara.microprofile.metrics.jmx.MBeanMetadataConfig;
 import fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper;
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Counting;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.Metered;
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Sampling;
+import org.eclipse.microprofile.metrics.Snapshot;
+import org.eclipse.microprofile.metrics.Timer;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.event.EventListener;
@@ -72,6 +85,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.metrics.MetricID;
@@ -81,7 +95,7 @@ import static org.eclipse.microprofile.metrics.MetricRegistry.Type.VENDOR;
 
 @Service(name = "microprofile-metrics-service")
 @RunLevel(StartupRunLevel.VAL)
-public class MetricsService implements EventListener {
+public class MetricsService implements EventListener, MonitoringDataSource {
 
     private static final Logger LOGGER = Logger.getLogger(MetricsService.class.getName());
 
@@ -124,6 +138,80 @@ public class MetricsService implements EventListener {
                 bootstrap();
             });
         }
+    }
+
+    @Override
+    public void collect(MonitoringDataCollector rootCollector) {
+        MonitoringDataCollector metricsCollector = rootCollector.in("metric");
+        if (metricsEnabled != null) {
+            metricsCollector.collect("enabled", metricsEnabled);
+        }
+        if (metricsSecure != null) {
+            metricsCollector.collect("secure", metricsSecure);
+        }
+        for (Entry<String, MetricRegistry> registry : REGISTRIES.entrySet()) {
+            MonitoringDataCollector appCollector = metricsCollector.app(registry.getKey());
+
+            // counters
+            appCollector.type("counter")
+                .collectAll(registry.getValue().getCounters(), (collector, counter) -> collector
+                    .collectObject(counter, MetricsService::collectCounting));
+
+            // gauges
+            appCollector.type("gauge")
+                .collectAll(registry.getValue().getGauges(), (collector, gauge) -> {
+                    Object value = gauge.getValue();
+                    if (value instanceof Number) {
+                        collector.collect("value", ((Number) value));
+                    }
+            });
+
+            // histograms
+            appCollector.type("histogram")
+                .collectAll(registry.getValue().getHistograms(), (collector, histogram) -> collector
+                    .collectObject(histogram, MetricsService::collectSampling)
+                    .collectObject(histogram, MetricsService::collectCounting));
+
+            // meters
+            appCollector.type("meter")
+                .collectAll(registry.getValue().getMeters(), MetricsService::collectMetered);
+
+            // timers
+            appCollector.type("timer")
+                .collectAll(registry.getValue().getTimers(), (collector, timer) -> collector
+                    .collectObject(timer, MetricsService::collectMetered)
+                    .collectObject(timer, MetricsService::collectSampling));
+        }
+    }
+
+    private static void collectCounting(MonitoringDataCollector collector, Counting obj) {
+        collector.collect("count", obj.getCount());
+    }
+
+    private static void collectSampling(MonitoringDataCollector collector, Sampling obj) {
+        Snapshot snapshot = obj.getSnapshot();
+        collector
+            .collect("min", snapshot.getMin())
+            .collect("max", snapshot.getMax())
+            .collect("mean", snapshot.getMean())
+            .collect("median", snapshot.getMedian())
+            .collect("stdDev", snapshot.getStdDev())
+            .collect("75thPercentile", snapshot.get75thPercentile())
+            .collect("95thPercentile", snapshot.get95thPercentile())
+            .collect("95thPercentile", snapshot.get95thPercentile())
+            .collect("98thPercentile", snapshot.get98thPercentile())
+            .collect("99thPercentile", snapshot.get99thPercentile())
+            .collect("999thPercentile", snapshot.get999thPercentile());
+    }
+
+    private static void collectMetered(MonitoringDataCollector collector, Metered obj) {
+        collectCounting(collector, obj);
+        collector
+            .collect("count", obj.getCount())
+            .collect("fifteenMinuteRate", obj.getFifteenMinuteRate())
+            .collect("fiveMinuteRate", obj.getFiveMinuteRate())
+            .collect("oneMinuteRate", obj.getOneMinuteRate())
+            .collect("meanRate", obj.getMeanRate());
     }
 
     private void checkSystemCpuLoadIssue(MBeanMetadataConfig metadataConfig) {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+ * Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
  */
 package org.glassfish.admin.amx.impl;
 
@@ -45,6 +45,7 @@ import org.glassfish.admin.amx.base.DomainRoot;
 import org.glassfish.admin.amx.base.MBeanTracker;
 import org.glassfish.admin.amx.base.MBeanTrackerMBean;
 import org.glassfish.admin.amx.base.SystemInfo;
+import org.glassfish.admin.amx.core.AMXProxy;
 import org.glassfish.admin.amx.core.proxy.ProxyFactory;
 import org.glassfish.admin.amx.impl.mbean.ComplianceMonitor;
 import org.glassfish.admin.amx.impl.mbean.DomainRootImpl;
@@ -54,8 +55,10 @@ import org.glassfish.admin.amx.impl.util.ImplUtil;
 import org.glassfish.admin.amx.impl.util.InjectedValues;
 import org.glassfish.admin.amx.impl.util.ObjectNameBuilder;
 import org.glassfish.admin.amx.impl.util.SingletonEnforcer;
+import org.glassfish.admin.amx.monitoring.ServerMon;
 import org.glassfish.admin.amx.util.ExceptionUtil;
 import org.glassfish.admin.amx.util.FeatureAvailability;
+import org.glassfish.admin.amx.util.MonitoringDataUtil;
 import org.glassfish.admin.amx.util.TimingDelta;
 import org.glassfish.admin.amx.util.jmx.stringifier.StringifierRegistryIniter;
 import org.glassfish.admin.amx.util.stringifier.StringifierRegistryImpl;
@@ -71,10 +74,14 @@ import org.glassfish.external.amx.MBeanListener;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.annotations.Service;
 
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
+
 import javax.inject.Inject;
 import javax.management.*;
 import javax.management.remote.JMXServiceURL;
 import java.util.Collection;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
@@ -87,7 +94,7 @@ import org.glassfish.hk2.api.PreDestroy;
  * An {@link AMXLoader} responsible for loading core AMX MBeans
  */
 @Service
-public final class AMXStartupService implements PostConstruct, PreDestroy, AMXStartupServiceMBean {
+public final class AMXStartupService implements PostConstruct, PreDestroy, AMXStartupServiceMBean, MonitoringDataSource {
 
     @Inject
     ServiceLocator mHabitat;
@@ -381,4 +388,18 @@ public final class AMXStartupService implements PostConstruct, PreDestroy, AMXSt
         }
     }
     // public Startup.Lifecycle getLifecycle() { return Startup.Lifecycle.SERVER; }
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        DomainRoot domainRoot = getDomainRootProxy();
+        if (domainRoot != null) {
+            MonitoringDataCollector amxCollector = collector.in("amx");
+            for (AMXProxy proxy : domainRoot.getQueryMgr().queryAll()) {
+                if ("monitoring".equals(proxy.extra().group())) {
+                    amxCollector.entity(proxy.getName().replaceAll("\\s|[=/]", "."))
+                        .collectObject(proxy, MonitoringDataUtil::collectBean);
+                }
+            }
+        }
+    }
 }

--- a/nucleus/common/internal-api/osgi.bundle
+++ b/nucleus/common/internal-api/osgi.bundle
@@ -40,6 +40,7 @@
 # Portions Copyright (c) 2019 Payara Foundation and/or its affiliates
 
 -exportcontents: \
+                        fish.payara.monitoring.collect; \
                         org.glassfish.internal.api; \
                         org.glassfish.internal.data; \
                         org.glassfish.internal.config; \

--- a/nucleus/common/internal-api/src/main/java/fish/payara/monitoring/collect/MonitoringDataCollector.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/monitoring/collect/MonitoringDataCollector.java
@@ -1,0 +1,243 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.monitoring.collect;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiConsumer;
+
+/**
+ * API for collecting monitoring data points from a {@link MonitoringDataSource}.
+ * 
+ * @author Jan Bernitt
+ */
+public interface MonitoringDataCollector {
+
+    /**
+     * Collect a single metric data point (within the current context of tags of this collector).
+     * 
+     * @param key the plain (context free) name of the metric (e.g. "size")
+     * @param value the current value of the metric
+     * @return this collector for chaining (with unchanged tags)
+     */
+    MonitoringDataCollector collect(CharSequence key, long value);
+
+    /**
+     * Creates a collector with an extended context.
+     * 
+     * For example if this collector has the context "foo=bar" and this method is called with name "x" and value "y" the
+     * resulting context is "foo=bar x=y".
+     * 
+     * When the context of this collector already contains the tag name the context restarts from that tag regardless if
+     * the value is different or identical to the previous one. For example if this collector has the context "foo=bar
+     * x=y" and tag is called with name "foo" and value "baz" the new context is "foo=baz" (not "foo=bar x=y foo=baz").
+     * 
+     * @param name  name of the type of context
+     * @param value identifier within the context type, if <code>null</code> or empty the tag is ignored
+     * @return A collector that collects data within the context of this collector extended by the given name-value
+     *         pair.
+     */
+    MonitoringDataCollector tag(CharSequence name, CharSequence value);
+
+
+    /*
+     * Helper methods for convenience and consistent tagging.
+     */
+
+
+    /**
+     * Same as {@link #collect(CharSequence, long)} except that zero value are ignored and not collected.
+     */
+    default MonitoringDataCollector collectNonZero(CharSequence key, long value) {
+        return value != 0L ? collect(key, value) : this;
+    }
+
+    /**
+     * Similar to {@link #collect(CharSequence, long)}. Double values are converted to long by multiplying with 10K
+     * effectively offering a precision of 4 fraction digits when converting back to FP number later on.
+     */
+    default MonitoringDataCollector collect(CharSequence key, double value) {
+        return collect(key, Math.round(value * 10000L));
+    }
+
+    /**
+     * Similar to {@link #collect(CharSequence, long)}, true becomes 1L, false zero. 
+     */
+    default MonitoringDataCollector collect(CharSequence key, boolean value) {
+        return collect(key, value ? 1L : 0L);
+    }
+
+    /**
+     * Similar to {@link #collect(CharSequence, long)}, the char simply becomes a number
+     */
+    default MonitoringDataCollector collect(CharSequence key, char value) {
+        return collect(key, (long) value);
+    }
+
+    /**
+     * Ignores <code>null</code>, collects {@link Double} and {@link Float} using
+     * {@link #collect(CharSequence, double)}, others using {@link #collect(CharSequence, long)}.
+     */
+    default MonitoringDataCollector collect(CharSequence key, Number value) {
+        if (value != null) {
+            if (value instanceof Double || value instanceof Float) {
+                return collect(key, value.doubleValue());
+            }
+            return collect(key, value.longValue());
+        }
+        return this;
+    }
+
+    /**
+     * Ignores <code>null</code>, otherwise collects using {@link #collect(CharSequence, boolean)}.
+     */
+    default MonitoringDataCollector collect(CharSequence key, Boolean value) {
+        return value != null ? collect(key, value.booleanValue()) : this;
+    }
+
+    /**
+     * Same as calling {@link #collect(CharSequence, long)} with a non null value and {@link Instant#toEpochMilli()}.
+     */
+    default MonitoringDataCollector collect(CharSequence key, Instant value) {
+        return value != null ?  collect(key, value.toEpochMilli()) : this;
+    }
+
+    /**
+     * Same as calling {@link BiConsumer#accept(Object, Object)} with this collector and the passed object.
+     * @return this for chaining, added purely to allow fluent API use
+     */
+    default <V> MonitoringDataCollector collectObject(V obj, BiConsumer<MonitoringDataCollector, V> collect) {
+        if (obj != null) {
+            collect.accept(this, obj);
+        }
+        return this;
+    }
+
+    /**
+     * Collects data points using the passed {@link BiConsumer} for every entry if the passed {@link Collection}.
+     * The context is not changed
+     * @param entries <code>null</code> or empty {@link Collection}s are ignored
+     * @param collect the function collecting the individual data points
+     * @return this for chaining (unchanged context)
+     */
+    default <V> MonitoringDataCollector collectObjects(Collection<V> entries, BiConsumer<MonitoringDataCollector, V> collect) {
+        if (entries != null) {
+            for (V entry : entries) {
+                collect.accept(this, entry);
+            }
+        }
+        return this;
+    }
+
+    default <K, V> MonitoringDataCollector collectAll(Map<K, V> entries,
+            BiConsumer<MonitoringDataCollector, V> collect) {
+        if (entries != null) {
+            collectNonZero("size", entries.size());
+            for (Entry<K,V> entry : entries.entrySet()) {
+                K key = entry.getKey();
+                CharSequence tag = key instanceof CharSequence ? (CharSequence) key : key.toString();
+                collect.accept(entity(tag), entry.getValue());
+            }
+        }
+        return this;
+    }
+
+    default <V> MonitoringDataCollector collectObject(V obj, Class<V> as) {
+        for (Method getter : as.getDeclaredMethods()) {
+            String name = getter.getName();
+            int offset = name.startsWith("get") ? 3 : name.startsWith("is") ? 2 : 0;
+            if (offset > 0) {
+                String property = Character.toLowerCase(name.charAt(offset)) + name.substring(offset+1);
+                Class<?> returnType = getter.getReturnType();
+                try {
+                    if (Boolean.class.isAssignableFrom(returnType) || returnType == boolean.class) {
+                        collect(property, (Boolean) getter.invoke(obj));
+                    } else if (Number.class.isAssignableFrom(returnType) || returnType.isPrimitive()) {
+                        collect(property, (Number) getter.invoke(obj));
+                    }
+                } catch (Exception e) {
+                    // try next
+                }
+            }
+        }
+        return this;
+    }
+
+    default MonitoringDataCollector app(CharSequence appName) {
+        return tag("app", appName);
+    }
+
+    /**
+     * Namespaces are used to distinguish data points of different origin.
+     * Each origin uses its own namespace. The namespace should be the first (top/right most) tag added.
+     *
+     * @param namespace the namespace to use, e.g. "health-monitor"
+     * @return A collector with the namespace context added/set
+     */
+    default MonitoringDataCollector in(CharSequence namespace) {
+        return tag("ns", namespace);
+    }
+
+    /**
+     * The type tag states the type of a collected entry. Most often used for collections of entries of the same kind.
+     * The type is usually the second tag added after the namespace.
+     *
+     * @param type type of entity or collection of entities that are about to be collected
+     * @return A collector with the type context added/set
+     */
+    default MonitoringDataCollector type(CharSequence type) {
+        return tag("type", type);
+    }
+
+    /**
+     * The entity tag states the identity that distinguishes values of one entry from another within the same collection
+     * of entries. The entity is usually the third tag added after the namespace and type (if needed).
+     *
+     * @param entity the entity to use, e.g. "log-notifier" (as opposed to "teams-notifier")
+     * @return A collector with the entity context added/set
+     */
+    default MonitoringDataCollector entity(CharSequence entity) {
+        return tag("entity", entity);
+    }
+
+}

--- a/nucleus/common/internal-api/src/main/java/fish/payara/monitoring/collect/MonitoringDataSource.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/monitoring/collect/MonitoringDataSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,61 +37,27 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.nucleus.eventbus;
+package fish.payara.monitoring.collect;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jvnet.hk2.annotations.Contract;
 
 /**
+ * Implemented by each source of monitoring data to provide the current data.
+ * 
+ * Each source first establishes its relative context using the
+ * {@link MonitoringDataCollector#tag(CharSequence, CharSequence)} method. After the context is complete for a group of
+ * data points these are added using {@link MonitoringDataCollector#collect(CharSequence, long)}.
  *
- * @author steve
+ * @author Jan Bernitt
  */
-public class TopicListener implements MessageListener {
-    
-    private final String topicName;
-    private String registrationID;
-    private final Set<MessageReceiver> receivers;
+@Contract
+@FunctionalInterface
+public interface MonitoringDataSource {
 
-    public TopicListener(String topicName) {
-        this.topicName = topicName;
-        receivers = ConcurrentHashMap.newKeySet(2);
-    }
-
-    public String getTopicName() {
-        return topicName;
-    }
-
-    public String getRegistrationID() {
-        return registrationID;
-    }
-
-    public void setRegistrationID(String registrationID) {
-        this.registrationID = registrationID;
-    }
-
-    int getReceiverCount() {
-        return receivers.size();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public void onMessage(Message msg) {
-        for (MessageReceiver receiver : receivers) {
-            receiver.receiveMessage((ClusterMessage)msg.getMessageObject());
-        }
-    }
-
-    void addMessageReceiver(MessageReceiver mr) {
-        receivers.add(mr);
-    }
-    
-    int removeMessageReceiver(MessageReceiver mr) {
-        receivers.remove(mr);
-        return receivers.size();
-    }
-    
-    
-    
+    /**
+     * Collects all the data points of this at the current moment.
+     * 
+     * @param collector the {@link MonitoringDataCollector} instance to use to collect the data points of this source
+     */
+    void collect(MonitoringDataCollector collector);
 }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ModuleInfo.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ModuleInfo.java
@@ -162,7 +162,9 @@ public class ModuleInfo {
 
     public Properties getModuleProps() {
         Properties props =  new Properties();
-        props.putAll(moduleProps);
+        if (moduleProps != null) {
+            props.putAll(moduleProps);
+        }
         return props;
     }
 

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/provider/FlashlightProbe.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/provider/FlashlightProbe.java
@@ -406,7 +406,11 @@ public class FlashlightProbe
         /* package */ final Object getState() { return state; }
         /* package */ final int getInvokerId() { return invokerId; }
     }
-    
+
+    public int getInvokerCount() {
+        return invokers.size();
+    }
+
     private Method probeMethod;
     public static final String SELF = "@SELF";
     private int id;

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -54,10 +54,19 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.Member;
 import com.hazelcast.kubernetes.KubernetesProperties;
+import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.scheduledexecutor.IScheduledFuture;
+import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.util.Utility;
+
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.nucleus.events.HazelcastEvents;
 import fish.payara.nucleus.hazelcast.contextproxy.CachingProviderProxy;
 import java.beans.PropertyChangeEvent;
@@ -67,6 +76,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -100,7 +111,7 @@ import org.jvnet.hk2.config.UnprocessedChangeEvents;
  */
 @Service(name = "hazelcast-core")
 @RunLevel(StartupRunLevel.VAL)
-public class HazelcastCore implements EventListener, ConfigListener {
+public class HazelcastCore implements EventListener, ConfigListener, MonitoringDataSource {
 
     public final static String INSTANCE_ATTRIBUTE = "GLASSFISH-INSTANCE";
     public final static String INSTANCE_GROUP_ATTRIBUTE = "GLASSFISH_INSTANCE_GROUP";
@@ -176,7 +187,33 @@ public class HazelcastCore implements EventListener, ConfigListener {
             memberGroup = nodeConfig.getMemberGroup();
         }
     }
-    
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        MonitoringDataCollector clusterCollector = collector.in("cluster")
+                .collect("booted", booted)
+                .collect("enabled", enabled);
+        for (Member member : getInstance().getCluster().getMembers()) {
+            clusterCollector.type("member").entity(member.getStringAttribute(HazelcastCore.INSTANCE_ATTRIBUTE))
+                .collect("local", member.localMember());
+        }
+        clusterCollector.type("executor").entity(HazelcastCore.CLUSTER_EXECUTOR_SERVICE_NAME)
+            .collectObject(getInstance().getExecutorService(HazelcastCore.CLUSTER_EXECUTOR_SERVICE_NAME).getLocalExecutorStats(), LocalExecutorStats.class);
+        Map<Member, List<IScheduledFuture<Object>>> scheduled = getInstance()
+                .getScheduledExecutorService(HazelcastCore.SCHEDULED_CLUSTER_EXECUTOR_SERVICE_NAME)
+                .getAllScheduledFutures();
+        int total = 0;
+        MonitoringDataCollector scheduledCollector = clusterCollector
+            .type("executor").entity(HazelcastCore.SCHEDULED_CLUSTER_EXECUTOR_SERVICE_NAME);
+        for (Entry<Member, List<IScheduledFuture<Object>>> entry : scheduled.entrySet()) {
+            total += entry.getValue().size();
+            scheduledCollector.tag("member", entry.getKey().getStringAttribute(HazelcastCore.INSTANCE_ATTRIBUTE))
+                .collect("scheduledFutureCount", entry.getValue().size());
+        }
+        scheduledCollector
+            .collect("totalScheduledFutureCount", total);
+    }
+
     /**
      * Returns the Hazelcast name of the instance
      * <p>

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckService.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckService.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,6 +39,9 @@
 package fish.payara.nucleus.healthcheck;
 
 import com.sun.enterprise.config.serverbeans.Config;
+
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import fish.payara.nucleus.healthcheck.configuration.HealthCheckServiceConfiguration;
 import fish.payara.nucleus.healthcheck.preliminary.BaseHealthCheck;
@@ -75,7 +78,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -85,10 +87,9 @@ import java.util.logging.Logger;
  */
 @Service(name = "healthcheck-core")
 @RunLevel(StartupRunLevel.VAL)
-public class HealthCheckService implements EventListener, ConfigListener {
+public class HealthCheckService implements EventListener, ConfigListener, MonitoringDataSource {
 
     private static final Logger logger = Logger.getLogger(HealthCheckService.class.getCanonicalName());
-    private static final String PREFIX = "healthcheck-service-";
 
     @Inject
     @Named(ServerEnvironment.DEFAULT_INSTANCE_NAME)
@@ -120,7 +121,6 @@ public class HealthCheckService implements EventListener, ConfigListener {
     private PayaraExecutorService executor;
 
     private List<NotifierExecutionOptions> notifierExecutionOptionsList;
-    private final AtomicInteger threadNumber = new AtomicInteger(1);
     private Map<String, HealthCheckTask> registeredTasks = new HashMap<>();
     private boolean enabled;
     private boolean historicalTraceEnabled;
@@ -128,6 +128,31 @@ public class HealthCheckService implements EventListener, ConfigListener {
     private Long historicalTraceStoreTimeout;
     private ScheduledFuture<?> historicalTraceTask;
     private Set<ScheduledFuture<?>> scheduledCheckers;
+
+    @Override
+    public void collect(MonitoringDataCollector rootCollector) {
+        rootCollector.in("health-check")
+            .collect("enabled", enabled)
+            .collect("historicalTraceEnabled", historicalTraceEnabled)
+            .collect("historicalTraceStoreSize", historicalTraceStoreSize)
+            .collect("notifiers", notifierExecutionOptionsList == null ? 0 : notifierExecutionOptionsList.size())
+            .collect("checkers", scheduledCheckers == null ? 0 : scheduledCheckers.size())
+            .type("checker").collectAll(registeredTasks, HealthCheckService::collectTask)
+            .type("notifier").collectObjects(notifierExecutionOptionsList, HealthCheckService::collectNotifierOption);
+    }
+
+    private static void collectTask(MonitoringDataCollector collector, HealthCheckTask task) {
+        HealthCheckExecutionOptions options = task.getCheck().getOptions();
+        collector
+            .collect("enabled", options.isEnabled())
+            .collectNonZero("interval", options.getUnit().toMillis(options.getTime()));
+    }
+
+    private static void collectNotifierOption(MonitoringDataCollector collector, NotifierExecutionOptions options) {
+        collector.entity(options.getNotifierType().name())
+            .collect("enabled", options.isEnabled())
+            .collect("noisy", options.isNoisy());
+    }
 
     @Override
     public void event(Event event) {

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseThresholdHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/BaseThresholdHealthCheck.java
@@ -73,7 +73,7 @@ public abstract class BaseThresholdHealthCheck<O extends HealthCheckWithThreshol
      * @param percentage
      * @return 
      */
-    protected HealthCheckResultStatus decideOnStatusWithRatio(Double percentage) {
+    protected HealthCheckResultStatus decideOnStatusWithRatio(double percentage) {
         if (percentage > options.getThresholdCritical()) {
             return HealthCheckResultStatus.CRITICAL;
         }

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/GarbageCollectorHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/GarbageCollectorHealthCheck.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,6 +39,8 @@
  */
 package fish.payara.nucleus.healthcheck.preliminary;
 
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.notification.healthcheck.HealthCheckResultEntry;
 import fish.payara.notification.healthcheck.HealthCheckResultStatus;
 import fish.payara.nucleus.healthcheck.*;
@@ -66,12 +68,27 @@ import static fish.payara.nucleus.notification.TimeHelper.prettyPrintDuration;
  */
 @Service(name = "healthcheck-gc")
 @RunLevel(StartupRunLevel.VAL)
-public class GarbageCollectorHealthCheck extends BaseThresholdHealthCheck<HealthCheckWithThresholdExecutionOptions, GarbageCollectorChecker> {
+public class GarbageCollectorHealthCheck
+        extends BaseThresholdHealthCheck<HealthCheckWithThresholdExecutionOptions, GarbageCollectorChecker>
+        implements MonitoringDataSource {
 
-    private long youngLastCollectionCount;
-    private long youngLastCollectionTime;
-    private long oldLastCollectionCount;
-    private long oldLastCollectionTime;
+    private volatile long youngLastCollectionCount;
+    private volatile long youngLastCollectionTime;
+    private volatile long oldLastCollectionCount;
+    private volatile long oldLastCollectionTime;
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        if (isReady()) {
+            collector.in("health-check").type("checker").entity("GBGC")
+                .collect("checksDone", getChecksDone())
+                .collectNonZero("checksFailed", getChecksFailed())
+                .collectNonZero("youngLastCollectionCount", youngLastCollectionCount)
+                .collectNonZero("youngLastCollectionTime", youngLastCollectionTime)
+                .collectNonZero("oldLastCollectionCount", oldLastCollectionCount)
+                .collectNonZero("oldLastCollectionTime", oldLastCollectionTime);
+        }
+    }
 
     @PostConstruct
     void postConstruct() {
@@ -89,7 +106,7 @@ public class GarbageCollectorHealthCheck extends BaseThresholdHealthCheck<Health
     }
 
     @Override
-    public HealthCheckResult doCheck() {
+    protected HealthCheckResult doCheckInternal() {
         HealthCheckResult result = new HealthCheckResult();
 
         List<GarbageCollectorMXBean> gcBeanList = ManagementFactory.getGarbageCollectorMXBeans();

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HeapMemoryUsageHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HeapMemoryUsageHealthCheck.java
@@ -40,6 +40,8 @@
 package fish.payara.nucleus.healthcheck.preliminary;
 
 import fish.payara.nucleus.healthcheck.HealthCheckResult;
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.notification.healthcheck.HealthCheckResultEntry;
 import fish.payara.nucleus.healthcheck.HealthCheckWithThresholdExecutionOptions;
 import fish.payara.nucleus.healthcheck.configuration.HeapMemoryUsageChecker;
@@ -57,7 +59,25 @@ import java.lang.management.MemoryUsage;
  */
 @Service(name = "healthcheck-heap")
 @RunLevel(StartupRunLevel.VAL)
-public class HeapMemoryUsageHealthCheck extends BaseThresholdHealthCheck<HealthCheckWithThresholdExecutionOptions, HeapMemoryUsageChecker> {
+public class HeapMemoryUsageHealthCheck
+        extends BaseThresholdHealthCheck<HealthCheckWithThresholdExecutionOptions, HeapMemoryUsageChecker>
+        implements MonitoringDataSource {
+
+    private volatile MemoryUsage heap;
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        if (isReady() && heap != null) {
+            collector.in("health-check").type("checker").entity("HEAP")
+                .collect("checksDone", getChecksDone())
+                .collectNonZero("checksFailed", getChecksFailed())
+                .collectNonZero("initBytes", heap.getInit())
+                .collectNonZero("usedBytes", heap.getUsed())
+                .collectNonZero("committedBytes", heap.getCommitted())
+                .collectNonZero("maxBytes", heap.getMax())
+                .collectNonZero("usedPercentage", calculatePercentage(heap));
+        }
+    }
 
     @PostConstruct
     void postConstruct() {
@@ -75,27 +95,24 @@ public class HeapMemoryUsageHealthCheck extends BaseThresholdHealthCheck<HealthC
     }
 
     @Override
-    public HealthCheckResult doCheck() {
+    protected HealthCheckResult doCheckInternal() {
         HealthCheckResult result = new HealthCheckResult();
         MemoryMXBean memBean = ManagementFactory.getMemoryMXBean() ;
-        MemoryUsage heap = memBean.getHeapMemoryUsage();
+        heap = memBean.getHeapMemoryUsage();
 
         String heapValueText = String.format("heap: init: %s, used: %s, committed: %s, max.: %s",
                 prettyPrintBytes(heap.getInit()),
                 prettyPrintBytes(heap.getUsed()),
                 prettyPrintBytes(heap.getCommitted()),
                 prettyPrintBytes(heap.getMax()));
-        Double percentage = calculatePercentage(heap);
+        long percentage = calculatePercentage(heap);
         result.add(new HealthCheckResultEntry(decideOnStatusWithRatio(percentage), heapValueText + "heap%: " + percentage + "%"));
 
         return result;
     }
 
-    private static Double calculatePercentage(MemoryUsage usage) {
-        if (usage.getMax() > 0) {
-            return Math.floor(((double)usage.getUsed() / (double)usage.getMax()) * 100);
-        }
-        return null;
+    private static long calculatePercentage(MemoryUsage usage) {
+        return usage.getMax() == 0L ? 0L : (long)Math.floor(((double)usage.getUsed() / (double)usage.getMax()) * 100d);
     }
 }
 

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HoggingThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HoggingThreadsHealthCheck.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -41,6 +41,8 @@ package fish.payara.nucleus.healthcheck.preliminary;
 
 import fish.payara.nucleus.healthcheck.HealthCheckHoggingThreadsExecutionOptions;
 import fish.payara.nucleus.healthcheck.HealthCheckResult;
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.notification.healthcheck.HealthCheckResultEntry;
 import fish.payara.notification.healthcheck.HealthCheckResultStatus;
 import fish.payara.nucleus.healthcheck.configuration.HoggingThreadsChecker;
@@ -53,8 +55,10 @@ import javax.annotation.PostConstruct;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static fish.payara.nucleus.notification.TimeHelper.prettyPrintDuration;
 
@@ -63,10 +67,22 @@ import static fish.payara.nucleus.notification.TimeHelper.prettyPrintDuration;
  */
 @Service(name = "healthcheck-threads")
 @RunLevel(StartupRunLevel.VAL)
-public class HoggingThreadsHealthCheck extends BaseHealthCheck<HealthCheckHoggingThreadsExecutionOptions,
-        HoggingThreadsChecker> {
+public class HoggingThreadsHealthCheck
+        extends BaseHealthCheck<HealthCheckHoggingThreadsExecutionOptions, HoggingThreadsChecker>
+        implements MonitoringDataSource {
 
-    private HashMap<Long, ThreadTimes> threadTimes = new HashMap<Long, ThreadTimes>();
+    private final Map<Long, ThreadTimes> threadTimes = new ConcurrentHashMap<>();
+    private final AtomicInteger hoggingThreads = new AtomicInteger();
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        if (isReady()) {
+            collector.in("health-check").type("checker").entity("HOGT")
+                .collect("checksDone", getChecksDone())
+                .collectNonZero("checksFailed", getChecksFailed())
+                .collectNonZero("hoggingThreads", hoggingThreads.get());
+        }
+    }
 
     @PostConstruct
     void postConstruct() {
@@ -87,10 +103,8 @@ public class HoggingThreadsHealthCheck extends BaseHealthCheck<HealthCheckHoggin
     }
 
     @Override
-    public HealthCheckResult doCheck() {
-        if (!getOptions().isEnabled()) {
-            return null;
-        }
+    protected HealthCheckResult doCheckInternal() {
+        hoggingThreads.set(0);
         HealthCheckResult result = new HealthCheckResult();
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
 
@@ -137,6 +151,7 @@ public class HoggingThreadsHealthCheck extends BaseHealthCheck<HealthCheckHoggin
                         times.setInitialStartUserTime(System.nanoTime());
                     }
                     if (times.getRetryCount() >= options.getRetryCount()) {
+                        hoggingThreads.incrementAndGet();
                         result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL,
                                 "Thread with <id-name>: " + id + "-" + times.getName() +
                                         " is a hogging thread for the last " +

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -40,6 +40,8 @@
 package fish.payara.nucleus.healthcheck.stuck;
 
 import fish.payara.nucleus.healthcheck.HealthCheckResult;
+import fish.payara.monitoring.collect.MonitoringDataCollector;
+import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.notification.healthcheck.HealthCheckResultEntry;
 import fish.payara.notification.healthcheck.HealthCheckResultStatus;
 import fish.payara.nucleus.healthcheck.HealthCheckStuckThreadExecutionOptions;
@@ -48,6 +50,8 @@ import fish.payara.nucleus.healthcheck.configuration.StuckThreadsChecker;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
@@ -62,40 +66,56 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service(name = "healthcheck-stuck")
 @RunLevel(StartupRunLevel.VAL)
-public class StuckThreadsHealthCheck extends BaseHealthCheck<HealthCheckStuckThreadExecutionOptions,
-        StuckThreadsChecker>{
-    
+public class StuckThreadsHealthCheck extends
+        BaseHealthCheck<HealthCheckStuckThreadExecutionOptions, StuckThreadsChecker> implements MonitoringDataSource {
+
     @Inject
     StuckThreadsStore stuckThreadsStore;
-    
+
     @Inject
     StuckThreadsChecker checker;
-    
+
+    private final Map<ThreadInfo, Long> stuckThreads = new ConcurrentHashMap<>();
+
+    @Override
+    public void collect(MonitoringDataCollector collector) {
+        if (isReady()) {
+            MonitoringDataCollector stuckCollector = collector.in("health-check").type("checker").entity("STUCK")
+                    .collect("checksDone", getChecksDone())
+                    .collectNonZero("checksFailed", getChecksFailed())
+                    .collectNonZero("size", stuckThreads.size());
+            for (Entry<ThreadInfo, Long> stuckThread : stuckThreads.entrySet()) {
+                stuckCollector.tag("thread", stuckThread.getKey().getThreadName())
+                    .collect("timeHeld", stuckThread.getValue());
+            }
+        }
+    }
+
     @PostConstruct
     void postConstruct() {
         postConstruct(this, StuckThreadsChecker.class);
     }
-    
+
     @Override
-    public HealthCheckResult doCheck() {
-        
+    protected HealthCheckResult doCheckInternal() {
+        stuckThreads.clear();
         HealthCheckResult result = new HealthCheckResult();
         ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-        
+
         Long thresholdNanos = TimeUnit.NANOSECONDS.convert(options.getTimeStuck(), options.getUnitStuck());
-        
+
         ConcurrentHashMap<Long, Long> threads = stuckThreadsStore.getThreads();
         for (Long thread : threads.keySet()){
             Long timeHeld = threads.get(thread);
             if (timeHeld > thresholdNanos){
                 ThreadInfo info = bean.getThreadInfo(thread, Integer.MAX_VALUE);
                 if (info != null){//check thread hasn't died already
+                    stuckThreads.put(info, timeHeld);
                     result.add(new HealthCheckResultEntry(HealthCheckResultStatus.WARNING, "Stuck Thread: " + info.toString()));
-                    
                 }
             }
         }
-        
+
         return result;
     }
 

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTraceSpanStore.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTraceSpanStore.java
@@ -42,9 +42,13 @@ package fish.payara.nucleus.requesttracing;
 import fish.payara.notification.requesttracing.RequestTrace;
 import fish.payara.notification.requesttracing.EventType;
 import fish.payara.notification.requesttracing.RequestTraceSpan;
+import fish.payara.nucleus.requesttracing.store.IterableThreadLocal;
+
 import org.jvnet.hk2.annotations.Service;
 
 import javax.inject.Singleton;
+
+import java.util.Map.Entry;
 import java.util.UUID;
 
 /**
@@ -59,27 +63,26 @@ import java.util.UUID;
 @Singleton
 public class RequestTraceSpanStore {
 
-    private ThreadLocal<RequestTrace> spanStore = new ThreadLocal<RequestTrace>() {
-        @Override
-        protected RequestTrace initialValue() {
-            return new RequestTrace();
-        }      
-    };
+    private IterableThreadLocal<RequestTrace> spanStore = new IterableThreadLocal<>(RequestTrace::new);
+
+    public Iterable<Entry<Thread, RequestTrace>> getTraces() {
+        return spanStore;
+    }
 
     /**
      * Adds a new event to the request trace
      * @param payaraSpan 
      */
-    void storeEvent(RequestTraceSpan payaraSpan) {       
+    void storeEvent(RequestTraceSpan payaraSpan) {
         RequestTrace currentTrace = spanStore.get();
         currentTrace.addEvent(payaraSpan);
     }
-    
-    void storeEvent(RequestTraceSpan payaraSpan, long timestampMillis) {       
+
+    void storeEvent(RequestTraceSpan payaraSpan, long timestampMillis) {
         RequestTrace currentTrace = spanStore.get();
         currentTrace.addEvent(payaraSpan, timestampMillis);
     }
-    
+
     void endTrace() {
         RequestTrace currentTrace = spanStore.get();
         currentTrace.endTrace();
@@ -107,7 +110,7 @@ public class RequestTraceSpanStore {
     String getTraceAsString() {
         return spanStore.get().toString();
     }
-    
+
     // test methods
     /**
      * Returns the full trace
@@ -126,7 +129,7 @@ public class RequestTraceSpanStore {
         RequestTrace trace = spanStore.get();
         return trace.getTraceId();
     }
-    
+
     void setTraceId(UUID newID) {
         RequestTrace trace = spanStore.get();
         trace.setTraceId(newID);

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/store/IterableThreadLocal.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/store/IterableThreadLocal.java
@@ -1,0 +1,53 @@
+package fish.payara.nucleus.requesttracing.store;
+
+import static java.util.Collections.synchronizedMap;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
+
+/**
+ * A {@link ThreadLocal} that allows to iterate over all available {@link Thread}-value pairs.
+ * Note that this is not strongly consistent and may differ from actual current state in moment of change.
+ * 
+ * @author Jan Bernitt
+ *
+ * @param <T> Type of the thread local value
+ */
+public class IterableThreadLocal<T> extends ThreadLocal<T> implements Iterable<Entry<Thread, T>> {
+
+    private final Map<Thread, T> entries;
+    private final Supplier<? extends T> initialValue;
+
+    public IterableThreadLocal(Supplier<? extends T> initialValue) {
+        this.initialValue = initialValue;
+        this.entries = synchronizedMap(new WeakHashMap<>());
+    }
+
+    @Override
+    protected T initialValue() {
+        T value = initialValue != null ? initialValue.get() : super.initialValue();
+        entries.put(Thread.currentThread(), value);
+        return value;
+    }
+
+    @Override
+    public void set(T value) {
+        super.set(value);
+        entries.put(Thread.currentThread(), value);
+    }
+
+    @Override
+    public void remove() {
+        super.remove();
+        entries.remove(Thread.currentThread());
+    }
+
+    @Override
+    public Iterator<Entry<Thread, T>> iterator() {
+        return entries.entrySet().iterator();
+    }
+
+}


### PR DESCRIPTION
### Synopsis
Introduces a new API to collect monitoring data consisting of two interface:

* `MonitoringDataSource` a `@Contract` implemented by `@Service` classes that have references to monitoring data in some form
* `MonitoringDataCollector` is passed to the sources so they can add any number of data points.

Data points are added in in a collection context that is implicit for the `MonitoringDataCollector` and can be extended using its `tag` method to create a new extended collection context.

The majority of actual code are the implementations of the `MonitoringDataSource`s where the different services add their information to the collection. 

More details can be found in the design document https://payara.atlassian.net/wiki/spaces/PAYAR/pages/870055939/Payara+Monitoring+Console+Design