### PR TITLE
PAYARA-4118 Speedup Payara shutdown by having GFFileHandler use its o…

### DIFF
--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -94,12 +94,6 @@
             <version>${jsonp.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.payara-modules</groupId>
-            <artifactId>payara-executor-service</artifactId>
-            <version>${project.version}</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
@@ -108,6 +102,13 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -51,8 +51,7 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.logging.AgentFormatterDelegate;
 import fish.payara.enterprise.server.logging.JSONLogFormatter;
-import fish.payara.enterprise.server.logging.PayaraNotificationLogRotationTimer;
-import fish.payara.nucleus.executorservice.PayaraExecutorService;
+import fish.payara.enterprise.server.logging.PayaraNotificationLogRotationTimer;;
 import java.io.*;
 import java.security.PrivilegedAction;
 import java.text.FieldPosition;
@@ -120,9 +119,6 @@ public class GFFileHandler extends StreamHandler implements
     @Inject
     private ServiceLocator habitat;
 
-    @Inject
-    private PayaraExecutorService payaraExecutorService;
-
     // This is a OutputStream to keep track of number of bytes
     // written out to the stream
     private MeteredStream meter;
@@ -175,22 +171,18 @@ public class GFFileHandler extends StreamHandler implements
     public static final int MINIMUM_ROTATION_LIMIT_VALUE = 500*1000;
 
     private BooleanLatch done = new BooleanLatch();
-
+    
     private boolean dayBasedFileRotation = false;
 
     private List<LogEventListener> logEventListeners = new ArrayList<>();
 
-    private Future<?> pumpFuture;
+    private Thread pump;
 
     protected String logFileProperty = "";
     private final LogManager manager = LogManager.getLogManager();
     private final String className = getClass().getName();
     private static final String GF_FILE_HANDLER = GFFileHandler.class.getCanonicalName() ;
     private LogRecord logRecord = new LogRecord(Level.INFO, LogFacade.GF_VERSION_INFO);
-
-    void setPayaraExecutorService(PayaraExecutorService payaraExecutorService) {
-        this.payaraExecutorService = payaraExecutorService;
-    }
 
     @Override
     public void postConstruct() {
@@ -433,12 +425,10 @@ public class GFFileHandler extends StreamHandler implements
 
         if (className.equals(GF_FILE_HANDLER)) {
             LogRotationTimer.getInstance().startTimer(
-                    payaraExecutorService.getUnderlyingScheduledExecutorService(),
                     new LogRotationTimerTask(rotationTask,
                             rotationTimeLimitValue / 60000));
         } else {
             PayaraNotificationLogRotationTimer.getInstance().startTimer(
-                    payaraExecutorService.getUnderlyingScheduledExecutorService(),
                     new LogRotationTimerTask(rotationTask,
                             rotationTimeLimitValue / 60000));
         }
@@ -453,17 +443,15 @@ public class GFFileHandler extends StreamHandler implements
 
             if (className.equals(GF_FILE_HANDLER)) {
                 LogRotationTimer.getInstance().startTimer(
-                        payaraExecutorService.getUnderlyingScheduledExecutorService(),
                         new LogRotationTimerTask(rotationTask,
                                 rotationTimeLimitValue));
             } else {
                 PayaraNotificationLogRotationTimer.getInstance().startTimer(
-                        payaraExecutorService.getUnderlyingScheduledExecutorService(),
                         new LogRotationTimerTask(rotationTask,
                                 rotationTimeLimitValue));
             }
         }
-}
+    }
 
     private void rotationOnFileSizeLimit(String propertyValue) {
         try {
@@ -585,14 +573,10 @@ public class GFFileHandler extends StreamHandler implements
     }
 
     void initializePump() {
-        if (pumpFuture != null) {
-            pumpFuture.cancel(true);
-            pumpFuture = null;
-        }
-        if (logToFile) {
-            pumpFuture = payaraExecutorService.submit(
-                () -> {
-                    while (!done.isSignalled() && logToFile) {
+        pump = new Thread() {
+            @Override
+            public void run() {
+                while (!done.isSignalled() && logToFile) {
                         try {
                             log();
                         } catch (Exception e) {
@@ -601,11 +585,10 @@ public class GFFileHandler extends StreamHandler implements
                         }
                     }
                 }
-            );
-        } else {
-            drainAllPendingRecords();
-            flush();
-        }
+        };
+        pump.setName("GFFileHandler log pump");
+        pump.setDaemon(true);
+        pump.start();
     }
 
     @Override
@@ -631,8 +614,8 @@ public class GFFileHandler extends StreamHandler implements
         }
 
         done.tryReleaseShared(1);
-        if (pumpFuture != null) {
-            pumpFuture.cancel(true);
+        if (pump != null) {
+            pump.interrupt();
         }
 
         // drain and return all
@@ -934,18 +917,18 @@ public class GFFileHandler extends StreamHandler implements
         if (dayBasedFileRotation) {
             if (className.equals(GF_FILE_HANDLER)) {
                 LogRotationTimer.getInstance()
-                        .restartTimerForDayBasedRotation(payaraExecutorService.getUnderlyingScheduledExecutorService());
+                        .restartTimerForDayBasedRotation();
             } else {
                 PayaraNotificationLogRotationTimer.getInstance()
-                        .restartTimerForDayBasedRotation(payaraExecutorService.getUnderlyingScheduledExecutorService());
+                        .restartTimerForDayBasedRotation();
             }
         } else {
             if (className.equals(GF_FILE_HANDLER)) {
                 LogRotationTimer.getInstance()
-                        .restartTimer(payaraExecutorService.getUnderlyingScheduledExecutorService());
+                        .restartTimer();
             } else {
                 PayaraNotificationLogRotationTimer.getInstance()
-                        .restartTimer(payaraExecutorService.getUnderlyingScheduledExecutorService());
+                        .restartTimer();
             }
         }
 

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -573,7 +573,7 @@ public class GFFileHandler extends StreamHandler implements
     }
 
     void initializePump() {
-        pump = new Thread() {
+        pump = new Thread() { //Not using the PayaraExecutorService here as it prevents shutdown happening quickly, see PAYARA-4118
             @Override
             public void run() {
                 while (!done.isSignalled() && logToFile) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogRotationTimerTask.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogRotationTimerTask.java
@@ -37,13 +37,14 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
+import java.util.TimerTask;
 import org.glassfish.api.logging.Task;
 
-public class LogRotationTimerTask implements Runnable {
+public class LogRotationTimerTask extends TimerTask {
 
     private long timerValue;
     public Task task;

--- a/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/LogEventListenerTest.java
+++ b/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/LogEventListenerTest.java
@@ -37,11 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
-import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import java.io.File;
 import java.util.concurrent.*;
 import java.util.logging.Level;
@@ -79,9 +78,7 @@ public class LogEventListenerTest {
         File testLog = new File(TEST_EVENTS_LOG);
 
         // Add a file handler with UniformLogFormatter
-        PayaraExecutorService payaraExecutorService = new TestPayaraExecutorService();
         gfFileHandler = new GFFileHandler();
-        gfFileHandler.setPayaraExecutorService(payaraExecutorService);
         gfFileHandler.changeFileName(testLog);
         UniformLogFormatter formatter = new UniformLogFormatter();
         formatter.setLogEventBroadcaster(gfFileHandler);
@@ -115,29 +112,6 @@ public class LogEventListenerTest {
         gfFileHandler.flush();
         gfFileHandler.close();
         gfFileHandler.preDestroy();
-    }
-
-    private static class TestPayaraExecutorService extends PayaraExecutorService {
-
-        private ScheduledExecutorService scheduledExecutorService;
-        private ExecutorService executorService;
-
-        TestPayaraExecutorService() {
-            super();
-            this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-            this.executorService = Executors.newSingleThreadExecutor();
-        }
-
-        @Override
-        public ScheduledExecutorService getUnderlyingScheduledExecutorService() {
-            return this.scheduledExecutorService;
-        }
-
-        @Override
-        public Future<?> submit(Runnable task) {
-            return this.executorService.submit(task);
-        }
-
     }
 
     private static class TestLogEventListener implements LogEventListener {


### PR DESCRIPTION
# Description
This is a performance imporvement

reverts #3437 
Due to the behaviour of GFFileHandler logpump it is better for it to be in it's own thread rather than use the executor service, having it as part of the executor service causes it to carry on running until killed.

# Testing

### New tests
None

### Testing Performed
Ran the command `asadmin start-domain --verbose --debug && date +"%Y-%m-%d %H:%M:%S.%3N` to print out time with milliseconds after domain is stopped, and compared that time with time that server shutdown was started.

Time before PR - 6.398 seconds
Time with 4ddcf7f - 1.235 seconds

### Test suites executed
<!-- Which test suites did you run this against? put an 'x' in the appropriate box(s). Feel free to add others.-->
- [ ] Quicklook
- [ ] Payara Samples
- [ ] Java EE7 Samples
- [ ] Java EE8 Samples
- [ ] Payara Private Tests
- [ ] Payara Microprofile TCKs Runner
- [ ] Jakarta TCKs
- [ ] Mojarra
- [ ] Cargo Tracker

### Testing Environment
"Zulu JDK 1.8_222 on Ubuntu 19.04 DIsco Dingo with Maven 3.6.0"-->
