### PR TITLE
PAYARA-4131: Fix race conditions in resource class generation

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestManagementResourceProvider.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestManagementResourceProvider.java
@@ -192,12 +192,14 @@ public class RestManagementResourceProvider extends AbstractRestResourceProvider
 
     private void generateASM(ServiceLocator habitat) {
         try {
-            Domain entity = habitat.getService(Domain.class);
-            Dom dom = Dom.unwrap(entity);
+            synchronized (RestManagementResourceProvider.class) {
+                Domain entity = habitat.getService(Domain.class);
+                Dom dom = Dom.unwrap(entity);
 
-            ResourcesGenerator resourcesGenerator = new ASMResourcesGenerator(habitat);
-            resourcesGenerator.generateSingle(dom.document.getRoot().model, dom.document);
-            resourcesGenerator.endGeneration();
+                ResourcesGenerator resourcesGenerator = new ASMResourcesGenerator(habitat);
+                resourcesGenerator.generateSingle(dom.document.getRoot().model, dom.document);
+                resourcesGenerator.endGeneration();
+            }
         } catch (Exception ex) {
             RestLogging.restLogger.log(Level.SEVERE, null, ex);
         }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ResourcesGeneratorBase.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ResourcesGeneratorBase.java
@@ -62,7 +62,7 @@ import org.jvnet.hk2.config.DomDocument;
  */
 public abstract class ResourcesGeneratorBase implements ResourcesGenerator {
 
-    private static Set<String> alreadyGenerated = new HashSet<String>();
+    private static Set<String> alreadyGenerated = Collections.synchronizedSet(new HashSet<String>());
     ServiceLocator habitat;
 
     public ResourcesGeneratorBase(ServiceLocator habitat) {
@@ -144,6 +144,7 @@ public abstract class ResourcesGeneratorBase implements ResourcesGenerator {
 
             classWriter.done();
         }
+        alreadyGenerated.add(className);
     }
 
     public void generateList(ConfigModel model, DomDocument domDocument) {
@@ -376,12 +377,7 @@ public abstract class ResourcesGeneratorBase implements ResourcesGenerator {
      * @return true if the given className is already generated. false otherwise.
      */
     protected boolean alreadyGenerated(String className) {
-        boolean retVal = true;
-        if (!alreadyGenerated.contains(className)) {
-            alreadyGenerated.add(className);
-            retVal = false;
-        }
-        return retVal;
+        return alreadyGenerated.contains(className);
     }
 
     /**


### PR DESCRIPTION
Resouce provider depends on quite unique (to use a neutral term) synchronization in order to generate classes that describe admin rest api. On every request it will try to generate them, and rely on static set in `ResourcesGeneratorBase` to remember which ones are done.

This breaks when second request is received while the first one builds the resources, and therefore needs to be synchronized.