### PR TITLE
PAYARA-3501 Configuration changes in MP health and metrics in Admin console don't warn about restart needed

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/admin/SetMetricsConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/admin/SetMetricsConfigurationCommand.java
@@ -146,10 +146,16 @@ public class SetMetricsConfigurationCommand extends SetSecureMicroprofileConfigu
                 }
                 if (enabled != null) {
                     configProxy.setEnabled(enabled.toString());
+                    if(dynamic != null && dynamic || Boolean.valueOf(metricsConfiguration.getDynamic())) {
+                        metricsService.resetMetricsEnabledProperty();
+                    }
                 }
                 if (secure != null) {
                     actionReport.setMessage("--secureMetrics option is deprecated, replaced by --securityEnabled option.");
                     configProxy.setSecureMetrics(secure.toString());
+                    if(dynamic != null && dynamic || Boolean.valueOf(metricsConfiguration.getDynamic())) {
+                        metricsService.resetMetricsSecureProperty();
+                    }
                 }
                 if (endpoint != null) {
                     configProxy.setEndpoint(endpoint);


### PR DESCRIPTION
Reopening due to small change that removed Dynamic config, thanks to @jGauravGupta for spotting it!