### PR TITLE
SPEC-282: Introduce JVM option to turn off variable support outside config

### DIFF
--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/SerialContext.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/SerialContext.java
@@ -467,7 +467,7 @@ public class SerialContext implements Context {
                 return (new SerialContext(myName, myEnv, services));
             }
 
-            name = (String)TranslatedConfigView.getTranslatedValue(name);
+            name = TranslatedConfigView.expandValue(name);
             name = getRelativeName(name);
 
             if (isjavaURL(name)) {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionHandler.java
@@ -274,7 +274,7 @@ public class ConnectionFactoryDefinitionHandler extends AbstractResourceHandler 
         desc.setMetadataSource(MetadataSource.ANNOTATION);
 
         desc.setName(defn.name());
-        desc.setResourceAdapter((String) TranslatedConfigView.getTranslatedValue(defn.resourceAdapter()));
+        desc.setResourceAdapter(TranslatedConfigView.expandValue(defn.resourceAdapter()));
         desc.setInterfaceName(defn.interfaceName());
         desc.setTransactionSupport(defn.transactionSupport().toString());
         desc.setMaxPoolSize(defn.maxPoolSize());
@@ -295,7 +295,7 @@ public class ConnectionFactoryDefinitionHandler extends AbstractResourceHandler 
                     if (index > 0 && index < property.length() - 1) {
                         String name = property.substring(0, index);
                         String value = property.substring(index + 1);
-                        properties.put(name.trim(), TranslatedConfigView.getTranslatedValue(value.trim()));
+                        properties.put(name.trim(), TranslatedConfigView.expandValue(value.trim()));
                     }
                 }
             }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorConnectionPoolAdminServiceImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorConnectionPoolAdminServiceImpl.java
@@ -677,7 +677,7 @@ public class ConnectorConnectionPoolAdminServiceImpl extends ConnectorService {
                 result = envProp.getValue();
             }
         }
