### PR TITLE
PAYARA-4144 Add support for deployment groups in commands that don't list targets

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
@@ -1369,6 +1369,7 @@ public class CommandRunnerImpl implements CommandRunner {
                         targetTypesAllowed.add(CommandTarget.STANDALONE_INSTANCE);
                         targetTypesAllowed.add(CommandTarget.CLUSTER);
                         targetTypesAllowed.add(CommandTarget.CONFIG);
+                        targetTypesAllowed.add(CommandTarget.DEPLOYMENT_GROUP);
                     }
 
                     // If the target is "server" and the command is not marked for DAS,


### PR DESCRIPTION
# Description
This is a bug fix

Error occurs with some asadmin commands, i.e. _list-app-refs when targeting a deployment group, leading to messages like:
    Target local-group is not a supported type. Command _list-app-refs supports these types of targets only: Default server, Stand alone instance, Cluster, Config, 

# Important Info

# Testing

### New tests
<!-- Link to the test suite PR or provide info -->

### Testing Performed
 create-instance --node=localhost-domain1 local-instance
create-deployment-group local-group
add-instance-to-deployment-group --instance=local-instance --deploymentGroup=local-group
start-deployment-group local-group
Then ran test app (See Jira)(which uses cargo plugin) with `mvn integration-test`

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Quicklook
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples
- Payara Private Tests
- Payara Microprofile TCKs Runner
- Jakarta TCKs
- Mojarra
- Cargo Tracker

### Testing Environment
Zulu JDK 1.8_222 on Ubuntu 18.04 with Maven 3.6.0
