### PR TITLE
SPEC-267: Fail operations on expired nonpersistent timers

### DIFF
--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/persistent/timer/PersistentEJBTimerService.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/persistent/timer/PersistentEJBTimerService.java
@@ -1027,7 +1027,7 @@ public class PersistentEJBTimerService extends NonPersistentEJBTimerService {
     protected Serializable getInfo(TimerPrimaryKey timerId) throws FinderException {
 
         // Check non-persistent timers first
-        if (!super.isPersistent(timerId)) {
+        if (isNonpersistent(timerId)) {
             return super.getInfo(timerId);
         }
 
@@ -1043,7 +1043,7 @@ public class PersistentEJBTimerService extends NonPersistentEJBTimerService {
     protected boolean isPersistent(TimerPrimaryKey timerId) throws FinderException {
 
         // Check non-persistent timers first
-        if (!super.isPersistent(timerId)) {
+        if (isNonpersistent(timerId)) {
             // Found and active
             return false;
         }
@@ -1083,7 +1083,7 @@ public class PersistentEJBTimerService extends NonPersistentEJBTimerService {
 
         // Check non-persistent timers first
         EJBTimerSchedule ts = null;
-        if (!super.isPersistent(timerId)) {
+        if (isNonpersistent(timerId)) {
             ts = super.getTimerSchedule(timerId);
         } else {
 

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
@@ -222,7 +222,7 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
     @Override
     protected Serializable getInfo(TimerPrimaryKey timerId) throws FinderException {
         // Check non-persistent timers first
-        if (!super.isPersistent(timerId)) {
+        if (isNonpersistent(timerId)) {
             return super.getInfo(timerId);
         }
 
@@ -400,7 +400,7 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
     protected EJBTimerSchedule getTimerSchedule(TimerPrimaryKey timerId) throws FinderException {
         // Check non-persistent timers first
         EJBTimerSchedule ts = null;
-        if (!super.isPersistent(timerId)) {
+        if (isNonpersistent(timerId)) {
             ts = super.getTimerSchedule(timerId);
         } else {
 
@@ -446,7 +446,7 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
     @Override
     protected boolean isPersistent(TimerPrimaryKey timerId) throws FinderException {
         // Check non-persistent timers first
-        if (!super.isPersistent(timerId)) {
+        if (isNonpersistent(timerId)) {
             // Found and active
             return false;
         }


### PR DESCRIPTION
Spec mandates throwing an exception on accessing nonpersistent
expired timers when accessed over public API.
Since NonPersistentEJBTimerService is base class for persistent
implementations, which pass their non-persistent functionality to it,
it needs internal method for verifying it would handle that timer.

This fixed ejb32/lite/timer tests, while not breaking ejb30/timer/tests at same time.