-        return (String)TranslatedConfigView.getTranslatedValue(result);
+        return TranslatedConfigView.expandValue(result);
     }
 
     private ResourcePrincipal getDefaultResourcePrincipal( PoolInfo poolInfo,

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/AdministeredObjectDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/AdministeredObjectDefinitionDeployer.java
@@ -222,7 +222,7 @@ public class AdministeredObjectDefinitionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return (String) TranslatedConfigView.getTranslatedValue(value);
+            return TranslatedConfigView.expandValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/ConnectionFactoryDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/ConnectionFactoryDefinitionDeployer.java
@@ -237,7 +237,7 @@ public class ConnectionFactoryDefinitionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return (String) TranslatedConfigView.getTranslatedValue(value);
+            return TranslatedConfigView.expandValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSConnectionFactoryDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSConnectionFactoryDefinitionDeployer.java
@@ -243,7 +243,7 @@ public class JMSConnectionFactoryDefinitionDeployer implements ResourceDeployer 
         }
 
         public String getValue() {
-            return (String) TranslatedConfigView.getTranslatedValue(value);
+            return TranslatedConfigView.expandValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSDestinationDefinitionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/JMSDestinationDefinitionDeployer.java
@@ -219,7 +219,7 @@ public class JMSDestinationDefinitionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return (String) TranslatedConfigView.getTranslatedValue(value);
+            return TranslatedConfigView.expandValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/MailSessionDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/MailSessionDeployer.java
@@ -364,7 +364,7 @@ public class MailSessionDeployer implements ResourceDeployer {
         }
 
         public String getValue() {
-            return (String) TranslatedConfigView.getTranslatedValue(value);
+            return TranslatedConfigView.expandValue(value);
         }
 
         public void setValue(String value) throws PropertyVetoException {
@@ -442,7 +442,7 @@ public class MailSessionDeployer implements ResourceDeployer {
 
         @Override
         public String getHost() {
-            return (String) TranslatedConfigView.getTranslatedValue(desc.getHost());
+            return TranslatedConfigView.expandValue(desc.getHost());
         }
 
         @Override
@@ -452,7 +452,7 @@ public class MailSessionDeployer implements ResourceDeployer {
 
         @Override
         public String getUser() {
-            return (String) TranslatedConfigView.getTranslatedValue(desc.getUser());
+            return TranslatedConfigView.expandValue(desc.getUser());
         }
 
         @Override
@@ -462,7 +462,7 @@ public class MailSessionDeployer implements ResourceDeployer {
 
         @Override
         public String getPassword(){
-            return (String) TranslatedConfigView.getTranslatedValue(desc.getPassword());
+            return TranslatedConfigView.expandValue(desc.getPassword());
         }
         
         @Override
@@ -484,7 +484,7 @@ public class MailSessionDeployer implements ResourceDeployer {
         
         @Override
         public String getFrom() {
-            return (String) TranslatedConfigView.getTranslatedValue(desc.getFrom());
+            return TranslatedConfigView.expandValue(desc.getFrom());
         }
 
         @Override

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/EjbReferenceDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/EjbReferenceDescriptor.java
@@ -237,7 +237,7 @@ public class EjbReferenceDescriptor extends EnvironmentProperty implements EjbRe
      */
     @Override
     public void setLinkName(String linkName) {
-        ejbLink = (String)TranslatedConfigView.getTranslatedValue(linkName);
+        ejbLink = TranslatedConfigView.expandValue(linkName);
     }
     /**
      * return the jndi name of the bean to which I refer.
@@ -276,7 +276,7 @@ public class EjbReferenceDescriptor extends EnvironmentProperty implements EjbRe
 
     @Override
     public void setLookupName(String l) {
-        lookupName = (String)TranslatedConfigView.getTranslatedValue(l);
+        lookupName = TranslatedConfigView.expandValue(l);
     }
 
     @Override

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/DeploymentDescriptorNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/DeploymentDescriptorNode.java
@@ -330,7 +330,7 @@ public abstract class DeploymentDescriptorNode<T> implements XMLNode<T> {
                     DOLUtils.getDefaultLogger().finer("With value " + attributes.getValue(i));
                 }
                 // we try the setAttributeValue first, if not processed then the setElement
-                String attrValue = (String) TranslatedConfigView.getTranslatedValue(attributes.getValue(i));
+                String attrValue = TranslatedConfigView.expandValue(attributes.getValue(i));
                 if (!setAttributeValue(element, new XMLElement(attributes.getQName(i)), attrValue)) {
                     setElementValue(new XMLElement(attributes.getQName(i)), attrValue);
                 }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/PersistenceUnitNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/PersistenceUnitNode.java
@@ -86,7 +86,7 @@ public class PersistenceUnitNode extends DeploymentDescriptorNode {
             PersistenceUnitDescriptor persistenceUnitDescriptor = (PersistenceUnitDescriptor) getDescriptor();
             String propName = attributes.getValue(
                     PersistenceTagNames.PROPERTY_NAME);
-            String propValue = (String) TranslatedConfigView.getTranslatedValue(attributes.getValue(
+            String propValue = TranslatedConfigView.expandValue(attributes.getValue(
                     PersistenceTagNames.PROPERTY_VALUE));
             persistenceUnitDescriptor.addProperty(propName, propValue);
             return;

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/SaxParserHandler.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/SaxParserHandler.java
@@ -568,11 +568,11 @@ public class SaxParserHandler extends DefaultHandler {
             }
             if (doReplace) {
                 element = new XMLElement(replacementName, namespaces);
-                topNode.setElementValue(element, (String) TranslatedConfigView.getTranslatedValue(replacementValue));
+                topNode.setElementValue(element, TranslatedConfigView.expandValue(replacementValue));
             } else if (doDelete) {
                 // don't set a value so that the element is not written out
             } else if (getElementsPreservingWhiteSpace().contains(element.getQName())) {
-                topNode.setElementValue(element, (String) TranslatedConfigView.getTranslatedValue(elementData.toString()));
+                topNode.setElementValue(element, TranslatedConfigView.expandValue(elementData.toString()));
             } else if (element.getQName().equals(TagNames.ENVIRONMENT_PROPERTY_VALUE)) {
                 Object envEntryDesc = topNode.getDescriptor();
                 if (envEntryDesc != null && envEntryDesc instanceof EnvironmentProperty) {
@@ -581,18 +581,18 @@ public class SaxParserHandler extends DefaultHandler {
                     // if the env-entry-type is java.lang.String or
                     // java.lang.Character
                     if (envProp.getType() != null && (envProp.getType().equals("java.lang.String") || envProp.getType().equals("java.lang.Character"))) {
-                        topNode.setElementValue(element, (String) TranslatedConfigView.getTranslatedValue(elementData.toString()));
+                        topNode.setElementValue(element, TranslatedConfigView.expandValue(elementData.toString()));
                     } else {
-                        topNode.setElementValue(element, (String) TranslatedConfigView.getTranslatedValue(elementData.toString().trim()));
+                        topNode.setElementValue(element, TranslatedConfigView.expandValue(elementData.toString().trim()));
                     }
                 } else {
-                    topNode.setElementValue(element, (String) TranslatedConfigView.getTranslatedValue(elementData.toString().trim()));
+                    topNode.setElementValue(element, TranslatedConfigView.expandValue(elementData.toString().trim()));
                 }
             } else {
                 /*
                  * Allow any case for true/false & convert to lower case
                  */
-                String val = (String) TranslatedConfigView.getTranslatedValue(elementData.toString().trim());
+                String val = TranslatedConfigView.expandValue(elementData.toString().trim());
                 if (TRUE_STR.equalsIgnoreCase(val)) {
                     topNode.setElementValue(element, val.toLowerCase(Locale.US));
                 } else if (FALSE_STR.equalsIgnoreCase(val)) {

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/annotation/handlers/AbstractEjbHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/annotation/handlers/AbstractEjbHandler.java
@@ -192,7 +192,7 @@ public abstract class AbstractEjbHandler extends AbstractHandler {
             elementName = ejbClass.getSimpleName();            
         }
         else {
-            elementName = (String)TranslatedConfigView.getTranslatedValue(elementName);
+            elementName = TranslatedConfigView.expandValue(elementName);
         }
 
         EjbBundleDescriptorImpl currentBundle = (EjbBundleDescriptorImpl) ctx.getDescriptor();

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/deployment/annotation/handlers/MessageDrivenHandler.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/deployment/annotation/handlers/MessageDrivenHandler.java
@@ -137,7 +137,7 @@ public class MessageDrivenHandler extends AbstractEjbHandler {
         for (ActivationConfigProperty acProp : mdAn.activationConfig()) {
             EnvironmentProperty envProp = new EnvironmentProperty(
                     acProp.propertyName(), 
-                    (String) TranslatedConfigView.getTranslatedValue(acProp.propertyValue()), "");
+                    TranslatedConfigView.expandValue(acProp.propertyValue()), "");
                                                 // with empty description
             // xml override
             if (acProp.propertyName().equals("resourceAdapter")) {

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
@@ -511,12 +511,12 @@ public class JdbcConnectionPoolDeployer implements ResourceDeployer {
                 } else if ("USERNAME".equals(name.toUpperCase(Locale.getDefault()))
                         || "USER".equals(name.toUpperCase(locale))) {
 
-                    propList.add(new ConnectorConfigProperty("User", (String) TranslatedConfigView.getTranslatedValue(rp.getValue()), "user name", "java.lang.String"));
+                    propList.add(new ConnectorConfigProperty("User", TranslatedConfigView.expandValue(rp.getValue()), "user name", "java.lang.String"));
 
                 } else if ("PASSWORD".equals(name.toUpperCase(locale))) {
 
                     propList.add(new ConnectorConfigProperty("Password",
-                            (String) TranslatedConfigView.getTranslatedValue(rp.getValue()), "Password", "java.lang.String"));
+                            TranslatedConfigView.expandValue(rp.getValue()), "Password", "java.lang.String"));
 
                 } else if ("JDBC30DATASOURCE".equals(name.toUpperCase(locale))) {
 
@@ -554,12 +554,12 @@ public class JdbcConnectionPoolDeployer implements ResourceDeployer {
 
                     propList.add(new ConnectorConfigProperty(
                             (String) mcfConPropKeys.get(name.toUpperCase(Locale.getDefault())),
-                            rp.getValue() == null ? "" : (String) TranslatedConfigView.getTranslatedValue(rp.getValue()),
+                            rp.getValue() == null ? "" : TranslatedConfigView.expandValue(rp.getValue()),
                             "Some property",
                             "java.lang.String"));
                 } else {
                     driverProperties = driverProperties + "set" + escape(name)
-                            + "#" + escape((String) TranslatedConfigView.getTranslatedValue(rp.getValue())) + "##";
+                            + "#" + escape(TranslatedConfigView.expandValue(rp.getValue())) + "##";
                 }
             }
 

--- a/appserver/payara-appserver-modules/healthcheck-checker/src/main/java/fish/payara/healthcheck/mphealth/MicroProfileHealthChecker.java
+++ b/appserver/payara-appserver-modules/healthcheck-checker/src/main/java/fish/payara/healthcheck/mphealth/MicroProfileHealthChecker.java
@@ -259,7 +259,7 @@ public class MicroProfileHealthChecker
             String sysPropsPort = configProps.getPropertyValue(basePort);
             truePort = Integer.parseInt(sysPropsPort);
         }
-        return new URI(protocol, null, (String) TranslatedConfigView.getTranslatedValue(listener.getAddress()), truePort, "/" + endpoint, null, null);
+        return new URI(protocol, null, TranslatedConfigView.expandValue(listener.getAddress()), truePort, "/" + endpoint, null, null);
     }
 
     //send request to remote healthcheck endpoint to get the status

--- a/appserver/payara-appserver-modules/security-oauth2/src/main/java/fish/payara/security/oauth2/OAuth2AuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/security-oauth2/src/main/java/fish/payara/security/oauth2/OAuth2AuthenticationMechanism.java
@@ -278,7 +278,7 @@ public class OAuth2AuthenticationMechanism implements HttpAuthenticationMechanis
         if (configResult.isPresent()) {
             return configResult.get();
         }
-        result = (String) TranslatedConfigView.getTranslatedValue(result);
+        result = TranslatedConfigView.expandValue(result);
         if (isELExpression(value)){
             result = (String) elProcessor.getValue(toRawExpression(result), String.class);
         }

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -66,7 +66,9 @@ public final class OpenIdUtil {
         if (configResult.isPresent()) {
             return configResult.get();
         }
-        result = (T) TranslatedConfigView.getTranslatedValue(result);
+        if (type == String.class) {
+            result = (T) TranslatedConfigView.expandValue((String) result);
+        }
         if (type == String.class && isELExpression((String) value)) {
             ELProcessor elProcessor = new ELProcessor();
             BeanManager beanManager = CDI.current().getBeanManager();

--- a/appserver/payara-appserver-modules/yubikey-authentication/src/main/java/fish/payara/security/identitystores/ConfigRetriever.java
+++ b/appserver/payara-appserver-modules/yubikey-authentication/src/main/java/fish/payara/security/identitystores/ConfigRetriever.java
@@ -74,7 +74,7 @@ public class ConfigRetriever {
            return microProfileConfigValue.get();
         }
         if(isPayaraConfigFormat(expression)) {
-            String translatedValue = (String)TranslatedConfigView.getTranslatedValue(expression);
+            String translatedValue = TranslatedConfigView.expandValue(expression);
             if(translatedValue.equals(expression) && isELImmediateFormat(expression)) {
                 return AnnotationELPProcessor.evalImmediate(expression);
             }

--- a/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/deployer/MailResourceDeployer.java
+++ b/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/deployer/MailResourceDeployer.java
@@ -292,11 +292,11 @@ public class MailResourceDeployer extends GlobalResourceDeployer
         mailResource.setStoreProtocolClass(mailResourceConfig.getStoreProtocolClass());
         mailResource.setTransportProtocol(mailResourceConfig.getTransportProtocol());
         mailResource.setTransportProtocolClass(mailResourceConfig.getTransportProtocolClass());
-        mailResource.setMailHost((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getHost()));
-        mailResource.setUsername((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getUser()));
-        mailResource.setPassword((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getPassword()));
+        mailResource.setMailHost(TranslatedConfigView.expandValue(mailResourceConfig.getHost()));
+        mailResource.setUsername(TranslatedConfigView.expandValue(mailResourceConfig.getUser()));
+        mailResource.setPassword(TranslatedConfigView.expandValue(mailResourceConfig.getPassword()));
         mailResource.setAuth(Boolean.valueOf(mailResourceConfig.getAuth()));
-        mailResource.setMailFrom((String) TranslatedConfigView.getTranslatedValue(mailResourceConfig.getFrom()));
+        mailResource.setMailFrom(TranslatedConfigView.expandValue(mailResourceConfig.getFrom()));
         mailResource.setDebug(Boolean.valueOf(mailResourceConfig.getDebug()));
 
         // sets the properties

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/annotation/handlers/WebServletHandler.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/annotation/handlers/WebServletHandler.java
@@ -199,7 +199,7 @@ public class WebServletHandler extends AbstractWebHandler {
                         validUrlPatterns = false;
                         break;
                     }
-                    webCompDesc.addUrlPattern((String)TranslatedConfigView.getTranslatedValue(up));
+                    webCompDesc.addUrlPattern(TranslatedConfigView.expandValue(up));
                 }
             }
 
@@ -223,7 +223,7 @@ public class WebServletHandler extends AbstractWebHandler {
             for (WebInitParam initParam : initParams) {
                 webCompDesc.addInitializationParameter(
                         new EnvironmentProperty(
-                            initParam.name(), (String)TranslatedConfigView.getTranslatedValue(initParam.value()),
+                            initParam.name(), TranslatedConfigView.expandValue(initParam.value()),
                             initParam.description()));
             }
         }
@@ -258,7 +258,7 @@ public class WebServletHandler extends AbstractWebHandler {
             servletName = webCompClass.getName();
         }
         else {
-            servletName = (String)TranslatedConfigView.getTranslatedValue(servletName);
+            servletName = TranslatedConfigView.expandValue(servletName);
         }
         return servletName;
     }

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -80,6 +80,9 @@ public class TranslatedConfigView implements ConfigView {
 
     private static final String ALIAS_TOKEN = "ALIAS";
     private static final int MAX_SUBSTITUTION_DEPTH = 100;
+
+    private static final boolean SUBSTITUTION_DISABLED = Boolean.valueOf(System.getProperty("fish.payara.substitution.disable", "false"));
+
     public static final ThreadLocal<Boolean> doSubstitution = new ThreadLocal<Boolean>() {
         @Override
         protected Boolean initialValue() {
@@ -87,8 +90,31 @@ public class TranslatedConfigView implements ConfigView {
         }
     };
 
+    /**
+     * Expand variables in string value (non-config usage).
+     * This expansion can be disabled by system property {@code fish.payara.substitution.disable}, and should be used by any code that handles
+     * deployment descriptors, where this constitutes a non-standard behavior.
+     * @param value value to be expanded
+     * @return expanded value or {@code null} when value is null. Original value when substitution is disabled.
+     */
+    public static String expandValue(String value) {
+        if (value == null || SUBSTITUTION_DISABLED) {
+            return value;
+        }
+        return (String) getTranslatedValue(value);
+    }
 
-    public static Object getTranslatedValue(Object value) {
+    /**
+     * Expand variables in string value (config usage).
+     * This method should be called when expanding values from config, where substitution is necessary at all times.
+     * @param value value to be expanded
+     * @return expanded value or {@code null} when value is null.     
+     */
+    public static String expandConfigValue(String value) {
+        return (String) getTranslatedValue(value);
+    }
+
+    private static Object getTranslatedValue(Object value) {
         if (value!=null && value instanceof String) {
             String stringValue = value.toString();
             if (stringValue.indexOf('$')==-1) {

--- a/nucleus/core/bootstrap/src/main/java/fish/payara/boot/runtime/BootCommands.java
+++ b/nucleus/core/bootstrap/src/main/java/fish/payara/boot/runtime/BootCommands.java
@@ -85,7 +85,7 @@ public class BootCommands {
                 commandStr = commandStr.trim();
                 // # is a comment
                 if (commandStr.length() > 0 && !commandStr.startsWith("#")) {
-                    commandStr = (String) TranslatedConfigView.getTranslatedValue(commandStr);
+                    commandStr = TranslatedConfigView.expandValue(commandStr);
                     String command[] = commandStr.split(" ");
                     if (command.length > 1) {
                         commands.add(new BootCommand(command[0], Arrays.copyOfRange(command, 1, command.length)));

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/listener/CombinedJavaConfigSystemPropertyListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/listener/CombinedJavaConfigSystemPropertyListener.java
@@ -318,7 +318,7 @@ public final class CombinedJavaConfigSystemPropertyListener implements PostConst
         if ( value.startsWith("=") ) {
             value = value.substring(1);
         }
-        value = TranslatedConfigView.getTranslatedValue(value).toString();
+        value = TranslatedConfigView.expandValue(value);
         return new String[] { name, value };
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
@@ -232,10 +232,11 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
                 Matcher m = p.matcher(jvmOption);
 
                 if (m.matches()) {
-                    setSystemProperty(m.group(1), TranslatedConfigView.getTranslatedValue(m.group(2)).toString());
+                    String value = TranslatedConfigView.expandConfigValue(m.group(2));
+                    setSystemProperty(m.group(1), value);
 
                     if (_logger.isLoggable(Level.FINE)) {
-                        _logger.fine("Setting " + m.group(1) + " = " + TranslatedConfigView.getTranslatedValue(m.group(2)));
+                        _logger.fine("Setting " + m.group(1) + " = " + value);
                     }
                 }
             }

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -498,7 +498,7 @@ public class GFFileHandler extends StreamHandler implements
                     LOG_FILE_NAME;
         }
 
-        return TranslatedConfigView.getTranslatedValue(logFileProperty).toString();
+        return TranslatedConfigView.expandConfigValue(logFileProperty);
     }
 
     Formatter findFormatterService(String formatterName) {
@@ -1109,7 +1109,7 @@ public class GFFileHandler extends StreamHandler implements
     }
     
     public synchronized void setLogFile(String fileName) {
-        String logFileName = TranslatedConfigView.getTranslatedValue(fileName).toString();
+        String logFileName = TranslatedConfigView.expandConfigValue(fileName);
         File logFile = new File(logFileName);
          if (!logFile.isAbsolute()) {
             logFile = new File(env.getInstanceRoot(), logFileName);

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/SyslogHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/SyslogHandler.java
@@ -86,13 +86,11 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
         LogManager manager = LogManager.getLogManager();
         String cname = getClass().getName();
 
-        Object obj = TranslatedConfigView.getTranslatedValue(manager.getProperty(cname + ".useSystemLogging"));
+        String systemLogging = TranslatedConfigView.expandValue(manager.getProperty(cname + ".useSystemLogging"));
         // Added below 2 lines of code to avoid NPE as per the bug http://java.net/jira/browse/GLASSFISH-16162
-        if(obj==null)
-            return;                
-        String systemLogging = obj.toString();
-        if (systemLogging.equals("false"))
+        if(systemLogging==null || systemLogging.equals("false")) {
             return;
+        }
 
         //set up the connection
         setupConnection();       

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilter.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilter.java
@@ -154,7 +154,7 @@ public class LogFilter {
 
         try {
             logFileDetailsForServer = loggingConfigFactory.provide().getLoggingFileDetails();
-            logFileDetailsForServer = TranslatedConfigView.getTranslatedValue(logFileDetailsForServer).toString();
+            logFileDetailsForServer = TranslatedConfigView.expandConfigValue(logFileDetailsForServer);
             logFileDetailsForServer = new File(logFileDetailsForServer).getAbsolutePath();
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, LogFacade.ERROR_EXECUTING_LOG_QUERY, ex);
@@ -225,7 +225,7 @@ public class LogFilter {
             try {
                 // getting log file attribute value from logging.properties file
                 logFileDetailsForServer = loggingConfigFactory.provide().getLoggingFileDetails();
-                logFileDetailsForServer = TranslatedConfigView.getTranslatedValue(logFileDetailsForServer).toString();
+                logFileDetailsForServer = TranslatedConfigView.expandConfigValue(logFileDetailsForServer);
                 logFileDetailsForServer = new File(logFileDetailsForServer).getAbsolutePath();
             } catch (Exception ex) {
                 LOGGER.log(Level.SEVERE, LogFacade.ERROR_EXECUTING_LOG_QUERY, ex);
@@ -286,7 +286,7 @@ public class LogFilter {
         if (targetServer.isDas()) {
             // getting log file for DAS from logging.properties and returning the same
             String logFileDetailsForServer = loggingConfigFactory.provide().getLoggingFileDetails();
-            logFileDetailsForServer = TranslatedConfigView.getTranslatedValue(logFileDetailsForServer).toString();
+            logFileDetailsForServer = TranslatedConfigView.expandConfigValue(logFileDetailsForServer);
             logFileDetailsForServer = new File(logFileDetailsForServer).getAbsolutePath();
             return logFileDetailsForServer;
         } else {

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/PayaraNotificationFileHandler.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/PayaraNotificationFileHandler.java
@@ -66,6 +66,6 @@ public class PayaraNotificationFileHandler extends GFFileHandler {
                     + NOTIFICATION_FILENAME;
         }
 
-        return TranslatedConfigView.getTranslatedValue(logFileProperty).toString();
+        return TranslatedConfigView.expandValue(logFileProperty);
     }
 }

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -99,7 +99,7 @@ public class GAVConvertor {
     public Map.Entry<String, URL> getArtefactMapEntry(String GAV, Collection<String> repositoryURLs) throws MalformedURLException {
         List<URL> repoURLs = new LinkedList<URL>();
         for (String url: repositoryURLs) {
-            String convertedURL = (String) TranslatedConfigView.getTranslatedValue(url);
+            String convertedURL = TranslatedConfigView.expandValue(url);
             if (!convertedURL.endsWith("/")) {
               convertedURL += "/";
             }


### PR DESCRIPTION
Performing variable expansion in descriptors is not spec compliant, therefore it needs to be switched off for TCK tests. The system property is called `fish.payara.substitution.disable` and needs to be set to true in order to disable the feature.

Some of the expansions need to be done regardless of the setting, therefore the original method was split into two.