### PR TITLE
PAYARA-3885 Implement Parameterized dynamically resolved role names

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) [2016-2018] Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -455,6 +455,14 @@
         <dependency>
             <groupId>org.glassfish.main.packager</groupId>
             <artifactId>microprofile-package</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.main.packager</groupId>
+            <artifactId>cdi-auth-roles</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>

--- a/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -90,6 +90,10 @@
             <groupId>fish.payara.api</groupId>
             <artifactId>payara-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
             <groupId>javax</groupId>

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/CallerAccessExceptionAutoDiscoverable.java
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/CallerAccessExceptionAutoDiscoverable.java
@@ -40,15 +40,13 @@
  */
 package fish.payara.appserver.cdi.auth.roles;
 
-import static javax.ws.rs.RuntimeType.SERVER;
-import static org.glassfish.internal.api.Globals.getDefaultHabitat;
-import static org.glassfish.jersey.internal.spi.AutoDiscoverable.DEFAULT_PRIORITY;
-
 import javax.annotation.Priority;
 import javax.ws.rs.ConstrainedTo;
+import static javax.ws.rs.RuntimeType.SERVER;
 import javax.ws.rs.core.FeatureContext;
-
+import static org.glassfish.internal.api.Globals.getDefaultHabitat;
 import org.glassfish.internal.deployment.Deployment;
