### PR TITLE
PAYARA-4118 Speed up PayaraExecutorService Shutdown 

### DIFF
--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -42,7 +42,6 @@
 -->
 
 <!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>fish.payara.server.internal.core</groupId>
@@ -52,7 +51,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>logging</artifactId>
     <packaging>glassfish-jar</packaging>
-
+    
     <name>Nucleus Logging Classes</name>
     <description>Glassfish logging classes</description>
 
@@ -94,12 +93,6 @@
             <version>${jsonp.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.payara-modules</groupId>
-            <artifactId>payara-executor-service</artifactId>
-            <version>${project.version}</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
@@ -127,6 +120,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogRotationTimerTask.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogRotationTimerTask.java
@@ -37,16 +37,17 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
+
 import org.glassfish.api.logging.Task;
+import java.util.TimerTask;
 
-public class LogRotationTimerTask implements Runnable {
-
+public class LogRotationTimerTask extends TimerTask {
     private long timerValue;
     public Task task;
+
 
     public LogRotationTimerTask(Task task, long timeInMinutes ) {
         timerValue = timeInMinutes * 60 * 1000;
@@ -58,7 +59,7 @@ public class LogRotationTimerTask implements Runnable {
     }
 
     public long getRotationTimerValueInMinutes( ) {
-        // We are just converting the value from milliseconds back to
+        // We are just converting the value from milliseconds back to 
         // minutes
         return timerValue/60000;
     }
@@ -66,5 +67,5 @@ public class LogRotationTimerTask implements Runnable {
     public void run( ) {
         task.run();
     }
-}
+}    
 

--- a/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/LogEventListenerTest.java
+++ b/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/LogEventListenerTest.java
@@ -37,20 +37,22 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
-
 package com.sun.enterprise.server.logging;
 
-import fish.payara.nucleus.executorservice.PayaraExecutorService;
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
-import java.util.concurrent.*;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test class to exercise the LogEvent notification mechanism.
@@ -58,10 +60,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class LogEventListenerTest {
 
-    private static final String FILE_SEP = File.pathSeparator;
-
+    private static final String FILE_SEP = System.getProperty("file.separator");
+    
     private static final String USER_DIR = System.getProperty("user.dir");
-
+    
     private static final String BASE_PATH = USER_DIR + FILE_SEP + "target";
 
     private static final String TEST_EVENTS_LOG =  BASE_PATH + FILE_SEP + "test-events.log";
@@ -71,17 +73,15 @@ public class LogEventListenerTest {
     private static final String LOGGER_NAME = "javax.enterprise.test.logging.events";
 
     private static final Logger LOGGER = Logger.getLogger(LOGGER_NAME);
-
+    
     @BeforeClass
     public static void initializeLoggingAnnotationsTest() throws Exception {
         File basePath = new File(BASE_PATH);
         basePath.mkdirs();
         File testLog = new File(TEST_EVENTS_LOG);
-
+        
         // Add a file handler with UniformLogFormatter
-        PayaraExecutorService payaraExecutorService = new TestPayaraExecutorService();
         gfFileHandler = new GFFileHandler();
-        gfFileHandler.setPayaraExecutorService(payaraExecutorService);
         gfFileHandler.changeFileName(testLog);
         UniformLogFormatter formatter = new UniformLogFormatter();
         formatter.setLogEventBroadcaster(gfFileHandler);
@@ -97,7 +97,7 @@ public class LogEventListenerTest {
     }
 
     private static TestLogEventListener logEventListener;
-
+    
     @Test
     public void testLogEventListenerNotifications() throws Exception {
         String msg = "Test message for testLogEventListenerNotifications";
@@ -106,49 +106,26 @@ public class LogEventListenerTest {
         assertEquals(msg, event.getMessage());
         System.out.println("Test testLogEventListenerNotifications passed.");
     }
-
+    
     @AfterClass
     public static void cleanupLoggingAnnotationsTest() throws Exception {
         logEventListener.logEvents.clear();
-        LOGGER.removeHandler(gfFileHandler);
+        LOGGER.removeHandler(gfFileHandler);        
         // Flush and Close the handler
         gfFileHandler.flush();
         gfFileHandler.close();
         gfFileHandler.preDestroy();
     }
-
-    private static class TestPayaraExecutorService extends PayaraExecutorService {
-
-        private ScheduledExecutorService scheduledExecutorService;
-        private ExecutorService executorService;
-
-        TestPayaraExecutorService() {
-            super();
-            this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-            this.executorService = Executors.newSingleThreadExecutor();
-        }
-
-        @Override
-        public ScheduledExecutorService getUnderlyingScheduledExecutorService() {
-            return this.scheduledExecutorService;
-        }
-
-        @Override
-        public Future<?> submit(Runnable task) {
-            return this.executorService.submit(task);
-        }
-
-    }
-
+    
     private static class TestLogEventListener implements LogEventListener {
-
-        private BlockingQueue<LogEvent> logEvents = new ArrayBlockingQueue<>(100);
+        
+        private BlockingQueue<LogEvent> logEvents = new ArrayBlockingQueue<LogEvent>(100);
 
         @Override
         public void messageLogged(LogEvent event) {
             logEvents.add(event);
         }
-
+        
     }
-
+    
 }

--- a/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
+++ b/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
@@ -136,14 +136,19 @@ public class PayaraExecutorService implements ConfigListener, EventListener {
             if (null == threadPoolExecutor) {
                 initialiseThreadPools();
             }
+        } else if (event.is(EventTypes.PREPARE_SHUTDOWN)) {
+            stopThreadPools();
         } else if (event.is(EventTypes.SERVER_SHUTDOWN)) {
             terminateThreadPools();
         }
     }
-
-    private void terminateThreadPools() {
+    
+    private void stopThreadPools() {
         threadPoolExecutor.shutdown();
         scheduledThreadPoolExecutor.shutdown();
+    }
+
+    private void terminateThreadPools() {
 
         // Wait until the schedulers actually terminate
         try {


### PR DESCRIPTION
# Description
This is a performance imporvement

reverts #3437 
Due to the behaviour of GFFileHandler logpump it is better for it to be in it's own thread rather than use the executor service, having it as part of the executor service causes it to carry on running until killed.

# Testing

### New tests
None

### Testing Performed
Ran the command `asadmin start-domain --verbose --debug && date +"%Y-%m-%d %H:%M:%S.%3N` to print out time with milliseconds after domain is stopped, and compared that time with time that server shutdown was started.

Time before PR - 6.398 seconds
Time with 3c57d71 - 6.099 seconds
Time with c98a042 - 0.984 seconds

### Test suites executed
<!-- Which test suites did you run this against? put an 'x' in the appropriate box(s). Feel free to add others.-->
- [ ] Quicklook
- [ ] Payara Samples
- [ ] Java EE7 Samples
- [ ] Java EE8 Samples
- [ ] Payara Private Tests
- [ ] Payara Microprofile TCKs Runner
- [ ] Jakarta TCKs
- [ ] Mojarra
- [ ] Cargo Tracker

### Testing Environment
"Zulu JDK 1.8_222 on Ubuntu 19.04 DIsco Dingo with Maven 3.6.0"-->
