### PR TITLE
PAYARA-3792 Fix failing test on Windows

### DIFF
--- a/nucleus/admin/server-mgmt/src/test/java/fish/payara/admin/servermgmt/cli/PrintCertificateCommandTest.java
+++ b/nucleus/admin/server-mgmt/src/test/java/fish/payara/admin/servermgmt/cli/PrintCertificateCommandTest.java
@@ -194,7 +194,7 @@ public class PrintCertificateCommandTest {
         assertEquals("Version:    3", output[4]);
         assertEquals("Issuer:     " + dn, output[5]);
         assertEquals("Public Key: RSA, 2048 bits", output[6]);
-        assertEquals("Sign. Alg.: SHA256withRSA (OID: 1.2.840.113549.1.1.11)", output[7]);
+        assertEquals("Sign. Alg.: SHA256withRSA (OID: 1.2.840.113549.1.1.11)", output[7].trim());
     }
 
 
@@ -214,7 +214,7 @@ public class PrintCertificateCommandTest {
         assertEquals("Version:    3", output[4]);
         assertEquals("Issuer:     " + dn, output[5]);
         assertEquals("Public Key: RSA, 2048 bits", output[6]);
-        assertEquals("Sign. Alg.: SHA256WITHRSA (OID: 1.2.840.113549.1.1.11)", output[7]);
+        assertEquals("Sign. Alg.: SHA256WITHRSA (OID: 1.2.840.113549.1.1.11)", output[7].trim());
     }
 
 


### PR DESCRIPTION
Test was failing because on Windows it has a `/r` on the end