### PR TITLE
PAYARA-4043 Removed Jvnet parent

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -46,30 +46,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>net.java</groupId>
-        <artifactId>jvnet-parent</artifactId>
-        <version>5</version>
-        <relativePath />
+        <groupId>fish.payara</groupId>
+        <artifactId>payara-aggregator</artifactId>
+        <version>5.193-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara</groupId>
     <artifactId>payara-nucleus-parent</artifactId>
-    <version>5.193-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Payara Nucleus Parent Project</name>
     <url>https://github.com/payara/Payara</url>
-
-    <scm>
-        <connection>scm:git:git@github.com:payara/payara.git</connection>
-        <url>https://github.com/payara/Payara/tree/master</url>
-        <developerConnection>scm:git:git@github.com:payara/payara.git</developerConnection>
-        <tag>payara-server-5.193-SNAPSHOT</tag>
-    </scm>
-
-    <issueManagement>
-        <system>Github</system>
-        <url>https://github.com/payara/Payara/issues</url>
-    </issueManagement>
 
     <licenses>
       <license>
@@ -79,16 +64,6 @@
         <comments>A business-friendly OSS license</comments>
       </license>
     </licenses>
-
-
-    <developers>
-        <developer>
-            <name>Payara Team</name>
-            <email>info@payara.fish</email>
-            <organization>Payara Foundation</organization>
-            <organizationUrl>http://www.payara.fish</organizationUrl>
-        </developer>
-    </developers>
 
     <repositories>
         <!-- Try Maven central first, not last, which happens when omitted here -->
@@ -162,7 +137,7 @@
             </snapshots>
         </repository>
 
-        <!--  
+        <!--
         <repository>
            <id>payara-patched-externals-local</id>
            <name>Payara Patched Externals local</name>
@@ -180,15 +155,15 @@
 
         <repository>
            <id>payara-patched-externals</id>
-	   <name>Payara Patched Externals</name>
-	   <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-	   <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url>-->
-           	<releases>
-           		<enabled>true</enabled>
-           	</releases>
-            	<snapshots>
-                	<enabled>false</enabled>
-            	</snapshots>
+             <name>Payara Patched Externals</name>
+             <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+             <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url>-->
+             <releases>
+                 <enabled>true</enabled>
+             </releases>
+              <snapshots>
+                  <enabled>false</enabled>
+              </snapshots>
         </repository>
 
     </repositories>
@@ -206,35 +181,28 @@
             </snapshots>
         </pluginRepository>
         <pluginRepository>
-           <id>payara-patched-externals</id>
-	   <name>Payara Patched Externals</name>
-	   <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-	   <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url> -->
-           	<releases>
-           		<enabled>true</enabled>
-           	</releases>
-            	<snapshots>
-                	<enabled>true</enabled>
-            	</snapshots>
+            <id>payara-patched-externals</id>
+            <name>Payara Patched Externals</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+            <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url> -->
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <build.id>${build.number}</build.id> <!-- on Hudson and RE, this gets replaced by real build ID -->
+        <!-- on Hudson and RE, ${build.number} gets replaced by real build ID -->
+        <build.id>${build.number}</build.id>
         <jdk.version>1.8.0</jdk.version>
         <javase.version>1.8</javase.version>
         <javadoc.skip>false</javadoc.skip>
 
-        <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
-        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
-        <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
-        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
-        <maven.jar.plugin.version>3.1.1</maven.jar.plugin.version>
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
         <maven.remote.resources.plugin.version>1.6.0</maven.remote.resources.plugin.version>
         <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
@@ -245,13 +213,9 @@
         <maven.bundle.plugin.version>4.1.0</maven.bundle.plugin.version>
         <maven.antlr.plugin.version>2.2</maven.antlr.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
-        <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
-        <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
         <maven.jaxws.plugin.version>2.5</maven.jaxws.plugin.version>
         <maven.apt.plugin.version>1.0-alpha-5</maven.apt.plugin.version>
         <maven.build.helper.plugin.version>3.0.0</maven.build.helper.plugin.version>
-        <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-        <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
         <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
 
         <deploy.skip>true</deploy.skip>
@@ -265,7 +229,7 @@
 
         <!-- Requires JDK8u161 or above-->
         <grizzly.npn.version>1.8</grizzly.npn.version>
-        
+
         <!-- Microprofile -->
         <microprofile-config.version>1.3</microprofile-config.version>
         <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