+import static org.glassfish.jersey.internal.spi.AutoDiscoverable.DEFAULT_PRIORITY;
 import org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable;
 
 @ConstrainedTo(SERVER)

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/CallerAccessExceptionAutoDiscoverable.java
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/CallerAccessExceptionAutoDiscoverable.java
@@ -1,0 +1,71 @@
+/*
+ *   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *   Copyright (c) [2019] Payara Foundation and/or its affiliates.
+ *   All rights reserved.
+ *
+ *   The contents of this file are subject to the terms of either the GNU
+ *   General Public License Version 2 only ("GPL") or the Common Development
+ *   and Distribution License("CDDL") (collectively, the "License").  You
+ *   may not use this file except in compliance with the License.  You can
+ *   obtain a copy of the License at
+ *   https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *   See the License for the specific
+ *   language governing permissions and limitations under the License.
+ *
+ *   When distributing the software, include this License Header Notice in each
+ *   file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *   GPL Classpath Exception:
+ *   The Payara Foundation designates this particular file as subject to the
+ *   "Classpath" exception as provided by the Payara Foundation in the GPL
+ *   Version 2 section of the License file that accompanied this code.
+ *
+ *   Modifications:
+ *   If applicable, add the following below the License Header, with the fields
+ *   enclosed by brackets [] replaced by your own identifying information:
+ *   "Portions Copyright [year] [name of copyright owner]"
+ *
+ *   Contributor(s):
+ *   If you wish your version of this file to be governed by only the CDDL or
+ *   only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *   elects to include this software in this distribution under the [CDDL or GPL
+ *   Version 2] license."  If you don't indicate a single choice of license, a
+ *   recipient has the option to distribute your version of this file under
+ *   either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *   its licensees as provided above.  However, if you add GPL Version 2 code
+ *   and therefore, elected the GPL Version 2 license, then the option applies
+ *   only if the new code is made subject to such option by the copyright
+ *   holder.
+ */
+package fish.payara.appserver.cdi.auth.roles;
+
+import static javax.ws.rs.RuntimeType.SERVER;
+import static org.glassfish.internal.api.Globals.getDefaultHabitat;
+import static org.glassfish.jersey.internal.spi.AutoDiscoverable.DEFAULT_PRIORITY;
+
+import javax.annotation.Priority;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.core.FeatureContext;
+
+import org.glassfish.internal.deployment.Deployment;
+import org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable;
+
+@ConstrainedTo(SERVER)
+@Priority(DEFAULT_PRIORITY)
+public final class CallerAccessExceptionAutoDiscoverable implements ForcedAutoDiscoverable {
+
+    @Override
+    public void configure(FeatureContext context) {
+        
+        Deployment deployment = getDefaultHabitat().getService(Deployment.class);
+        // Only register for application deployments (not the admin console)
+        if (deployment.getCurrentDeploymentContext() == null) {
+            return;
+        }
+
+        if (!context.getConfiguration().isRegistered(CallerAccessExceptionMapper.class)) {
+            context.register(CallerAccessExceptionMapper.class);
+        }
+    }
+}

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/CallerAccessExceptionMapper.java
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/CallerAccessExceptionMapper.java
@@ -1,0 +1,63 @@
+/*
+ *   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *   Copyright (c) [2019] Payara Foundation and/or its affiliates.
+ *   All rights reserved.
+ *
+ *   The contents of this file are subject to the terms of either the GNU
+ *   General Public License Version 2 only ("GPL") or the Common Development
+ *   and Distribution License("CDDL") (collectively, the "License").  You
+ *   may not use this file except in compliance with the License.  You can
+ *   obtain a copy of the License at
+ *   https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *   See the License for the specific
+ *   language governing permissions and limitations under the License.
+ *
+ *   When distributing the software, include this License Header Notice in each
+ *   file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *   GPL Classpath Exception:
+ *   The Payara Foundation designates this particular file as subject to the
+ *   "Classpath" exception as provided by the Payara Foundation in the GPL
+ *   Version 2 section of the License file that accompanied this code.
+ *
+ *   Modifications:
+ *   If applicable, add the following below the License Header, with the fields
+ *   enclosed by brackets [] replaced by your own identifying information:
+ *   "Portions Copyright [year] [name of copyright owner]"
+ *
+ *   Contributor(s):
+ *   If you wish your version of this file to be governed by only the CDDL or
+ *   only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *   elects to include this software in this distribution under the [CDDL or GPL
+ *   Version 2] license."  If you don't indicate a single choice of license, a
+ *   recipient has the option to distribute your version of this file under
+ *   either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *   its licensees as provided above.  However, if you add GPL Version 2 code
+ *   and therefore, elected the GPL Version 2 license, then the option applies
+ *   only if the new code is made subject to such option by the copyright
+ *   holder.
+ */
+package fish.payara.appserver.cdi.auth.roles;
+
+import fish.payara.cdi.auth.roles.CallerAccessException;
+import javax.ws.rs.core.Response;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ *
+ * @author jGauravGupta
+ */
+@Provider
+public class CallerAccessExceptionMapper implements ExceptionMapper<CallerAccessException> {
+
+    @Override
+    public Response toResponse(CallerAccessException cae) {
+         return Response.status(FORBIDDEN)
+                 .entity(cae.getMessage())
+                 .build();
+    }
+
+}

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/RolesPermittedInterceptor.java
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/RolesPermittedInterceptor.java
@@ -40,39 +40,35 @@
  */
 package fish.payara.appserver.cdi.auth.roles;
 
+import fish.payara.cdi.auth.roles.CallerAccessException;
 import static fish.payara.cdi.auth.roles.LogicalOperator.AND;
 import static fish.payara.cdi.auth.roles.LogicalOperator.OR;
-import static java.util.Arrays.asList;
-import static org.glassfish.soteria.cdi.CdiUtils.getAnnotation;
-
+import fish.payara.cdi.auth.roles.RolesPermitted;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import static java.util.Arrays.asList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
-
 import javax.annotation.Priority;
+import javax.el.ELProcessor;
 import javax.enterprise.inject.Intercepted;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import javax.security.enterprise.SecurityContext;
-
-import fish.payara.cdi.auth.roles.CallerAccessException;
-import fish.payara.cdi.auth.roles.RolesPermitted;
-import java.lang.reflect.Parameter;
-import javax.el.ELProcessor;
-import javax.inject.Named;
 import javax.security.enterprise.AuthenticationStatus;
 import static javax.security.enterprise.AuthenticationStatus.NOT_DONE;
 import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
 import static javax.security.enterprise.AuthenticationStatus.SUCCESS;
+import javax.security.enterprise.SecurityContext;
 import static javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -80,6 +76,7 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.Context;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.hasAnyELExpression;
