### PR TITLE
PAYARA-3819: Remove java.net repositories

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -1058,7 +1058,7 @@
             <dependency>
                 <groupId>org.glassfish.fighterfish</groupId>
                 <artifactId>osgi-cdi</artifactId>
-                <version>1.0.4</version>
+                <version>1.0.6</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.fighterfish</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -77,54 +77,6 @@
         </repository>
 
         <repository>
-            <id>jvnet-nexus-releases</id>
-            <name>Java.net Releases Repositories</name>
-            <url>https://maven.java.net/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-staging</id>
-            <name>Java.net Staging Repositories</name>
-            <url>https://maven.java.net/content/repositories/staging</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-promoted</id>
-            <name>Java.net Promoted Repositories</name>
-            <url>https://maven.java.net/content/repositories/promoted/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-1074</id>
-            <name>Java.net orgglassfish-1074 Repositories</name>
-            <url>https://maven.java.net/content/repositories/orgglassfish-1074/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
             <id>eclipse.microprofile</id>
             <name>Eclipse MicroProfile Repository</name>
             <url>https://repo.eclipse.org/content/groups/microprofile/</url>
@@ -136,22 +88,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-
-        <!--
-        <repository>
-           <id>payara-patched-externals-local</id>
-           <name>Payara Patched Externals local</name>
-           <url>file:///opt/PayaraDev/Payara_PatchedProjects</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-        -->
 
         <repository>
            <id>payara-patched-externals</id>
@@ -169,17 +105,6 @@
     </repositories>
 
     <pluginRepositories>
-        <pluginRepository>
-            <id>jvnet-nexus-promoted</id>
-            <name>Java.net Promoted Repositories</name>
-            <url>https://maven.java.net/content/repositories/promoted/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
         <pluginRepository>
             <id>payara-patched-externals</id>
             <name>Payara Patched Externals</name>


### PR DESCRIPTION
The repositories do not contain anything relevant outside one unreleased version of fighterfish osgi-cdi, which already has more recent version on central.

Also for local patched_projects it's just better to place that as a mirror in settings.xml, no need to pollute pom.xml with that.