@@ -323,7 +287,7 @@
         <!-- GlassFish MBean Annotation Library -->
         <gmbal.version>4.0.0</gmbal.version>
         <antlr.version>2.7.7</antlr.version>
-        
+
         <commons-io.version>2.6</commons-io.version>
 
         <!-- Jackson is a high-performance JSON processor (parser, generator) -->
@@ -334,7 +298,7 @@
         <jsonp.version>1.1.5</jsonp.version>
 
         <mimepull.version>1.9.11</mimepull.version>
-        
+
         <opentracing.version>0.31.0</opentracing.version>
 
         <jline.version>3.11.0</jline.version>
@@ -646,7 +610,7 @@
                             <exclude>**/Q*.*</exclude>
                         </excludes>
                     </configuration>
-                    
+
                     <executions>
                         <execution>
                             <id>default-prepare-agent</id>
@@ -733,11 +697,10 @@
                     </execution>
                 </executions>
             </plugin>
-	    -->
+      -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add-resource</id>
@@ -827,7 +790,6 @@
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>config-generator</artifactId>
-                <version>2.5.0-b53</version>
                 <configuration>
                     <excludes>**/.ade_path/**</excludes>
                     <supportedProjectTypes>jar,glassfish-jar</supportedProjectTypes>
@@ -1434,8 +1396,8 @@ Parent is ${project.parent}</echo>
                 <module>tests</module>
             </modules>
         </profile>
-    
-        
+
+
         <profile>
             <id>default</id>
             <activation>
@@ -1501,7 +1463,7 @@ Parent is ${project.parent}</echo>
                 </pluginManagement>
             </build>
         </profile>
-        
+
         <profile>
             <id>embed-source</id>
             <build>
@@ -1521,7 +1483,7 @@ Parent is ${project.parent}</echo>
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>release-phase2</id>
             <build>
@@ -1687,7 +1649,7 @@ Parent is ${project.parent}</echo>
             <optional>true</optional>
         </dependency>
     </dependencies>
-    
+
     <reporting>
         <plugins>
             <plugin>
@@ -1712,5 +1674,5 @@ Parent is ${project.parent}</echo>
             </plugin>
         </plugins>
     </reporting>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,99 +39,81 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2017-2018] Payara Foundation and/or affiliates
+    Portions Copyright [2017-2019] Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.glassfish.main</groupId>
-    <artifactId>glassfish-main-aggregator</artifactId>
+    <groupId>fish.payara</groupId>
+    <artifactId>payara-aggregator</artifactId>
     <version>5.193-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>Payara Project</name>
-    
+
+    <modules>
+        <module>nucleus</module>
+        <module>appserver</module>
+        <module>api</module>
+    </modules>
+
     <scm>
         <connection>scm:git:git@github.com:payara/payara.git</connection>
         <url>scm:git:git@github.com:payara/payara.git</url>
         <developerConnection>scm:git:git@github.com:payara/payara.git</developerConnection>
         <tag>payara-server-5.193-SNAPSHOT</tag>
     </scm>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-    
+    <issueManagement>
+        <system>Github</system>
+        <url>https://github.com/payara/Payara/issues</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <name>Payara Team</name>
+            <email>info@payara.fish</email>
+            <organization>Payara Foundation</organization>
+            <organizationUrl>http://www.payara.fish</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
+        <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
+        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+        <maven.jar.plugin.version>3.1.1</maven.jar.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
+        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-        <maven.install.plugin.version>2.5.2</maven.install.plugin.version>
-        <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
-        <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-        <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
+        <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
+        <maven.source.plugin.version>3.1.0</maven.source.plugin.version>
+        <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
+        <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <profiles>
         <profile>
-            <id>release-phase2</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <modules>
-                <module>nucleus</module>
-                <module>appserver</module>
-                <module>api</module>
-            </modules>
-        </profile>
-        <profile>
-            <!--
-                RE profile for release purposes. 
-            -->
-            <id>ips</id>
-            <activation>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <modules>
-                <module>nucleus</module>
-                <module>appserver</module>
-                <module>api</module>
-            </modules>
-        </profile>
-        
-        <profile>
             <id>source</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
                 <property>
                     <name>source</name>
                     <value>true</value>
                 </property>
             </activation>
-            <modules>
-                <module>nucleus</module>
-                <module>appserver</module>
-                <module>api</module>
-            </modules>
-            <properties>
-                <maven.test.skip>true</maven.test.skip>
-                <project>payara</project> 
-            </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>${maven.source.plugin.version}</version>
                         <configuration>
                             <excludeResources>true</excludeResources>
                             <excludes>**/*.properties</excludes>
