### PR TITLE
PAYARA-4028 PostConstruct values lost in Clustered Singleton EJBs

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/AbstractSingletonContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/AbstractSingletonContainer.java
@@ -554,7 +554,9 @@ public abstract class AbstractSingletonContainer
             if (doPostConstruct) {
                 intercept(CallbackType.POST_CONSTRUCT, context);
                 // Make sure to update Object stored in Map
-                clusteredLookup.getClusteredSingletonMap().set(sessionKey, context.getEJB());
+                if (clusteredLookup.isClusteredEnabled()) {
+                    clusteredLookup.getClusteredSingletonMap().set(sessionKey, context.getEJB());
+                }
             }
 
         } catch ( Throwable th ) {

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/AbstractSingletonContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/AbstractSingletonContainer.java
@@ -213,7 +213,7 @@ public abstract class AbstractSingletonContainer
             try {
                 invocationManager.preInvoke(inv);
                 if (clusteredLookup.getClusteredSingletonMap().containsKey(clusteredLookup.getClusteredSessionKey())) {
-                    clusteredLookup.getClusteredSingletonMap().put(clusteredLookup.getClusteredSessionKey(), inv.context.getEJB());
+                    clusteredLookup.getClusteredSingletonMap().set(clusteredLookup.getClusteredSessionKey(), inv.context.getEJB());
                 }
             }
             finally {
@@ -553,6 +553,8 @@ public abstract class AbstractSingletonContainer
 
             if (doPostConstruct) {
                 intercept(CallbackType.POST_CONSTRUCT, context);
+                // Make sure to update Object stored in Map
+                clusteredLookup.getClusteredSingletonMap().set(sessionKey, context.getEJB());
             }
 
         } catch ( Throwable th ) {


### PR DESCRIPTION
Due to serialisation of the objects put into the Hazelcast map, they need to be explicitly updated.