### PR TITLE
PAYARA-4079: Fix NPE in DeployCommand

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -537,11 +537,11 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             Transaction t = deployment.prepareAppConfigChanges(deploymentContext);
             span.finish(); // next phase is launched by prepare
             Deployment.ApplicationDeployment deplResult = deployment.prepare(null, deploymentContext);
-            if(!loadOnly) {
+            if(deplResult != null && !loadOnly) {
                 // initialize makes its own phase as well
                 deployment.initialize(deplResult.appInfo, deplResult.appInfo.getSniffers(), deplResult.context);
             }
-            ApplicationInfo appInfo = deplResult.appInfo;
+            ApplicationInfo appInfo = deplResult != null ? deplResult.appInfo : null;
 
             /*
              * Various deployers might have added to the downloadable or


### PR DESCRIPTION
When deployment fails, prepare returns null and action report contains details of the failure. Line 542 caused NullPointerException in such case, silently erasing that diagnostic information.