### PR TITLE
SPEC-245: Support embedded  EJBContainer

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerService.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerService.java
@@ -193,7 +193,7 @@ public abstract class EJBTimerService {
         if (isNull(persistentTimerService) && isNull(nonPersistentTimerService)) {
             if (!nonPersistentTimerServiceVerified) {
                 // this happens when timer service is injected into bean with no timeout methods.
-                // such constallation is useless, but very present in TCK test cases, so we give it a non-persistent
+                // such constellation is useless, but very present in TCK test cases, so we give it a non-persistent
                 // timer service
                 initNonPersistentTimerService(null, true);
             } else {

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerService.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBTimerService.java
@@ -191,7 +191,14 @@ public abstract class EJBTimerService {
 
     public static EJBTimerServiceWrapper getEJBTimerServiceWrapper(EJBContextImpl ejbContext) {
         if (isNull(persistentTimerService) && isNull(nonPersistentTimerService)) {
-            throw new IllegalStateException("EJB Timer Service not available");
+            if (!nonPersistentTimerServiceVerified) {
+                // this happens when timer service is injected into bean with no timeout methods.
+                // such constallation is useless, but very present in TCK test cases, so we give it a non-persistent
+                // timer service
+                initNonPersistentTimerService(null, true);
+            } else {
+                throw new IllegalStateException("EJB Timer Service not available");
+            }
         }
         return new EJBTimerServiceWrapper(
                 persistentTimerService,

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatefulSessionContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatefulSessionContainer.java
@@ -2689,6 +2689,9 @@ public final class StatefulSessionContainer
      */
 
     private void deserializeContext(SessionContextImpl ctx) throws Exception {
+        if (ctx == null) {
+            return;
+        }
         Object ejb = ctx.getEJB();
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "StatefulSessionContainer.deserializeData: " + ((ejb == null) ? null : ejb.getClass()));

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -157,13 +157,6 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>
-            <artifactId>glassfish-cluster</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.packager</groupId>
             <artifactId>glassfish-common-full</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
@@ -304,7 +297,75 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>json</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>javadb</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <!-- hazelcast package -->
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
             <artifactId>metro</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>requesttracing</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.packager</groupId>
+            <artifactId>notification-package</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.packager</groupId>
+            <artifactId>payara-api-package</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>payara-executor-service</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>cdi-auth-roles</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <!-- Micro Service -->
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>payara-micro</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>

--- a/appserver/packager/requesttracing/pom.xml
+++ b/appserver/packager/requesttracing/pom.xml
@@ -103,19 +103,16 @@
             <artifactId>requesttracing-package</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>fish.payara.payara-appserver-modules</groupId>
             <artifactId>jaxrs-client-tracing</artifactId>
             <version>${project.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>fish.payara.payara-appserver-modules</groupId>
             <artifactId>opentracing-cdi</artifactId>
             <version>${project.version}</version>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/jaxrs-client-tracing/pom.xml
+++ b/appserver/payara-appserver-modules/jaxrs-client-tracing/pom.xml
@@ -59,11 +59,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
-            <version>${opentracing.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/src/main/java/fish/payara/appserver/monitoring/rest/service/adapter/RestMonitoringAdapter.java
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/src/main/java/fish/payara/appserver/monitoring/rest/service/adapter/RestMonitoringAdapter.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -315,22 +316,22 @@ public final class RestMonitoringAdapter extends HttpHandler implements Adapter 
 
     @Override
     public String getContextRoot() {
-        return endpointDecider.getContextRoot();
+        return endpointDecider == null ? null : endpointDecider.getContextRoot();
     }
 
     @Override
     public int getListenPort() {
-        return endpointDecider.getListenPort();
+        return endpointDecider == null ? -1 : endpointDecider.getListenPort();
     }
 
     @Override
     public InetAddress getListenAddress() {
-        return endpointDecider.getListenAddress();
+        return endpointDecider == null ? null : endpointDecider.getListenAddress();
     }
 
     @Override
     public List<String> getVirtualServers() {
-        return endpointDecider.getHosts();
+        return endpointDecider == null ? Collections.emptyList() : endpointDecider.getHosts();
     }
 
     @Override

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
@@ -174,13 +174,13 @@ public class GenericAnnotationDetector extends AnnotationScanner {
                             jarSubArchive.close();
                         }
                     } catch (Exception ioe) {
-                        Object args[] = { entryName, ioe.getMessage() };
+                        Object args[] = { entryName, ioe };
                         deplLogger.log(Level.WARNING, JAR_ENTRY_ERROR, args);
                     }
                 }
             }
         } catch (Exception e) {
-          deplLogger.log(Level.WARNING, FAILED_ANNOTATION_SCAN, e.getMessage());
+          deplLogger.log(Level.WARNING, FAILED_ANNOTATION_SCAN, e);
         }
     }
 }

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -54,23 +54,13 @@
     
     <dependencies>
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
-            <version>${opentracing.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-mock</artifactId>
-            <version>${opentracing.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-util</artifactId>
-            <version>${opentracing.version}</version>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.external</groupId>
+            <artifactId>opentracing-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
+++ b/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
@@ -69,6 +69,7 @@ import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.EventTypes;
 import org.glassfish.api.event.Events;
 import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.deployment.Deployment;
 import org.jvnet.hk2.annotations.Optional;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigBeanProxy;
@@ -129,7 +130,13 @@ public class PayaraExecutorService implements ConfigListener, EventListener {
      */
     @Override
     public void event(Event event) {
-        if (event.is(EventTypes.SERVER_SHUTDOWN)) {
+        if (event.is(Deployment.ALL_APPLICATIONS_LOADED)) {
+            // there is awkward point in embedded EJBContainer initialization, where same server
+            // instance is started twice. In such case, we need to reinitialize.
+            if (threadPoolExecutor.isShutdown()) {
+                initialiseThreadPools();
+            }
+        } else if (event.is(EventTypes.SERVER_SHUTDOWN)) {
             threadPoolExecutor.shutdown();
             scheduledThreadPoolExecutor.shutdown();
         }


### PR DESCRIPTION
TCK uses `glassfish-embedded-static-shell` to launch an embedded container, that is isolated from installed domain but inherits domain's settings. This module needed broader dependencies, which uncovered issues in request tracing related modules.

The startup of embedded container is quite special. First, it doesn't start with HTTP ports, which `RestMonitoringService` doesn't expect and needed to handle. Second the server starts up twice -- once to get security configuration to copy, and second time to run with this new configuration. `PayaraExecutorService` had to be adapted to cope with double startup.

Also added fix for cases where an EJB injects a `TimerService` but doesn't use it. Before we wouldn't initialize any service and injection would fail.

Also present in this bunch is fix for failing async methods on stateful EJBs. Apparently, these do not have ejb invocation context, which came as a surprise to context deserialization method.