@@ -139,81 +121,63 @@
                             <excludes>**/*.class</excludes>
                             <excludes>**/*.html</excludes>
                             <includePom>false</includePom>
+                            <finalName>payara-${project.version}</finalName>
+                            <includePom>false</includePom>
                         </configuration>
                         <executions>
                             <execution>
+                                <id>attach-sources-aggregate</id>
                                 <phase>pre-site</phase>
-                                <id>attach-sources</id>
+                                <inherited>false</inherited>
                                 <goals>
-                                    <goal>jar-no-fork</goal>
                                     <goal>aggregate</goal>
                                 </goals>
-                                <configuration>
-                                    <finalName>payara-5.193-SNAPSHOT</finalName>    
-                                    <includePom>false</includePom>                            
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
-             
+
         <profile>
             <id>javadoc</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
                 <property>
                     <name>javadoc</name>
                     <value>true</value>
                 </property>
             </activation>
-            <modules>
-                <module>nucleus</module>
-                <module>appserver</module>
-                <module>api</module>
-            </modules>
-            <properties>
-                <maven.test.skip>true</maven.test.skip>
-            </properties>
             <build>
+                <finalName>payara-${project.version}</finalName>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
-                            <!-- Default configuration for all reports -->
                             <docencoding>UTF-8</docencoding>
                             <includeDependencySources>false</includeDependencySources>
                             <!-- This parameter is to be added when using JDK8 -->
                             <additionalOptions>
                                 <additionalOption>-Xdoclint:none</additionalOption>
                             </additionalOptions>
+                            <finalName>payara-${project.version}</finalName>
+                            <minmemory>512m</minmemory>
+                            <maxmemory>2g</maxmemory>
                         </configuration>
                         <executions>
                             <execution>
-                                <id>aggregate</id>
+                                <id>attach-javadoc-aggregate</id>
+                                <phase>pre-site</phase>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <verbose>true</verbose>
+                                </configuration>
                                 <goals>
                                     <goal>aggregate-no-fork</goal>
-                                    <!--
-                                        until no-fork variant of jar is available, we'll package
-                                        directly with jar plugin
-                                    -->
-                                    <!--<goal>aggregate-jar</goal>-->
                                 </goals>
-                                <phase>pre-site</phase>
-                                <configuration>
-                                    <!-- Specific configuration for the aggregate report -->
-                                    <finalName>payara-5.193-SNAPSHOT</finalName>
-                                    <minmemory>512m</minmemory>
-                                    <maxmemory>2g</maxmemory>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
                         <executions>
                             <execution>
@@ -222,22 +186,24 @@
                                    <goal>jar</goal>
                                 </goals>
                                 <phase>pre-site</phase>
+                                <inherited>false</inherited>
                                 <configuration>
                                     <classesDirectory>${project.build.directory}/site/apidocs</classesDirectory>
                                     <classifier>javadoc</classifier>
+                                    <archive>
+                                        <manifestFile />
+                                    </archive>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
-                <finalName>payara-${project.version}</finalName>
             </build>
         </profile>
 
         <profile>
             <id>gpgsign</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
                 <property>
                     <name>gpgsign</name>
                     <value>true</value>
@@ -246,9 +212,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>${maven.gpg.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -262,34 +226,47 @@
                 </plugins>
             </build>
         </profile>
-        
+
     </profiles>
-   
-    <!--
-        Skip deploy and install as this is an aggregator POM
-    -->
+
     <build>
         <defaultGoal>install</defaultGoal>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven.jar.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven.source.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven.javadoc.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven.gpg.plugin.version}</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>${maven.install.plugin.version}</version>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven.deploy.plugin.version}</version>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven.release.plugin.version}</version>
                 </plugin>


### PR DESCRIPTION
- new parent relation introduced problems with it's configuration poisoning
  all it's grandchildren - profiles source and javadoc did not work.
  This is now fixed.
- source and javadoc profiles now produce same artifacts as before
- it is possible to combine profiles and build phases
- removed duplicated and redundant configuration parts.
- modules moved from profiles to the main pom.
- aggregator also changed the id