### PR TITLE
PAYARA-4087 Allow the use of a single char as the operand for Micro

### DIFF
--- a/nucleus/core/bootstrap/src/main/java/fish/payara/boot/runtime/BootCommands.java
+++ b/nucleus/core/bootstrap/src/main/java/fish/payara/boot/runtime/BootCommands.java
@@ -71,7 +71,7 @@ public class BootCommands {
      * [\"'].+?[\"'] e.g --description "results in error"
      *
      */
-    private static final Pattern COMMAND_FLAG_PATTERN = Pattern.compile("([^\"']\\S+=[\"'].+?[\"']|[^\"']\\S+|[\"'].+?[\"'])\\s*");
+    private static final Pattern COMMAND_FLAG_PATTERN = Pattern.compile("([^\"']\\S+=[\"'].+?[\"']|[^\"']\\S*|[\"'].+?[\"'])\\s*");
     private final List<BootCommand> commands;
 
     private static final Logger LOGGER = Logger.getLogger(BootCommands.class.getName());

--- a/nucleus/core/bootstrap/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
+++ b/nucleus/core/bootstrap/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
@@ -56,21 +56,23 @@ public class BootCommandsTest {
     @Test
     public void parseCommand() throws IOException {
         BootCommands bootCommands = new BootCommands();
-        String commandText = "create-custom-resource --restype java.lang.String --name='custom-res' --description=\"results in error\" --property value=\"${ENV=ini_ws_uri}\" vfp/vfp-menu/ini.ws.uri";
+        String commandText = "create-custom-resource --restype java.lang.String -s v --name='custom-res' --description=\"results in error\" --property value=\"${ENV=ini_ws_uri}\" vfp/vfp-menu/ini.ws.uri";
         try (Reader reader = new StringReader(commandText)){
             bootCommands.parseCommandScript(reader);
         }
         assertThat(bootCommands.getCommands().size(), is(1));
         
         BootCommand command = bootCommands.getCommands().get(0);
-        assertThat(command.getArguments().length, is(7));
+        assertThat(command.getArguments().length, is(9));
         assertEquals(command.getArguments()[0], "--restype");
         assertEquals(command.getArguments()[1], "java.lang.String");
-        assertEquals(command.getArguments()[2], "--name='custom-res'");
-        assertEquals(command.getArguments()[3], "--description=\"results in error\"");
-        assertEquals(command.getArguments()[4], "--property");
-        assertEquals(command.getArguments()[5], "value=\"${ENV=ini_ws_uri}\"");
-        assertEquals(command.getArguments()[6], "vfp/vfp-menu/ini.ws.uri");
+        assertEquals(command.getArguments()[2], "-s");
+        assertEquals(command.getArguments()[3], "v");
+        assertEquals(command.getArguments()[4], "--name='custom-res'");
+        assertEquals(command.getArguments()[5], "--description=\"results in error\"");
+        assertEquals(command.getArguments()[6], "--property");
+        assertEquals(command.getArguments()[7], "value=\"${ENV=ini_ws_uri}\"");
+        assertEquals(command.getArguments()[8], "vfp/vfp-menu/ini.ws.uri");
     }
 
 }


### PR DESCRIPTION
For commands used in pre- or post-boot file allow the operand to be a single
char