+import static org.glassfish.soteria.cdi.CdiUtils.getAnnotation;
 
 /**
  * The RolesPermitted Interceptor authenticates requests to methods and classes
@@ -263,7 +260,7 @@ public class RolesPermittedInterceptor {
 
         return elProcessor;
     }
-    
+
     private void authenticate(String[] roles) {
         if (request != null && response != null
                 && roles.length > 0 && !isAuthenticated()) {
@@ -275,7 +272,8 @@ public class RolesPermittedInterceptor {
                 throw new NotAuthorizedException("Authentication resulted in " + status);
             }
 
-            if (status == SUCCESS && !isAuthenticated()) { // compensate for possible Soteria bug, need to investigate
+            // compensate for possible Soteria bug, need to investigate
+            if (status == SUCCESS && !isAuthenticated()) {
                 throw new NotAuthorizedException("Authentication not done (i.e. no credential found)");
             }
         }

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/extension/RolesCDIExtension.java
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/extension/RolesCDIExtension.java
@@ -40,13 +40,12 @@
  */
 package fish.payara.appserver.cdi.auth.roles.extension;
 
+import fish.payara.appserver.cdi.auth.roles.RolesPermittedInterceptor;
+import fish.payara.cdi.auth.roles.RolesPermitted;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
-
-import fish.payara.appserver.cdi.auth.roles.RolesPermittedInterceptor;
-import fish.payara.cdi.auth.roles.RolesPermitted;
 
 /**
  * Extension to get the runtime to find the Roles Interceptor.

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/extension/RolesCDIExtension.java
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/java/fish/payara/appserver/cdi/auth/roles/extension/RolesCDIExtension.java
@@ -1,7 +1,7 @@
 /*
  *   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *   Copyright (c) [2017-2018] Payara Foundation and/or its affiliates.
+ *   Copyright (c) [2017-2019] Payara Foundation and/or its affiliates.
  *   All rights reserved.
  *
  *   The contents of this file are subject to the terms of either the GNU
@@ -45,7 +45,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
 
-import fish.payara.appserver.cdi.auth.roles.RolesCDIInterceptor;
+import fish.payara.appserver.cdi.auth.roles.RolesPermittedInterceptor;
 import fish.payara.cdi.auth.roles.RolesPermitted;
 
 /**
@@ -58,8 +58,7 @@ public class RolesCDIExtension implements Extension {
     void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
         beforeBeanDiscovery.addInterceptorBinding(RolesPermitted.class);
 
-        beforeBeanDiscovery.addAnnotatedType(
-            beanManager.createAnnotatedType(RolesCDIInterceptor.class),
-            "RolesCDIExtension " + RolesCDIInterceptor.class.getName());
+        beforeBeanDiscovery.addAnnotatedType(beanManager.createAnnotatedType(RolesPermittedInterceptor.class),
+            "RolesCDIExtension " + RolesPermittedInterceptor.class.getName());
     }
 }

--- a/appserver/payara-appserver-modules/cdi-auth-roles/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable
@@ -1,0 +1,1 @@
+fish.payara.appserver.cdi.auth.roles.CallerAccessExceptionAutoDiscoverable


### PR DESCRIPTION
Implemented Parameterized dynamically resolved role names feature by using existing annotation @RolesPermitted: e.g 

```
@RolesPermitted("#{'CustomerCare_'.concat(customer.name)}")
public void updateCustomer(@Named("customer") Customer customer){
}
```

In the above example, `Named` annotation is used to define the parameter name in dynamic role expression. 

Multiple parameters can be used in el expression:  e.g 
```
@RolesPermitted("#{self.findRole(customer, product)}")
public void updateCustomer(@Named("customer") Customer customer, @Named("product") Product product){
}
```

If the parameter name not defined using `Named` annotation and method parameter count is 1 then default `param` name is used, e.g 
```
@RolesPermitted("#{'CustomerCare_'.concat(param.name)}")
public void updateCustomer(Customer customer){
}
```

Testcases: https://github.com/payara/payara-samples/pull/24