### PR TITLE
PAYARA-4056 HttpServletRequest.getServletPath() not returning original path

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/RequestFacade.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/RequestFacade.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 package org.apache.catalina.connector;
 
 import com.sun.enterprise.security.web.integration.WebPrincipal;
@@ -870,13 +870,6 @@ public class RequestFacade implements HttpServletRequest {
 
         if (request == null) {
             throw new IllegalStateException(rb.getString(LogFacade.CANNOT_USE_REQUEST_OBJECT_OUTSIDE_SCOPE_EXCEPTION));
-        }
-
-        // PAYARA-917 WELD Request Beans access the Request Facade directly not via the
-        // wrapper class when requests are forwarded
-        String forwardedPath = (String) request.getAttribute("fish.payara.servlet.dispatchPath");
-        if (forwardedPath != null) {
-            return forwardedPath;
         }
 
         return request.getServletPath();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ApplicationDispatcher.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ApplicationDispatcher.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates.]
 package org.apache.catalina.core;
 
 import fish.payara.nucleus.requesttracing.RequestTracingService;
@@ -318,14 +318,7 @@ public final class ApplicationDispatcher
      */
     public void forward(ServletRequest request, ServletResponse response)
             throws ServletException, IOException {
-        // store previous forward
-        Object prevForward = request.getAttribute("fish.payara.servlet.dispatchPath");
-        request.setAttribute("fish.payara.servlet.dispatchPath", this.servletPath);
-        try {
-            dispatch(request, response, DispatcherType.FORWARD);
-        }finally {
-            request.setAttribute("fish.payara.servlet.dispatchPath",prevForward);
-        }
+        dispatch(request, response, DispatcherType.FORWARD);
     }
 
     /**
@@ -522,10 +515,8 @@ public final class ApplicationDispatcher
                 state.outerRequest.setAttribute(
                     Globals.DISPATCHER_REQUEST_PATH_ATTR,
                     getCombinedPath());
-                invoke(state.outerRequest, response, state);
-            } else {
-                invoke(state.outerRequest, response, state);
             }
+            invoke(state.outerRequest, response, state);
         }
     }
 


### PR DESCRIPTION
Revert fix made for [PAYARA-917](https://github.com/payara/Payara/pull/1081) as it currently breaks the Servlet TCK.
Requires the following PR into the EE7 samples repo to be merged to pass Jenkins tests - as the fix was originally put it to fix a couple of tests in `jaspic/dispatching-jsf-cdi` around something that doesn't seem to be mentioned in any specs: https://github.com/payara/patched-src-javaee7-samples/pull/44

What should be the outcome of calling `getServletPath()` on a HttpServletRequest injected into a Bean, which is injected into a Servlet which has been forwarded to? The original servlet (before the forward), or the forwarded-to servlet (as is what you'd get if calling the method on the HttpServletRequest parameter of the forwarded to Servlet's `doGet` method)