### PR TITLE
PAYARA-4067: Put JSON-B api on AppClient classpath

### DIFF
--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -389,6 +389,11 @@
         <artifactId>webservices-api-osgi</artifactId>
      </dependency>
 
+     <dependency>
+         <groupId>javax.json.bind</groupId>
+         <artifactId>javax.json.bind-api</artifactId>
+     </dependency>
+
      <!-- JAXR -JSR-93 Support-->
      <dependency>
          <groupId>javax.xml.registry</groupId>


### PR DESCRIPTION
This will make `javax.json.bind-api` to appear in the `Class-Path` manifest of `acc-standalone` (also known as `gf-client.jar`), and therefore makes classes available to application client runtime.

Makes Jakarta EE 8 signature tests pass for these packages.