### PR TITLE
PAYARA-4115 Fix invalid number of columns message when running list-nodes-docker

### DIFF
--- a/appserver/docker/src/main/java/fish/payara/docker/node/admin/ListNodesDockerCommand.java
+++ b/appserver/docker/src/main/java/fish/payara/docker/node/admin/ListNodesDockerCommand.java
@@ -70,7 +70,7 @@ import javax.inject.Inject;
 })
 public class ListNodesDockerCommand implements AdminCommand {
 
-    private final static String[] OUTPUT_HEADERS = new String[]{"Name", "Host", "Image", "Port"};
+    private final static String[] OUTPUT_HEADERS = new String[]{"Name", "Host", "Image", "Port", "TLS Enabled"};
 
     @Inject
     private Nodes nodes;


### PR DESCRIPTION
Title.

Previously when you run the command you'd just get an error, due to the number of columns in the formatter not matching the number of actual parameters.