### PR TITLE
Remove checkboxes from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,16 +26,16 @@ This is a bug fix / feature. <!-- delete/modify as applicable-->
 <!--- Please describe how you tested these changes.  -->
 
 ### Test suites executed
-<!-- Which test suites did you run this against? put an 'x' in the appropriate box(s). Feel free to add others.-->
-- [ ] Quicklook
-- [ ] Payara Samples
-- [ ] Java EE7 Samples
-- [ ] Java EE8 Samples
-- [ ] Payara Private Tests
-- [ ] Payara Microprofile TCKs Runner
-- [ ] Jakarta TCKs
-- [ ] Mojarra
-- [ ] Cargo Tracker
+<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
+- Quicklook
+- Payara Samples
+- Java EE7 Samples
+- Java EE8 Samples
+- Payara Private Tests
+- Payara Microprofile TCKs Runner
+- Jakarta TCKs
+- Mojarra
+- Cargo Tracker
 
 ### Testing Environment
 <!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->


### PR DESCRIPTION


# Description
This is a bug fix. <!-- delete/modify as applicable-->

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->
Checkboxes for executed tests suites in PR description produce progress bars in PR overview and give false signal of PR being incomplete:

![image](https://user-images.githubusercontent.com/1588543/66131956-940a6180-e5f4-11e9-9863-cfbb004b59bc.png)

Instead of that the submitter should edit the list of test suites. Removed the checkboxes and modified instructions.

# Testing

### Testing Performed
<!--- Please describe how you tested these changes.  -->
- Making test PR against my own repo

# Documentation
<!-- Link to the documentation PR where applicable -->
https://help.github.com/en/articles/about-task-lists

