### PR TITLE
PAYARA-3989 Mark applications as unavailable as soon as they are disabled

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
@@ -50,16 +50,6 @@ import com.sun.enterprise.web.connector.MapperListener;
 import com.sun.enterprise.web.connector.extension.GrizzlyConfig;
 import com.sun.enterprise.web.connector.grizzly.DummyConnectorLauncher;
 import com.sun.enterprise.web.pwc.connector.coyote.PwcCoyoteRequest;
-import org.glassfish.grizzly.config.dom.*;
-import org.glassfish.web.util.IntrospectionUtils;
-import org.apache.catalina.*;
-import org.apache.catalina.connector.Connector;
-import org.glassfish.security.common.CipherInfo;
-import org.glassfish.web.LogFacade;
-import org.glassfish.web.admin.monitor.RequestProbeProvider;
-
-import javax.management.Notification;
-import javax.servlet.http.HttpServletRequest;
 import java.io.*;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -69,6 +59,16 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.management.Notification;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.catalina.*;
+import org.apache.catalina.connector.Connector;
+import org.glassfish.grizzly.config.dom.*;
+import org.glassfish.security.common.CipherInfo;
+import org.glassfish.web.LogFacade;
+import org.glassfish.web.admin.monitor.RequestProbeProvider;
+import org.glassfish.web.util.IntrospectionUtils;
+
 import static org.glassfish.grizzly.config.dom.Ssl.SSL2;
 import static org.glassfish.grizzly.config.dom.Ssl.SSL2_HELLO;
 import static org.glassfish.grizzly.config.dom.Ssl.SSL3;
@@ -1193,10 +1193,13 @@ public class PECoyoteConnector extends Connector {
             if (host != null) {
                 hostName = host.getName();
             }
-            requestProbeProvider.requestStartEvent(
-                appName, hostName,
-                request.getServerName(), request.getServerPort(),
-                request.getContextPath(), request.getServletPath());
+
+            if (context.getAvailable()) {
+                requestProbeProvider.requestStartEvent(
+                        appName, hostName,
+                        request.getServerName(), request.getServerPort(),
+                        request.getContextPath(), request.getServletPath());
+            }
         }
     };
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix to fix an issue where an application still response with an empty HTTP 200 for a few seconds when it is on the process of being disabled. 

# Testing

### New tests
None

### Testing Performed
Local build test

### Test suites executed
<!-- Which test suites did you run this against? put an 'x' in the appropriate box(s). Feel free to add others.-->
- [ ] Quicklook
- [ ] Payara Samples
- [ ] Java EE7 Samples
- [ ] Java EE8 Samples
- [ ] Payara Private Tests
- [ ] Payara Microprofile TCKs Runner
- [ ] Jakarta TCKs
- [ ] Mojarra
- [ ] Cargo Tracker

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Documentation
No required

# Notes for Reviewers
I could not reproduce this issue and can't confirm my code changes will fix this issue.  See [JIRA Issue](https://payara.atlassian.net/browse/PAYARA-3989) for more info.
