### PR TITLE
PAYARA-4031 Master Password Synchronisation Inconsistencies Across Nodes

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1229,6 +1229,9 @@ public abstract class CLICommand implements PostConstruct {
      * @return 
      */
     protected char[] readPassword(String prompt) {
+        if (!programOpts.isInteractive()) {
+            return null;
+        }
         try {
             buildTerminal();
             buildLineReader();

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
@@ -41,6 +41,7 @@
 
 package com.sun.enterprise.admin.servermgmt;
 
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 import com.sun.enterprise.admin.servermgmt.pe.PEFileLayout;
 import com.sun.enterprise.security.store.PasswordAdapter;
 import com.sun.enterprise.util.i18n.StringManager;
@@ -62,7 +63,6 @@ import java.io.File;
  */
 public class MasterPasswordFileManager extends KeystoreManager {              
 
-    private static final String MASTER_PASSWORD_ALIAS="master-password";
     private static final String ENCODED_CHARSET = "UTF-8";
     private static final int SALT_SIZE = 8;
     
@@ -80,7 +80,7 @@ public class MasterPasswordFileManager extends KeystoreManager {
     private char[] getMasterPasswordPassword() throws RepositoryException 
     {
         //XXX fixed String
-        return MASTER_PASSWORD_ALIAS.toCharArray();
+        return MASTERPASSWORD_FILE.toCharArray();
     }
     
     protected void deleteMasterPasswordFile(RepositoryConfig config)
@@ -105,7 +105,7 @@ public class MasterPasswordFileManager extends KeystoreManager {
         final File pwdFile = layout.getMasterPasswordFile();                     
         try {                    
             PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), getMasterPasswordPassword());
-            p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, masterPassword.getBytes());
+            p.setPasswordForAlias(MASTERPASSWORD_FILE, masterPassword.getBytes());
             FileProtectionUtility.chmod0600(pwdFile);
         } catch (Exception ex) {                        
             throw new RepositoryException(STRING_MANAGER.getString("masterPasswordFileNotCreated", pwdFile),
@@ -128,7 +128,7 @@ public class MasterPasswordFileManager extends KeystoreManager {
             try {                    
                 PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), 
                     getMasterPasswordPassword());
-                return p.getPasswordForAlias(MASTER_PASSWORD_ALIAS);
+                return p.getPasswordForAlias(MASTERPASSWORD_FILE);
             } catch (Exception ex) {            
                 throw new RepositoryException(STRING_MANAGER.getString("masterPasswordFileNotRead", pwdFile),
                     ex);
@@ -170,7 +170,7 @@ public class MasterPasswordFileManager extends KeystoreManager {
         	 try {                    
                  PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), 
                      getMasterPasswordPassword());
-                 p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, newPassword.getBytes());
+                 p.setPasswordForAlias(MASTERPASSWORD_FILE, newPassword.getBytes());
                  FileProtectionUtility.chmod0600(pwdFile);
              } catch (Exception ex) {                        
                  throw new RepositoryException(STRING_MANAGER.getString("masterPasswordFileNotCreated", pwdFile),

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
@@ -37,18 +37,20 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+
+import java.io.File;
+
 import com.sun.enterprise.admin.servermgmt.pe.PEFileLayout;
 import com.sun.enterprise.security.store.PasswordAdapter;
 import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.enterprise.util.io.FileUtils;
-import org.glassfish.security.common.FileProtectionUtility;
 
-import java.io.File;
+import org.glassfish.security.common.FileProtectionUtility;
 
 
 /**

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -576,8 +576,12 @@ public abstract class LocalServerCommand extends CLICommand {
         for (int i = 0; i < times; i++) {
             // XXX - I18N
             String prompt = STRINGS.get("mp.prompt", (times - i));
-            char[] mpvArr = super.readPassword(prompt);
-            mpv = mpvArr != null ? new String(mpvArr) : null;
+            try {
+                char[] mpvArr = super.readPassword(prompt);
+                mpv = mpvArr != null ? new String(mpvArr) : null;
+            } catch (Throwable t) {
+                throw new CommandException(STRINGS.get("no.console"), t);
+            }
             if (mpv == null)
                 throw new CommandException(STRINGS.get("no.console"));
             // ignore retries :)

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -83,7 +83,11 @@ public abstract class LocalServerCommand extends CLICommand {
     ////////////////////////////////////////////////////////////////
     private ServerDirs serverDirs;
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(LocalDomainCommand.class);
-    private static final String DEFAULT_MASTER_PASSWORD = "changeit";
+    
+    ////////////////////////////////////////////////////////////////
+    /// Section:  protected variables
+    ////////////////////////////////////////////////////////////////
+    protected static final String DEFAULT_MASTER_PASSWORD = "changeit";
     
     ////////////////////////////////////////////////////////////////
     /// Section:  protected methods that are OK to override

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -38,23 +38,24 @@
  * holder.
  */
 
-// Portions Copyright [2016-2018] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.util.List;
+import java.util.logging.Level;
+
 import com.sun.enterprise.admin.cli.CLICommand;
 import com.sun.enterprise.admin.cli.CLIConstants;
 import com.sun.enterprise.admin.cli.ProgramOptions;
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
-import com.sun.enterprise.util.io.FileUtils;
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.security.KeyStore;
-import org.glassfish.api.ActionReport;
-
-import org.glassfish.api.admin.CommandException;
 import com.sun.enterprise.security.store.PasswordAdapter;
 import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.universal.io.SmartFile;
@@ -63,8 +64,11 @@ import com.sun.enterprise.universal.process.ProcessUtils;
 import com.sun.enterprise.universal.xml.MiniXmlParser;
 import com.sun.enterprise.universal.xml.MiniXmlParserException;
 import com.sun.enterprise.util.HostAndPort;
+import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.util.io.ServerDirs;
-import java.util.logging.Level;
+
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.admin.CommandException;
 
 /**
  * A class that's supposed to capture all the behavior common to operation

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -576,16 +576,8 @@ public abstract class LocalServerCommand extends CLICommand {
         for (int i = 0; i < times; i++) {
             // XXX - I18N
             String prompt = STRINGS.get("mp.prompt", (times - i));
-            try {
-                char[] mpvArr = super.readPassword(prompt);
-                mpv = mpvArr != null ? new String(mpvArr) : null;
-            } catch (Exception ex) {
-                // JLine sneaky throws IOException, so check for it here
-                if (ex instanceof IOException) {
-                    throw new CommandException(STRINGS.get("no.console"), ex);
-                }
-                throw ex;
-            }
+            char[] mpvArr = super.readPassword(prompt);
+            mpv = mpvArr != null ? new String(mpvArr) : null;
             if (mpv == null)
                 throw new CommandException(STRINGS.get("no.console"));
             // ignore retries :)

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -42,6 +42,7 @@
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 import com.sun.enterprise.admin.cli.CLICommand;
 import com.sun.enterprise.admin.cli.CLIConstants;
 import com.sun.enterprise.admin.cli.ProgramOptions;
@@ -82,6 +83,7 @@ public abstract class LocalServerCommand extends CLICommand {
     ////////////////////////////////////////////////////////////////
     private ServerDirs serverDirs;
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(LocalDomainCommand.class);
+    private static final String DEFAULT_MASTER_PASSWORD = "changeit";
     
     ////////////////////////////////////////////////////////////////
     /// Section:  protected methods that are OK to override
@@ -205,8 +207,8 @@ public abstract class LocalServerCommand extends CLICommand {
             return null;   // no master password  saved
         try {
             PasswordAdapter pw = new PasswordAdapter(mpf.getAbsolutePath(),
-                    "master-password".toCharArray()); // fixed key
-            return pw.getPasswordForAlias("master-password");
+                    MASTERPASSWORD_FILE.toCharArray()); // fixed key
+            return pw.getPasswordForAlias(MASTERPASSWORD_FILE);
         }
         catch (Exception e) {
             logger.log(Level.FINER, "master password file reading error: {0}", e.getMessage());
@@ -260,7 +262,7 @@ public abstract class LocalServerCommand extends CLICommand {
         long t0 = now();
         String mpv = passwords.get(CLIConstants.MASTER_PASSWORD);
         if (mpv == null) { //not specified in the password file
-            mpv = "changeit";  //optimization for the default case -- see 9592
+            mpv = DEFAULT_MASTER_PASSWORD;  //optimization for the default case -- see 9592
             if (!verifyMasterPassword(mpv)) {
                 mpv = readFromMasterPasswordFile();
                 if (!verifyMasterPassword(mpv)) {
@@ -553,7 +555,7 @@ public abstract class LocalServerCommand extends CLICommand {
         if (serverDirs == null)
             return null;
 
-        File mp = new File(serverDirs.getConfigDir(), "master-password");
+        File mp = new File(serverDirs.getConfigDir(), MASTERPASSWORD_FILE);
         if (!mp.canRead())
             return null;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -579,8 +579,12 @@ public abstract class LocalServerCommand extends CLICommand {
             try {
                 char[] mpvArr = super.readPassword(prompt);
                 mpv = mpvArr != null ? new String(mpvArr) : null;
-            } catch (Throwable t) {
-                throw new CommandException(STRINGS.get("no.console"), t);
+            } catch (Exception ex) {
+                // JLine sneaky throws IOException, so check for it here
+                if (ex instanceof IOException) {
+                    throw new CommandException(STRINGS.get("no.console"), ex);
+                }
+                throw ex;
             }
             if (mpv == null)
                 throw new CommandException(STRINGS.get("no.console"));

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 ## list-domains
 ## domain1 running
@@ -197,7 +197,7 @@ DomainLocation=Started domain: {0}\nDomain location: {1}\nLog file: {2}
 DomainAdminPort=Admin port for the domain: {0}
 DomainDebugPort=Debug port for the domain: {0}
 mp.prompt=Enter master password ({0}) attempt(s) remain)>
-no.console=The Master Password is required to start the domain.  No console, no prompting possible.  You should either create the domain \
+no.console=The Master Password is required to start the server.  No console, no prompting possible.  You should either create the domain \
 with --savemasterpassword=true or provide a password file with the --passwordfile option.
 retry.mp=Sorry, incorrect master password, retry
 mp.giveup=Number of attempts ({0}) exhausted, giving up

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
@@ -42,6 +42,8 @@
 
 package com.sun.enterprise.admin.servermgmt.pe;
 
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.io.File;
@@ -764,7 +766,6 @@ public class PEFileLayout
         return new File(getConfigRoot(), TRUSTSTORE);
     }
 
-    public static final String MASTERPASSWORD_FILE = "master-password";
     public File getMasterPasswordFile()
     {
         return new File(getConfigRoot(), MASTERPASSWORD_FILE);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
@@ -38,26 +38,24 @@
  * holder.
  */
 
-// Portions Copyright [2016-2018] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.pe;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Locale;
-import java.io.File;
-
-import com.sun.enterprise.util.OS;
-import com.sun.enterprise.util.io.FileUtils;
-import com.sun.enterprise.util.i18n.StringManager;
-
-import com.sun.enterprise.admin.servermgmt.RepositoryException;
-import com.sun.enterprise.admin.servermgmt.RepositoryConfig;
-import com.sun.enterprise.util.SystemPropertyConstants;
-
-import com.sun.enterprise.security.store.PasswordAdapter;
 import java.util.Map;
+
+import com.sun.enterprise.admin.servermgmt.RepositoryConfig;
+import com.sun.enterprise.admin.servermgmt.RepositoryException;
+import com.sun.enterprise.security.store.PasswordAdapter;
+import com.sun.enterprise.util.OS;
+import com.sun.enterprise.util.SystemPropertyConstants;
+import com.sun.enterprise.util.i18n.StringManager;
+import com.sun.enterprise.util.io.FileUtils;
 
 public class PEFileLayout
 {

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -144,17 +144,6 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
         }
     }
 
-    /**
-     * Create the master password keystore. This routine can also modify the master
-     * password if the keystore already exists
-     *
-     * @throws CommandException if an error occurred while writing the master
-     *                          password file
-     */
-    protected void createMasterPasswordFile() throws CommandException {
-
-    }
-
     @Override
     public int execute(String... argv) throws CommandException {
         // We iterate through all the instances and so it should relax this requirement

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -139,8 +139,8 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
             p.setPasswordForAlias(MASTERPASSWORD_FILE, newPassword.getBytes());
             FileProtectionUtility.chmod0600(pwdFile);
             return 0;
-        } catch (Throwable t) {
-            throw new CommandException(STRINGS.get("masterPasswordFileNotCreated", pwdFile), t);
+        } catch (Exception ex) {
+            throw new CommandException(STRINGS.get("masterPasswordFileNotCreated", pwdFile), ex);
         }
     }
 

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -39,128 +39,121 @@
  */
 // Portions Copyright [2016-2019] [Payara Foundation]
 
-
 package com.sun.enterprise.admin.cli.cluster;
 
-import com.sun.enterprise.admin.servermgmt.NodeKeystoreManager;
-import com.sun.enterprise.admin.servermgmt.RepositoryConfig;
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+import static java.util.Arrays.asList;
+import static java.util.Optional.ofNullable;
+
+import java.io.File;
+import java.util.List;
+import java.util.logging.Logger;
+
 import com.sun.enterprise.admin.util.CommandModelData.ParamModelData;
 import com.sun.enterprise.security.store.PasswordAdapter;
 import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.universal.xml.MiniXmlParser;
 import com.sun.enterprise.universal.xml.MiniXmlParserException;
 import com.sun.enterprise.util.HostAndPort;
+
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
-
+import org.glassfish.api.admin.CommandValidationException;
+import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.security.common.FileProtectionUtility;
 import org.jvnet.hk2.annotations.Service;
-import org.glassfish.hk2.api.PerLookup;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
- * The change-master-password command for a node.
- * It takes in a nodeDir and node name
+ * The change-master-password command for a node. It takes in a nodeDir and node
+ * name
  *
  * @author Bhakti Mehta
+ * @author Matt Gill
  */
 @Service(name = "_change-master-password-node")
 @PerLookup
+public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
 
-public  class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
+    private static final Logger LOGGER = Logger.getLogger(ChangeNodeMasterPasswordCommand.class.getName());
 
-    @Param(name = "nodedir", optional = true)
-    protected String nodeDir0;           // nodeDirRoot
+    private static final LocalStringsImpl STRINGS = new LocalStringsImpl(ChangeNodeMasterPasswordCommand.class);
+
+    protected static final String OLD_PASSWORD_ALIAS = "AS_ADMIN_MASTERPASSWORD";
+    protected static final String NEW_PASSWORD_ALIAS = "AS_ADMIN_NEWMASTERPASSWORD";
 
     @Param(name = "node", primary = true)
-    protected String node0;
+    protected String node;
 
-    @Param(name = "savemasterpassword", optional = true, defaultValue = "false")
-    protected boolean savemp;
+    @Param(name = "savemasterpassword", optional = true)
+    private boolean saveMasterPassword;
 
-    private static final String MASTER_PASSWORD_ALIAS="master-password";
-
-    private static final LocalStringsImpl strings = new LocalStringsImpl(ChangeNodeMasterPasswordCommand.class);
+    protected File selectedNodeDir;
 
     private String newPassword;
 
-    private String oldPassword;
+    @Override
+    protected void inject() throws CommandException {
+        super.inject();
 
+        selectedNodeDir = new File(nodeDir, node);
+    }
+
+    @Override
+    protected void validate() throws CommandException, CommandValidationException {
+        super.validate();
+
+        if (saveMasterPassword) {
+            LOGGER.warning(STRINGS.get("savemasterpassword.unused"));
+        }
+
+        // Check node exists
+        if (!selectedNodeDir.isDirectory()) {
+            throw new CommandException(STRINGS.get("bad.node.dir", selectedNodeDir));
+        }
+
+        // Check instances aren't running
+        for (File instanceDir : getInstanceDirectories()) {
+            if (isRunning(instanceDir)) {
+                throw new CommandException(STRINGS.get("instance.is.running", instanceDir.getName()));
+            }
+        }
+
+        // Find and verify old password
+        String oldPassword = findOldPassword();
+        String currentPassword = ofNullable(readFromMasterPasswordFile()).orElse(DEFAULT_MASTER_PASSWORD);
+        if (!oldPassword.equals(currentPassword)) {
+            throw new CommandException(STRINGS.get("incorrect.old.mp"));
+        }
+
+        // Find and set new password
+        setNewPassword();
+    }
 
     @Override
     protected int executeCommand() throws CommandException {
-
+        // Find the master password file
+        final File pwdFile = new File(this.getServerDirs().getAgentDir(), MASTERPASSWORD_FILE);
         try {
-            nodeDir = nodeDir0;
-            node = node0;
-            File serverDir = new File(nodeDir,node);
-
-            if (!serverDir.isDirectory()) {
-                throw new CommandException(strings.get("bad.node.dir",serverDir));
-            }
-
-            ArrayList<String> serverNames = getInstanceDirs(serverDir);
-            for (String serverName: serverNames) 
-                if (isRunning(serverDir, serverName))
-                    throw new CommandException(strings.get("instance.is.running",
-                            serverName));
-
-            oldPassword = passwords.get("AS_ADMIN_MASTERPASSWORD");
-            if (oldPassword == null) {
-                char[] opArr = super.readPassword(strings.get("old.mp"));
-                oldPassword = opArr != null ? new String(opArr) : null;
-            }
-            if (oldPassword == null)
-                throw new CommandException(strings.get("no.console"));
-
-            // for each instance iterate through the instances first,
-            // read each keystore with the old password,
-            // only then should it save the new master password.
-            boolean valid = true;
-            for(String instanceDir0: getInstanceDirs(nodeDirChild)) {
-               valid &= verifyInstancePassword(new File(nodeDirChild,instanceDir0));
-           }
-           if (!valid) {
-               throw new CommandException(strings.get("incorrect.old.mp"));
-           }
-            ParamModelData nmpo = new ParamModelData("AS_ADMIN_NEWMASTERPASSWORD",
-                    String.class, false, null);
-            nmpo.prompt = strings.get("new.mp");
-            nmpo.promptAgain = strings.get("new.mp.again");
-            nmpo.param._password = true;
-            char[] npArr = super.getPassword(nmpo, null, true);
-            newPassword = npArr != null ? new String(npArr) : null;
-
-            // for each instance encrypt the keystore
-            for(String instanceDir2: getInstanceDirs(nodeDirChild)) {
-               encryptKeystore(instanceDir2);
-           }
-            if (savemp) {
-                createMasterPasswordFile();
-            }
+            // Write the master password file
+            PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), MASTERPASSWORD_FILE.toCharArray());
+            p.setPasswordForAlias(MASTERPASSWORD_FILE, newPassword.getBytes());
+            FileProtectionUtility.chmod0600(pwdFile);
             return 0;
-        } catch(Exception e) {
-            throw new CommandException(e.getMessage(),e);
+        } catch (Throwable t) {
+            throw new CommandException(STRINGS.get("masterPasswordFileNotCreated", pwdFile), t);
         }
     }
 
     /**
-     * This will load and verify the keystore for each of the instances
-     * in a node
-     * @param instanceDir0 The instance directory
-     * @return  if the password is valid for the instance keystore
+     * Create the master password keystore. This routine can also modify the master
+     * password if the keystore already exists
+     *
+     * @throws CommandException if an error occurred while writing the master
+     *                          password file
      */
-    private boolean verifyInstancePassword(File instanceDir) {
+    protected void createMasterPasswordFile() throws CommandException {
 
-        File mp = new File(new File(instanceDir, "config"), "cacerts.jks");
-        return loadAndVerifyKeystore(mp,oldPassword);
     }
-
-
 
     @Override
     public int execute(String... argv) throws CommandException {
@@ -171,89 +164,88 @@ public  class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
     }
 
     /**
-     * Create the master password keystore. This routine can also modify the master password
-     * if the keystore already exists
-     *
-     * @throws CommandException
+     * Find the old password from the property in the password file with the name
+     * {@link #OLD_PASSWORD_ALIAS} if it exists, or by prompting the user otherwise.
+     * 
+     * @throws CommandException if the password is null
      */
-    protected void createMasterPasswordFile() throws CommandException {
-        final File pwdFile = new File(this.getServerDirs().getAgentDir(), MASTER_PASSWORD_ALIAS);
-        try {
-            PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(),
-                MASTER_PASSWORD_ALIAS.toCharArray());
-            p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, newPassword.getBytes());
-            FileProtectionUtility.chmod0600(pwdFile);
-        } catch (Exception ex) {
-            throw new CommandException(strings.get("masterPasswordFileNotCreated", pwdFile),ex);
-        }
-    }
+    protected String findOldPassword() throws CommandException {
+        // Fetch from password file
+        String oldPassword = passwords.get(OLD_PASSWORD_ALIAS);
 
-
-    /*
-     * This will encrypt the keystore
-     */
-    public void encryptKeystore(String f) throws CommandException {
-
-        RepositoryConfig nodeConfig = new RepositoryConfig(f,
-                new File(nodeDir, node).toString(), f);
-        NodeKeystoreManager km = new NodeKeystoreManager();
-        try {
-            km.encryptKeystore(nodeConfig,oldPassword,newPassword);
-
-        } catch (Exception e) {
-             throw new CommandException(strings.get("Keystore.not.encrypted"), e);
+        // Prompt user
+        if (oldPassword == null) {
+            char[] opArr = super.readPassword(STRINGS.get("old.mp"));
+            oldPassword = opArr != null ? new String(opArr) : null;
         }
 
+        // Check if password was collected
+        if (oldPassword == null) {
+            throw new CommandException(STRINGS.get("no.console"));
+        }
+
+        return oldPassword;
     }
 
     /**
-     * This will get all the instances for a given node
-     * @param parent  node
-     * @return   The list of instances for a node
-     * @throws CommandException
+     * Set the {@link #newPassword} field from the property in the password file
+     * with the name {@link #OLD_PASSWORD_ALIAS} if it exists, or by prompting the
+     * user twice otherwise.
+     * 
+     * @throws CommandException if the passwords don't match or are null
      */
-    private ArrayList<String> getInstanceDirs(File parent) throws CommandException {
+    protected void setNewPassword() throws CommandException {
+        ParamModelData nmpo = new ParamModelData(NEW_PASSWORD_ALIAS, String.class, false, null);
+        nmpo.prompt = STRINGS.get("new.mp");
+        nmpo.promptAgain = STRINGS.get("new.mp.again");
+        nmpo.param._password = true;
+        char[] npArr = super.getPassword(nmpo, null, true);
+        newPassword = npArr != null ? new String(npArr) : null;
 
-         ArrayList<String> instancesList = new ArrayList<String>();
-         File[] files = parent.listFiles(new FileFilter() {
-             @Override
-             public boolean accept(File f) {
-                 return f.isDirectory();
-             }
-         });
+        // Check if password was collected
+        if (newPassword == null) {
+            throw new CommandException(STRINGS.get("no.console"));
+        }
+    }
 
-         if (files == null || files.length == 0) {
-             throw new CommandException(
-                     strings.get("Instance.noInstanceDirs", parent));
-         }
+    /**
+     * This will get the directory of all instances for the selected node.
+     * 
+     * @return The list of instances for the selected node
+     * @throws CommandException if there are no instances
+     */
+    private List<File> getInstanceDirectories() throws CommandException {
 
-         for (File f : files) {
-             if (!f.getName().equals("agent"))
-                 instancesList.add(f.getName());
-         }
-         return instancesList;
+        File[] instanceDirectories = selectedNodeDir.listFiles(f -> f.isDirectory() && !f.getName().equals("agent"));
 
-     }
+        if (instanceDirectories == null || instanceDirectories.length == 0) {
+            throw new CommandException(STRINGS.get("Instance.noInstanceDirs", selectedNodeDir));
+        }
 
-    private boolean isRunning(File nodeDirChild, String serverName)
-            throws CommandException {
+        return asList(instanceDirectories);
+    }
+
+    /**
+     * @param instanceDir the directory of the instance to check
+     * @return if the instance is currently running
+     */
+    private boolean isRunning(File instanceDir) throws CommandException {
         try {
-            File serverDir = new File(nodeDirChild, serverName);
-            File configDir = new File(serverDir, "config");
+            File configDir = new File(instanceDir, "config");
             File domainXml = new File(configDir, "domain.xml");
             if (!domainXml.exists()) {
                 return false;
             }
-            MiniXmlParser parser = new MiniXmlParser(domainXml, serverName);
+            MiniXmlParser parser = new MiniXmlParser(domainXml, instanceDir.getName());
             List<HostAndPort> addrSet = parser.getAdminAddresses();
             if (addrSet.isEmpty()) {
-                throw new CommandException(strings.get("NoAdminPort"));
+                throw new CommandException(STRINGS.get("NoAdminPort"));
             }
             HostAndPort addr = addrSet.get(0);
             return isRunning(addr.getHost(), addr.getPort());
         } catch (MiniXmlParserException ex) {
-            throw new CommandException(strings.get("NoAdminPortEx", ex), ex);
+            throw new CommandException(STRINGS.get("NoAdminPortEx", ex), ex);
         }
     }
-    
+
 }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -45,6 +45,12 @@ package com.sun.enterprise.admin.cli.cluster;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.logging.Level;
+
 import com.sun.enterprise.admin.cli.CLIConstants;
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.admin.servermgmt.KeystoreManager;
@@ -54,23 +60,18 @@ import com.sun.enterprise.universal.glassfish.TokenResolver;
 import com.sun.enterprise.util.OS;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.io.FileUtils;
-import fish.payara.admin.cli.cluster.NamingHelper;
-import fish.payara.util.cluster.PayaraServerNameGenerator;
+
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
-
+import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.security.common.FileProtectionUtility;
 import org.jvnet.hk2.annotations.Service;
-import org.glassfish.hk2.api.PerLookup;
 
-import java.io.File;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.logging.Level;
+import fish.payara.admin.cli.cluster.NamingHelper;
+import fish.payara.util.cluster.PayaraServerNameGenerator;
 
 
 /**

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -43,6 +43,8 @@
 
 package com.sun.enterprise.admin.cli.cluster;
 
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+
 import com.sun.enterprise.admin.cli.CLIConstants;
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.admin.servermgmt.KeystoreManager;
@@ -122,8 +124,7 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
     private String _node;
     private static final String DEFAULT_MASTER_PASSWORD = KeystoreManager.DEFAULT_MASTER_PASSWORD;
     private ParamModelData masterPasswordOption;
-    private static final String MASTER_PASSWORD_ALIAS="master-password";
-
+    
     @Override
     protected void validate() throws CommandException {
         echoCommand();
@@ -318,10 +319,10 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
      * @throws CommandException
      */
     protected void createMasterPasswordFile(String masterPassword) throws CommandException {
-        final File pwdFile = new File(this.getServerDirs().getAgentDir(), MASTER_PASSWORD_ALIAS);
+        final File pwdFile = new File(this.getServerDirs().getAgentDir(), MASTERPASSWORD_FILE);
         try {
-            PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), MASTER_PASSWORD_ALIAS.toCharArray());
-            p.setPasswordForAlias(MASTER_PASSWORD_ALIAS, masterPassword.getBytes());
+            PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), MASTERPASSWORD_FILE.toCharArray());
+            p.setPasswordForAlias(MASTERPASSWORD_FILE, masterPassword.getBytes());
             FileProtectionUtility.chmod0600(pwdFile);
         } catch (Exception ex) {
             throw new CommandException(Strings.get("masterPasswordFileNotCreated", pwdFile),

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalInstanceCommand.java
@@ -43,6 +43,17 @@ package com.sun.enterprise.admin.cli.cluster;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+import java.util.logging.Level;
+
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.admin.servermgmt.cli.LocalServerCommand;
 import com.sun.enterprise.universal.io.SmartFile;
@@ -52,15 +63,10 @@ import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.util.io.InstanceDirs;
 import com.sun.enterprise.util.io.ServerDirs;
 import com.sun.enterprise.util.net.NetUtils;
+
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
-
-import java.io.*;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Properties;
-import java.util.logging.Level;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.UserInterruptException;
 

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalInstanceCommand.java
@@ -41,6 +41,8 @@
 
 package com.sun.enterprise.admin.cli.cluster;
 
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.admin.servermgmt.cli.LocalServerCommand;
 import com.sun.enterprise.universal.io.SmartFile;
@@ -671,7 +673,7 @@ public abstract class LocalInstanceCommand extends LocalServerCommand {
         if (nodeDirChild == null)
             return null;
 
-        File mp = new File(new File(nodeDirChild,"agent"), "master-password");
+        File mp = new File(new File(nodeDirChild,"agent"), MASTERPASSWORD_FILE);
         if (!mp.canRead()) {
             return null;
         }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalStrings.properties
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalStrings.properties
@@ -189,6 +189,7 @@ CreateLocalInstance.errSetLastMod=Attempt to set lastModified date for {0} faile
 #change-master-password-node
 instance.is.running=Server {0} is running. You need to stop the instance before the master-password can be changed.
 ## change-master-password-node
+savemasterpassword.unused=Warning: Option "savemasterpassword" is always true for nodes.
 current.mp=Enter the current master password>
 no.console=Not connected to console, giving up.
 incorrect.mp=Incorrect current master password. You will not be able to change it.

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalStrings.properties
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalStrings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2019] [Payara Foundation and/or affiliates]
 cantResolveIpAddress=Can't find the IP address for the hostname: {0}
 cantdelete=Cannot delete temporary file {0}.
 AgentPortInUse=Node agent port {0} is in use.


### PR DESCRIPTION
For anyone reviewing, a brief explanation of the behaviour change. The following functionality causes a problem:

1. Create a node
2. Create an instance on that node
3. Change master password for domain
4. Attempt to start instance (node still has the old master password saved, which doesn't unlock the keystore as the keystore has been synchronised from the DAS to the instance, so must be unlocked using the DAS master password)
5. Attempt to change master password for node (can't as the `change-master-password` command for the node will check the password against the keystore of each instance, which has now been updated with the DAS keystore)

This PR attempts to remedy this by causing the `change-master-password` command, when run against a node, to only change the saved password for the node, and not touch existing keystores. This will mean that the keystores will only have their password changed when changing the master password for the DAS, and the master password should then be updated on each node to reflect this change.