### PR TITLE
PAYARA-4195 Cleanup related to deployment-client

### DIFF
--- a/appserver/deployment/client/src/main/java/org/glassfish/deployapi/SunDeploymentManager.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployapi/SunDeploymentManager.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] Payara Foundation and/or affiliates
 
 package org.glassfish.deployapi;
 
@@ -52,10 +53,8 @@ import org.glassfish.api.admin.ProcessEnvironment;
 import org.glassfish.deployapi.config.SunDeploymentConfiguration;
 import org.glassfish.deployment.client.DeploymentFacility;
 import org.glassfish.deployment.client.DeploymentFacilityFactory;
-import org.glassfish.deployment.client.ServerConnectionEnvironment;
 import org.glassfish.deployment.client.ServerConnectionIdentifier;
 import org.glassfish.api.deployment.archive.ReadableArchive;
-import org.glassfish.api.deployment.archive.Archive;
 import com.sun.enterprise.deploy.shared.ArchiveFactory;
 import com.sun.enterprise.deployment.deploy.shared.MemoryMappedArchive;
 import org.glassfish.deployment.client.DFDeploymentProperties;
@@ -80,8 +79,6 @@ import java.util.Properties;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.net.URI;
-
 import javax.enterprise.deploy.spi.DeploymentManager;
 import javax.enterprise.deploy.model.DeployableObject;
 import javax.enterprise.deploy.shared.CommandType;
@@ -99,29 +96,26 @@ import javax.enterprise.deploy.spi.Target;
 import javax.enterprise.deploy.spi.TargetModuleID;
 
 /**
- *
  * @author Jerome Dochez
  * @author Tim Quinn
+ * @author David Matejcek
  */
 public class SunDeploymentManager implements DeploymentManager {
-    
-    // store ID to server connection
-    private ServerConnectionIdentifier serverId = null;
-    
+
+    private static final Logger LOG = Logger.getLogger(SunDeploymentManager.class.getName());
+
     /** cached reference to a connected DeploymentFacility */
-    private DeploymentFacility deploymentFacility = null;
+    private DeploymentFacility deploymentFacility;
 
     private static LocalStringManagerImpl localStrings =
 	    new LocalStringManagerImpl(SunDeploymentManager.class);
-    
+
     private static Locale defaultLocale = Locale.US;
     private Locale currentLocale = defaultLocale;
     private static Locale[] supportedLocales = { Locale.US };
-    private String disconnectedMessage = localStrings.getLocalString(
+    private final String disconnectedMessage = localStrings.getLocalString(
 			"enterprise.deployapi.spi.disconnectedDM", // NOI18N
 			"Illegal operation for a disconnected DeploymentManager");// NOI18N
-
-    private static final String ENABLED_ATTRIBUTE_NAME = "Enabled"; // NOI18N
 
     private ServiceLocator habitat;
 
@@ -129,142 +123,58 @@ public class SunDeploymentManager implements DeploymentManager {
     /** Creates a new instance of DeploymentManager */
     public SunDeploymentManager() {
     }
-    
+
     /** Creates a new instance of DeploymentManager */
     public SunDeploymentManager(ServerConnectionIdentifier sci) {
-        deploymentFacility = 
-            DeploymentFacilityFactory.getDeploymentFacility();
+        deploymentFacility = DeploymentFacilityFactory.getDeploymentFacility();
         deploymentFacility.connect(sci);
         prepareHabitat();
     }
 
-    /**     
-     * Set additional env vars for the jmx https connector, provided
-     * by the client. This method is expected to be called right after
-     * the client retrieves the DeploymentManager, before
-     * the client makes any calls on the DM that requires MBean Server
-     * connection.
-     */     
-    public void setServerConnectionEnvironment(ServerConnectionEnvironment env) {
-        serverId.setConnectionEnvironment(env);
-    }       
-    
-   /**
-    * Retrieve the list of deployment targets supported by 
-    * this DeploymentManager.
-    *<p>
-    * @throws IllegalStateException is thrown when there is a problem getting
-    *                               Connection Source
-    * @return   A list of deployment Target designators the 
-    *           user may select for application deployment or 'null'
-    *           if there are none.
-    */
+    @Override
     public Target[] getTargets() throws IllegalStateException {
         verifyConnected();
         try {
             return deploymentFacility.listTargets();
         } catch (Throwable e) {
-            IllegalStateException ex = new  IllegalStateException(e.getMessage());
-            ex.initCause(e);
-            throw ex;
+            throw new IllegalStateException(e);
         }
     }
 
-   /**
-    * Retrieve the list of J2EE application modules distributed 
-    * to the identified targets and that are currently running 
-    * on the associated server or servers.
-    *
-    * @param moduleType A predefined designator for a J2EE 
-    *                   module type.
-    * 
-    * @param targetList A list of deployment Target designators
-    *                   the user wants checked for module run
-    *                   status.
-    * 
-    * @return An array of TargetModuleID objects representing
-    *                   the running modules or 'null' if there
-    *                   are none.
-    *
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @throws TargetException An invalid Target designator
-    *                   encountered.
-    */
+    @Override
     public TargetModuleID[] getRunningModules(ModuleType moduleType,
 		Target[] targetList) throws TargetException, IllegalStateException {
-
         return getModules(moduleType, targetList, DFDeploymentProperties.RUNNING);
     }
 
-   /**
-    * Retrieve the list of J2EE application modules distributed 
-    * to the identified targets and that are currently not
-    * running on the associated server or servers.
-    *
-    * @param moduleType A predefined designator for a J2EE 
-    *                   module type.
-    * 
-    * @param targetList A list of deployment Target designators
-    *                   the user wants checked for module not 
-    *                   running status.
-    * 
-    * @return An array of TargetModuleID objects representing
-    *                   the non-running modules or 'null' if
-    *                   there are none.
-    *
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @throws TargetException An invalid Target designator
-    *                   encountered.
-    */
-    public TargetModuleID[] getNonRunningModules(ModuleType moduleType,
-			Target[] targetList) throws TargetException, IllegalStateException {
+    @Override
+    public TargetModuleID[] getNonRunningModules(ModuleType moduleType, Target[] targetList)
+        throws TargetException, IllegalStateException {
         return getModules(moduleType, targetList, DFDeploymentProperties.NON_RUNNING);
     }
-    
-   /**
-    * Retrieve the list of all J2EE application modules running 
-    * or not running on the identified targets.
-    *
-    * @param moduleType A predefined designator for a J2EE 
-    *                   module type.
-    * 
-    * @param targetList A list of deployment Target designators
-    *                   the user wants checked for module not 
-    *                   running status.
-    * 
-    * @return An array of TargetModuleID objects representing
-    *                   all deployed modules running or not or
-    *                   'null' if there are no deployed modules.
-    *
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @throws TargetException An invalid Target designator
-    *                   encountered.
-    */
-    public TargetModuleID[] getAvailableModules(ModuleType moduleType,
-			Target[] targetList) throws TargetException,
-            IllegalStateException {
 
+    @Override
+    public TargetModuleID[] getAvailableModules(ModuleType moduleType, Target[] targetList)
+        throws TargetException, IllegalStateException {
         return getModules(moduleType, targetList, DFDeploymentProperties.ALL);
     }
 
     /**
-     *Single method used by several public methods to make sure the deployment manager is 
-     *connected and, if not, throw the IllegalStateException. 
+     * Single method used by several public methods to make sure the deployment manager is
+     * connected and, if not, throw the IllegalStateException.
      *
-     *@throws IllegalStateException if the deployment manager is not connected.
+     * @throws IllegalStateException if the deployment manager is not connected.
      */
     private void verifyConnected() {
-        if(isDisconnected()) {
+        if (isDisconnected()) {
             throw new IllegalStateException(disconnectedMessage);
         }
     }
 
     /**
-     *Report whether the deployment manager is currently disconnected from the DAS.
-     *@returns whether the deployment manager is disconnected from the DAS
+     * Report whether the deployment manager is currently disconnected from the DAS.
+     *
+     * @returns whether the deployment manager is disconnected from the DAS
      */
     private boolean isDisconnected(){
         if (deploymentFacility == null) {
@@ -273,36 +183,33 @@ public class SunDeploymentManager implements DeploymentManager {
         return (!deploymentFacility.isConnected());
     }
 
-    
     /**
-     *Get all modules in the specified state from the targets specified in the
-     argument list. 
-     *@param moduleType which returned modules must match
-     *@param array of Target indicating which targets should be searched for matching modules
-     *@param state state of the modules
-     *have for the indicated attribute to be matched
-     *@exception TargetException if a target was improperly formed
-     *@exception IllegalStateException if the method is called after release was called
+     * Get all modules in the specified state from the targets specified in the argument list.
+     *
+     * @param moduleType which returned modules must match
+     * @param array of Target indicating which targets should be searched for matching modules
+     * @param state state of the modules have for the indicated attribute to be matched
+     * @throws TargetException if a target was improperly formed
+     * @throws IllegalStateException if the method is called after release was called
      */
-    private TargetModuleID[] getModules(ModuleType moduleType, Target[] targetList, String state) throws TargetException, IllegalStateException {
+    private TargetModuleID[] getModules(ModuleType moduleType, Target[] targetList, String state)
+        throws TargetException, IllegalStateException {
 
         verifyConnected();
-        if (moduleType==null) {
+        if (moduleType == null) {
             return null;
         }
 
         try {
-            Vector resultingTMIDs = new Vector();
-            for (int i = 0; i < targetList.length; i++) {
-                TargetImpl aTarget = (TargetImpl) targetList[i];
+            Vector<TargetModuleID> resultingTMIDs = new Vector<>();
+            for (Target element : targetList) {
+                TargetImpl aTarget = (TargetImpl) element;
 
-                TargetModuleID[] tmids = deploymentFacility._listAppRefs(new Target[] {aTarget}, state, getTypeFromModuleType(moduleType));
+                TargetModuleID[] tmids = deploymentFacility._listAppRefs(new Target[] {aTarget}, state,
+                    getTypeFromModuleType(moduleType));
                 addToTargetModuleIDs(tmids, moduleType, aTarget, resultingTMIDs);
             }
-            /*
-             *Return an array of runtime type TargetModuleIDImpl [].
-             */
-            TargetModuleID [] answer = (TargetModuleID []) resultingTMIDs.toArray(new TargetModuleIDImpl[resultingTMIDs.size()]);
+            TargetModuleID [] answer = resultingTMIDs.toArray(new TargetModuleIDImpl[resultingTMIDs.size()]);
             return answer;
 
 
@@ -316,6 +223,9 @@ public class SunDeploymentManager implements DeploymentManager {
         }
     }
 
+    /**
+     * @return web/ejb/appclient/connector/ear
+     */
     private String getTypeFromModuleType(ModuleType moduleType) {
        if (moduleType.equals(ModuleType.WAR)) {
            return "web";
@@ -331,6 +241,11 @@ public class SunDeploymentManager implements DeploymentManager {
        return null;
     }
 
+    /**
+     * @param type war/ejb/car/rar/ear
+     *
+     * @return {@link ModuleType} for accepted types or null
+     */
     private ModuleType getModuleTypeFromType(String type) {
        if (type.equals("war")) {
            return ModuleType.WAR;
@@ -346,100 +261,97 @@ public class SunDeploymentManager implements DeploymentManager {
        return null;
     }
 
-    
     /**
-     *Augments a Collection of TargetModuleIDs with new entries for target module IDs of a given module type on the specified target.
-     *@param tmids array of TargetModuleIDs
-     *@param type the ModuleType of interest
-     *@param targetImpl the TargetImpl from which to retrieve modules of the selected type
-     *@param resultingTMIDs pre-instantiated List to which TargetModuleIDs will be added
+     * Augments a Collection of TargetModuleIDs with new entries for target module IDs of a given
+     * module type on the specified target.
+     *
+     * @param tmids array of TargetModuleIDs
+     * @param type the ModuleType of interest
+     * @param targetImpl the TargetImpl from which to retrieve modules of the selected type
+     * @param resultingTMIDs pre-instantiated List to which TargetModuleIDs will be added
      */
-    private void addToTargetModuleIDs(TargetModuleID[] tmids, ModuleType type, TargetImpl targetImpl, Collection resultingTMIDs)  throws IOException {
+    private void addToTargetModuleIDs(TargetModuleID[] tmids, ModuleType type, TargetImpl targetImpl,
+        Collection<TargetModuleID> resultingTMIDs) throws IOException {
 
-        for (int j = 0;j< tmids.length;j++) {
-            
+        for (TargetModuleID tmid : tmids) {
+
             // Get the host name and port where the application was deployed
-            HostAndPort webHost = deploymentFacility.getHostAndPort(targetImpl.getName(), tmids[j].getModuleID(), false);
+            HostAndPort webHost = deploymentFacility.getHostAndPort(targetImpl.getName(), tmid.getModuleID(), false);
 
-            if (tmids[j] instanceof TargetModuleIDImpl) {
-                ((TargetModuleIDImpl)tmids[j]).setModuleType(type);
+            if (tmid instanceof TargetModuleIDImpl) {
+                ((TargetModuleIDImpl) tmid).setModuleType(type);
             }
-            resultingTMIDs.add(tmids[j]);
-            
+            resultingTMIDs.add(tmid);
+
             /*
-             *Set additional information on the target module ID, depending on what type of
-             *module this is.  For J2EE apps, this includes constructing sub TargetModuleIDs.
+             * Set additional information on the target module ID, depending on what type of
+             * module this is. For J2EE apps, this includes constructing sub TargetModuleIDs.
              */
             try {
                 if (type.equals(ModuleType.EAR)) {
-                    setJ2EEApplicationTargetModuleIDInfo(tmids[j], webHost);
+                    setJ2EEApplicationTargetModuleIDInfo(tmid, webHost);
                 } else if (type.equals(ModuleType.WAR)) {
-                    setWebApplicationTargetModuleIDInfo(tmids[j], webHost);
+                    setWebApplicationTargetModuleIDInfo(tmid, webHost);
                 }
+            } catch (Exception exp) {
+                LOG.log(Level.WARNING, exp.getLocalizedMessage(), exp);
             }
-            catch(Exception exp){
-                Logger.getAnonymousLogger().log(Level.WARNING, exp.getLocalizedMessage(), exp); 
-            }            
         }
     }
 
     /**
-     *Attach child target module IDs to a J2EE application target module ID.
-     *@param tmid the target module ID for the J2EE application.
-     *@param targetImpl the target identifying which installation of this module is of interest
-     *@param webHost the host and port for this target
+     * Attach child target module IDs to a J2EE application target module ID.
+     *
+     * @param tmid the target module ID for the J2EE application.
+     * @param targetImpl the target identifying which installation of this module is of interest
+     * @param webHost the host and port for this target
      */
-    private void setJ2EEApplicationTargetModuleIDInfo(TargetModuleID tmid, 
-        HostAndPort hostAndPort) throws MalformedURLException, IOException {
+    private void setJ2EEApplicationTargetModuleIDInfo(TargetModuleID tmid, HostAndPort hostAndPort) {
         TargetImpl targetImpl = (TargetImpl) tmid.getTarget();
         try {
             List<String> subModuleInfoList = deploymentFacility.getSubModuleInfoForJ2EEApplication(tmid.getModuleID());
             for (String subModuleInfo : subModuleInfoList) {
-                List<String> infoParts = StringUtils.parseStringList(
-                    subModuleInfo, ":");   
+                List<String> infoParts = StringUtils.parseStringList(subModuleInfo, ":");
                 String subModuleName = infoParts.get(0);
                 String subModuleID = tmid.getModuleID() + "#" + subModuleName;
                 String subType = infoParts.get(1);
                 ModuleType subModuleType = getModuleTypeFromType(subType);
-                TargetModuleIDImpl childTmid = new TargetModuleIDImpl(
-                    targetImpl, subModuleID); 
+                TargetModuleIDImpl childTmid = new TargetModuleIDImpl(targetImpl, subModuleID);
                 childTmid.setModuleType(subModuleType);
                 if (subType.equals("war")) {
-                    // get the web url
-                    URL webURL = new URL("http", hostAndPort.getHost(), 
-                        hostAndPort.getPort(), infoParts.get(2));
+                    URL webURL = new URL("http", hostAndPort.getHost(), hostAndPort.getPort(), infoParts.get(2));
                     childTmid.setWebURL(webURL.toExternalForm());
                 }
                 if (tmid instanceof TargetModuleIDImpl) {
-                    ((TargetModuleIDImpl)tmid).addChildTargetModuleID(
-                        childTmid);
+                    ((TargetModuleIDImpl) tmid).addChildTargetModuleID(childTmid);
                 }
             }
-        }
-        catch(Exception exp){
-            Logger.getAnonymousLogger().log(Level.WARNING, exp.getLocalizedMessage(), exp); 
+        } catch(Exception exp){
+            LOG.log(Level.WARNING, exp.getLocalizedMessage(), exp);
         }
     }
-    
+
     /**
-     *Set additional type-specific information on the target module ID.
-     *@param tmid the target module ID for the Web app
-     *@param targetImpl the target identifying which installation of this module is of interest
-     *@param webHost the host and port for this target
+     * Set additional type-specific information on the target module ID.
+     *
+     * @param tmid the target module ID for the Web app
+     * @param targetImpl the target identifying which installation of this module is of interest
+     * @param webHost the host and port for this target
      */
-    private void setWebApplicationTargetModuleIDInfo(TargetModuleID tmid, HostAndPort webHost) throws MalformedURLException, IOException {
+    private void setWebApplicationTargetModuleIDInfo(TargetModuleID tmid, HostAndPort webHost)
+        throws MalformedURLException, IOException {
 
         String path = deploymentFacility.getContextRoot(tmid.getModuleID());
         if (!path.startsWith("/")) { //NOI18N
             path = "/" + path; //NOI18N
         }
-        
+
         URL webURL = new URL("http", webHost.getHost(), webHost.getPort(), path); //NOI18N
         if (tmid instanceof TargetModuleIDImpl) {
             ((TargetModuleIDImpl)tmid).setWebURL(webURL.toExternalForm());
         }
     }
-    
+
    /**
     * Retrieve the object that provides server-specific deployment
     * configuration information for the J2EE deployable component.
@@ -449,11 +361,9 @@ public class SunDeploymentManager implements DeploymentManager {
     *                      unknown or unsupport component for this
     *                      configuration tool.
     */
-
-    public DeploymentConfiguration createConfiguration(DeployableObject dObj)
-            throws InvalidModuleException
-    {
-        try { 
+    @Override
+    public DeploymentConfiguration createConfiguration(DeployableObject dObj) throws InvalidModuleException {
+        try {
             SunDeploymentConfiguration deploymentConfiguration = new SunDeploymentConfiguration(dObj);
             deploymentConfiguration.setDeploymentManager(this);
             return deploymentConfiguration;
@@ -464,230 +374,99 @@ public class SunDeploymentManager implements DeploymentManager {
         }
     }
 
-
-   /**
-    * The distribute method performs three tasks; it validates the
-    * deployment configuration data, generates all container specific 
-    * classes and interfaces, and moves the fully baked archive to 
-    * the designated deployment targets.
-    *
-    * @param targetList   A list of server targets the user is specifying
-    *                     this application be deployed to. 
-    * @param moduleArchive The file name of the application archive
-    *                      to be disrtibuted.
-    * @param deploymentPlan The XML file containing the runtime 
-    *                       configuration information associated with
-    *                       this application archive.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @return ProgressObject an object that tracks and reports the 
-    *                       status of the distribution process.
-    */
-
-    public ProgressObject distribute(Target[] targetList,
-           File moduleArchive, File deploymentPlan)
-           throws IllegalStateException
-    {
-        return deploy(targetList, moduleArchive, deploymentPlan, null /* presetOptions */);
-    }     
-
-   /**
-    * The distribute method performs three tasks; it validates the
-    * deployment configuration data, generates all container specific 
-    * classes and interfaces, and moves the fully baked archive to 
-    * the designated deployment targets.
-    *
-    * @param targetList   A list of server targets the user is specifying
-    *                     this application be deployed to. 
-    * @param moduleArchive The input stream containing the application 
-    *                      archive to be disrtibuted.
-    * @param deploymentPlan The input stream containing the deployment
-    *                       configuration information associated with
-    *                       this application archive.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @return ProgressObject an object that tracks and reports the 
-    *                       status of the distribution process.
-    *
-    */
-    public ProgressObject distribute(Target[] targetList,
-           InputStream moduleArchive, InputStream deploymentPlan)
-           throws IllegalStateException 
-    {
+    @Override
+    public ProgressObject distribute(Target[] targetList, File moduleArchive, File deploymentPlan)
+        throws IllegalStateException {
         return deploy(targetList, moduleArchive, deploymentPlan, null /* presetOptions */);
     }
 
-    /**
-     * The distribute method performs three tasks; it validates the
-     * deployment configuration data, generates all container specific
-     * classes and interfaces, and moves the fully baked archive to
-     * the designated deployment targets.
-     *
-     * @param targetList   A list of server targets the user is specifying
-     *                     this application be deployed to.
-     * @param moduleType   The module type of this application archive.
-     * @param moduleArchive The input stream containing the application
-     *                      archive to be disrtibuted.
-     * @param deploymentPlan The input stream containing the deployment
-     *                       configuration information associated with
-     *                       this application archive.
-     * @throws IllegalStateException is thrown when the method is
-     *                    called when running in disconnected mode.
-     * @return ProgressObject an object that tracks and reports the
-     *                       status of the distribution process.
-     *
-     */
-    
-    public ProgressObject distribute(Target[] targetList, ModuleType type,
-            InputStream moduleArchive, InputStream deploymentPlan)
-            throws IllegalStateException
-    {
+    @Deprecated
+    @Override
+    public ProgressObject distribute(Target[] targetList, InputStream moduleArchive, InputStream deploymentPlan)
+        throws IllegalStateException {
+        return deploy(targetList, moduleArchive, deploymentPlan, null /* presetOptions */);
+    }
+
+    @Override
+    public ProgressObject distribute(Target[] targetList, ModuleType type, InputStream moduleArchive,
+        InputStream deploymentPlan) throws IllegalStateException {
         DFDeploymentProperties dProps = new DFDeploymentProperties();
-        dProps.setProperty("type", getTypeFromModuleType(type));
-        return deploy(targetList, moduleArchive, deploymentPlan, (Properties)dProps);
+        dProps.setProperty(DFDeploymentProperties.MODULE_EXTENSION, type.getModuleExtension());
+        return deploy(targetList, moduleArchive, deploymentPlan, dProps);
     }
 
-   /**
-    * Start the application running.  
-    *
-    * <p> Only the TargetModuleIDs which represent a root module
-    * are valid for being started. A root TargetModuleID has no parent.
-    * A TargetModuleID with a parent can not be individually started. 
-    * A root TargetModuleID module and all its child modules will be 
-    * started.
-    *
-    * @param moduleIDList  A array of TargetModuleID objects 
-    *                    representing the modules to be started.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @return ProgressObject an object that tracks and reports the 
-    *                       status of the start operation.
-    */
-
-    public ProgressObject start(TargetModuleID[] moduleIDList)
-             throws IllegalStateException
-    {
+    @Override
+    public ProgressObject start(TargetModuleID[] moduleIDList) throws IllegalStateException {
         return executeCommandUsingFacility(CommandType.START, moduleIDList);
     }
 
-   /**
-    * Stop the application running.  
-    *
-    * <p> Only the TargetModuleIDs which represent a root module
-    * are valid for being stopped. A root TargetModuleID has no parent.
-    * A TargetModuleID with a parent can not be individually stopped. 
-    * A root TargetModuleID module and all its child modules will be 
-    * stopped.
-    *
-    * @param moduleIDList  A array of TargetModuleID objects 
-    *                    representing the modules to be stopped.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @return ProgressObject an object that tracks and reports the 
-    *                       status of the stop operation.
-    */
-
-    public ProgressObject stop(TargetModuleID [] moduleIDList)
-             throws IllegalStateException 
-    {
+    @Override
+    public ProgressObject stop(TargetModuleID[] moduleIDList) throws IllegalStateException {
         return executeCommandUsingFacility(CommandType.STOP, moduleIDList);
     }
-    
 
-   /**
-    * Remove the application from the target server.  
-	*
-    * <p> Only the TargetModuleIDs which represent a root module
-    * are valid for undeployment. A root TargetModuleID has no parent.
-    * A TargetModuleID with a parent can not be undeployed. A root
-    * TargetModuleID module and all its child modules will be undeployed.
-	* The root TargetModuleID module and all its child modules must
-    * stopped before they can be undeployed. 
-    *
-    * @param moduleIDList An array of TargetModuleID objects representing
-    *                   the root modules to be stopped.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @return ProgressObject an object that tracks and reports the 
-    *                       status of the stop operation.
-    */
-
-    public ProgressObject undeploy(TargetModuleID[] moduleIDList)
-               throws IllegalStateException 
-    {
+    @Override
+    public ProgressObject undeploy(TargetModuleID[] moduleIDList) throws IllegalStateException {
         return executeCommandUsingFacility(CommandType.UNDEPLOY, moduleIDList);
     }
-         
 
-   /**
-    * This method designates whether this platform vendor provides
-    * application redeployment functionality. A value of true means
-    * it is supported.  False means it is not.
-    *
-    * @return A value of true means redeployment is supported by this
-    *                   vendor's DeploymentManager.  False means it
-    *                   is not.
-    */
+    @Override
     public boolean isRedeploySupported() {
         return true;
     }
 
-   /**
-    * (optional)
-    * The redeploy method provides a means for updating currently
-    * deployed J2EE applications.  This is an optional method for
-    * vendor implementation.
-    *
-    * Redeploy replaces a currently deployed application with an
-    * updated version.  The runtime configuration information for 
-    * the updated application must remain identical to the application 
-    * it is updating.  
-    *
-    * When an application update is redeployed, all existing client
-    * connections to the original running application must not be disrupted; 
-    * new clients will connect to the application update.
-    *
-    * This operation is valid for TargetModuleIDs that represent a
-    * root module. A root TargetModuleID has no parent. A root
-    * TargetModuleID module and all its child modules will be redeployed.
-    * A child TargetModuleID module cannot be individually redeployed.
-    * The redeploy operation is complete only when this action for 
-    * all the modules has completed.
-    *
-    * @param moduleIDList An array of designators of the applications
-    *                      to be updated.
-    * @param moduleArchive The file name of the application archive
-    *                      to be disrtibuted.
-    * @param deploymentPlan The deployment configuration information
-    *                       associated with this application archive.
-    * @return ProgressObject an object that tracks and reports the
-    *                       status of the redeploy operation.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @throws UnsupportedOperationException this optional command
-    *         is not supported by this implementation.
-    */
-
-    public ProgressObject redeploy(TargetModuleID[] moduleIDList,
-           File moduleArchive, File deploymentPlan)
-           throws UnsupportedOperationException, IllegalStateException 
-    {
+    @Override
+    public ProgressObject redeploy(TargetModuleID[] moduleIDList, File moduleArchive, File deploymentPlan)
+        throws UnsupportedOperationException, IllegalStateException {
         try {
             /*
              *To support multiple different modules in the module ID list, use a TargetModuleIDCollection to
-             *organize them and work on each module one at a time.  
+             *organize them and work on each module one at a time.
              */
             TargetModuleIDCollection coll = new TargetModuleIDCollection(moduleIDList);
-            for (Iterator it = coll.iterator(); it.hasNext();) {
+            for (Iterator<DeploymentFacilityModuleWork> it = coll.iterator(); it.hasNext();) {
+                DeploymentFacilityModuleWork work = it.next();
+                /*
+                 *Set the name in the properties according to the moduleID.  The module is the same for all the
+                 *targets represented by this single work object.
+                 */
+                DFDeploymentProperties options = getRedeployOptions(work.getModuleID());
+                ProgressObject progress = deploy(work.targets(), moduleArchive, deploymentPlan, options);
+
+                /*
+                 *The work instance needs to know about its own progress object, and the
+                 *aggregate progress object needs to also.
+                 */
+                work.setProgressObject(progress);
+                coll.getProgressObjectSink().sinkProgressObject(progress);
+            }
+            return coll.getProgressObjectSink();
+        } catch (Throwable e) {
+            return prepareErrorProgressObject(CommandType.REDEPLOY, e);
+        }
+    }
+
+
+    @Override
+    public ProgressObject redeploy(TargetModuleID[] moduleIDList, InputStream moduleArchive, InputStream deploymentPlan)
+        throws UnsupportedOperationException, IllegalStateException {
+        try {
+            /*
+             *To support multiple different modules in the module ID list, use a TargetModuleIDCollection to
+             *organize them and work on each module one at a time.
+             */
+            TargetModuleIDCollection coll = new TargetModuleIDCollection(moduleIDList);
+            for (Iterator<DeploymentFacilityModuleWork> it = coll.iterator(); it.hasNext();) {
                 /*
                  *The iterator returns one work instance for each module present in the collection.
                  */
-                DeploymentFacilityModuleWork work = (DeploymentFacilityModuleWork) it.next();
+                DeploymentFacilityModuleWork work = it.next();
                 /*
-                 *Set the name in the properties according to the moduleID.  The module is the same for all the 
+                 *Set the name in the properties according to the moduleID.  The module is the same for all the
                  *targets represented by this single work object.
                  */
-                ProgressObject po = deploy(work.targets(), moduleArchive, deploymentPlan, getRedeployOptions(work.getModuleID()));
+                DFDeploymentProperties options = getRedeployOptions(work.getModuleID());
+                ProgressObject po = deploy(work.targets(), moduleArchive, deploymentPlan, options);
 
                 /*
                  *The work instance needs to know about its own progress object, and the
@@ -702,138 +481,28 @@ public class SunDeploymentManager implements DeploymentManager {
         }
     }
 
-   /**
-    * (optional)
-    * The redeploy method provides a means for updating currently
-    * deployed J2EE applications.  This is an optional method for
-    * vendor implementation.
-    *
-    * Redeploy replaces a currently deployed application with an
-    * updated version.  The runtime configuration information for 
-    * the updated application must remain identical to the application 
-    * it is updating.
-    *
-    * When an application update is redeployed, all existing client
-    * connections to the original running application must not be disrupted; 
-    * new clients will connect to the application update.
-    *
-    * This operation is valid for TargetModuleIDs that represent a
-    * root module. A root TargetModuleID has no parent. A root
-    * TargetModuleID module and all its child modules will be redeployed.
-    * A child TargetModuleID module cannot be individually redeployed.
-    * The redeploy operation is complete only when this action for 
-    * all the modules has completed.
-    *
-    * @param moduleIDList An array of designators of the applications
-    *                      to be updated.
-    * @param moduleArchive The input stream containing the application
-    *                      archive to be disrtibuted.
-    * @param deploymentPlan The input stream containing the runtime
-    *                       configuration information associated with
-    *                       this application archive.
-    * @return ProgressObject an object that tracks and reports the
-    *                       status of the redeploy operation.
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @throws UnsupportedOperationException this optional command
-    *         is not supported by this implementation.
-    */
-
-    public ProgressObject redeploy(TargetModuleID[] moduleIDList,
-           InputStream moduleArchive, InputStream deploymentPlan)
-           throws UnsupportedOperationException, IllegalStateException 
-    {
-        try {
-            /*
-             *To support multiple different modules in the module ID list, use a TargetModuleIDCollection to
-             *organize them and work on each module one at a time.  
-             */
-            TargetModuleIDCollection coll = new TargetModuleIDCollection(moduleIDList);
-            for (Iterator it = coll.iterator(); it.hasNext();) {
-                /*
-                 *The iterator returns one work instance for each module present in the collection.
-                 */
-                DeploymentFacilityModuleWork work = (DeploymentFacilityModuleWork) it.next();
-                /*
-                 *Set the name in the properties according to the moduleID.  The module is the same for all the 
-                 *targets represented by this single work object.
-                 */
-                DFDeploymentProperties dProps = getRedeployOptions(work.getModuleID());
-                // type is not needed for v3 server code now
-                // dProps.setType(deploymentFacility.getModuleType(work.getModuleID()));
-                ProgressObject po = deploy(work.targets(), moduleArchive, deploymentPlan, dProps);
-
-                /*
-                 *The work instance needs to know about its own progress object, and the
-                 *aggregate progress object needs to also.
-                 */
-                work.setProgressObject(po);
-                coll.getProgressObjectSink().sinkProgressObject(po);
-            }
-            return coll.getProgressObjectSink();
-        } catch (Throwable e) {
-            return prepareErrorProgressObject(CommandType.REDEPLOY, e);
-        }
-    }
-
-   /**
-    * The release method is the mechanism by which the tool signals 
-    * to the DeploymentManager that the tool does not need it to
-    * continue running connected to the platform. 
-    *
-    * The tool may be signaling it wants to run in a disconnected 
-    * mode or it is planning to shutdown.
-    * 
-    * When release is called the DeploymentManager may close any
-    * J2EE resource connections it had for deployment configuration
-    * and perform other related resource cleanup.  It should not
-    * accept any new operation requests (i.e., distribute, start
-    * stop, undeploy, redeploy.  It should finish any operations 
-    * that are currently in process.  Each ProgressObject associated
-    * with a running operation should be marked as released (see
-    * the ProgressObject).
-    * 
-    */
-
+    @Override
     public void release() {
-        /*
-         *Make sure multiple releases are handled gracefully.
-         */
-        if ( ! isDisconnected() ) {
+        // Make sure multiple releases are handled gracefully.
+        if (!isDisconnected()) {
             deploymentFacility = null;
         }
     }
 
-   /**
-    * Returns the default locale supported by this implementation of
-    * javax.enterprise.deploy.spi subpackages.
-    *
-    * @return Locale the default locale for this implementation.
-    */
+    @Override
     public Locale getDefaultLocale() {
         return defaultLocale;
     }
 
-   /**
-    * Returns the active locale this implementation of
-    * javax.enterprise.deploy.spi subpackages is running.
-    *
-    * @return Locale the active locale of this implementation.
-    */
+    @Override
     public Locale getCurrentLocale() {
         return currentLocale;
     }
 
-   /**
-    * Set the active locale for this implementation of
-    * javax.enterprise.deploy.spi subpackages to run.
-    *
-    * @throws UnsupportedOperationException the provide locale is
-    *      not supported.
-    */
+    @Override
     public void setLocale(Locale locale) throws UnsupportedOperationException {
-        for (int i=0;i<supportedLocales.length;i++) {
-            if (supportedLocales[i] == locale) {
+        for (Locale supportedLocale : supportedLocales) {
+            if (supportedLocale == locale) {
                 currentLocale = locale;
                 return;
             }
@@ -843,68 +512,34 @@ public class SunDeploymentManager implements DeploymentManager {
                 "Locale {0} is not supported", new Object[] {locale})); //NOI18N
     }
 
-   /**
-    * Returns an array of supported locales for this implementation.
-    *
-    * @return Locale[] the list of supported locales.
-    */
+    @Override
     public Locale[] getSupportedLocales() {
         return supportedLocales;
     }
 
-   /**
-    * Reports if this implementation supports the designated locale.
-    *
-    * @return  A value of 'true' means it is support and 'false' it is
-    *      not.
-    */
+    @Override
     public boolean isLocaleSupported(Locale locale) {
         Locale[] locales = getSupportedLocales();
-        for (int i=0;i<locales.length;i++) {
-            if (locales[i].equals(locale)) 
+        for (Locale locale2 : locales) {
+            if (locale2.equals(locale)) {
                 return true;
+            }
         }
         return false;
     }
 
-   /**
-    * Returns the J2EE platform version number for which the
-    * configuration beans are provided.  The beans must have 
-    * been compiled with the J2SE version required by the J2EE 
-    * platform.
-    *
-    * @return a DConfigBeanVersionType object representing the 
-    * platform version number for which these beans are provided.
-    */
-   public DConfigBeanVersionType getDConfigBeanVersion() {
-       return DConfigBeanVersionType.V5;
-   }
+    @Override
+    public DConfigBeanVersionType getDConfigBeanVersion() {
+        return DConfigBeanVersionType.V5;
+    }
 
-   /**
-    * Returns 'true' if the configuration beans support the J2EE platform
-    * version specified.  It returns 'false' if the version is
-    * not supported.
-    *
-    * @param version a DConfigBeanVersionType object representing the 
-    *	J2EE platform version for which support is requested.
-    * @return 'true' if the version is supported and 'false if not.
-    */
+   @Override
    public boolean isDConfigBeanVersionSupported(DConfigBeanVersionType version) {
        return version.getValue()==getDConfigBeanVersion().getValue();
    }
 
-   /**
-    * Set the configuration beans to be used to the J2EE platform 
-    * version specificed.
-    *
-    * @param version a DConfigBeanVersionType object representing the 
-    * J2EE platform version for which support is requested.
-    * @throws DConfigBeanVersionUnsupportedException when the
-    *        requested bean version is not supported.
-    */
-   public void setDConfigBeanVersion(DConfigBeanVersionType version) throws
-            DConfigBeanVersionUnsupportedException {
-                               
+   @Override
+    public void setDConfigBeanVersion(DConfigBeanVersionType version) throws DConfigBeanVersionUnsupportedException {
        if (!isDConfigBeanVersionSupported(version)) {
            throw new DConfigBeanVersionUnsupportedException(
             localStrings.getLocalString(
@@ -913,35 +548,38 @@ public class SunDeploymentManager implements DeploymentManager {
                 new Object[] {version.toString()}));
        }
    }
-    
-   /**
-    *Return deployment options for the DeploymentFacility preset for the needs of redeployment. 
-    *These properties will be merged with and will override the options set for normal deployment.
-    *@return Properties with the conventional preset properties for redeployment
-    */
-   private DFDeploymentProperties getRedeployOptions(String moduleID) {
+
+
+    /**
+     * Return deployment options for the DeploymentFacility preset for the needs of redeployment.
+     * These properties will be merged with and will override the options set for normal deployment.
+     *
+     * @return Properties with the conventional preset properties for redeployment
+     */
+    private DFDeploymentProperties getRedeployOptions(String moduleID) {
         DFDeploymentProperties deplProps = new DFDeploymentProperties();
         deplProps.setForce(true);
         deplProps.setName(moduleID);
         deplProps.setRedeploy(true);
         return deplProps;
    }
-   
+
+
     /**
-     *Deploy the specified module to the list of targets. 
-     *The deployment plan archive can be null.
-     *@param Target[] the targets to which to deploy the module
-     *@param File the archive stream to be deployed
-     *@param File the (optional) deployment plan stream
-     *@param options set by the caller to override and augment any settings made here
-     *@return ProgressObject to communicate progress and results of the deployment
-     *@exception IllegalStateException if the DeploymentManager has disconnected
-     *@exception IOException if there are problems working with the input streams
+     * Deploy the specified module to the list of targets.
+     * The deployment plan archive can be null.
+     *
+     * @param targetList the targets to which to deploy the module
+     * @param moduleStream the archive stream to be deployed
+     * @param deploymentPlanStream the (optional) deployment plan stream
+     * @param presetOptions options set by the caller to override and augment any settings made here
+     * @return ProgressObject to communicate progress and results of the deployment
+     * @throws IllegalStateException if the DeploymentManager has disconnected
+     * @throws IOException if there are problems working with the input streams
      */
-    private ProgressObject deploy(Target[] targetList,
-           InputStream moduleStream, InputStream deploymentPlanStream, Properties presetOptions)
-           throws IllegalStateException {
-        
+    private ProgressObject deploy(Target[] targetList, InputStream moduleStream, InputStream deploymentPlanStream,
+        Properties presetOptions) throws IllegalStateException {
+
         /*
          *Create archives for the module's input stream and, if present, the deployment plan's
          *input stream, and then delegate to the variant of deploy that accepts archives as
@@ -949,7 +587,7 @@ public class SunDeploymentManager implements DeploymentManager {
          */
         MemoryMappedArchive moduleArchive = null;
         MemoryMappedArchive deploymentPlanArchive = null;
-        
+
         try {
             moduleArchive = new MemoryMappedArchive(moduleStream);
             if (deploymentPlanStream != null) {
@@ -966,21 +604,22 @@ public class SunDeploymentManager implements DeploymentManager {
         }
     }
 
+
     /**
-     *Deploy the specified module to the list of targets. 
-     *The deployment plan archive can be null.
-     *@param Target[] the targets to which to deploy the module
-     *@param File the archive file to be deployed
-     *@param File the (optional) deployment plan file
-     *@param options set by the caller to override and augment any settings made here
-     *@return ProgressObject to communicate progress and results of the deployment
-     *@exception IllegalStateException if the DeploymentManager has disconnected
-     *@exception IOException if there are problems opening the archive files
+     * Deploy the specified module to the list of targets.
+     * The deployment plan archive can be null.
+     *
+     * @param targetList the targets to which to deploy the module
+     * @param moduleArchive the archive file to be deployed
+     * @param deploymentPlan the (optional) deployment plan file
+     * @param options set by the caller to override and augment any settings made here
+     * @return ProgressObject to communicate progress and results of the deployment
+     * @throws IllegalStateException if the DeploymentManager has disconnected
+     * @throws IOException if there are problems opening the archive files
      */
-    private ProgressObject deploy(Target[] targetList,
-           File moduleArchive, File deploymentPlan, Properties presetOptions)
-           throws IllegalStateException {
-           
+    private ProgressObject deploy(Target[] targetList, File moduleArchive, File deploymentPlan, Properties options)
+        throws IllegalStateException {
+
         /*
          *Create archives for the module file and, if present, the deployment plan file, and
          *then delegate to the variant of deploy that accepts archives as arguments.
@@ -988,22 +627,22 @@ public class SunDeploymentManager implements DeploymentManager {
         ReadableArchive appArchive = null;
         ReadableArchive planArchive = null;
         ArchiveFactory archiveFactory = getArchiveFactory();
-        
+
         try {
             appArchive = archiveFactory.openArchive(moduleArchive);
-        
-            if(deploymentPlan != null && deploymentPlan.length() != 0) {
+
+            if (deploymentPlan != null && deploymentPlan.length() != 0) {
                 planArchive = archiveFactory.openArchive(deploymentPlan);
                 if (planArchive == null) {
                     throw new IllegalArgumentException(localStrings.getLocalString(
-                        "enterprise.deployapi.spi.noarchivisthandlesplan", 
+                        "enterprise.deployapi.spi.noarchivisthandlesplan",
                         "No archivist is able to handle the deployment plan {0}",
                         new Object [] {deploymentPlan.getAbsolutePath()}
                     ));
                 }
             }
-            
-            ProgressObject po = deploy(targetList, appArchive, planArchive, presetOptions);
+
+            ProgressObject po = deploy(targetList, appArchive, planArchive, options);
             return po;
         } catch (Exception se) {
             String msg = localStrings.getLocalString(
@@ -1013,65 +652,68 @@ public class SunDeploymentManager implements DeploymentManager {
             ex.initCause(se);
             return prepareErrorProgressObject(CommandType.DISTRIBUTE, ex);
         } finally {
-            closeArchives(CommandType.DISTRIBUTE, appArchive, moduleArchive.getAbsolutePath(), planArchive, (deploymentPlan != null) ? deploymentPlan.getAbsolutePath() : null);
+            closeArchives(CommandType.DISTRIBUTE, appArchive, moduleArchive.getAbsolutePath(), planArchive,
+                (deploymentPlan != null) ? deploymentPlan.getAbsolutePath() : null);
         }
     }
 
+
     /**
-     *Deploy the specified module to the list of targets. 
-     *The deployment plan archive can be null.
-     *@param Target[] the targets to which to deploy the module
-     *@param ReadableArchive the archive to be deployed
-     *@param ReadableArchive the (optional) deployment plan
-     *@param options set by the caller to override and augment any settings made here
-     *@return ProgressObject to communicate progress and results of the deployment
-     *@exception IllegalStateException if the DeploymentManager has disconnected
+     * Deploy the specified module to the list of targets.
+     * The deployment plan archive can be null.
+     *
+     * @param targetList the targets to which to deploy the module
+     * @param moduleArchive the archive to be deployed
+     * @param planArchive the (optional) deployment plan
+     * @param options set by the caller to override and augment any settings made here
+     * @return ProgressObject to communicate progress and results of the deployment
+     * @throws IllegalStateException if the DeploymentManager has disconnected
      */
-    private ProgressObject deploy(Target[] targetList,
-           ReadableArchive moduleArchive, ReadableArchive planArchive, Properties presetOptions)
-           throws IllegalStateException {
-               
+    private ProgressObject deploy(Target[] targetList, ReadableArchive moduleArchive, ReadableArchive planArchive,
+        Properties presetOptions) throws IllegalStateException {
+
         verifyConnected();
-        
+
         ProgressObject progressObj = null;
 
         try {
-            Properties options = getProperties();
+            DFDeploymentProperties options = getProperties();
 
-            /*
-             *If any preset options were specified by the caller, use them to 
-             *override or augment the just-assigned set.
-             */
+            // If any preset options were specified by the caller, use them to
+            // override or augment the just-assigned set.
             if (presetOptions != null) {
                 options.putAll(presetOptions);
             }
             progressObj = deploymentFacility.deploy(targetList, moduleArchive, planArchive, options);
-            
-        } catch(Throwable e) {
-            /*
-             *Prepare a progress object with a deployment status "wrapper" around this exception.
-             */
+
+        } catch (Throwable e) {
+            // Prepare a progress object with a deployment status "wrapper" around this exception.
             progressObj = prepareErrorProgressObject(CommandType.DISTRIBUTE, e);
         }
-        return progressObj;               
+        return progressObj;
     }
 
+
     /**
-     *Closes the module archive and the plan archive, if any, preparing a
-     *ProgressObject if any error occurred.
-     *@param commandType the CommandType in progress - used in preparing the progress object (if needed)
-     *@param moduleArchive the main module archive to be closed
-     *@param moduleArchiveSpec a String representation of the main module archive
-     *@param planArchive the deployment plan archive (if any) to be closed
-     *@param planArchiveSpec a String representation of the deployment plan archive (if any) to be closed
-     *@return ProgressObject an error progress object if any error ocurred trying to close the archive(s)
+     * Closes the module archive and the plan archive, if any, preparing a ProgressObject if any
+     * error occurred.
+     *
+     * @param commandType the CommandType in progress - used in preparing the progress object
+     *            (if needed)
+     * @param moduleArchive the main module archive to be closed
+     * @param moduleArchiveSpec a String representation of the main module archive
+     * @param planArchive the deployment plan archive (if any) to be closed
+     * @param planArchiveSpec a String representation of the deployment plan archive (if any)
+     *            to be closed
+     * @return ProgressObject an error progress object if any error ocurred trying to close
+     *         the archive(s)
      */
     private ProgressObject closeArchives(CommandType commandType, ReadableArchive moduleArchive, String moduleArchiveSpec, ReadableArchive planArchive, String planArchiveSpec) {
         ProgressObject errorPO = null;
-        
+
         IOException moduleIOE = closeArchive(moduleArchive);
         IOException planIOE = closeArchive(planArchive);
-        
+
         IOException excForProgressObject = null;
         String errorMsg = null;
         /*
@@ -1081,7 +723,7 @@ public class SunDeploymentManager implements DeploymentManager {
         if (moduleIOE != null) {
             excForProgressObject = moduleIOE;
             /*
-             *If there was a problem with both the module archive and the plan archive, 
+             *If there was a problem with both the module archive and the plan archive,
              *compose an appropriate message that says both failed.
              */
             if (planIOE != null) {
@@ -1096,7 +738,6 @@ public class SunDeploymentManager implements DeploymentManager {
                  *a message about only the module archive.
                  */
                 errorMsg = localStrings.getLocalString(
-                        
                         "enterprise.deployapi.spi.errclosemodulearch",
                         "Could not close module archive {0}",
                         new Object[] {moduleArchiveSpec}
@@ -1104,10 +745,10 @@ public class SunDeploymentManager implements DeploymentManager {
             }
         } else if (planIOE != null) {
             /*
-             *The module archive was closed fine.  If the plan archive exists and 
+             *The module archive was closed fine.  If the plan archive exists and
              *could not be closed, compose an error message to that effect and
-             *record the IOException that occurred during the attempt to close the 
-             *deployment plan archive for use in the error progress object returned 
+             *record the IOException that occurred during the attempt to close the
+             *deployment plan archive for use in the error progress object returned
              *to the caller.
              */
             excForProgressObject = planIOE;
@@ -1117,9 +758,9 @@ public class SunDeploymentManager implements DeploymentManager {
                     new Object[] {planArchiveSpec}
             );
         }
-        
-        /**
-         *If an error occurred trying to close either archive, build an error progress object 
+
+        /*
+         *If an error occurred trying to close either archive, build an error progress object
          *for return to the caller.
          */
         if (errorMsg != null) {
@@ -1127,14 +768,16 @@ public class SunDeploymentManager implements DeploymentManager {
             ioe.initCause(excForProgressObject); // Only reflects the module exception if both occurred, but the msg describes both.
             errorPO = prepareErrorProgressObject(commandType, ioe);
         }
-        
+
         return errorPO;
     }
-    
+
+
     /**
-     *Closes the specified archive, returning any IOException encountered in the process.
-     *@param archive the archive to be closed
-     *@return IOException describing any error; null if the close succeeded
+     * Closes the specified archive, returning any IOException encountered in the process.
+     *
+     * @param archive the archive to be closed
+     * @return IOException describing any error; null if the close succeeded
      */
     private IOException closeArchive(ReadableArchive archive) {
         IOException errorIOE = null;
@@ -1147,51 +790,52 @@ public class SunDeploymentManager implements DeploymentManager {
         }
         return errorIOE;
     }
-    
+
+
     /**
-     *Perform the selected command on the DeploymentFacility using the specified target module IDs.
-     *<p>
-     *Several of the deployment facility methods have the same signature except for the name.
-     *This method collects the pre- and post-processing around those method calls in one place, then
-     *chooses which of the deployment facility methods to actually invoke based on the 
-     *command type provided as an argument.
+     * Perform the selected command on the DeploymentFacility using the specified target module IDs.
+     * <p>
+     * Several of the deployment facility methods have the same signature except for the name.
+     * This method collects the pre- and post-processing around those method calls in one place,
+     * then chooses which of the deployment facility methods to actually invoke based on
+     * the command type provided as an argument.
      *
-     *@param commandType selects which method should be invoked
-     *@param moduleIDList array of TargetModuleID to be started
-     *@exception IllegalArgumentException if the command type is not supported
-     *@exception IllegalStateException if the deployment manager had been released previously 
+     * @param commandType selects which method should be invoked
+     * @param moduleIDList array of TargetModuleID to be started
+     * @throws IllegalArgumentException if the command type is not supported
+     * @throws IllegalStateException if the deployment manager had been released previously
      */
      private ProgressObject executeCommandUsingFacility(
-        CommandType commandType, TargetModuleID[] targetModuleIDList) 
+        CommandType commandType, TargetModuleID[] targetModuleIDList)
         throws IllegalStateException {
 
          verifyConnected();
-       try {  
+       try {
         /*
          *Create a temporary collection based on the target module IDs to make it easier to deal
          *with the different modules and the set of targets.
          */
         TargetModuleIDCollection coll = new TargetModuleIDCollection(targetModuleIDList);
-        
+
         /*
-         *For each distinct module ID present in the list, ask the deployment facility to 
+         *For each distinct module ID present in the list, ask the deployment facility to
          *operate on that module on all the relevant targets.
          */
-        
-        for (Iterator it = coll.iterator(); it.hasNext();) {
+
+        for (Iterator<DeploymentFacilityModuleWork> it = coll.iterator(); it.hasNext();) {
             /*
              *The iterator returns one work instance for each module present in the collection.
              *Each work instance reflects one invocation of a method on the DeploymentFacility.
              */
-            DeploymentFacilityModuleWork work = (DeploymentFacilityModuleWork) it.next();
+            DeploymentFacilityModuleWork work = it.next();
             ProgressObject po = null;
-            
+
             if (commandType.equals(CommandType.START)) {
                 po = deploymentFacility.enable(work.targets(), work.getModuleID());
-                
+
             } else if (commandType.equals(CommandType.STOP)) {
                 po = deploymentFacility.disable(work.targets(), work.getModuleID());
-                
+
             } else if (commandType.equals(CommandType.UNDEPLOY)) {
                 po = deploymentFacility.undeploy(work.targets(), work.getModuleID());
 
@@ -1202,7 +846,7 @@ public class SunDeploymentManager implements DeploymentManager {
                     new Object [] {commandType.toString()}
                     ));
             }
-            
+
             /*
              *The new work instance needs to know about its own progress object, and the
              *aggregate progress object needs to also.
@@ -1210,22 +854,23 @@ public class SunDeploymentManager implements DeploymentManager {
             work.setProgressObject(po);
             coll.getProgressObjectSink().sinkProgressObject(po);
         }
-        
+
         /*
          *Return the single progress object to return to the caller.
          */
         return coll.getProgressObjectSink();
-        
+
       } catch (Throwable thr) {
         return prepareErrorProgressObject(commandType, thr);
       }
     }
-    
+
     /**
-     *Prepare a ProgressObject that reflects an error, with a related Throwable cause.
-     *@param commandType being processed at the time of the error
-     *@param throwable that occurred
-     *@return ProgressObject set to FAILED with linked cause reporting full error info
+     * Prepare a ProgressObject that reflects an error, with a related Throwable cause.
+     *
+     * @param commandType being processed at the time of the error
+     * @param throwable that occurred
+     * @return ProgressObject set to FAILED with linked cause reporting full error info
      */
     private ProgressObject prepareErrorProgressObject (CommandType commandType, Throwable thr) {
         DeploymentStatus ds = new DeploymentStatusImplWithError(CommandType.DISTRIBUTE, thr);
@@ -1235,85 +880,19 @@ public class SunDeploymentManager implements DeploymentManager {
         return progressObj;
     }
 
-    protected Properties getProperties() {
+    /**
+     * Creates new properties; enabled is set to false, nothing else is set.
+     *
+     * @return {@link DFDeploymentProperties}
+     */
+    protected DFDeploymentProperties getProperties() {
         // we don't set name from client side and will let server side
-        // determine it 
+        // determine it
         DFDeploymentProperties dProps = new DFDeploymentProperties();
         dProps.setEnabled(false);
-        return (Properties)dProps;
-    }
-    
-   /**
-    * The distribute method performs three tasks; it validates the
-    * deployment configuration data, generates all container specific 
-    * classes and interfaces, and moves the fully baked archive to 
-    * the designated deployment targets.
-    *
-    * @param targetList   A list of server targets the user is specifying
-    *                     this application be deployed to. 
-    * @param moduleArchive The abstraction for the application 
-    *                      archive to be disrtibuted.
-    * @param deploymentPlan The archive containing the deployment
-    *                       configuration information associated with
-    *                       this application archive.
-    * @param deploymentOptions is a JavaBeans compliant component 
-    *                   containing all deployment options for this deployable
-    *                   unit. This object must be created using the 
-    *                   BeanInfo instance returned by 
-    *                   DeploymentConfiguration.getDeploymentOptions
-    * @throws IllegalStateException is thrown when the method is
-    *                    called when running in disconnected mode.
-    * @return ProgressObject an object that tracks and reports the 
-    *                       status of the distribution process.
-    *
-    */        
-    public ProgressObject distribute(Target[] targetList, 
-                                     Archive moduleArchive, 
-                                     Archive deploymentPlan, 
-                                     Object deploymentOptions) 
-            throws IllegalStateException {
-        return null;
+        return dProps;
     }
 
-    /**
-     * Creates a new instance of Archive which can be used to 
-     * store application elements in a layout that can be directly used by 
-     * the application server. Implementation of this method should carefully
-     * return the appropriate implementation of the interface that suits 
-     * the server needs and provide the fastest deployment time.
-     * An archive may already exist at the location and elements may be 
-     * read but not changed or added depending on the underlying medium.
-     * @param path the directory in which to create this archive if local 
-     * storage is a possibility. 
-     * @param name is the desired name for the archive
-     * @return the writable archive instance
-     */    
-    public Archive getArchive(URI path, String name)
-        throws IOException
-    {
-        
-        if (path==null) {
-            // no particular path was provided, using tmp jar file
-            File root = File.createTempFile(name,".jar");  //NOI18N
-            path = root.toURI();
-        }
-        ArchiveFactory factory = getArchiveFactory();
-        boolean exists = false;
-        if ((path.getScheme().equals("file")) ||  //NOI18N
-            (path.getScheme().equals("jar"))) { //NOI18N
-        
-            File target = new File(path);
-            exists = target.exists();                    
-        } else {
-            return null;
-        }
-        if (exists) {
-            return factory.openArchive(path);            
-        } else {
-            return factory.createArchive(path);
-        }
-    }
-    
     private void prepareHabitat() {
         ModulesRegistry registry = new StaticModulesRegistry(getClass().getClassLoader());
         ServiceLocator serviceLocator = registry.createServiceLocator("default");
@@ -1329,56 +908,61 @@ public class SunDeploymentManager implements DeploymentManager {
     }
 
     /**
-     *Organizes the target module IDs passed by a JSR88 client for easy processing one module ID
-     *at a time.
-     *<p>
-     *Several methods in the JSR88 DeploymentManager interface accept a list of TargetModuleID values,
-     *and these lists can refer to multiple module IDs and multiple targets.
-     *Each invocation of a DeploymentFacility method, on the other hand, can work on only a single module 
-     *although with perhaps multiple targets.  This class provides a central way of organizing the 
-     *target module IDs as passed from the JSR88 client and making the information for a single 
-     *module ID readily available.  
-     *<p>
-     *Typically, a client will use three methods:
-     *<ul>
-     *<le>the constructor - pass a TargetModuleID array as supplied by a client
-     *<le>the iterator() method, which the client uses to step through the DeploymentFacilityModuleWork
-     *instances, each representing a single module and perhaps multiple targets.
-     *<le>the getProgressObjectSink which returns the aggregator for the ProgressObjects
-     *from each work element
-     *</ul>
+     * Organizes the target module IDs passed by a JSR88 client for easy processing one module ID
+     * at a time.
+     * <p>
+     * Several methods in the JSR88 DeploymentManager interface accept a list of TargetModuleID
+     * values, and these lists can refer to multiple module IDs and multiple targets.
+     * Each invocation of a DeploymentFacility method, on the other hand, can work on only a single
+     * module although with perhaps multiple targets. This class provides a central way
+     * of organizing the target module IDs as passed from the JSR88 client and making
+     * the information for a single module ID readily available.
+     * <p>
+     * Typically, a client will use three methods:
+     * <ul>
+     * <li>the constructor - pass a TargetModuleID array as supplied by a client
+     * <li>the iterator() method, which the client uses to step through
+     * the DeploymentFacilityModuleWork instances, each representing a single module and perhaps
+     * multiple targets.
+     * <li>the getProgressObjectSink which returns the aggregator for the ProgressObjects
+     * from each work element
+     * </ul>
      */
     protected static class TargetModuleIDCollection {
-        /* Maps the module ID to that module's instance of DeploymentFacilityModuleWork. */
-        private HashMap moduleIDToInfoMap = new HashMap();
-        
-        /* Collects together the individual progress objects into a single aggregate one. */
-        ProgressObjectSink progressObjectSink = null;
-        
-        /**
-         *Create a new instance of TargetModuleIDCollection.
-         *Accept the array of targetModuleIDs as passed by the JSR88 client and set up the
-         *internal data structures.
-         *@param targetModuleIDs array of {@link javax.deployment.api.TargetModuleID TargetModuleID} provided from the calling JSR88 client
-         */
-        public TargetModuleIDCollection(TargetModuleID [] targetModuleIDs) throws IllegalArgumentException {
+        /** Maps the module ID to that module's instance of DeploymentFacilityModuleWork. */
+        private final HashMap<String, DeploymentFacilityModuleWork> moduleIDToInfoMap = new HashMap<>();
 
-            for (int i = 0; i < targetModuleIDs.length; i++) {
+        /** Collects together the individual progress objects into a single aggregate one. */
+        private ProgressObjectSink progressObjectSink;
+
+
+        /**
+         * Create a new instance of TargetModuleIDCollection.
+         * Accept the array of targetModuleIDs as passed by the JSR88 client and set up
+         * the internal data structures.
+         *
+         * @param targetModuleIDs array of {@link TargetModuleID TargetModuleID} provided from
+         *            the calling JSR88 client
+         * @throws IllegalArgumentException unsupported target implementation
+         */
+        public TargetModuleIDCollection(TargetModuleID[] targetModuleIDs) throws IllegalArgumentException {
+
+            for (TargetModuleID targetModuleID : targetModuleIDs) {
                 /*
                  *Make sure that this target module ID has a target that is a TargetImpl and was created by this DM.
                  */
-                Target candidateTarget = targetModuleIDs[i].getTarget();
-                if ( ! (candidateTarget instanceof TargetImpl)) {
+                Target candidateTarget = targetModuleID.getTarget();
+                if (!(candidateTarget instanceof TargetImpl)) {
                     throw new IllegalArgumentException(
                     localStrings.getLocalString("enterprise.deployapi.spi.nott", //NOI18N
                         "Expected TargetImpl instance but found instance of {0}", new Object[] {candidateTarget.getClass().getName() } )); //NOI18N
                 }
-                String moduleID = targetModuleIDs[i].getModuleID();
-                
+                String moduleID = targetModuleID.getModuleID();
+
                 /*
                  *Look for the entry in the hash map for this module.
                  */
-                DeploymentFacilityModuleWork work = (DeploymentFacilityModuleWork) moduleIDToInfoMap.get(moduleID);
+                DeploymentFacilityModuleWork work = moduleIDToInfoMap.get(moduleID);
                 if (work == null) {
                     /*
                      *This module ID is not yet in the map.  Add a work instance for it with the module ID as the key.
@@ -1387,38 +971,40 @@ public class SunDeploymentManager implements DeploymentManager {
                     moduleIDToInfoMap.put(moduleID, work);
                 }
                 /*
-                 *Either the entry already exists or one has been created.  
+                 *Either the entry already exists or one has been created.
                  *In either case, add the target to the work to be done with this module.
                  */
                 work.addTarget(candidateTarget);
             }
         }
-        
+
         /**
-         *Provides an Iterator over the module work items in the collection.
-         *The iterator provides one element for each distinct module that appeared in the original
-         *array of TargetModuleIDs.
+         * Provides an Iterator over the module work items in the collection.
+         * The iterator provides one element for each distinct module that appeared in the original
+         * array of TargetModuleIDs.
          *
-         *@return Iterator over the DeploymentFacilityModuleWork elements in the collection
+         * @return Iterator over the DeploymentFacilityModuleWork elements in the collection
          */
-        public Iterator iterator() {
+        public Iterator<DeploymentFacilityModuleWork> iterator() {
             return moduleIDToInfoMap.values().iterator();
         }
 
         /**
-         *Reports the number of elements in the collection.
-         *This is also a measure of the number of distinct module IDs specified in the TargetModuleID array
-         *passed to the constructor of the collection.
-         *@return the number of DeploymentFacilityModuleWork elements contained in the collection
+         * Reports the number of elements in the collection.
+         * This is also a measure of the number of distinct module IDs specified
+         * in the TargetModuleID array passed to the constructor of the collection.
+         *
+         * @return the number of DeploymentFacilityModuleWork elements contained in the collection
          */
         public int size() {
             return moduleIDToInfoMap.size();
         }
-        
+
         /**
-         *Returns the aggregate progress object for the collection.
-         *Creates a new ProgressObjectSink if needed.
-         *@return ProgressObjectSink
+         * Returns the aggregate progress object for the collection.
+         * Creates a new ProgressObjectSink if needed.
+         *
+         * @return {@link ProgressObjectSink}
          */
         public ProgressObjectSink getProgressObjectSink() {
             if (progressObjectSink == null) {
@@ -1427,76 +1013,84 @@ public class SunDeploymentManager implements DeploymentManager {
             return progressObjectSink;
         }
     }
-    
+
     /**
-     *Encapsulates information used with a single invocation of a DeploymentFacility method--
-     *that is, one item of "work" the DeploymentFacility is being asked to perform.
-     *This includes the single target ID of interest (because the DF methods operate on a 
-     *single module), a collection of all the targets to be included in the operation on that
-     *module, and the progress object resulting from the DF method invocation.
+     * Encapsulates information used with a single invocation of a DeploymentFacility method--
+     * that is, one item of "work" the DeploymentFacility is being asked to perform.
+     * This includes the single target ID of interest (because the DF methods operate on a
+     * single module), a collection of all the targets to be included in the operation on that
+     * module, and the progress object resulting from the DF method invocation.
      */
     protected static class DeploymentFacilityModuleWork {
-        
+
         /** The module ID this work handles */
         private String moduleID = null;
-        
+
         /** The targets this work should affect. */
-        private Collection targets = new Vector();
-        
+        private final Collection<Target> targets = new Vector<>();
+
         /** The ProgressObject for this work returned by the DeploymentFacility method invocation. */
         private ProgressObject progressObject = null;
-        
+
         /**
-         *Creates a new instance of DeploymentFacilityModuleWork.
-         *@param the module ID common to all work recorded in this instance
+         * Creates a new instance of DeploymentFacilityModuleWork.
+         *
+         * @param moduleID the module ID common to all work recorded in this instance
          */
         public DeploymentFacilityModuleWork(String moduleID) {
             this.moduleID = moduleID;
         }
-        
+
+
         /**
-         *Adds a target to the collection of targets for the work to be done for this distinct module.
-         *@param the {@link javax.enterprise.deploy.spi.Target Target} to be added for this module
+         * Adds a target to the collection of targets for the work to be done for this distinct
+         * module.
+         *
+         * @param target the {@link Target Target} to be added for this module
          */
         public void addTarget(Target target) {
             if ( ! (target instanceof TargetImpl) ) {
                 throw new IllegalArgumentException(localStrings.getLocalString(
                     "enterprise.deployapi.spi.unexptargettyp",
                     "Target must be of type TargetImpl but encountered {0}",
-                    new Object [] {target.getClass().getName()} 
+                    new Object [] {target.getClass().getName()}
                 ));
             }
             targets.add(target);
         }
-        
+
         /**
-         *Returns an array of {@link javax.enterprise.deploy.spi.Target Target} instances recorded for
-         *this module.  Note the return of an array of runtime type TargetImpl[].
-         *@return array of Target
+         * Returns an array of {@link Target Target} instances recorded for
+         * this module. Note the return of an array of runtime type TargetImpl[].
+         *
+         * @return array of Target
          */
         public Target [] targets() {
-            return (Target []) targets.toArray(new TargetImpl[targets.size()]);
+            return targets.toArray(new TargetImpl[targets.size()]);
         }
-        
+
+
         /**
-         *Returns the {@link javax.enterprise.deploy.spi.status.ProgressObject ProgressObject} that the
-         *DeploymentFacility method returned when it was invoked.
-         *@return the ProgressObject
+         * Returns the {@link ProgressObject ProgressObject} that the DeploymentFacility method
+         * returned when it was invoked.
+         *
+         * @return the ProgressObject
          */
         public ProgressObject getProgressObject() {
             return this.progressObject;
         }
-        
+
+
         /**
-         *Records the {@link javax.enterprise.deploy.spi.status.ProgressObject ProgressObject} that the
-         *DeploymentFacility returned when its method was invoked.
-         *@param the ProgressObject provided by the DeploymentFacility
-         *method
+         * Records the {@link ProgressObject ProgressObject} that the DeploymentFacility returned
+         * when its method was invoked.
+         *
+         * @param progressObject the ProgressObject provided by the DeploymentFacility method
          */
-        public void setProgressObject (ProgressObject progressObject) {
+        public void setProgressObject(ProgressObject progressObject) {
             this.progressObject = progressObject;
         }
-        
+
         /**
          *Reports the module ID for this instance of DeploymentFacilityModuleWork
          *@return the module ID

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployapi/TargetImpl.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployapi/TargetImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] Payara Foundation and/or affiliates
 
 package org.glassfish.deployapi;
 
@@ -49,63 +50,65 @@ import java.io.IOException;
  * Implements the Target interface as specified by JSR-88.
  * <p>
  * This implementation is independent of the concrete type of its owner.
- * 
+ *
  * @author tjquinn
+ * @author David Matejcek
  */
 public class TargetImpl implements Target {
 
-    private TargetOwner owner;
-    
-    private String name;
-    
-    private String description;
-    
+    private final TargetOwner owner;
+    private final String name;
+    private final String description;
+
     /**
      * Creates a new TargetImpl object.
      * <p>
      * Note that this constructor should normally be used only by a TargetOwner.
-     * Logic that needs to create {@link Target} instances should invoke {@link TargetOwner#createTarget} or 
+     * Logic that needs to create {@link Target} instances should invoke {@link TargetOwner#createTarget} or
      * {@link TargetOwner#createTargets} on the TargetOwner.
-     * 
+     *
      * @param owner
      * @param name
      * @param description
-     */ // XXX It would be nice to move classes around so this could be package-visible and not public
+     */
     public TargetImpl(TargetOwner owner, String name, String description) {
         this.owner = owner;
         this.name = name;
         this.description = description;
     }
 
-    /**
-     * Returns the name of the Target.
-     * @return
-     */
+    @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * Returns the description of the Target.
-     * @return
-     */
+    @Override
     public String getDescription() {
         return description;
     }
-    
+
     public TargetOwner getOwner() {
         return owner;
     }
 
+
     /**
-     *  Exports the Client stub jars to the given location.
-     *  @param appName The name of the application or module.
-     *  @param destDir The directory into which the stub jar file
-     *  should be exported.
-     *  @return the absolute location to the main jar file.
+     * Exports the Client stub jars to the given location.
+     *
+     * @param appName The name of the application or module.
+     * @param destDir The directory into which the stub jar file
+     *            should be exported.
+     * @return the absolute location to the main jar file.
      */
-    public String exportClientStubs(String appName, String destDir) 
-        throws IOException {
+    public String exportClientStubs(String appName, String destDir) throws IOException {
         return owner.exportClientStubs(appName, destDir);
+    }
+
+    /**
+     * Returns the name of this target.
+     */
+    @Override
+    public String toString() {
+        return getName();
     }
 }

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployapi/TargetModuleIDImpl.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployapi/TargetModuleIDImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] Payara Foundation and/or affiliates
 
 package org.glassfish.deployapi;
 
@@ -44,90 +45,111 @@ import javax.enterprise.deploy.shared.ModuleType;
 import javax.enterprise.deploy.spi.Target;
 import javax.enterprise.deploy.spi.TargetModuleID;
 
+import org.glassfish.deployment.client.TargetOwner;
+
 /**
  * Implements the {@link TargetModuleID} interface from JSR-88, representing the
  * presence of a given module on a given {@link Target}.
  * <p>
  * This implementation is independent of the {@link TargetOwner} that owns the
  * corresponding Target.
- * 
+ *
  * @author tjquinn
  */
 public class TargetModuleIDImpl implements TargetModuleID {
 
-    private TargetImpl target;
-    private String moduleID;
+    private final TargetImpl target;
+    private final String moduleID;
     private TargetModuleIDImpl parent;
     private TargetModuleIDImpl[] children = new TargetModuleIDImpl[0];
     private ModuleType moduleType;
-    
+
+
     /**
      * Creates a new implementation object of TargetModuleID.
      * <p>
      * Normally this constructor should be used only by implementations of
-     * TargetOwner.  Other code will normally retrieve TargetModuleID objects
-     * from other methods that create them as part of their work (such as 
+     * TargetOwner. Other code will normally retrieve TargetModuleID objects
+     * from other methods that create them as part of their work (such as
      * deployment, for example).
+     *
      * @param target the target on which the module resides
      * @param moduleID the name of the module
      * @param parent the higher-level TargetModuleIDImpl (if this object represents
-     * a submodule of a module that is deployed to a Target)
-     * @param children TargetModuleIDImpl objects representing the submodules 
-     * of this module as deployed to the Target
+     *            a submodule of a module that is deployed to a Target)
+     * @param children TargetModuleIDImpl objects representing the submodules
+     *            of this module as deployed to the Target
      */
-    public TargetModuleIDImpl(
-            TargetImpl target, 
-            String moduleID, 
-            TargetModuleIDImpl parent, 
-            TargetModuleIDImpl[] children) {
+    public TargetModuleIDImpl(TargetImpl target, String moduleID, TargetModuleIDImpl parent,
+        TargetModuleIDImpl[] children) {
         this.target = target;
         this.moduleID = moduleID;
         this.parent = parent;
         this.children = children;
     }
-    
+
+
     /**
      * Creates a new implementation object of TargetModuleId with no parent
      * and no children.
+     *
      * @param target the target on which the module resides
      * @param moduleID the name of the module
      */
     public TargetModuleIDImpl(TargetImpl target, String moduleID) {
         this(target, moduleID, null, new TargetModuleIDImpl[0]);
     }
+
+
     /**
      * Returns the Target on which the module is deployed.
-     * @return the Target
+     *
+     * @return the {@link TargetImpl}
      */
+    @Override
     public Target getTarget() {
         return target;
     }
 
+
+    /**
+     * Returns the Target on which the module is deployed.
+     *
+     * @return the {@link TargetImpl}
+     */
     public TargetImpl getTargetImpl() {
         return target;
     }
-    
+
+
     /**
      * Returns the name of the module that is deployed to a given Target.
+     *
      * @return the module name
      */
+    @Override
     public String getModuleID() {
         return moduleID;
     }
 
+
     /**
-     * Returns the URL for running the Web module, if this TargetModuleID 
+     * Returns the URL for running the Web module, if this TargetModuleID
      * represents a Web module or submodule on a Target.
+     *
      * @return the URL
      */
+    @Override
     public String getWebURL() {
         return target.getOwner().getWebURL(this);
     }
 
+
     /**
      * Sets the URL for running the Web module, if this TargetModuleID
      * represents a Web module or submodule on a Target.
-     * @param the webURL
+     *
+     * @param webURL
      */
     public void setWebURL(String webURL) {
         target.getOwner().setWebURL(this, webURL);
@@ -137,27 +159,32 @@ public class TargetModuleIDImpl implements TargetModuleID {
     /**
      * Returns the TargetModuleID for the containing module on the Target, if
      * this TargetModuleID represents a submodule.
+     *
      * @return the parent TargetModuleID
      */
+    @Override
     public TargetModuleID getParentTargetModuleID() {
         return parent;
     }
 
+
     /**
-     * Returns the TargetModuleIDs representing submodules of this module 
+     * Returns the TargetModuleIDs representing submodules of this module
      * deployed to the Target.
+     *
      * @return the child TargetModuleID objects
      */
+    @Override
     public TargetModuleID[] getChildTargetModuleID() {
         return children;
     }
+
 
     /**
      * Add a child TargetModuleID to this TargetModuleID
      */
     public void addChildTargetModuleID(TargetModuleIDImpl child) {
-        TargetModuleIDImpl[] newChildren = 
-            new TargetModuleIDImpl[children.length+1];
+        TargetModuleIDImpl[] newChildren = new TargetModuleIDImpl[children.length + 1];
 
         System.arraycopy(children, 0, newChildren, 0, children.length);
 
@@ -168,6 +195,7 @@ public class TargetModuleIDImpl implements TargetModuleID {
         child.setParentTargetModuleID(this);
     }
 
+
     /**
      * Sets the parent TargetModuleID
      */
@@ -175,13 +203,16 @@ public class TargetModuleIDImpl implements TargetModuleID {
         this.parent = parent;
     }
 
+
     /**
      * Sets the module type for this deployed module
-     * @param the module type
+     *
+     * @param moduleType {@link ModuleType}
      */
     public void setModuleType(ModuleType moduleType) {
         this.moduleType = moduleType;
     }
+
 
     /**
      * @return the module type of this deployed module
@@ -190,4 +221,12 @@ public class TargetModuleIDImpl implements TargetModuleID {
         return moduleType;
     }
 
+
+    /**
+     * Returns {@link #getModuleID()}.
+     */
+    @Override
+    public String toString() {
+        return getModuleID();
+    }
 }

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/AbstractDeploymentFacility.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/AbstractDeploymentFacility.java
@@ -40,39 +40,40 @@
 // Portions Copyright [2019] Payara Foundation and/or affiliates
 package org.glassfish.deployment.client;
 
-import org.glassfish.api.admin.CommandException;
+import com.sun.enterprise.deployment.deploy.shared.MemoryMappedArchive;
+import com.sun.enterprise.util.HostAndPort;
 import com.sun.enterprise.util.LocalStringManagerImpl;
-import java.io.File;
-import java.io.IOException;
-import java.io.EOFException;
-import java.io.FileOutputStream;
-import java.io.BufferedOutputStream;
+
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.enterprise.deploy.shared.CommandType;
 import javax.enterprise.deploy.shared.ModuleType;
 import javax.enterprise.deploy.spi.Target;
 import javax.enterprise.deploy.spi.TargetModuleID;
-import javax.enterprise.deploy.spi.status.ClientConfiguration;
+
+import org.glassfish.api.admin.CommandException;
+import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.deployapi.ProgressObjectImpl;
 import org.glassfish.deployapi.TargetImpl;
 import org.glassfish.deployapi.TargetModuleIDImpl;
-import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.deployment.common.DeploymentProperties;
-import com.sun.enterprise.util.HostAndPort;
-import com.sun.enterprise.deployment.deploy.shared.MemoryMappedArchive;
-
 import org.glassfish.logging.annotation.LogMessageInfo;
-import org.glassfish.logging.annotation.LoggerInfo;
 import org.glassfish.logging.annotation.LogMessagesResourceBundle;
+import org.glassfish.logging.annotation.LoggerInfo;
 
 /**
  * Provides common behavior for the local and remote deployment facilities.
@@ -82,12 +83,14 @@ import org.glassfish.logging.annotation.LogMessagesResourceBundle;
  * <p>
  *
  * @author tjquinn
+ * @author David Matejcek
  */
 public abstract class AbstractDeploymentFacility implements DeploymentFacility, TargetOwner {
-    private static final String DEFAULT_SERVER_NAME = "server";
-    protected static final LocalStringManagerImpl localStrings = new LocalStringManagerImpl(AbstractDeploymentFacility.class);
 
-    private static final String LIST_COMMAND = "list";
+    private static final String TARGET_DOMAIN = "domain";
+    private static final String DEFAULT_SERVER_NAME = "server";
+    private static final LocalStringManagerImpl localStrings = new LocalStringManagerImpl(AbstractDeploymentFacility.class);
+
     private static final String LIST_SUB_COMPONENTS_COMMAND = "list-sub-components";
     private static final String GET_CLIENT_STUBS_COMMAND = "get-client-stubs";
     private static final String GET_COMMAND = "get";
@@ -95,19 +98,18 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
     private boolean connected;
     private TargetImpl domain;
     private ServerConnectionIdentifier targetDAS;
-    private Map<String, String> targetModuleWebURLs =
-        new HashMap<String, String>();
+    private final Map<String, String> targetModuleWebURLs = new HashMap<>();
 
     @LogMessagesResourceBundle
     private static final String SHARED_LOGMESSAGE_RESOURCE = "org.glassfish.deployment.LogMessages";
 
     // Reserve this range [AS-DEPLOYMENT-04001, AS-DEPLOYMENT-06000]
     // for message ids used in this deployment dol module
-    @LoggerInfo(subsystem = "DEPLOYMENT", description="Deployment logger for client module", publish=true)
+    @LoggerInfo(subsystem = "DEPLOYMENT", description = "Deployment logger for client module", publish = true)
     private static final String DEPLOYMENT_LOGGER = "javax.enterprise.system.tools.deployment.client";
 
-    public static final Logger deplLogger =
-        Logger.getLogger(DEPLOYMENT_LOGGER, SHARED_LOGMESSAGE_RESOURCE);
+    /** Shared deployment logger: {@value #DEPLOYMENT_LOGGER} */
+    public static final Logger deplLogger = Logger.getLogger(DEPLOYMENT_LOGGER, SHARED_LOGMESSAGE_RESOURCE);
 
     @LogMessageInfo(message = "Error in deleting file {0}", level="WARNING")
     private static final String FILE_DELETION_ERROR = "AS-DEPLOYMENT-04017";
@@ -122,7 +124,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
          * Runs the command.
          *
          * @return the DF deployment status reflecting the outcome of the operation
-         * @throws com.sun.enterprise.cli.framework.CommandException
+         * @throws CommandException
          */
         DFDeploymentStatus run() throws CommandException;
     }
@@ -133,12 +135,12 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @param commandName
      * @param commandOptions
      * @param operands
-     * @return
-     * @throws com.sun.enterprise.cli.framework.CommandException
+     * @return {@link DFCommandRunner}
+     * @throws CommandException
      */
     protected abstract DFCommandRunner getDFCommandRunner(
             String commandName,
-            Map<String,Object> commandOptions,
+            DFDeploymentProperties commandOptions,
             String[] operands) throws CommandException;
 
     /**
@@ -149,41 +151,45 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @param moduleID name of the module affected
      * @param commandName enable or disable
      * @param action name enabling or disabling
+     *
      * @return DFProgressObject the caller can use to monitor progress and query final status
      */
     protected DFProgressObject changeState(Target[] targets, String moduleID, String commandName, String action) {
         ensureConnected();
-        targets = prepareTargets(targets);
+
+        targets = getTargetServers(targets);
         ProgressObjectImpl po = new ProgressObjectImpl(targets);
-	if(commandName.equals("enable")) {
-            po.setCommand(CommandType.START, null);
-        } else if(commandName.equals("disable")) {
-            po.setCommand(CommandType.STOP, null);
+        if (commandName.equals("enable")) {
+            po.setCommand(CommandType.START);
+        } else if (commandName.equals("disable")) {
+            po.setCommand(CommandType.STOP);
         }
-        List<TargetModuleIDImpl> targetModuleIDList =
-            new ArrayList<TargetModuleIDImpl>();
+        List<TargetModuleIDImpl> targetModuleIDList = new ArrayList<>();
         try {
             for (Target target : targets) {
-                Map commandParams = new HashMap();
+                DFDeploymentProperties commandParams = new DFDeploymentProperties();
                 commandParams.put(DFDeploymentProperties.TARGET, target.getName());
                 DFCommandRunner commandRunner = getDFCommandRunner(commandName, commandParams, new String[]{moduleID});
                 DFDeploymentStatus ds = commandRunner.run();
                 DFDeploymentStatus mainStatus = ds.getMainStatus();
-                if(!po.checkStatusAndAddStage((TargetImpl)target, localStrings.getLocalString("enterprise.deployment.client.change_state", "{0} of {1} in target {2}", action, moduleID, target.getName()), mainStatus)) {
+                String message = localStrings.getLocalString("enterprise.deployment.client.change_state",
+                    "{0} of {1} in target {2}", action, moduleID, target.getName());
+                if (!po.checkStatusAndAddStage((TargetImpl) target, message, mainStatus)) {
                     return po;
-                } else {
-                    TargetModuleIDImpl targetModuleID =
-                        new TargetModuleIDImpl((TargetImpl)target, moduleID);
-                    targetModuleIDList.add(targetModuleID);
                 }
+                TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl) target, moduleID);
+                targetModuleIDList.add(targetModuleID);
             }
-            TargetModuleIDImpl[] targetModuleIDs =
-                new TargetModuleIDImpl[targetModuleIDList.size()];
-            targetModuleIDs = (TargetModuleIDImpl[])targetModuleIDList.toArray(targetModuleIDs);
-            po.setupForNormalExit(localStrings.getLocalString("enterprise.deployment.client.change_state_all", "{0} of application in all targets", action), (TargetImpl)targets[0],  targetModuleIDs);
+            TargetModuleIDImpl[] targetModuleIDs = new TargetModuleIDImpl[targetModuleIDList.size()];
+            targetModuleIDs = targetModuleIDList.toArray(targetModuleIDs);
+            po.setupForNormalExit(localStrings.getLocalString("enterprise.deployment.client.change_state_all",
+                "{0} of application in all targets", action), (TargetImpl) targets[0], targetModuleIDs);
             return po;
         } catch (Throwable ioex) {
-            po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.state_change_failed", "Attempt to change the state of the application {0} failed - {1}", moduleID, ioex.toString()), (TargetImpl)targets[0]);
+            po.setupForAbnormalExit(
+                localStrings.getLocalString("enterprise.deployment.client.state_change_failed",
+                    "Attempt to change the state of the application {0} failed - {1}", moduleID, ioex.toString()),
+                (TargetImpl) targets[0]);
             return po;
         }
     }
@@ -196,13 +202,15 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
 
     /**
      * Connects the deployment facility to the DAS.
+     *
      * @param targetDAS the DAS to contact
      * @return true if the connection was made successfully; false otherwise
      */
+    @Override
     public boolean connect(ServerConnectionIdentifier targetDAS) {
         connected = true;
         this.targetDAS = targetDAS;
-        domain = new TargetImpl(this, "domain", localStrings.getLocalString(
+        domain = new TargetImpl(this, TARGET_DOMAIN, localStrings.getLocalString(
                 "enterprise.deployment.client.administrative_domain",
                 "administrative-domain"));
         return doConnect();
@@ -210,14 +218,17 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
 
     /**
      * Performs any local- or remote-specific work to end the connection to the DAS.
+     *
      * @return true if the disconnection succeeded; false otherwise
      */
     protected abstract boolean doDisconnect();
 
     /**
      * Disconnects the deployment facility from the DAS.
+     *
      * @return true if the disconnection was successful; false otherwise
      */
+    @Override
     public boolean disconnect() {
         connected = false;
         domain = null;
@@ -225,22 +236,26 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         return doDisconnect();
     }
 
+    @Override
     public DFProgressObject createAppRef(Target[] targets, String moduleID, Map options) {
         return changeAppRef(targets, moduleID, "create-application-ref", "Creation", options);
     }
 
+    @Override
     public DFProgressObject deleteAppRef(Target[] targets, String moduleID, Map options) {
         return changeAppRef(targets, moduleID, "delete-application-ref", "Removal", options);
     }
 
-    protected DFProgressObject changeAppRef(Target[] targets, String moduleID, String commandName, String action, Map options) {
+
+    private DFProgressObject changeAppRef(Target[] targets, String moduleID, String commandName, String action,
+        Map origOptions) {
         ensureConnected();
-        Throwable commandExecutionException = null;
-        targets = prepareTargets(targets);
+        targets = getTargetServers(targets);
         ProgressObjectImpl po = new ProgressObjectImpl(targets);
-        List<TargetModuleIDImpl> targetModuleIDList =
-            new ArrayList<TargetModuleIDImpl>();
+        List<TargetModuleIDImpl> targetModuleIDList = new ArrayList<>();
         try {
+            final DFDeploymentProperties options = new DFDeploymentProperties();
+            options.putAll(origOptions);
             for (Target target : targets) {
                 options.put(DFDeploymentProperties.TARGET, target.getName());
                 String[] operands = new String[] {moduleID};
@@ -248,29 +263,35 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
                 DFCommandRunner commandRunner = getDFCommandRunner(commandName, options, operands);
                 DFDeploymentStatus ds = commandRunner.run();
                 mainStatus = ds.getMainStatus();
-                if(!po.checkStatusAndAddStage((TargetImpl)target, localStrings.getLocalString("enterprise.deployment.client.create_reference", "Creation of reference for application in target {0}", target.getName()),  mainStatus)) {
+                String message = localStrings.getLocalString("enterprise.deployment.client.create_reference",
+                    "Creation of reference for application in target {0}", target.getName());
+                if (!po.checkStatusAndAddStage((TargetImpl) target, message, mainStatus)) {
                     return po;
-                } else {
-                    TargetModuleIDImpl targetModuleID =
-                        new TargetModuleIDImpl((TargetImpl)target, moduleID);
-                    targetModuleIDList.add(targetModuleID);
                 }
+                TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl) target, moduleID);
+                targetModuleIDList.add(targetModuleID);
             }
-            TargetModuleIDImpl[] targetModuleIDs =
-                new TargetModuleIDImpl[targetModuleIDList.size()];
-            targetModuleIDs = (TargetModuleIDImpl[])targetModuleIDList.toArray(targetModuleIDs);
-            po.setupForNormalExit(localStrings.getLocalString("enterprise.deployment.client.change_reference_application", "{0} of application reference in all targets", action), (TargetImpl)targets[0], targetModuleIDs);
+            TargetModuleIDImpl[] targetModuleIDs = new TargetModuleIDImpl[targetModuleIDList.size()];
+            targetModuleIDs = targetModuleIDList.toArray(targetModuleIDs);
+            String message = localStrings.getLocalString("enterprise.deployment.client.change_reference_application",
+                "{0} of application reference in all targets", action);
+            po.setupForNormalExit(message, (TargetImpl) targets[0], targetModuleIDs);
             return po;
         } catch (Throwable ioex) {
-           po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.change_reference_application_failed", "{0} of application reference failed - {1}", action, ioex.getMessage()), (TargetImpl)targets[0]);
+            String message = localStrings.getLocalString(
+                "enterprise.deployment.client.change_reference_application_failed",
+                "{0} of application reference failed - {1}", action, ioex.getMessage());
+            po.setupForAbnormalExit(message, (TargetImpl) targets[0]);
             return po;
         }
     }
 
+    @Override
     public Target createTarget(String name) {
         return new TargetImpl(this, name, "");
     }
 
+    @Override
     public Target[] createTargets(String[] targets) {
         if (targets == null) {
             targets = new String[0];
@@ -283,7 +304,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         return result;
     }
 
-    protected String createTargetsParam(Target[] targets) {
+    private String createTargetsParam(Target[] targets) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < targets.length; i++) {
             sb.append(targets[i].getName());
@@ -294,7 +315,9 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         return sb.toString();
     }
 
-    public DFProgressObject deploy(Target[] targets, ReadableArchive source, ReadableArchive deploymentPlan, Map deploymentOptions) throws IOException {
+    @Override
+    public DFProgressObject deploy(Target[] targets, ReadableArchive source, ReadableArchive deploymentPlan,
+        Map deploymentOptions) throws IOException {
         if (source == null) {
             throw new IllegalArgumentException();
         }
@@ -302,8 +325,8 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         File tempPlanFile = null;
         if (source instanceof MemoryMappedArchive) {
             try {
-                String type = (String)deploymentOptions.remove("type");
-                tempSourceFile = writeMemoryMappedArchiveToTempFile((MemoryMappedArchive)source, getSuffixFromType(type));
+                String extension = (String) deploymentOptions.remove(DFDeploymentProperties.MODULE_EXTENSION);
+                tempSourceFile = writeMemoryMappedArchiveToTempFile((MemoryMappedArchive)source, extension);
                 URI tempPlanURI = null;
                 if (deploymentPlan != null && deploymentPlan instanceof MemoryMappedArchive) {
                     tempPlanFile = writeMemoryMappedArchiveToTempFile((MemoryMappedArchive)deploymentPlan, ".jar");
@@ -315,17 +338,13 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
                 if (tempSourceFile != null) {
                     boolean isDeleted = tempSourceFile.delete();
                     if (!isDeleted) {
-                        deplLogger.log(Level.WARNING,
-                                       FILE_DELETION_ERROR,
-                                       tempSourceFile.getAbsolutePath());
+                        deplLogger.log(Level.WARNING, FILE_DELETION_ERROR, tempSourceFile.getAbsolutePath());
                     }
                 }
                 if (tempPlanFile != null) {
-                    boolean isDeleted =tempPlanFile.delete();
+                    boolean isDeleted = tempPlanFile.delete();
                     if (!isDeleted) {
-                        deplLogger.log(Level.WARNING,
-                                       FILE_DELETION_ERROR,
-                                       tempPlanFile.getAbsolutePath());
+                        deplLogger.log(Level.WARNING, FILE_DELETION_ERROR, tempPlanFile.getAbsolutePath());
                     }
                 }
             }
@@ -354,7 +373,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
                 try {
                     for (int totalCount = 0, count = 0;
                         count != -1 && totalCount < actual;
-                        totalCount += (count = bis.read(bytes, totalCount, actual - totalCount)));
+                        totalCount += (count = bis.read(bytes, totalCount, actual - totalCount))) {/**/}
                     bos.write(bytes);
                 } catch (EOFException eof) {
                     break;
@@ -376,134 +395,145 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         return tempFile;
     }
 
-    /**
-     * Deploys the application (with optional deployment plan) to the specified
-     * targets with the indicated options.
-     * @param targets targets to which to deploy the application
-     * @param source the app
-     * @param deploymentPlan the deployment plan (null if not specified)
-     * @param deploymentOptions options to be applied to the deployment
-     * @return DFProgressObject the caller can use to monitor progress and query status
-     */
-    public DFProgressObject deploy(Target[] targets, URI source, URI deploymentPlan, Map deploymentOptions) {
-        ensureConnected();
-        targets = prepareTargets(targets);
-        ProgressObjectImpl po = new ProgressObjectImpl(targets);
-        if(deploymentOptions instanceof DFDeploymentProperties) {
-            if (((DFDeploymentProperties) deploymentOptions).getRedeploy())
-                po.setCommand(CommandType.REDEPLOY, null);
-            else
-                po.setCommand(CommandType.DISTRIBUTE, null);
-        }
-        List<TargetModuleIDImpl> targetModuleIDList =
-            new ArrayList<TargetModuleIDImpl>();
+    @Override
+    public DFProgressObject deploy(final Target[] targets, final URI source, final URI deploymentPlan,
+        final Map origOptions) {
+        deplLogger.fine(() -> String.format("deploy(targets=%s, source=%s, deploymentPlan=%s, origOptions=%s)",
+            targets, source, deploymentPlan, origOptions));
 
-        //Make sure the file permission is correct when deploying a file
+        ensureConnected();
+        final Target[] targetServers = getTargetServers(targets);
+        final ProgressObjectImpl po = new ProgressObjectImpl(targetServers);
+        final DFDeploymentProperties deploymentOptions = new DFDeploymentProperties();
+        deploymentOptions.putAll(origOptions);
+        // target for deployment is always domain
+        // references to targets are created after successful deployment
+        deploymentOptions.put(DFDeploymentProperties.TARGET, TARGET_DOMAIN);
+        final boolean isRedeploy = deploymentOptions.getRedeploy();
+        deplLogger.finest(() -> "isRedeploy=" + isRedeploy);
+        // redeploy is not supported command argument, must be removed, because
+        // we use this instance directly
+        deploymentOptions.remove(DFDeploymentProperties.REDEPLOY);
+        if (isRedeploy) {
+            po.setCommand(CommandType.REDEPLOY);
+        } else {
+            po.setCommand(CommandType.DISTRIBUTE);
+        }
+        List<TargetModuleIDImpl> targetModuleIDList = new ArrayList<>();
+
+        // Make sure the file permission is correct when deploying a file
         if (source == null) {
-            po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.archive_not_specified", "Archive to be deployed is not specified at all."), (TargetImpl)targets[0]);
+            String msg = localStrings.getLocalString("enterprise.deployment.client.archive_not_specified",
+                "Archive to be deployed is not specified at all.");
+            po.setupForAbnormalExit(msg, domain);
             return po;
         }
         File tmpFile = new File(source.getSchemeSpecificPart());
         if (!tmpFile.exists()) {
-            po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.archive_not_in_location", "Unable to find the archive to be deployed in specified location."), domain);
+            String msg = localStrings.getLocalString("enterprise.deployment.client.archive_not_in_location",
+                "Unable to find the archive to be deployed in specified location.");
+            po.setupForAbnormalExit(msg, domain);
             return po;
         }
         if (!tmpFile.canRead()) {
-            po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.archive_no_read_permission", "Archive to be deployed does not have read permission."), domain);
+            String msg = localStrings.getLocalString("enterprise.deployment.client.archive_no_read_permission",
+                "Archive to be deployed does not have read permission.");
+            po.setupForAbnormalExit(msg, domain);
             return po;
         }
         try {
             if (deploymentPlan != null) {
                 File dp = new File(deploymentPlan.getSchemeSpecificPart());
                 if (!dp.exists()) {
-                    po.setupForAbnormalExit(localStrings.getLocalString(
-                            "enterprise.deployment.client.plan_not_in_location",
-                            "Unable to find the deployment plan in specified location."), domain);
+                    String msg = localStrings.getLocalString("enterprise.deployment.client.plan_not_in_location",
+                        "Unable to find the deployment plan in specified location.");
+                    po.setupForAbnormalExit(msg, domain);
                     return po;
                 }
                 if (!dp.canRead()) {
-                    po.setupForAbnormalExit(localStrings.getLocalString(
-                            "enterprise.deployment.client.plan_no_read_permission",
-                            "Deployment plan does not have read permission."), domain);
+                    String msg = localStrings.getLocalString("enterprise.deployment.client.plan_no_read_permission",
+                        "Deployment plan does not have read permission.");
+                    po.setupForAbnormalExit(msg, domain);
                     return po;
                 }
                 deploymentOptions.put(DFDeploymentProperties.DEPLOYMENT_PLAN, dp.getAbsolutePath());
             }
 
-            // it's redeploy, set the enable attribute accordingly
-            boolean isRedeploy = Boolean.valueOf((String)deploymentOptions.remove(DFDeploymentProperties.REDEPLOY));
             if (isRedeploy) {
-                String appName = (String)deploymentOptions.get(
-                    DFDeploymentProperties.NAME);
-                if (!isTargetsMatched(appName, targets)) {
-                    po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.specifyAllTargets", "Application {0} is already deployed on other targets. Please remove all references or specify all targets (or domain target if using asadmin command line) before attempting {1} operation", appName, "redeploy"), domain);
+                String appName = (String) deploymentOptions.get(DFDeploymentProperties.NAME);
+                if (!isTargetsMatched(appName, targetServers)) {
+                    String msg = localStrings.getLocalString(
+                        "enterprise.deployment.client.specifyAllTargets",
+                        "Application {0} is already deployed on other targets. Please remove all references or specify"
+                        + " all targets (or domain target if using asadmin command line) before attempting"
+                        + " {1} operation",
+                        appName, "redeploy");
+                    po.setupForAbnormalExit(msg, domain);
                 }
-                // set the enable attribute accordingly
-                String enabledAttr = getAppRefEnabledAttr(
-                    targets[0].getName(), appName);
-                deploymentOptions.put(DFDeploymentProperties.ENABLED,
-                    enabledAttr);
-                deploymentOptions.put("forceName","true");
+                String enabled = getAppRefEnabledAttr(TARGET_DOMAIN, appName);
+                deploymentOptions.put(DFDeploymentProperties.ENABLED, enabled);
+                deploymentOptions.put("isredeploy", "true");
+                deploymentOptions.put("forcename", "true");
+                deploymentOptions.setForce(true);
             }
 
-            Target[] origTargets = targets;
-
-            // first deploy to first target
-            if (isRedeploy && targets.length > 1) {
-                // if it's redeploy and having more than one target,
-                // we should just redeploy with the special domain target
-                targets = createTargets(new String[] {"domain"});
-            }
-            deploymentOptions.put(DFDeploymentProperties.TARGET, targets[0].getName());
-            DFCommandRunner commandRunner = getDFCommandRunner(
-                "deploy", deploymentOptions, new String[]{tmpFile.getAbsolutePath()});
+            // note about the current relation of commands: redeploy uses deploy.
+            final String command = isRedeploy ? "redeploy" : "deploy";
+            DFCommandRunner commandRunner = getDFCommandRunner(command, deploymentOptions,
+                new String[] {tmpFile.getAbsolutePath()});
             DFDeploymentStatus ds = commandRunner.run();
             DFDeploymentStatus mainStatus = ds.getMainStatus();
-            String moduleID;
-            if (!po.checkStatusAndAddStage((TargetImpl)targets[0], localStrings.getLocalString("enterprise.deployment.client.deploy_to_first_target", "Deploying application to target {0}", targets[0].getName()),  mainStatus)) {
+            String msg = localStrings.getLocalString("enterprise.deployment.client.deploy_to_first_target",
+                "Deploying application to target {0}", targetServers[0].getName());
+            if (!po.checkStatusAndAddStage((TargetImpl) targetServers[0], msg, mainStatus)) {
                 return po;
-            } else {
-                moduleID = mainStatus.getProperty(DFDeploymentProperties.NAME);
-                if (moduleID == null) {
-                    moduleID = (String)deploymentOptions.get(DFDeploymentProperties.NAME);
-                }
-                po.setModuleID(moduleID);
             }
+            String moduleID = mainStatus.getProperty(DFDeploymentProperties.NAME);
+            deplLogger.finest("moduleID retrieved from mainStatus: " + moduleID);
+            if (moduleID == null) {
+                moduleID = (String) deploymentOptions.get(DFDeploymentProperties.NAME);
+                deplLogger.finest("moduleID retrieved from deploymentOptions: " + moduleID);
+            }
+            po.setModuleID(moduleID);
 
-            Map createAppRefOptions = new HashMap();
+            final DFDeploymentProperties createAppRefOptions = new DFDeploymentProperties();
             if (deploymentOptions.get(DFDeploymentProperties.ENABLED) != null) {
-                createAppRefOptions.put(DFDeploymentProperties.ENABLED, deploymentOptions.get(DFDeploymentProperties.ENABLED));
+                createAppRefOptions.put(DFDeploymentProperties.ENABLED,
+                    deploymentOptions.get(DFDeploymentProperties.ENABLED));
             }
             if (deploymentOptions.get(DFDeploymentProperties.VIRTUAL_SERVERS) != null) {
-                createAppRefOptions.put(DFDeploymentProperties.VIRTUAL_SERVERS, deploymentOptions.get(DFDeploymentProperties.VIRTUAL_SERVERS));
+                createAppRefOptions.put(DFDeploymentProperties.VIRTUAL_SERVERS,
+                    deploymentOptions.get(DFDeploymentProperties.VIRTUAL_SERVERS));
             }
             // then create application references to the rest of the targets
-            for (int i = 1; i < targets.length; i++) {
-                createAppRefOptions.put(DFDeploymentProperties.TARGET, targets[i].getName());
-                DFCommandRunner commandRunner2 = getDFCommandRunner(
-                    "create-application-ref", createAppRefOptions, new String[] {moduleID});
+            for (Target target : targetServers) {
+                createAppRefOptions.put(DFDeploymentProperties.TARGET, target.getName());
+                DFCommandRunner commandRunner2 = getDFCommandRunner("create-application-ref", createAppRefOptions,
+                    new String[] {moduleID});
                 DFDeploymentStatus ds2 = commandRunner2.run();
                 DFDeploymentStatus mainStatus2 = ds2.getMainStatus();
-                if (!po.checkStatusAndAddStage((TargetImpl)targets[i],
-"create app ref", mainStatus2)) {
+                if (!po.checkStatusAndAddStage((TargetImpl) target, "create app ref", mainStatus2)) {
+                    deplLogger.finest("create-application-ref failed, mainStatus2: " + mainStatus2);
                     return po;
                 }
             }
 
-            // we use origTargets to populate the targetModuleIDList
+            // we use targetServers to populate the targetModuleIDList
             // so it takes care of the redeploy using domain target case too
-            for (int i = 0; i < origTargets.length; i++) {
-                TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl)origTargets[i], moduleID);
+            for (Target target : targetServers) {
+                TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl) target, moduleID);
                 targetModuleIDList.add(targetModuleID);
             }
 
-            TargetModuleIDImpl[] targetModuleIDs =
-                new TargetModuleIDImpl[targetModuleIDList.size()];
-            targetModuleIDs = (TargetModuleIDImpl[])targetModuleIDList.toArray(targetModuleIDs);
-            po.setupForNormalExit(localStrings.getLocalString("enterprise.deployment.client.deploy_application", "Deployment of application {0}", moduleID), (TargetImpl)targets[0], targetModuleIDs);
+            TargetModuleIDImpl[] targetModuleIDs = new TargetModuleIDImpl[targetModuleIDList.size()];
+            targetModuleIDs = targetModuleIDList.toArray(targetModuleIDs);
+            po.setupForNormalExit(localStrings.getLocalString("enterprise.deployment.client.deploy_application",
+                "Deployment of application {0}", moduleID), (TargetImpl) targetServers[0], targetModuleIDs);
             return po;
         } catch (Throwable ioex) {
-            po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.deploy_application_failed", "Deployment of application failed - {0} ", ioex.toString()), (TargetImpl)targets[0]);
+            String msg = localStrings.getLocalString("enterprise.deployment.client.deploy_application_failed",
+                "Deployment of application failed - {0} ", ioex.toString());
+            po.setupForAbnormalExit(msg, (TargetImpl) targetServers[0]);
             return po;
         }
     }
@@ -514,10 +544,12 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @param moduleID the app
      * @return DFProgressObject for monitoring progress and querying status
      */
+    @Override
     public DFProgressObject disable(Target[] targets, String moduleID) {
         return changeState(targets, moduleID, "disable", "Disable");
     }
 
+    @Override
     public String downloadFile(File location, String moduleID, String moduleURI) throws IOException {
         throw new UnsupportedOperationException("Not supported in v3");
     }
@@ -528,6 +560,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @param moduleID the app
      * @return DFProgressObject for monitoring progress and querying status
      */
+    @Override
     public DFProgressObject enable(Target[] targets, String moduleID) {
         return changeState(targets, moduleID, "enable", "Enable");
     }
@@ -542,10 +575,12 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * Reports whether the deployment facility is connected.
      * @return true if connected, false otherwise
      */
+    @Override
     public boolean isConnected() {
         return connected;
     }
 
+    @Override
     public List<String> getSubModuleInfoForJ2EEApplication(String appName) throws IOException {
         ensureConnected();
         String commandName = LIST_SUB_COMPONENTS_COMMAND;
@@ -556,46 +591,40 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             DFCommandRunner commandRunner = getDFCommandRunner(commandName, null, operands);
             DFDeploymentStatus ds = commandRunner.run();
             mainStatus = ds.getMainStatus();
-            List<String> subModuleInfoList = new ArrayList<String>();
+            List<String> subModuleInfoList = new ArrayList<>();
 
             if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
-                for (Iterator subIter = mainStatus.getSubStages();
-                    subIter.hasNext();) {
-                    DFDeploymentStatus subStage =
-                        (DFDeploymentStatus) subIter.next();
+                for (Iterator<DFDeploymentStatus> subIter = mainStatus.getSubStages(); subIter.hasNext();) {
+                    DFDeploymentStatus subStage = subIter.next();
                     if (subStage.getProperty(DeploymentProperties.MODULE_INFO) != null) {
-                        subModuleInfoList.add(
-                            subStage.getProperty(DeploymentProperties.MODULE_INFO));
+                        subModuleInfoList.add(subStage.getProperty(DeploymentProperties.MODULE_INFO));
                     }
                 }
             } else {
                 /*
                  * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because getContextRoot does not
+                 * reported as unsuccessful. Because getContextRoot does not
                  * return a ProgressObject which the caller could use to find
                  * out about the success or failure, we must throw an exception
                  * so the caller knows about the failure.
                  */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
+                commandExecutionException = new IOException("remote command execution failed on the server");
+                commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+                throw (IOException) commandExecutionException;
             }
             return subModuleInfoList;
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException)commandExecutionException;
         }
     }
 
     private String getAppRefEnabledAttr(String target, String moduleName) throws IOException {
         ensureConnected();
         String commandName = "show-component-status";
-        Map commandParams = new HashMap();
+        DFDeploymentProperties commandParams = new DFDeploymentProperties();
         commandParams.put(DFDeploymentProperties.TARGET, target);
         String[] operands = new String[] { moduleName };
         DFDeploymentStatus mainStatus = null;
@@ -607,10 +636,9 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             String enabledAttr = null;
 
             if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
-                Iterator subIter = mainStatus.getSubStages();
+                Iterator<DFDeploymentStatus> subIter = mainStatus.getSubStages();
                 if (subIter.hasNext()) {
-                    DFDeploymentStatus subStage =
-                        (DFDeploymentStatus) subIter.next();
+                    DFDeploymentStatus subStage = subIter.next();
                     String result = subStage.getProperty(DeploymentProperties.STATE);
                     if (result.equals("enabled")) {
                         enabledAttr = "true";
@@ -621,33 +649,30 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             } else {
                 /*
                  * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because getContextRoot does not
+                 * reported as unsuccessful. Because getContextRoot does not
                  * return a ProgressObject which the caller could use to find
                  * out about the success or failure, we must throw an exception
                  * so the caller knows about the failure.
                  */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
+                commandExecutionException = new IOException("remote command execution failed on the server");
+                commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+                throw (IOException) commandExecutionException;
             }
             return enabledAttr;
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException)commandExecutionException;
         }
     }
 
+    @Override
     public String getContextRoot(String moduleName) throws IOException {
         ensureConnected();
         String commandName = GET_COMMAND;
-        String patternParam = "applications.application." + moduleName +
-            ".context-root";
-        String[] operands = new String[] { patternParam };
+        String patternParam = "applications.application." + moduleName + ".context-root";
+        String[] operands = new String[] {patternParam};
         DFDeploymentStatus mainStatus = null;
         Throwable commandExecutionException = null;
         try {
@@ -657,13 +682,11 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             String contextRoot = null;
 
             if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
-                Iterator subIter = mainStatus.getSubStages();
+                Iterator<DFDeploymentStatus> subIter = mainStatus.getSubStages();
                 if (subIter.hasNext()) {
-                    DFDeploymentStatus subStage =
-                        (DFDeploymentStatus) subIter.next();
+                    DFDeploymentStatus subStage = subIter.next();
                     String result = subStage.getStageStatusMessage();
-                    contextRoot =
-                        getValueFromDottedNameGetResult(result);
+                    contextRoot = getValueFromDottedNameGetResult(result);
                 }
             } else {
                 /*
@@ -683,12 +706,12 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException)commandExecutionException;
         }
     }
 
+    @Override
     public ModuleType getModuleType(String moduleName) throws IOException {
         ensureConnected();
         String commandName = GET_COMMAND;
@@ -700,43 +723,39 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             DFCommandRunner commandRunner = getDFCommandRunner(commandName, null, operands);
             DFDeploymentStatus ds = commandRunner.run();
             mainStatus = ds.getMainStatus();
-            List<String> resultList = new ArrayList<String>();
+            List<String> resultList = new ArrayList<>();
 
             if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
-                for (Iterator subIter = mainStatus.getSubStages();
-                    subIter.hasNext();) {
-                    DFDeploymentStatus subStage =
-                        (DFDeploymentStatus) subIter.next();
+                for (Iterator<DFDeploymentStatus> subIter = mainStatus.getSubStages(); subIter.hasNext();) {
+                    DFDeploymentStatus subStage = subIter.next();
                     resultList.add(subStage.getStageStatusMessage());
                 }
                 return getJavaEEModuleTypeFromResult(resultList);
-            } else {
-                /*
-                 * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because get does not
-                 * return a ProgressObject which the caller could use to find
-                 * out about the success or failure, we must throw an exception
-                 * so the caller knows about the failure.
-                 */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
             }
+            /*
+             * We received a response from the server but the status was
+             * reported as unsuccessful. Because get does not
+             * return a ProgressObject which the caller could use to find
+             * out about the success or failure, we must throw an exception
+             * so the caller knows about the failure.
+             */
+            commandExecutionException = new IOException("remote command execution failed on the server");
+            commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+            throw (IOException) commandExecutionException;
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException)commandExecutionException;
         }
     }
 
+    @Override
     public Target[] listTargets() throws IOException {
         return listReferencedTargets("*");
     }
 
+    @Override
     public Target[] listReferencedTargets(String appName) throws IOException {
         ensureConnected();
         String commandName = "_get-targets";
@@ -747,47 +766,41 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             DFCommandRunner commandRunner = getDFCommandRunner(commandName, null, operands);
             DFDeploymentStatus ds = commandRunner.run();
             mainStatus = ds.getMainStatus();
-            List<Target> targets = new ArrayList<Target>();
+            List<Target> targets = new ArrayList<>();
 
             if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
-                for (Iterator subIter = mainStatus.getSubStages();
-                    subIter.hasNext();) {
-                    DFDeploymentStatus subStage =
-                        (DFDeploymentStatus) subIter.next();
+                for (Iterator<DFDeploymentStatus> subIter = mainStatus.getSubStages(); subIter.hasNext();) {
+                    DFDeploymentStatus subStage = subIter.next();
                     String result = subStage.getStageStatusMessage();
                     targets.add(createTarget(result));
                 }
-                Target[] result =
-                    new Target[targets.size()];
-                return (Target[]) targets.toArray(result);
-            } else {
-                /*
-                 * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because listTargets does not
-                 * return a ProgressObject which the caller could use to find
-                 * out about the success or failure, we must throw an exception
-                 * so the caller knows about the failure.
-                 */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
+                Target[] result = new Target[targets.size()];
+                return targets.toArray(result);
             }
+            /*
+             * We received a response from the server but the status was
+             * reported as unsuccessful. Because listTargets does not
+             * return a ProgressObject which the caller could use to find
+             * out about the success or failure, we must throw an exception
+             * so the caller knows about the failure.
+             */
+            commandExecutionException = new IOException("remote command execution failed on the server");
+            commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+            throw (IOException) commandExecutionException;
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException)commandExecutionException;
         }
     }
 
+    @Override
     public void getClientStubs(String location, String moduleID)
         throws IOException {
         ensureConnected();
         String commandName = GET_CLIENT_STUBS_COMMAND;
-        Map commandParams = new HashMap();
+        DFDeploymentProperties commandParams = new DFDeploymentProperties();
         commandParams.put("appname", moduleID);
         String[] operands = new String[] { location };
         DFDeploymentStatus mainStatus = null;
@@ -800,39 +813,41 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
             if (mainStatus.getStatus() == DFDeploymentStatus.Status.FAILURE) {
                 /*
                  * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because getClientStubs does not
+                 * reported as unsuccessful. Because getClientStubs does not
                  * return a ProgressObject which the caller could use to find
                  * out about the success or failure, we must throw an exception
                  * so the caller knows about the failure.
                  */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
+                commandExecutionException = new IOException("remote command execution failed on the server");
+                commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+                throw (IOException) commandExecutionException;
             }
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException) commandExecutionException;
         }
     }
 
+    @Override
     public HostAndPort getHostAndPort(String target) throws IOException {
         return getHostAndPort(target, false);
     }
 
-    public HostAndPort getHostAndPort(String target, boolean securityEnabled)
-        throws IOException {
+    @Override
+    public HostAndPort getHostAndPort(String target, boolean securityEnabled) throws IOException {
         return getHostAndPort(target, null, securityEnabled);
     }
 
-    public HostAndPort getVirtualServerHostAndPort(String target, String virtualServer, boolean securityEnabled) throws IOException {
+
+    @Override
+    public HostAndPort getVirtualServerHostAndPort(String target, String virtualServer, boolean securityEnabled)
+        throws IOException {
         return getHostAndPort(target, null, virtualServer, securityEnabled);
     }
 
+    @Override
     public HostAndPort getHostAndPort(String target, String moduleId, boolean securityEnabled)
         throws IOException {
         return getHostAndPort(target, moduleId, null, securityEnabled);
@@ -842,7 +857,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         String virtualServer, boolean securityEnabled) throws IOException {
         ensureConnected();
         String commandName = "_get-host-and-port";
-        Map commandParams = new HashMap();
+        DFDeploymentProperties commandParams = new DFDeploymentProperties();
         commandParams.put(DFDeploymentProperties.TARGET, "server");
         if (moduleId != null) {
             commandParams.put("moduleId", moduleId);
@@ -865,115 +880,110 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
                     hap = new HostAndPort(hostPortStr);
                 }
                 return hap;
-            } else {
-                /*
-                 * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because getHostAndPort does not
-                 * return a ProgressObject which the caller could use to find
-                 * out about the success or failure, we must throw an exception
-                 * so the caller knows about the failure.
-                 */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
             }
+            /*
+             * We received a response from the server but the status was
+             * reported as unsuccessful. Because getHostAndPort does not
+             * return a ProgressObject which the caller could use to find
+             * out about the success or failure, we must throw an exception
+             * so the caller knows about the failure.
+             */
+            commandExecutionException = new IOException("remote command execution failed on the server");
+            commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+            throw (IOException) commandExecutionException;
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException) commandExecutionException;
         }
     }
 
+    @Override
     public TargetModuleID[] listAppRefs(String[] targets) throws IOException {
         ensureConnected();
         List<TargetModuleIDImpl> targetModuleIDList =
-            new ArrayList<TargetModuleIDImpl>();
+            new ArrayList<>();
         Throwable commandExecutionException = null;
         try {
-            Target[] targetImpls = prepareTargets(createTargets(targets));
+            Target[] targetImpls = getTargetServers(createTargets(targets));
             for (Target target : targetImpls) {
                 String commandName = "list-application-refs";
                 String[] operands = new String[] { target.getName() };
-                Map commandParams = new HashMap();
+                DFDeploymentProperties commandParams = new DFDeploymentProperties();
                 DFDeploymentStatus mainStatus = null;
                 DFCommandRunner commandRunner = getDFCommandRunner(commandName, commandParams, operands);
                 DFDeploymentStatus ds = commandRunner.run();
                 mainStatus = ds.getMainStatus();
 
                 if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
-                    for (Iterator appRefIter = mainStatus.getSubStages(); appRefIter.hasNext();) {
-                        DFDeploymentStatus appRefSubStage = (DFDeploymentStatus) appRefIter.next();
+                    for (Iterator<DFDeploymentStatus> appRefIter = mainStatus.getSubStages(); appRefIter.hasNext();) {
+                        DFDeploymentStatus appRefSubStage = appRefIter.next();
                         String moduleID = appRefSubStage.getStageStatusMessage();
-                        TargetModuleIDImpl targetModuleID =
-                            new TargetModuleIDImpl((TargetImpl)target, moduleID);
+                        TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl) target, moduleID);
                         targetModuleIDList.add(targetModuleID);
                     }
                 } else {
-                /*
-                 * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because listAppRefs does not
-                 * return a ProgressObject which the caller could use to find
-                 * out about the success or failure, we must throw an exception
-                 * so the caller knows about the failure.
-                 */
-                    commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                    commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                    throw (IOException)commandExecutionException;
+                    /*
+                     * We received a response from the server but the status was
+                     * reported as unsuccessful.  Because listAppRefs does not
+                     * return a ProgressObject which the caller could use to find
+                     * out about the success or failure, we must throw an exception
+                     * so the caller knows about the failure.
+                     */
+                    commandExecutionException = new IOException("remote command execution failed on the server");
+                    commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+                    throw (IOException) commandExecutionException;
                 }
             }
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw (IOException)commandExecutionException;
         }
-        TargetModuleIDImpl[] result =
-            new TargetModuleIDImpl[targetModuleIDList.size()];
-        return (TargetModuleIDImpl[]) targetModuleIDList.toArray(result);
+        TargetModuleIDImpl[] result = new TargetModuleIDImpl[targetModuleIDList.size()];
+        return targetModuleIDList.toArray(result);
     }
 
+    @Override
     public TargetModuleID[] _listAppRefs(String[] targets) throws IOException {
         return _listAppRefs(targets, DFDeploymentProperties.ALL);
     }
 
+    @Override
     public TargetModuleID[] _listAppRefs(String[] targets, String state) throws IOException {
         return _listAppRefs(targets, state, null);
     }
 
+    @Override
     public TargetModuleID[] _listAppRefs(String[] targets, String state, String type) throws IOException {
-        Target[] targetImpls = prepareTargets(createTargets(targets));
+        Target[] targetImpls = getTargetServers(createTargets(targets));
         return _listAppRefs(targetImpls, state, type);
     }
 
+    @Override
     public TargetModuleID[] _listAppRefs(Target[] targets, String state, String type) throws IOException {
         ensureConnected();
         String commandName = "_list-app-refs";
         String targetsParam = createTargetsParam(targets);
-        Map commandParams = new HashMap();
+        DFDeploymentProperties commandParams = new DFDeploymentProperties();
         commandParams.put(DFDeploymentProperties.TARGET, targetsParam);
         commandParams.put("state", state);
         if (type != null) {
             commandParams.put("type", type);
         }
         DFDeploymentStatus mainStatus = null;
-        Throwable commandExecutionException = null;
+        IOException commandExecutionException = null;
         try {
             DFCommandRunner commandRunner = getDFCommandRunner(commandName, commandParams, null);
             DFDeploymentStatus ds = commandRunner.run();
             mainStatus = ds.getMainStatus();
-            List<TargetModuleIDImpl> targetModuleIDList =
-                new ArrayList<TargetModuleIDImpl>();
+            List<TargetModuleIDImpl> targetModuleIDList = new ArrayList<>();
 
             if (mainStatus.getStatus() != DFDeploymentStatus.Status.FAILURE) {
                 /*
-                 * There will be one substage for each target.  And within each
+                 * There will be one substage for each target. And within each
                  * of those will be a substage for each module assigned to
                  * that target
                  */
@@ -987,50 +997,44 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
                          * Each substage below the target substage is for
                          * a module deployed to that target.
                          */
-                        for (Iterator appRefIter = mainStatus.getSubStages(); appRefIter.hasNext();) {
-                            DFDeploymentStatus appRefSubStage = (DFDeploymentStatus) appRefIter.next();
+                        for (Iterator<DFDeploymentStatus> appRefIter = mainStatus.getSubStages(); appRefIter.hasNext();) {
+                            DFDeploymentStatus appRefSubStage = appRefIter.next();
                             String moduleID = appRefSubStage.getStageStatusMessage();
                             if (target instanceof TargetImpl) {
-                                TargetModuleIDImpl targetModuleID =
-                                    new TargetModuleIDImpl((TargetImpl)target, moduleID);
+                                TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl) target,
+                                    moduleID);
                                 targetModuleIDList.add(targetModuleID);
                             }
                         }
                     }
                 }
 
-                TargetModuleIDImpl[] result =
-                    new TargetModuleIDImpl[targetModuleIDList.size()];
-                return (TargetModuleIDImpl[]) targetModuleIDList.toArray(result);
+                TargetModuleIDImpl[] result = new TargetModuleIDImpl[targetModuleIDList.size()];
+                return targetModuleIDList.toArray(result);
 
-            } else {
-                /*
-                 * We received a response from the server but the status was
-                 * reported as unsuccessful.  Because listAppRefs does not
-                 * return a ProgressObject which the caller could use to find
-                 * out about the success or failure, we must throw an exception
-                 * so the caller knows about the failure.
-                 */
-                commandExecutionException = new IOException(
-                        "remote command execution failed on the server");
-                commandExecutionException.initCause(
-                        new RuntimeException(mainStatus.getAllStageMessages()));
-                throw (IOException)commandExecutionException;
             }
+            /*
+             * We received a response from the server but the status was
+             * reported as unsuccessful.  Because listAppRefs does not
+             * return a ProgressObject which the caller could use to find
+             * out about the success or failure, we must throw an exception
+             * so the caller knows about the failure.
+             */
+            commandExecutionException = new IOException("remote command execution failed on the server");
+            commandExecutionException.initCause(new RuntimeException(mainStatus.getAllStageMessages()));
+            throw commandExecutionException;
         } catch (Throwable ex) {
             if (commandExecutionException == null) {
                 throw new RuntimeException("error submitting remote command", ex);
-            } else {
-                throw (IOException)commandExecutionException;
             }
+            throw commandExecutionException;
         }
     }
 
-    private Target[] prepareTargets(Target[] targets) {
+    private Target[] getTargetServers(Target[] targets) {
         if (targets == null || targets.length == 0) {
-            targets = new Target[]{targetForDefaultServer()};
+            targets = new Target[] {targetForDefaultServer()};
         }
-
         return targets;
     }
 
@@ -1040,8 +1044,8 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @return Target for the default server
      */
     private Target targetForDefaultServer() {
-        TargetImpl t = new TargetImpl(this, DEFAULT_SERVER_NAME, localStrings.getLocalString("enterprise.deployment.client.default_server_description", "default server"));
-        return t;
+        return new TargetImpl(this, DEFAULT_SERVER_NAME,
+            localStrings.getLocalString("enterprise.deployment.client.default_server_description", "default server"));
     }
 
     /**
@@ -1050,75 +1054,87 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @param moduleID the app
      * @return DFProgressObject for monitoring progress and querying status
      */
+    @Override
     public DFProgressObject undeploy(Target[] targets, String moduleID) {
-        return undeploy(targets, moduleID, new HashMap());
+        return undeploy(targets, moduleID, new DFDeploymentProperties());
     }
 
     /**
      * Undeploys an application from specified targets.
-     * @param targets the targets from which to undeploy the app
+     *
+     * @param origTargets the targets from which to undeploy the app
      * @param moduleID the app
-     * @param undeploymentOptions options to control the undeployment
+     * @param origOptions options to control the undeployment
      * @return DFProgressObject for monitoring progress and querying status
      */
-    public DFProgressObject undeploy(Target[] targets, String moduleID, Map undeploymentOptions) {
+    @Override
+    public DFProgressObject undeploy(final Target[] origTargets, final String moduleID, final Map origOptions) {
+        deplLogger.fine(() -> String.format("undeploy(origTargets=%s, moduleID=%s, origOptions=%s)", //
+            origTargets, moduleID, origOptions));
         ensureConnected();
-        targets = prepareTargets(targets);
+        Target[] targets = getTargetServers(origTargets);
         ProgressObjectImpl po = new ProgressObjectImpl(targets);
-        po.setCommand(CommandType.UNDEPLOY,null);
-        List<TargetModuleIDImpl> targetModuleIDList =
-            new ArrayList<TargetModuleIDImpl>();
+        po.setCommand(CommandType.UNDEPLOY);
+        final DFDeploymentProperties undeploymentOptions = new DFDeploymentProperties();
+        undeploymentOptions.putAll(origOptions);
+        List<TargetModuleIDImpl> targetModuleIDList = new ArrayList<>();
         try {
             if (!isTargetsMatched(moduleID, targets)) {
-                po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.specifyAllTargets", "Application {0} is already deployed on other targets. Please remove all references or specify all targets (or domain target if using asadmin command line) before attempting {1} operation", moduleID, "undeploy"), domain);
+                String message = localStrings.getLocalString("enterprise.deployment.client.specifyAllTargets",
+                    "Application {0} is already deployed on other targets. Please remove all references or specify"
+                    + " all targets (or domain target if using asadmin command line) before attempting {1} operation",
+                    moduleID, "undeploy");
+                po.setupForAbnormalExit(message, domain);
             }
 
-            // first remove the application references from targets except
-            // last one
-            Map deleteAppRefOptions = new HashMap();
+            // first remove the application references from targets
+            DFDeploymentProperties deleteAppRefOptions = new DFDeploymentProperties();
             if (undeploymentOptions.get(DFDeploymentProperties.CASCADE) != null) {
-                deleteAppRefOptions.put(DFDeploymentProperties.CASCADE, undeploymentOptions.get(DFDeploymentProperties.CASCADE));
+                deleteAppRefOptions.put(DFDeploymentProperties.CASCADE,
+                    undeploymentOptions.get(DFDeploymentProperties.CASCADE));
             }
-            for (int i = 0 ; i < targets.length - 1 ; i++) {
-                deleteAppRefOptions.put(DFDeploymentProperties.TARGET, targets[i].getName());
-                DFCommandRunner commandRunner = getDFCommandRunner(
-                    "delete-application-ref", deleteAppRefOptions, new String[] {moduleID});
+            for (Target target : targets) {
+                deleteAppRefOptions.put(DFDeploymentProperties.TARGET, target.getName());
+                DFCommandRunner commandRunner = getDFCommandRunner("delete-application-ref", deleteAppRefOptions,
+                    new String[] {moduleID});
                 DFDeploymentStatus ds = commandRunner.run();
                 DFDeploymentStatus mainStatus = ds.getMainStatus();
-                if (!po.checkStatusAndAddStage((TargetImpl)targets[i], localStrings.getLocalString("enterprise.deployment.client.undeploy_remove_ref", "While undeploying, trying to remove reference for application in target {0}", targets[i].getName()), mainStatus)) {
+                String message = localStrings.getLocalString("enterprise.deployment.client.undeploy_remove_ref",
+                    "While undeploying, trying to remove reference for application in target {0}", target.getName());
+                if (!po.checkStatusAndAddStage((TargetImpl) target, message, mainStatus)) {
                     return po;
-                } else {
-                    TargetModuleIDImpl targetModuleID =
-                       new TargetModuleIDImpl((TargetImpl)targets[i], moduleID);
-                    targetModuleIDList.add(targetModuleID);
                 }
+                TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl((TargetImpl) target, moduleID);
+                targetModuleIDList.add(targetModuleID);
             }
 
-            // then undeploy from last target
-            Target lastTarget = targets[targets.length -1];
-            undeploymentOptions.put(DFDeploymentProperties.TARGET, lastTarget.getName());
-            DFCommandRunner commandRunner2 = getDFCommandRunner(
-                    "undeploy",
-                    undeploymentOptions,
-                    new String[]{moduleID});
+            // then undeploy from domain
+            undeploymentOptions.put(DFDeploymentProperties.TARGET, TARGET_DOMAIN);
+            DFCommandRunner commandRunner2 = getDFCommandRunner("undeploy", undeploymentOptions,
+                new String[] {moduleID});
             DFDeploymentStatus ds2 = commandRunner2.run();
             DFDeploymentStatus mainStatus2 = ds2.getMainStatus();
-            if (!po.checkStatusAndAddStage((TargetImpl)lastTarget, localStrings.getLocalString("enterprise.deployment.client.undeploy_from_target", "Trying to undeploy application from target {0}", lastTarget.getName()), mainStatus2)) {
+            if (!po.checkStatusAndAddStage(domain,
+                localStrings.getLocalString("enterprise.deployment.client.undeploy_from_target",
+                    "Trying to undeploy application from target {0}", domain.getName()),
+                mainStatus2)) {
                 return po;
             }
 
-            TargetModuleIDImpl targetModuleID =
-                new TargetModuleIDImpl((TargetImpl)lastTarget, moduleID);
+            TargetModuleIDImpl targetModuleID = new TargetModuleIDImpl(domain, moduleID);
             targetModuleIDList.add(targetModuleID);
 
-            TargetModuleIDImpl[] targetModuleIDs =
-                new TargetModuleIDImpl[targetModuleIDList.size()];
-            targetModuleIDs = (TargetModuleIDImpl[])targetModuleIDList.toArray(targetModuleIDs);
+            TargetModuleIDImpl[] targetModuleIDs = new TargetModuleIDImpl[targetModuleIDList.size()];
+            targetModuleIDs = targetModuleIDList.toArray(targetModuleIDs);
 
-            po.setupForNormalExit(localStrings.getLocalString("enterprise.deployment.client.undeploy_application", "Undeployment of application {0}", moduleID), (TargetImpl)targets[0], targetModuleIDs);
+            String message = localStrings.getLocalString("enterprise.deployment.client.undeploy_application",
+                "Undeployment of application {0}", moduleID);
+            po.setupForNormalExit(message, (TargetImpl) targets[0], targetModuleIDs);
             return po;
         } catch (Throwable ioex) {
-            po.setupForAbnormalExit(localStrings.getLocalString("enterprise.deployment.client.undeploy_application_failed", "Undeployment failed - {0}", ioex.toString()), (TargetImpl)targets[0]);
+            String msg = localStrings.getLocalString("enterprise.deployment.client.undeploy_application_failed",
+                "Undeployment failed - {0}", ioex.toString());
+            po.setupForAbnormalExit(msg, (TargetImpl) targets[0]);
             return po;
         }
     }
@@ -1130,6 +1146,7 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      *  should be exported.
      *  @return the absolute location to the main jar file.
      */
+    @Override
     public String exportClientStubs(String appName, String destDir)
         throws IOException {
         getClientStubs(destDir, appName);
@@ -1142,15 +1159,17 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
      * @param po DFProgressObject for the operation of interestt
      * @return DFDeploymentStatus final status for the operation
      */
+    @Override
     public DFDeploymentStatus waitFor(DFProgressObject po) {
         return po.waitFor();
     }
 
-
+    @Override
     public String getWebURL(TargetModuleID tmid) {
         return targetModuleWebURLs.get(tmid.getModuleID());
     }
 
+    @Override
     public void setWebURL(TargetModuleID tmid, String webURL) {
         targetModuleWebURLs.put(tmid.getModuleID(), webURL);
     }
@@ -1167,9 +1186,8 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         return result.substring(index+1);
     }
 
-
     private ModuleType getJavaEEModuleTypeFromResult(List<String> resultList) {
-        List<String> sniffersFound = new ArrayList<String>();
+        List<String> sniffersFound = new ArrayList<>();
         for (String result : resultList) {
             if (result.endsWith("property.isComposite=true")) {
                 return ModuleType.EAR;
@@ -1203,31 +1221,13 @@ public abstract class AbstractDeploymentFacility implements DeploymentFacility, 
         return null;
     }
 
-    private String getSuffixFromType(String type) {
-        if (type == null) {
-            return null;
-        }
-        if (type.equals("war")) {
-            return ".war";
-        } else if (type.equals("ejb")) {
-            return ".jar";
-        } else if (type.equals("car")) {
-            return ".car";
-        } else if (type.equals("rar")) {
-            return ".rar";
-        } else if (type.equals("ear")) {
-            return ".ear";
-        }
-        return null;
-    }
-
     private boolean isTargetsMatched(String appName, Target[] targets)
         throws IOException {
         Target[] referencedTargets = listReferencedTargets(appName);
         if (targets.length != referencedTargets.length) {
             return false;
         }
-        List<String> referencedTargetNames = new ArrayList<String>();
+        List<String> referencedTargetNames = new ArrayList<>();
         for (Target target : referencedTargets) {
             referencedTargetNames.add(target.getName());
         }

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/DFDeploymentProperties.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/DFDeploymentProperties.java
@@ -37,10 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] Payara Foundation and/or affiliates
 
 package org.glassfish.deployment.client;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.glassfish.deployment.common.DeploymentUtils;
@@ -51,227 +51,11 @@ import org.glassfish.deployment.common.DeploymentUtils;
  * <p>
  * Heavily inspired by the original from common-utils but copied here to
  * minimize dependencies.
- * 
+ *
  * @author tjquinn
  */
 public class DFDeploymentProperties extends Properties {
 
-//    private Properties deplProps = new Properties();
-    
-    public String getWsdlTargetHint() throws IllegalArgumentException {
-        return getProperty(WSDL_TARGET_HINT, null);
-    }
-    
-    public void setWsdlTargetHint(String target) {
-        if(target != null) {
-            setProperty(WSDL_TARGET_HINT, target);
-        }
-    }
-    
-    public String getTarget() throws IllegalArgumentException {
-        return getProperty(TARGET, null);
-    }
-    
-    public void setTarget(String target) {
-        if (target != null)
-            setProperty(TARGET, target);
-    }
-    
-    public boolean getRedeploy() {
-        return Boolean.valueOf(getProperty(REDEPLOY, DEFAULT_REDEPLOY)).booleanValue();
-    }
-
-    public void setRedeploy(boolean redeploy) {
-        setProperty(REDEPLOY, Boolean.valueOf(redeploy).toString());
-    }
-
-    public boolean getForce() {
-        return Boolean.valueOf(getProperty(FORCE,DEFAULT_FORCE)).booleanValue();
-    }
-    
-    public void setForce(boolean force) {
-        setProperty(FORCE, Boolean.valueOf(force).toString());
-    }
-
-    public boolean getReload() {
-        return Boolean.valueOf(getProperty(RELOAD,DEFAULT_RELOAD)).booleanValue();
-    }
-
-    public void setReload(boolean reload) {
-        setProperty(RELOAD, Boolean.valueOf(reload).toString());
-    }
-
-    public boolean getCascade() {
-        return Boolean.valueOf(getProperty(CASCADE,DEFAULT_CASCADE)).booleanValue();
-    }
-    
-    public void setCascade(boolean cascade) {
-        setProperty(CASCADE, Boolean.valueOf(cascade).toString());
-    }
-    
-    public boolean getPrecompileJSP() {
-        return Boolean.valueOf(getProperty(PRECOMPILE_JSP,DEFAULT_PRECOMPILE_JSP)).booleanValue();
-    }
-    
-    public void setPrecompileJSP(boolean precompileJSP) {
-        setProperty(PRECOMPILE_JSP, Boolean.valueOf(precompileJSP).toString());
-    }
-    
-    public boolean getVerify() {
-        return Boolean.valueOf(getProperty(VERIFY,DEFAULT_VERIFY)).booleanValue();
-    }
-    
-    public void setVerify(boolean verify) {
-        setProperty(VERIFY, Boolean.valueOf(verify).toString());
-    }
-    
-    public String getVirtualServers() {
-        return getProperty(VIRTUAL_SERVERS , DEFAULT_VIRTUAL_SERVERS);
-    }
-    
-    public void setVirtualServers(String virtualServers) {
-        if(virtualServers != null)
-	        setProperty(VIRTUAL_SERVERS, virtualServers);
-    }
-    
-    public boolean getEnabled() {
-        return Boolean.valueOf(getProperty(ENABLED,DEFAULT_ENABLED)).booleanValue();
-    }
-    
-    public void setEnabled(boolean enabled) {
-        setProperty(ENABLED, Boolean.valueOf(enabled).toString());
-    }
-    
-    public String getContextRoot() {
-        return getProperty(CONTEXT_ROOT, null);
-    }
-    
-    public void setContextRoot(String contextRoot) {
-        if(contextRoot != null)
-            setProperty(CONTEXT_ROOT, contextRoot);
-    }
-    
-    public String getName() {
-        return getProperty(NAME);
-    }
-    
-    public void setName(String name) {
-        if(name != null)
-            setProperty(NAME, name);
-    }
-    
-    public String getDescription() {
-        return getProperty(DESCRIPTION, "");
-    }
-
-    public void setDescription(String description) {
-        if(description != null)
-            setProperty(DESCRIPTION, description);
-    }
-
-    public boolean getGenerateRMIStubs() {
-        return Boolean.valueOf(getProperty(GENERATE_RMI_STUBS,DEFAULT_GENERATE_RMI_STUBS)).booleanValue();
-    }
-
-    public void setGenerateRMIStubs(boolean generateRMIStubs ) {
-        setProperty(GENERATE_RMI_STUBS,
-                    Boolean.valueOf(generateRMIStubs).toString());
-    }
-
-    public boolean getAvailabilityEnabled() {
-        return Boolean.valueOf(getProperty(AVAILABILITY_ENABLED,DEFAULT_AVAILABILITY_ENABLED)).booleanValue();
-    }
-
-    public void setAvailabilityEnabled(boolean availabilityEnabled ) {
-        setProperty(AVAILABILITY_ENABLED,
-                    Boolean.valueOf(availabilityEnabled).toString());
-    }
-
-    public boolean getJavaWebStartEnabled() {
-        return Boolean.valueOf(getProperty(DEPLOY_OPTION_JAVA_WEB_START_ENABLED, DEFAULT_JAVA_WEB_START_ENABLED)).booleanValue();
-    }
-    
-    public void setJavaWebStartEnabled(boolean javaWebStartEnabled) {
-        setProperty(DEPLOY_OPTION_JAVA_WEB_START_ENABLED,
-                    Boolean.valueOf(javaWebStartEnabled).toString()); 
-    }
-
-    public String getLibraries() {
-        return getProperty(DEPLOY_OPTION_LIBRARIES, null  );
-    }
-        
-    public void setLibraries(String libraries) {
-        if(libraries != null) {
-            setProperty(DEPLOY_OPTION_LIBRARIES, libraries);
-        }
-    }
-
-    public String getResourceAction() {
-        return getProperty(RESOURCE_ACTION, null );
-    }
-
-    public void setResourceAction(String resourceAction) {
-        if(resourceAction != null) {
-            setProperty(RESOURCE_ACTION, resourceAction);
-        }
-    }
-
-    public String getResourceTargetList() {
-        return getProperty(RESOURCE_TARGET_LIST, null );
-    }
-
-    public void setResourceTargetList(String resTargetList) {
-        if(resTargetList != null) {
-            setProperty(RESOURCE_TARGET_LIST, resTargetList);
-        }
-    }
-
-    public void setUpload(boolean uploadEnabled) {
-        setProperty(UPLOAD, Boolean.toString(uploadEnabled));
-    }
-    
-    public boolean getUpload() {
-        return Boolean.valueOf(getProperty(UPLOAD, DEFAULT_UPLOAD)).booleanValue();
-    }
-
-    public void setExternallyManaged(boolean isExternallyManaged) {
-        setProperty(EXTERNALLY_MANAGED, Boolean.toString(isExternallyManaged));
-    }
-              
-    public void setPath(String path) {
-        setProperty(PATH, path);
-    }
-    
-    public String getPath() {
-        return getProperty(PATH);
-    }
-    public boolean getExternallyManaged() {
-        return Boolean.valueOf(getProperty(EXTERNALLY_MANAGED, DEFAULT_EXTERNALLY_MANAGED)).booleanValue();
-    }
-
-    public void setProperties(Properties props) {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<Object,Object> prop : props.entrySet()) {
-            if (sb.length() > 0) {
-                sb.append(PROPERTY_SEPARATOR);
-            }
-            sb.append(prop.getKey()).append("=").append(prop.getValue());
-        }
-        setProperty(PROPERTY, sb.toString());
-    }
-
-    public Properties getProperties() {
-        Properties result = new Properties();
-        String[] settings = getProperty(PROPERTY).split(PROPERTY_SEPARATOR);
-        for (String setting : settings) {
-            int equals = setting.indexOf('=');
-            if (equals != -1) {
-                result.setProperty(setting.substring(0, equals), setting.substring(equals + 1));
-            }
-        }
-        return result;
-    }
-    
     public static final String WSDL_TARGET_HINT = "wsdlTargetHint";
     public static final String TARGET = "target";
     public static final String REDEPLOY = "redeploy";
@@ -308,7 +92,7 @@ public class DFDeploymentProperties extends Properties {
 
     public static final String PROPERTY = "property";
     private static final String PROPERTY_SEPARATOR = ":";
-    
+
     public static final String DEFAULT_UPLOAD = "true";
     public static final String DEFAULT_EXTERNALLY_MANAGED = "false";
     // resource constants
@@ -322,7 +106,8 @@ public class DFDeploymentProperties extends Properties {
     public static final String RES_UNDEPLOYMENT = "resUndeployment";
     public static final String RES_REDEPLOYMENT = "resRedeployment";
     public static final String RES_NO_OP = "resNoOp";
-    public static final String DEPLOY_OPTION_JAVA_WEB_START_ENABLED = DeploymentUtils.DEPLOYMENT_PROPERTY_JAVA_WEB_START_ENABLED;
+    public static final String DEPLOY_OPTION_JAVA_WEB_START_ENABLED
+                                 = DeploymentUtils.DEPLOYMENT_PROPERTY_JAVA_WEB_START_ENABLED;
     public static final String DEPLOY_OPTION_LIBRARIES = "libraries";
 
     // possible values for module state
@@ -336,22 +121,223 @@ public class DFDeploymentProperties extends Properties {
     public static final String CLASSPATH = "classpath";
     public static final String LOAD_ORDER = "load-order";
     public static final String IS_FAILURE_FATAL = "is-failure-fatal";
-    public static final String IS_LIFECYCLE = "isLifecycle"; 
-    public static final String IS_COMPOSITE = "isComposite"; 
+    public static final String IS_LIFECYCLE = "isLifecycle";
+    public static final String IS_COMPOSITE = "isComposite";
+    public static final String MODULE_EXTENSION = "moduleExtension";
 
-    public Map<String,String> asMap() {
-        return new HashMap<String,String>();
+    public String getWsdlTargetHint() throws IllegalArgumentException {
+        return getProperty(WSDL_TARGET_HINT, null);
     }
-    
-//    private String getProperty(String propertyName, String defaultValue) {
-//        return deplProps.getProperty(propertyName, defaultValue);
-//    }
-//    
-//    private String getProperty(String propertyName) {
-//        return deplProps.getProperty(propertyName);
-//    }
-//    
-//    private void setProperty(String propertyName, String value) {
-//        deplProps.setProperty(propertyName, value);
-//    }
+
+    public void setWsdlTargetHint(String target) {
+        if(target != null) {
+            setProperty(WSDL_TARGET_HINT, target);
+        }
+    }
+
+    public String getTarget() throws IllegalArgumentException {
+        return getProperty(TARGET, null);
+    }
+
+    public void setTarget(String target) {
+        if (target != null) {
+            setProperty(TARGET, target);
+        }
+    }
+
+    public boolean getRedeploy() {
+        return Boolean.parseBoolean(getProperty(REDEPLOY, DEFAULT_REDEPLOY));
+    }
+
+    public void setRedeploy(boolean redeploy) {
+        setProperty(REDEPLOY, Boolean.valueOf(redeploy).toString());
+    }
+
+    public boolean getForce() {
+        return Boolean.parseBoolean(getProperty(FORCE,DEFAULT_FORCE));
+    }
+
+    public void setForce(boolean force) {
+        setProperty(FORCE, Boolean.valueOf(force).toString());
+    }
+
+    public boolean getReload() {
+        return Boolean.parseBoolean(getProperty(RELOAD,DEFAULT_RELOAD));
+    }
+
+    public void setReload(boolean reload) {
+        setProperty(RELOAD, Boolean.valueOf(reload).toString());
+    }
+
+    public boolean getCascade() {
+        return Boolean.parseBoolean(getProperty(CASCADE,DEFAULT_CASCADE));
+    }
+
+    public void setCascade(boolean cascade) {
+        setProperty(CASCADE, Boolean.valueOf(cascade).toString());
+    }
+
+    public boolean getPrecompileJSP() {
+        return Boolean.parseBoolean(getProperty(PRECOMPILE_JSP,DEFAULT_PRECOMPILE_JSP));
+    }
+
+    public void setPrecompileJSP(boolean precompileJSP) {
+        setProperty(PRECOMPILE_JSP, Boolean.valueOf(precompileJSP).toString());
+    }
+
+    public boolean getVerify() {
+        return Boolean.parseBoolean(getProperty(VERIFY,DEFAULT_VERIFY));
+    }
+
+    public void setVerify(boolean verify) {
+        setProperty(VERIFY, Boolean.valueOf(verify).toString());
+    }
+
+    public String getVirtualServers() {
+        return getProperty(VIRTUAL_SERVERS , DEFAULT_VIRTUAL_SERVERS);
+    }
+
+    public void setVirtualServers(String virtualServers) {
+        if(virtualServers != null) {
+            setProperty(VIRTUAL_SERVERS, virtualServers);
+        }
+    }
+
+    public boolean getEnabled() {
+        return Boolean.parseBoolean(getProperty(ENABLED,DEFAULT_ENABLED));
+    }
+
+    public void setEnabled(boolean enabled) {
+        setProperty(ENABLED, Boolean.valueOf(enabled).toString());
+    }
+
+    public String getContextRoot() {
+        return getProperty(CONTEXT_ROOT, null);
+    }
+
+    public void setContextRoot(String contextRoot) {
+        if(contextRoot != null) {
+            setProperty(CONTEXT_ROOT, contextRoot);
+        }
+    }
+
+    public String getName() {
+        return getProperty(NAME);
+    }
+
+    public void setName(String name) {
+        if(name != null) {
+            setProperty(NAME, name);
+        }
+    }
+
+    public String getDescription() {
+        return getProperty(DESCRIPTION, "");
+    }
+
+    public void setDescription(String description) {
+        if(description != null) {
+            setProperty(DESCRIPTION, description);
+        }
+    }
+
+    public boolean getGenerateRMIStubs() {
+        return Boolean.parseBoolean(getProperty(GENERATE_RMI_STUBS,DEFAULT_GENERATE_RMI_STUBS));
+    }
+
+    public void setGenerateRMIStubs(boolean generateRMIStubs) {
+        setProperty(GENERATE_RMI_STUBS, Boolean.valueOf(generateRMIStubs).toString());
+    }
+
+    public boolean getAvailabilityEnabled() {
+        return Boolean.parseBoolean(getProperty(AVAILABILITY_ENABLED,DEFAULT_AVAILABILITY_ENABLED));
+    }
+
+    public void setAvailabilityEnabled(boolean availabilityEnabled) {
+        setProperty(AVAILABILITY_ENABLED, Boolean.valueOf(availabilityEnabled).toString());
+    }
+
+    public boolean getJavaWebStartEnabled() {
+        return Boolean.parseBoolean(getProperty(DEPLOY_OPTION_JAVA_WEB_START_ENABLED, DEFAULT_JAVA_WEB_START_ENABLED));
+    }
+
+    public void setJavaWebStartEnabled(boolean javaWebStartEnabled) {
+        setProperty(DEPLOY_OPTION_JAVA_WEB_START_ENABLED, Boolean.valueOf(javaWebStartEnabled).toString());
+    }
+
+    public String getLibraries() {
+        return getProperty(DEPLOY_OPTION_LIBRARIES, null  );
+    }
+
+    public void setLibraries(String libraries) {
+        if (libraries != null) {
+            setProperty(DEPLOY_OPTION_LIBRARIES, libraries);
+        }
+    }
+
+    public String getResourceAction() {
+        return getProperty(RESOURCE_ACTION, null );
+    }
+
+    public void setResourceAction(String resourceAction) {
+        if(resourceAction != null) {
+            setProperty(RESOURCE_ACTION, resourceAction);
+        }
+    }
+
+    public String getResourceTargetList() {
+        return getProperty(RESOURCE_TARGET_LIST, null );
+    }
+
+    public void setResourceTargetList(String resTargetList) {
+        if(resTargetList != null) {
+            setProperty(RESOURCE_TARGET_LIST, resTargetList);
+        }
+    }
+
+    public void setUpload(boolean uploadEnabled) {
+        setProperty(UPLOAD, Boolean.toString(uploadEnabled));
+    }
+
+    public boolean getUpload() {
+        return Boolean.parseBoolean(getProperty(UPLOAD, DEFAULT_UPLOAD));
+    }
+
+    public void setExternallyManaged(boolean isExternallyManaged) {
+        setProperty(EXTERNALLY_MANAGED, Boolean.toString(isExternallyManaged));
+    }
+
+    public void setPath(String path) {
+        setProperty(PATH, path);
+    }
+
+    public String getPath() {
+        return getProperty(PATH);
+    }
+    public boolean getExternallyManaged() {
+        return Boolean.parseBoolean(getProperty(EXTERNALLY_MANAGED, DEFAULT_EXTERNALLY_MANAGED));
+    }
+
+    public void setProperties(Properties props) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<Object,Object> prop : props.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append(PROPERTY_SEPARATOR);
+            }
+            sb.append(prop.getKey()).append("=").append(prop.getValue());
+        }
+        setProperty(PROPERTY, sb.toString());
+    }
+
+    public Properties getProperties() {
+        Properties result = new Properties();
+        String[] settings = getProperty(PROPERTY).split(PROPERTY_SEPARATOR);
+        for (String setting : settings) {
+            int equals = setting.indexOf('=');
+            if (equals != -1) {
+                result.setProperty(setting.substring(0, equals), setting.substring(equals + 1));
+            }
+        }
+        return result;
+    }
 }

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/DFDeploymentStatus.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/DFDeploymentStatus.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2019] Payara Foundation and/or affiliates
 package org.glassfish.deployment.client;
 
 import java.util.List;
@@ -49,38 +49,40 @@ import java.io.PrintWriter;
 
 /**
  * This class encapsulates all status related to backend deployment
- * Backend deployement can consist of several stages. Those stages 
+ * Backend deployement can consist of several stages. Those stages
  * are organized in a parent/children relationship where the children
  * are the sub stages of a parent stage. For instance, deployment stage
- * consist of j2eec stage and application loading stage. For a stage to 
- * be sucessful, its status and all its children's status  must be warning 
- * or success  
- * 
+ * consist of j2eec stage and application loading stage. For a stage to
+ * be sucessful, its status and all its children's status  must be warning
+ * or success
+ *
  * @author Jerome Dochez
  *
  */
 public class DFDeploymentStatus {
-	/**
-	 * Possible status for a stage or overall deployment status
-         * <p>
-         * Note that ordering from worst to best simplifies comparisons among
-         * Status values.  
-	 */
-        public enum Status {
-            FAILURE,
-            WARNING,
-            SUCCESS,
-            NOTINITIALIZED;
-                    
-            public boolean isWorseThan(Status other) {
-                return (compareTo(other) < 0);
-            }
 
-            public boolean isWorseThanOrEqual(Status other) {
-                return (compareTo(other) <= 0);
-            }
+    /**
+     * Possible status for a stage or overall deployment status
+     * <p>
+     * Note that ordering from worst to best simplifies comparisons among
+     * Status values.
+     */
+    public enum Status {
+        FAILURE,
+        WARNING,
+        SUCCESS,
+        NOTINITIALIZED;
+
+        public boolean isWorseThan(Status other) {
+            return (compareTo(other) < 0);
         }
-        private static final String NEWLINE = System.getProperty("line.separator");
+
+        public boolean isWorseThanOrEqual(Status other) {
+            return (compareTo(other) <= 0);
+        }
+    }
+
+    private static final String NEWLINE = System.getProperty("line.separator");
 
     /*
      * Possible properties for the additional status
@@ -97,34 +99,36 @@ public class DFDeploymentStatus {
     public static final String COUNT              = "NumberOfEntries";
 
 	/**
-	 * instance information : 
-	 * 	- information about this stage
-	 *      - information about sub stages
-	 */	
+	 * instance information :
+	 * <ul>
+	 * <li>information about this stage
+	 * <li>information about sub stages
+	 * </ul>
+	 */
 	private String stageDescription;
 	private Status stageStatus = Status.NOTINITIALIZED;
 	private String stageStatusMessage = "";
 	private Throwable stageException;
-	
-	private List<DFDeploymentStatus> subStages = new ArrayList<DFDeploymentStatus>();
-        private DFDeploymentStatus parent = null;
-        
-        /**
-         * backend deployment can transfer some information back to the 
-         * client process through these properties.
-         */
-        private Map additionalStatus = new Properties();
 
-        // this field is still kept for backward compatibility reason
-        private Properties props=null;
-        
-	
+    private final List<DFDeploymentStatus> subStages = new ArrayList<>();
+    private DFDeploymentStatus parent = null;
+
+    /**
+     * backend deployment can transfer some information back to the
+     * client process through these properties.
+     */
+    private Map additionalStatus = new Properties();
+
+    // this field is still kept for backward compatibility reason
+    private Properties props = null;
+
+
 	/**
 	 *  Creates a new uninitialized DFDeploymentStatus instance
 	 */
 	public DFDeploymentStatus() {
 	}
-	
+
 	/**
 	 * Creates a new uninitialized DFDeploymentStatus instance as a
 	 * sub stage deployment status of the passed DFDeploymentStatus
@@ -136,18 +140,18 @@ public class DFDeploymentStatus {
 		}
 		parent.addSubStage(this);
 	}
-	
+
 	/**
-	 * @return the combined status for the stage and its children, 
+	 * @return the combined status for the stage and its children,
 	 * it will return the lowest status as defined in the constants
 	 */
 	public Status getStatus() {
-		
+
 		Status currentStatus = stageStatus;
-		
+
 		// iterate over all sub stages to get their status
-		for (Iterator stageItr = subStages.iterator();stageItr.hasNext();) {
-			DFDeploymentStatus subStage = (DFDeploymentStatus) stageItr.next();
+		for (Object element : subStages) {
+			DFDeploymentStatus subStage = (DFDeploymentStatus) element;
 			Status subStageStatus= subStage.getStatus();
 			// if the sub stage status is a lower number than our current, something
 			// went horribly wrong in the substage, update ours
@@ -157,41 +161,43 @@ public class DFDeploymentStatus {
 		}
 		return currentStatus;
 	}
-	
+
 	/**
-	 * Add a sub stage to this deployment status 
-	 * @param the sub stage deployment status
+	 * Add a sub stage to this deployment status
+	 * @param subStage the sub stage deployment status
 	 */
-	public void addSubStage(DFDeploymentStatus subStage) {
-		subStages.add(subStage);
-                subStage.setParent(this);
-	}
-	
+    public void addSubStage(DFDeploymentStatus subStage) {
+        subStages.add(subStage);
+        subStage.setParent(this);
+    }
+
 	/**
 	 * Get the list of sub stages for this deployment status
 	 * @return an Iterator for the sub stages
 	 */
-	public Iterator getSubStages() {
+	public Iterator<DFDeploymentStatus> getSubStages() {
 		return subStages.iterator();
 	}
-		
-	/**
-	 *  Set the status for this stage
-	 * @param the status as defined in the constants
-	 */
+
+
+    /**
+     * Set the status for this stage
+     *
+     * @param status the status as defined in the constants
+     */
 	public void setStageStatus(Status status) {
 		stageStatus = status;
 	}
-	
-	/** 
+
+	/**
 	 * @return the status for this stage (ignoring sub stages status)
 	 */
 	public Status getStageStatus() {
 		return stageStatus;
 	}
-	
+
 	/**
-	 * @return the exception if an exception was thrown during 
+	 * @return the exception if an exception was thrown during
 	 *  the execution of the stage
 	 */
 	public Throwable getStageException() {
@@ -205,13 +211,12 @@ public class DFDeploymentStatus {
 		return stageDescription;
 	}
 
-        /**
-         * @return a meaningful i18ned stage description
-         */
-        public String getStageDescription() {
-                return stageDescription;
-        }
-
+    /**
+     * @return a meaningful i18ned stage description
+     */
+    public String getStageDescription() {
+        return stageDescription;
+    }
 
 	/**
 	 * @return a meaningful i18ned reason for failure or warning
@@ -221,7 +226,7 @@ public class DFDeploymentStatus {
 	}
 
 	/**
-	 * When the stage throws an exception, it should store it here in 
+	 * When the stage throws an exception, it should store it here in
 	 * the assiciated deployment status
 	 * @param throwable
 	 */
@@ -248,271 +253,233 @@ public class DFDeploymentStatus {
 	public void setStageStatusMessage(String string) {
 		stageStatusMessage = string;
 	}
-        
-        /** 
-         * @return the current deployment status or one of the sub stage
-         * deployment status with a status equal to the provided level.
-         */
-        public DFDeploymentStatus getStageStatusForLevel(Status level) {
-            if (stageStatus == level) {
-                return this;
-            } else {
-                for (Iterator itr = subStages.iterator();itr.hasNext();) {
-                    DFDeploymentStatus subStage = (DFDeploymentStatus) itr.next();
-                    if (subStage.getStatus()==level) {
-                        return subStage;
-                    }
-                }
-            }
-            return null;
-        }
 
-        /**
-         * @return the parent status for this status if any
-         */
-        public DFDeploymentStatus getParent() {
-            return parent;
-        }
-        
-        /**
-         * Setthe parent status for this status
-         */
-        public void setParent(DFDeploymentStatus parent) {
-            this.parent = parent;
-        }
-        
-        /**
-         * @return the main status for this deployment operation, which is 
-         * the parent of all status in this hierarchy
-         */
-        public DFDeploymentStatus getMainStatus() {
-            if (parent!=null) {
-                return parent.getMainStatus();
-            }
-            // if this is the top level DF, strip the outmost level 
-            // which contains no information
-            Iterator subIter = getSubStages();
-            if (subIter.hasNext()) {
-                DFDeploymentStatus subStage =
-                    (DFDeploymentStatus) subIter.next();
-                if (this.getStageStatus().isWorseThan(
-                    subStage.getStageStatus())) {                
-                    subStage.setStageStatus(this.getStageStatus()); 
-                }
-                return subStage;
-                
-            } 
+
+    /**
+     * @return the current deployment status or one of the sub stage
+     *         deployment status with a status equal to the provided level.
+     */
+    public DFDeploymentStatus getStageStatusForLevel(Status level) {
+        if (stageStatus == level) {
             return this;
         }
-        
-        /**
-         * Add a new property to this status object
-         */
-        public void addProperty(String propertyName, String propertyValue) {
-            additionalStatus.put(propertyName, propertyValue);
-
-            // the name-value pair is also stored in props 
-            // for backward compatibility
-            if (props==null) {
-                props = new Properties();
+        for (Object element : subStages) {
+            DFDeploymentStatus subStage = (DFDeploymentStatus) element;
+            if (subStage.getStatus() == level) {
+                return subStage;
             }
-            props.put(propertyName, propertyValue);
         }
-        
-        /**
-         * @return the value of for property name
-         */
-        public String getProperty(String propertyName) {
-            if (additionalStatus.get(propertyName) != null) {
-                return (String)additionalStatus.get(propertyName);
-            } else {
-            // we also try to retrieve from props 
-            // for backward compatibility
-                if (props==null) {
-                    return null;
+        return null;
+    }
+
+
+    /**
+     * @return the parent status for this status if any
+     */
+    public DFDeploymentStatus getParent() {
+        return parent;
+    }
+
+
+    /**
+     * Setthe parent status for this status
+     */
+    public void setParent(DFDeploymentStatus parent) {
+        this.parent = parent;
+    }
+
+
+    /**
+     * @return the main status for this deployment operation, which is
+     *         the parent of all status in this hierarchy
+     */
+    public DFDeploymentStatus getMainStatus() {
+        if (parent != null) {
+            return parent.getMainStatus();
+        }
+        // if this is the top level DF, strip the outmost level
+        // which contains no information
+        Iterator<DFDeploymentStatus> subIter = getSubStages();
+        if (subIter.hasNext()) {
+            DFDeploymentStatus subStage = subIter.next();
+            if (this.getStageStatus().isWorseThan(subStage.getStageStatus())) {
+                subStage.setStageStatus(this.getStageStatus());
+            }
+            return subStage;
+
+        }
+        return this;
+    }
+
+
+    /**
+     * Add a new property to this status object
+     */
+    public void addProperty(String propertyName, String propertyValue) {
+        additionalStatus.put(propertyName, propertyValue);
+
+        // the name-value pair is also stored in props
+        // for backward compatibility
+        if (props == null) {
+            props = new Properties();
+        }
+        props.put(propertyName, propertyValue);
+    }
+
+
+    /**
+     * @return the value of for property name
+     */
+    public String getProperty(String propertyName) {
+        if (additionalStatus.get(propertyName) != null) {
+            return (String) additionalStatus.get(propertyName);
+        }
+        // we also try to retrieve from props
+        // for backward compatibility
+        if (props == null) {
+            return null;
+        }
+        return props.getProperty(propertyName);
+    }
+
+
+    /**
+     * @return the additional status map
+     */
+    public Map getAdditionalStatus() {
+        return additionalStatus;
+    }
+
+
+    public String getAllStageMessages() {
+        StringBuilder sb = new StringBuilder();
+        getAllStageMessages(this, sb);
+        return sb.toString();
+    }
+
+
+    public static void getAllStageMessages(DFDeploymentStatus status, StringBuilder sb) {
+        sb.append(status.getStageStatusMessage());
+        for (DFDeploymentStatus child : status.subStages) {
+            sb.append(NEWLINE);
+            getAllStageMessages(child, sb);
+        }
+    }
+
+
+    /**
+     * Set the additional status for this status
+     */
+    public void setAdditionalStatus(Map additionalStatus) {
+        this.additionalStatus = additionalStatus;
+    }
+
+
+    /**
+     * @return a meaningful string about mysefl
+     */
+    @Override
+    public String toString() {
+        return "Status " + stageStatus + " message " + stageStatusMessage + " \nException " + stageException;
+    }
+
+
+    /**
+     * Get all stages with this deployment status level
+     *
+     * @param status parent status it needs to iterate through
+     * @param level status level it's looking for
+     * @return an iterator for the stages with the level
+     */
+    public static Iterator<DFDeploymentStatus> getAllStageStatusForLevel(DFDeploymentStatus status, Status level) {
+        List<DFDeploymentStatus> stages = new ArrayList<>();
+        if (status.getStageStatus() == level) {
+            stages.add(status);
+        }
+        // need to iterate through the rest of status hierarchy
+        for (Iterator<DFDeploymentStatus> itr = status.getSubStages(); itr.hasNext();) {
+            DFDeploymentStatus subStage = itr.next();
+            if (subStage.getStageStatus() == level) {
+                stages.add(subStage);
+            }
+            for (Iterator<DFDeploymentStatus> itr2 = subStage.getSubStages(); itr2.hasNext();) {
+                DFDeploymentStatus subStage2 = itr2.next();
+                if (subStage2.getStageStatus() == level) {
+                    stages.add(subStage2);
                 }
-                return props.getProperty(propertyName);
-            }
-        }
 
-        /**
-         * @return the additional status map
-         */
-        public Map getAdditionalStatus() {
-            return additionalStatus;
-        }
-
-        public String getAllStageMessages() {
-            StringBuilder sb = new StringBuilder();
-            getAllStageMessages(this, sb);
-            return sb.toString();
-        }
-        
-        public static void getAllStageMessages(DFDeploymentStatus status, StringBuilder sb) {
-            sb.append(status.getStageStatusMessage());
-            for (DFDeploymentStatus child : status.subStages) {
-                sb.append(NEWLINE);
-                getAllStageMessages(child, sb);
-            }
-        }
-        
-        
-        /**
-         * Set the additional status for this status
-         */
-        public void setAdditionalStatus(Map additionalStatus) {
-            this.additionalStatus = additionalStatus;
-        }
-        
-        /**
-         * @return a meaningful string about mysefl
-         */
-        @Override
-        public String toString() {
-            return "Status " + stageStatus + " message " + stageStatusMessage 
-                + " \nException " + stageException;
-        }
-
-        /**
-         * Get all stages with this deployment status level
-         * @param parent status it needs to iterate through
-         * @param status level it's looking for
-         * @return an iterator for the stages with the level
-         */
-        public static Iterator getAllStageStatusForLevel(
-            DFDeploymentStatus status,
-            Status level) {
-            List stages = new ArrayList();
-            if (status.getStageStatus() == level) {
-                stages.add(status);
-            }
-            // need to iterate through the rest of status hierarchy
-            for (Iterator itr = status.getSubStages();itr.hasNext();) {
-                DFDeploymentStatus subStage = (DFDeploymentStatus) itr.next();
-                if (subStage.getStageStatus() == level) {
-                    stages.add(subStage);
-                }
-                for (Iterator itr2 = subStage.getSubStages();itr2.hasNext();) {
-                    DFDeploymentStatus subStage2 = (DFDeploymentStatus) itr2.next();
-                    if (subStage2.getStageStatus() == level) {
-                        stages.add(subStage2);
-                    }
-
-                    for (Iterator itr3 = subStage2.getSubStages();
-                        itr3.hasNext();) {
-                        DFDeploymentStatus subStage3 = 
-                            (DFDeploymentStatus) itr3.next();
-                        if (subStage3.getStageStatus() == level) {
-                            stages.add(subStage3);
-                        }
-                    }
-                }
-            }
-            return stages.iterator();
-        }
-
-//        /**
-//         * Implement the MapCapable interface so DFDeploymentStatus 
-//         * can be converted back and forth with CompositeData
-//         */
-//        public Map asMap() {
-//            HashMap m = new HashMap();
-//            m.put(MapCapable.MAP_CAPABLE_CLASS_NAME_KEY, com.sun.appserv.management.deploy.DFDeploymentStatus.DEPLOYMENT_STATUS_CLASS_NAME );
-//            m.put(com.sun.appserv.management.deploy.DFDeploymentStatus.STAGE_STATUS_KEY, new Integer(stageStatus));
-//            m.put(com.sun.appserv.management.deploy.DFDeploymentStatus.STAGE_STATUS_MESSAGE_KEY, stageStatusMessage);
-//            m.put(com.sun.appserv.management.deploy.DFDeploymentStatus.STAGE_DESCRIPTION_KEY, stageDescription);
-//            m.put(com.sun.appserv.management.deploy.DFDeploymentStatus.SUB_STAGES_KEY, subStagesToMapList());
-//            m.put(com.sun.appserv.management.deploy.DFDeploymentStatus.STAGE_THROWABLE_KEY, stageException);
-//            m.put(com.sun.appserv.management.deploy.DFDeploymentStatus.ADDITIONAL_STATUS_KEY, additionalStatus);
-//            return( m );
-//
-//        }
-//
-//        /**
-//         * DFDeploymentStatus class may not be available on the client side.
-//         *
-//         * Converts the list of DFDeploymentStatus objects to list of Maps.
-//         * Iterates through the substages list and calls asMap().
-//         */
-//        List subStagesToMapList() {
-//            final List l = new ArrayList(subStages.size());
-//            final Iterator it = subStages.iterator();
-//            while (it.hasNext()) {
-//                final MapCapable mc = (MapCapable)it.next();
-//                l.add(mc.asMap());
-//            }
-//            return l;
-//        }
-//
-//        /**
-//                Return the interface that this Map represents
-//                (the Java classname).
-//         */
-//        public String   getMapClassName() {
-//	    return com.sun.appserv.management.deploy.DFDeploymentStatus.DEPLOYMENT_STATUS_CLASS_NAME;
-//	}
-
-
-        /**
-         * Traverse through the DeploymenStatus hierarchy and 
-         * write failure/warning msgs to the print writer
-         */
-        public static void parseDeploymentStatus(DFDeploymentStatus status, 
-            PrintWriter pw) {
-            if (status != null) {
-                // if it's falure case, print all exceptions
-                if (status.getStatus() == DFDeploymentStatus.Status.FAILURE) {
-                    for (Iterator itr = getAllStageStatusForLevel(status, DFDeploymentStatus.Status.FAILURE); itr.hasNext();) {
-                        DFDeploymentStatus stage = (DFDeploymentStatus) itr.next();
-                        if (stage.getParent() == null) {
-                            // don't print the message from the outmost level
-                            continue;
-                        }
-                        printFailure(pw, stage);
-                    }
-                } 
-
-                // if it's warning case, print all warnings
-                else if (status.getStatus() == DFDeploymentStatus.Status.WARNING) {
-                    for (Iterator itr = getAllStageStatusForLevel(status, DFDeploymentStatus.Status.WARNING); itr.hasNext();) {
-                        DFDeploymentStatus stage = (DFDeploymentStatus) itr.next();
-                        if (stage.getParent() == null) {
-                            // don't print the message from the outmost level
-                            continue;
-                        }
-                        String msg = stage.getStageStatusMessage();
-                        if (msg != null) {
-                            pw.println(msg);
-                        }
+                for (Iterator<DFDeploymentStatus> itr3 = subStage2.getSubStages(); itr3.hasNext();) {
+                    DFDeploymentStatus subStage3 = itr3.next();
+                    if (subStage3.getStageStatus() == level) {
+                        stages.add(subStage3);
                     }
                 }
-                pw.flush();
             }
         }
+        return stages.iterator();
+    }
 
-        /**
-        * Prints the status string and/or status exception
-        * @param pw PrintWriter to which info is printed.
-        * @param status DFDeploymentStatus
-        * @param t Throwable to print
-        */
-        private static void printFailure(PrintWriter pw, 
-            DFDeploymentStatus status) {
-            String msg = status.getStageStatusMessage();
-            Throwable t = status.getStageException();
-            if (msg != null && msg.trim().length() > 0) {
-                pw.println(msg);
-                // only print the exception if it's not the same as the 
-                // the status message 
-                if (t != null && t.getMessage() != null && 
-                    !t.getMessage().equals(msg)) {
-                    pw.println(t.toString());
-                }
-            } else {
-                if (t != null) {
-                    pw.println(t.toString());
+
+    /**
+     * Traverse through the DeploymenStatus hierarchy and
+     * write failure/warning msgs to the print writer
+     */
+    public static void parseDeploymentStatus(DFDeploymentStatus status, PrintWriter pw) {
+        if (status != null) {
+            // if it's falure case, print all exceptions
+            if (status.getStatus() == DFDeploymentStatus.Status.FAILURE) {
+                for (Iterator<DFDeploymentStatus> itr = getAllStageStatusForLevel(status,
+                    DFDeploymentStatus.Status.FAILURE); itr.hasNext();) {
+                    DFDeploymentStatus stage = itr.next();
+                    if (stage.getParent() == null) {
+                        // don't print the message from the outmost level
+                        continue;
+                    }
+                    printFailure(pw, stage);
                 }
             }
-        }
 
+            // if it's warning case, print all warnings
+            else if (status.getStatus() == DFDeploymentStatus.Status.WARNING) {
+                for (Iterator<DFDeploymentStatus> itr = getAllStageStatusForLevel(status,
+                    DFDeploymentStatus.Status.WARNING); itr.hasNext();) {
+                    DFDeploymentStatus stage = itr.next();
+                    if (stage.getParent() == null) {
+                        // don't print the message from the outmost level
+                        continue;
+                    }
+                    String msg = stage.getStageStatusMessage();
+                    if (msg != null) {
+                        pw.println(msg);
+                    }
+                }
+            }
+            pw.flush();
+        }
+    }
+
+
+    /**
+     * Prints the status string and/or status exception
+     *
+     * @param pw PrintWriter to which info is printed.
+     * @param status DFDeploymentStatus
+     * @param t Throwable to print
+     */
+    private static void printFailure(PrintWriter pw, DFDeploymentStatus status) {
+        String msg = status.getStageStatusMessage();
+        Throwable t = status.getStageException();
+        if (msg != null && msg.trim().length() > 0) {
+            pw.println(msg);
+            // only print the exception if it's not the same as the
+            // the status message
+            if (t != null && t.getMessage() != null && !t.getMessage().equals(msg)) {
+                pw.println(t.toString());
+            }
+        } else {
+            if (t != null) {
+                pw.println(t.toString());
+            }
+        }
+    }
 }

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/DeploymentFacility.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/DeploymentFacility.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.deployment.client;
 
@@ -49,13 +50,12 @@ import java.net.URI;
 import javax.enterprise.deploy.shared.ModuleType;
 import javax.enterprise.deploy.spi.Target;
 import javax.enterprise.deploy.spi.TargetModuleID;
-import javax.enterprise.deploy.spi.status.DeploymentStatus;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 
 import com.sun.enterprise.util.HostAndPort;
 
 /**
- * This interface defines basic deployment related facilities 
+ * This interface defines basic deployment related facilities
  * such as deploying any j2ee modules on a Domain Admin Server
  * or target servers as well as retrieving non portable artifacts
  * for successful runs in a client mode configuration.
@@ -64,59 +64,59 @@ import com.sun.enterprise.util.HostAndPort;
  */
 public interface DeploymentFacility {
 
-    final static String STUBS_JARFILENAME = "clientstubs.jar";
-    
+    String STUBS_JARFILENAME = "clientstubs.jar";
+
     /**
-     * Connects to a particular instance of the domain adminstration 
+     * Connects to a particular instance of the domain adminstration
      * server using the provided connection information
      * <p>
      * Most other methods require that connect be invoked first.
      * @param targetDAS the {@link ServerConnectionIdentifier} that specifies which DAS to connect to
      * @return whether or not the connection attempt succeeded
      */
-    
-    public boolean connect(ServerConnectionIdentifier targetDAS);
-    
-    /** 
-     * @return true if we are connected to a domain adminstration 
+
+    boolean connect(ServerConnectionIdentifier targetDAS);
+
+    /**
+     * @return true if we are connected to a domain adminstration
      * server
      */
-    public boolean isConnected();
-    
-    /** 
+    boolean isConnected();
+
+    /**
      * Disconnects from a domain administration server and releases
      * all associated resouces.
      */
-    public boolean disconnect();
-        
+    boolean disconnect();
+
     /**
-     * Initiates a deployment operation on the server, using a source 
-     * archive abstraction and an optional deployment plan if the 
-     * server specific information is not embedded in the source 
-     * archive. The deploymentOptions is a key-value pair map of 
-     * deployment options for this operation. 
+     * Initiates a deployment operation on the server, using a source
+     * archive abstraction and an optional deployment plan if the
+     * server specific information is not embedded in the source
+     * archive. The deploymentOptions is a key-value pair map of
+     * deployment options for this operation.
      * <p>
-     * Once the deployment 
+     * Once the deployment
      * is successful, the TargetModuleID objects representing where the application
      * now resides are available using the {@link DFProgressObject#getResultTargetModuleIDs} method.
-     * 
+     *
      * @param targets the Target objects to which to deploy the application - an empty array indicates a request to deploy to the default server
-     * @param source URI to the Java EE module abstraction (with or without 
-     * the server specific artifacts). 
-     * @param deploymentPlan URI to the optional deployment plan if the source 
+     * @param source URI to the Java EE module abstraction (with or without
+     * the server specific artifacts).
+     * @param deploymentPlan URI to the optional deployment plan if the source
      * archive is portable.
      * @param deploymentOptions deployment options
      * @return a DFProgressObject to receive deployment events and status
      * @throws IllegalStateException if the client has not invoked connect yet
      */
-    public DFProgressObject deploy(Target[] targets, URI source, 
+    DFProgressObject deploy(Target[] targets, URI source,
         URI deploymentPlan, Map deploymentOptions);
-    
-    public DFProgressObject deploy(Target[] targets, ReadableArchive source,
+
+    DFProgressObject deploy(Target[] targets, ReadableArchive source,
         ReadableArchive deploymentPlan, Map deploymentOptions) throws IOException;
 
     // FIXME : This will go once admin-cli changes its code
-    public DFProgressObject undeploy(Target[] targets, String moduleID);
+    DFProgressObject undeploy(Target[] targets, String moduleID);
 
     /**
      * Initiates an undeployment operation of the specified module affecting the selected targets.
@@ -128,144 +128,144 @@ public interface DeploymentFacility {
      * @return a {@link DFProgressObject} to receive undeployment events and completion status
      * @throws IllegalStateException if the deployment facility has not been connected to the back-end
      */
-    public DFProgressObject undeploy(Target[] targets, String moduleID, Map options);
-    
+    DFProgressObject undeploy(Target[] targets, String moduleID, Map options);
+
     /**
      * Enables a deployed component on the provided list of targets.
-     */ 
-    public DFProgressObject enable(Target[] targets, String moduleID);
+     */
+    DFProgressObject enable(Target[] targets, String moduleID);
 
     /**
      * Disables a deployed component on the provided list of targets
      */
-    public DFProgressObject disable(Target[] targets, String moduleID);
-    
+    DFProgressObject disable(Target[] targets, String moduleID);
+
     /**
      * Add an application ref on the selected targets
-     */ 
-    public DFProgressObject createAppRef(Target[] targets, String moduleID, Map options);
+     */
+    DFProgressObject createAppRef(Target[] targets, String moduleID, Map options);
 
     /**
      * remove the application ref for the provided list of targets.
      */
-    public DFProgressObject deleteAppRef(Target[] targets, String moduleID, Map options);    
+    DFProgressObject deleteAppRef(Target[] targets, String moduleID, Map options);
 
     /**
      * get the host and port information
      */
-    public HostAndPort getHostAndPort(String target) throws IOException;
+    HostAndPort getHostAndPort(String target) throws IOException;
 
     /**
      * get the host and port information with security enabled attribute
      */
-    public HostAndPort getHostAndPort(String target, boolean securityEnabled) throws IOException;
+    HostAndPort getHostAndPort(String target, boolean securityEnabled) throws IOException;
 
     /**
      * get the host and port information with the specified virtual server and
      * security enabled attribute
      */
-    public HostAndPort getVirtualServerHostAndPort(String target, String virtualServer, boolean securityEnabled) throws IOException;
+    HostAndPort getVirtualServerHostAndPort(String target, String virtualServer, boolean securityEnabled) throws IOException;
 
    /**
-     * get the host and port information with the specified module id and 
+     * get the host and port information with the specified module id and
      * security enabled attribute
      */
-    public HostAndPort getHostAndPort(String target, String modID, boolean securityEnabled) throws IOException;
+    HostAndPort getHostAndPort(String target, String modID, boolean securityEnabled) throws IOException;
 
    /**
      * list all application refs that are present in the provided list of targets
      */
-    public TargetModuleID[] listAppRefs(String[] targets) throws IOException;
+    TargetModuleID[] listAppRefs(String[] targets) throws IOException;
 
     /**
      * list all application refs that are present in the provided list of targets
      */
-    public TargetModuleID[] _listAppRefs(String[] targets) throws IOException;
+    TargetModuleID[] _listAppRefs(String[] targets) throws IOException;
 
     /**
      * list all application refs that are present in the provided list of targets with the specified state
      */
-    public TargetModuleID[] _listAppRefs(String[] targets, String state) throws IOException;
+    TargetModuleID[] _listAppRefs(String[] targets, String state) throws IOException;
 
     /**
      * list all application refs that are present in the provided list of targets with the specified state and specified type
      */
-    public TargetModuleID[] _listAppRefs(String[] targets, String state, String type) throws IOException;
+    TargetModuleID[] _listAppRefs(String[] targets, String state, String type) throws IOException;
 
     /**
      * list all application refs that are present in the provided list of targets with the specified state and specified type
      */
-    public TargetModuleID[] _listAppRefs(Target[] targets, String state, String type) throws IOException;
+    TargetModuleID[] _listAppRefs(Target[] targets, String state, String type) throws IOException;
 
     /**
      * Get sub module info for ear
      */
-    public List<String> getSubModuleInfoForJ2EEApplication(String appName) throws IOException;
+    List<String> getSubModuleInfoForJ2EEApplication(String appName) throws IOException;
 
     /**
      * Get context root for the module
      */
-    public String getContextRoot(String moduleName) throws IOException;
+    String getContextRoot(String moduleName) throws IOException;
 
     /**
      * Get module type for the module
      */
-   public ModuleType getModuleType(String moduleName) throws IOException;
+   ModuleType getModuleType(String moduleName) throws IOException;
 
     /**
      * list all targets
      */
-    public Target[] listTargets() throws IOException;
+    Target[] listTargets() throws IOException;
 
     /**
      * list the referenced targets for application
      */
-    public Target[] listReferencedTargets(String appName) throws IOException;
+    Target[] listReferencedTargets(String appName) throws IOException;
 
-    
+
     /**
-     * Downloads a particular file from the server repository. 
-     * The filePath is a relative path from the root directory of the 
-     * deployed component identified with the moduleID parameter. 
-     * The resulting downloaded file should be placed in the 
-     * location directory keeping the relative path constraint. 
-     * 
-     * @param location is the root directory where to place the 
+     * Downloads a particular file from the server repository.
+     * The filePath is a relative path from the root directory of the
+     * deployed component identified with the moduleID parameter.
+     * The resulting downloaded file should be placed in the
+     * location directory keeping the relative path constraint.
+     *
+     * @param location is the root directory where to place the
      * downloaded file
-     * @param moduleID is the moduleID of the deployed component 
+     * @param moduleID is the moduleID of the deployed component
      * to download the file from
-     * @param moduleURI is the relative path to the file in the repository 
+     * @param moduleURI is the relative path to the file in the repository
      * or STUBS_JARFILENAME to download the appclient jar file.
      * @return the downloaded local file absolute path.
      */
-    public String downloadFile(File location, String moduleID, 
+    String downloadFile(File location, String moduleID,
             String moduleURI) throws IOException;
-    
+
     /**
      * Downloads the client stubs from the server repository.
      *
-     * @param location is the root path where to place the 
+     * @param location is the root path where to place the
      * downloaded stubs
      * @param moduleID is the moduleID of the deployed component
      * to download the stubs for
      */
-    public void getClientStubs(String location, String moduleID) 
+    void getClientStubs(String location, String moduleID)
         throws IOException;
 
     /**
-     * Wait for a progress object to be in a completed state 
-     * (sucessful or failed) and return the DeploymentStatus for 
+     * Wait for a progress object to be in a completed state
+     * (sucessful or failed) and return the DeploymentStatus for
      * this progress object.
      * @param the progress object to wait for completion
      * @return the deployment status
      */
-    public DFDeploymentStatus waitFor(DFProgressObject po);
-    
+    DFDeploymentStatus waitFor(DFProgressObject po);
+
     /**
      * Creates an array of Target objects corresponding to the list of target names.
      * @param targets the names of the targets of interest
      * @return an array of Target objects for the selected target names
      */
-    public Target[] createTargets(String[] targets );
-    
+    Target[] createTargets(String[] targets );
+
 }

--- a/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/TargetOwner.java
+++ b/appserver/deployment/client/src/main/java/org/glassfish/deployment/client/TargetOwner.java
@@ -37,12 +37,12 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.deployment.client;
 
 import javax.enterprise.deploy.spi.Target;
 import javax.enterprise.deploy.spi.TargetModuleID;
-import javax.enterprise.deploy.spi.status.ClientConfiguration;
 
 import java.io.IOException;
 
@@ -56,7 +56,7 @@ import java.io.IOException;
  * <p>
  * Fully-formed Target objects will have links back to their respective TargetOwner
  * objects.
- * 
+ *
  * @author tjquinn
  */
 public interface TargetOwner {
@@ -66,22 +66,22 @@ public interface TargetOwner {
      * @param name the name of the Target to be returned
      * @return a new Target
      */
-    public Target createTarget(String name);
-    
+    Target createTarget(String name);
+
     /**
      * Creates several {@link Target} objects with the specified names.
      * @param names the names of the targets to be returned
      * @return new Targets, one for each name specified
      */
-    public Target[] createTargets(String[] names);
-    
+    Target[] createTargets(String[] names);
+
     /**
      * Returns the Web URL for the specified module on the {@link Target}
      * implied by the TargetModuleID.
      * @param tmid
      * @return web url
      */
-    public String getWebURL(TargetModuleID tmid);
+    String getWebURL(TargetModuleID tmid);
 
     /**
      * Sets the Web URL for the specified module on the {@link Target} implied
@@ -90,7 +90,7 @@ public interface TargetOwner {
      * @param tmid
      * @param the URL
      */
-    public void setWebURL(TargetModuleID tmid, String webURL);
+    void setWebURL(TargetModuleID tmid, String webURL);
 
     /**
      *  Exports the Client stub jars to the given location.
@@ -99,6 +99,6 @@ public interface TargetOwner {
      *  should be exported.
      *  @return the absolute location to the main jar file.
      */
-    public String exportClientStubs(String appName, String destDir) 
+    String exportClientStubs(String appName, String destDir)
         throws IOException;
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -171,7 +171,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     public enum ContainerType {
         STATELESS, STATEFUL, SINGLETON, MESSAGE_DRIVEN, ENTITY, READ_ONLY
-    };
+    }
 
     protected static final Logger _logger  = LogFacade.getLogger();
 
@@ -243,7 +243,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected ContainerType containerType;
 
-    private RequestTracingService requestTracing;
+    private final RequestTracingService requestTracing;
 
     // constants for EJB(Local)Home/EJB(Local)Object methods,
     // used in authorizeRemoteMethod and authorizeLocalMethod
@@ -436,7 +436,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     // Holds information such as remote reference factory that are associated
     // with a particular remote business interface
     protected Map<String, RemoteBusinessIntfInfo> remoteBusinessIntfInfo
-        = new HashMap<String, RemoteBusinessIntfInfo>();
+        = new HashMap<>();
 
     //
     // END -- Data members for Remote views
@@ -482,7 +482,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     private static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(BaseContainer.class);
 
-    private ThreadLocal threadLocalContext = new ThreadLocal();
+    private final ThreadLocal threadLocalContext = new ThreadLocal();
 
     protected static final int CONTAINER_INITIALIZING = -1;
     protected static final int CONTAINER_STARTED = 0;
@@ -507,7 +507,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected ContainerInfo                 containerInfo;
 
-    private String _debugDescription;
+    private final String _debugDescription;
 
     //protected Agent callFlowAgent;
 
@@ -515,7 +515,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected InterceptorManager interceptorManager;
 
-    private Set<Object> pendingInterceptors = new HashSet<>();
+    private final Set<Object> pendingInterceptors = new HashSet<>();
 
     // the order must be the same as CallbackType and getPre30LifecycleMethodNames
     private static final Class[] lifecycleCallbackAnnotationClasses = {
@@ -524,7 +524,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         PrePassivate.class, PostActivate.class
     };
 
-    private Set<Class> monitoredGeneratedClasses = new HashSet<Class>();
+    private final Set<Class> monitoredGeneratedClasses = new HashSet<>();
 
     protected InvocationManager invocationManager;
 
@@ -542,14 +542,14 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected EjbOptionalIntfGenerator optIntfClassLoader;
 
-    private Set<String> publishedPortableGlobalJndiNames = new HashSet<String>();
+    private final Set<String> publishedPortableGlobalJndiNames = new HashSet<>();
 
-    private Set<String> publishedNonPortableGlobalJndiNames = new HashSet<String>();
+    private final Set<String> publishedNonPortableGlobalJndiNames = new HashSet<>();
 
-    private Set<String> publishedInternalGlobalJndiNames = new HashSet<String>();
+    private final Set<String> publishedInternalGlobalJndiNames = new HashSet<>();
 
 
-    private Map<String, JndiInfo> jndiInfoMap = new HashMap<String, JndiInfo>();
+    private final Map<String, JndiInfo> jndiInfoMap = new HashMap<>();
 
     private String optIntfClassName;
 
@@ -743,7 +743,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                 this.optIntfClassName = EJBUtils.getGeneratedOptionalInterfaceName(ejbClass.getName());
                 optIntfClassLoader = new EjbOptionalIntfGenerator(loader);
-                ((EjbOptionalIntfGenerator) optIntfClassLoader).generateOptionalLocalInterface(ejbClass, optIntfClassName);
+                optIntfClassLoader.generateOptionalLocalInterface(ejbClass, optIntfClassName);
                 ejbGeneratedOptionalLocalBusinessIntfClass = optIntfClassLoader.loadClass(optIntfClassName);
             }
 
@@ -945,10 +945,12 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 this, ejbDescriptor, compType);
     }
 
+    @Override
     public String toString() {
 	return _debugDescription;
     }
 
+    @Override
     public final void setStartedState() {
 
         if ( containerState == CONTAINER_STARTED ) {
@@ -997,6 +999,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         }
     }
 
+    @Override
     public final void setStoppedState() {
         containerState = CONTAINER_STOPPED;
     }
@@ -1005,6 +1008,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return containerState == CONTAINER_STOPPED;
     }
 
+    @Override
     public final void setUndeployedState() {
         containerState = CONTAINER_UNDEPLOYED;
     }
@@ -1013,30 +1017,37 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 	    return (containerState == CONTAINER_UNDEPLOYED);
     }
 
+    @Override
     public final boolean isTimedObject() {
         return isTimedObject_;
     }
 
+    @Override
     public final boolean isLocalObject() {
         return isLocal;
     }
 
+    @Override
     public final boolean isRemoteObject() {
         return isRemote;
     }
 
+    @Override
     public final ClassLoader getContainerClassLoader() {
         return loader;
     }
 
+    @Override
     public final ClassLoader getClassLoader() {
         return loader;
     }
 
+    @Override
     public final String getUseThreadPoolId() {
         return ejbDescriptor.getIASEjbExtraDescriptors().getUseThreadPoolId();
     }
 
+    @Override
     public final boolean getPassByReference() {
         return ejbDescriptor.getIASEjbExtraDescriptors().getPassByReference();
     }
@@ -1049,6 +1060,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return ejbDescriptor.getApplication().getUniqueId();
     }
 
+    @Override
     public final EjbDescriptor getEjbDescriptor() {
         return ejbDescriptor;
     }
@@ -1056,10 +1068,12 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     /**
      * Method defined on JavaEEContainer
      */
+    @Override
     public final Descriptor getDescriptor() {
         return getEjbDescriptor();
     }
 
+    @Override
     public final EJBMetaData getEJBMetaData() {
         return metadata;
     }
@@ -1078,6 +1092,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * the first check and this method covers the second.  It is called
      * by the UserTransaction implementation to verify access.
      */
+    @Override
     public boolean userTransactionMethodsAllowed(ComponentInvocation inv) {
         // Overridden by containers that allowed BMT;
         return false;
@@ -1087,6 +1102,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return ejbHomeStub;
     }
 
+    @Override
     public final EJBHome getEJBHome() {
         return ejbHome;
     }
@@ -1121,6 +1137,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return ejbClass;
     }
 
+    @Override
     public final SecurityManager getSecurityManager() {
         return securityManager;
     }
@@ -1151,6 +1168,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             } else {
                 java.security.AccessController.doPrivileged(
                         new java.security.PrivilegedAction() {
+                    @Override
                     public java.lang.Object run() {
                         currentThread.setContextClassLoader(myClassLoader);
                         return null;
@@ -1176,6 +1194,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             } else {
                 java.security.AccessController.doPrivileged(
                         new java.security.PrivilegedAction() {
+                    @Override
                     public java.lang.Object run() {
                         currentThread.setContextClassLoader(previousClassLoader);
                         return null;
@@ -1245,7 +1264,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
 
             invocationHandler.setContainer(this);
-            Object servant = (Object) Proxy.newProxyInstance
+            Object servant = Proxy.newProxyInstance
                     (loader, new Class[] { serviceEndpointIntfClass },
                     invocationHandler);
 
@@ -1270,7 +1289,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             }
         }
 
-        Map<String, Object> intfsForPortableJndi = new HashMap<String, Object>();
+        Map<String, Object> intfsForPortableJndi = new HashMap<>();
 
         // Root of portable global JNDI name for this bean
         String javaGlobalName = getJavaGlobalJndiNamePrefix();
@@ -1563,7 +1582,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
             if (hasOptionalLocalBusinessView) {
                 EJBLocalHomeImpl obj = instantiateEJBOptionalLocalBusinessHomeImpl();
-                ejbOptionalLocalBusinessHomeImpl = (EJBLocalHomeImpl) obj;
+                ejbOptionalLocalBusinessHomeImpl = obj;
 
                 ejbOptionalLocalBusinessHome = (GenericEJBLocalHome)
                     ejbOptionalLocalBusinessHomeImpl.getEJBLocalHome();
@@ -1864,6 +1883,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * Called from the ProtocolManager when a remote invocation arrives.
      * @exception NoSuchObjectLocalException if the target object does not exist
      */
+    @Override
     public java.rmi.Remote getTargetObject(byte[] instanceKey,
                                           String generatedRemoteBusinessIntf) {
 
@@ -1902,10 +1922,12 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * Release the EJBObject/EJBHome object.
      * Called from the ProtocolManager after a remote invocation completes.
      */
+    @Override
     public void releaseTargetObject(java.rmi.Remote remoteObj) {
         externalPostInvoke();
     }
 
+    @Override
     public void externalPreInvoke() {
         BeanContext bc = new BeanContext();
         final Thread currentThread = Thread.currentThread();
@@ -1917,7 +1939,8 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 	    } else {
 	        java.security.AccessController.doPrivileged(
 			      new java.security.PrivilegedAction() {
-		                  public java.lang.Object run() {
+		                  @Override
+                        public java.lang.Object run() {
 				      currentThread.setContextClassLoader( getClassLoader());
 				      return null;
 				  }
@@ -1936,6 +1959,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         beanContextStack.push(bc);
     }
 
+    @Override
     public void externalPostInvoke() {
         try {
           ArrayDeque beanContextStack =
@@ -1948,7 +1972,8 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 		        } else {
 		            java.security.AccessController.doPrivileged(
 				        new java.security.PrivilegedAction() {
-		                      public java.lang.Object run() {
+		                      @Override
+                            public java.lang.Object run() {
 					  Thread.currentThread().setContextClassLoader(
 								    bc.previousClassLoader);
 					  return null;
@@ -1992,6 +2017,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * }
      *
      */
+    @Override
     public void preInvoke(EjbInvocation inv) {
 
         if ( _logger.isLoggable(Level.FINE) ) {
@@ -2098,12 +2124,14 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     /**
      * Containers that allow extended EntityManager will override this method.
      */
+    @Override
     public EntityManager lookupExtendedEntityManager(EntityManagerFactory emf) {
         throw new IllegalStateException(localStrings.getLocalString(
             "ejb.extended_persistence_context_not_supported",
             "EntityManager with PersistenceContextType.EXTENDED is not supported for this bean type"));
     }
 
+    @Override
     public void webServicePostInvoke(EjbInvocation inv) {
         // postInvokeTx is handled by WebServiceInvocationHandler.
         // Invoke postInvoke with instructions to skip tx processing portion.
@@ -2113,6 +2141,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     /**
      * Called from EJBObject/EJBHome after invoking on bean.
      */
+    @Override
     public void postInvoke(EjbInvocation inv) {
         postInvoke(inv, true);
     }
@@ -2148,10 +2177,11 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 }
             } catch (Exception ex) {
                 _logger.log(Level.FINE, "Exception occurred in postInvokeTx  : [{0}]", ex);
-                if (ex instanceof EJBException)
-                    inv.exception = (EJBException) ex;
-                else
+                if (ex instanceof EJBException) {
+                    inv.exception = ex;
+                } else {
                     inv.exception = new EJBException(ex);
+                }
             }
             releaseContext(inv);
         }
@@ -2257,14 +2287,16 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         if ( !authorize(inv) ) {
             // TODO see note above about additional special exception handling needed
             Throwable t = mapRemoteException(inv);
-            if ( t instanceof RuntimeException )
+            if ( t instanceof RuntimeException ) {
                 throw (RuntimeException)t;
-            else if ( t instanceof RemoteException )
+            } else if ( t instanceof RemoteException ) {
                 throw (RemoteException)t;
-            else
+            }
+            else {
                 throw new AccessException(localStrings.getLocalString(
                     "ejb.client_not_authorized",
                     "Client not authorized for this invocation")); // throw the AccessException
+            }
         }
     }
 
@@ -2307,6 +2339,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             } else {
                 java.security.AccessController.doPrivileged(
                         new java.security.PrivilegedExceptionAction() {
+                    @Override
                     public java.lang.Object run() throws Exception {
                         if ( !ejbTimeoutAccessible.isAccessible() ) {
                             ejbTimeoutAccessible.setAccessible(true);
@@ -2431,6 +2464,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     /**
      * Common code to handle EJB security manager authorization call.
      */
+    @Override
     public boolean authorize(EjbInvocation inv) {
 
         // There are a few paths (e.g. authorizeLocalMethod,
@@ -2711,32 +2745,38 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return null;
     }
     // default implementation
+    @Override
     public void removeBeanUnchecked(Object pkey) {
         assertSupportedOption("removeBeanUnchecked");
     }
 
     // default implementation
+    @Override
     public void removeBeanUnchecked(EJBLocalObject bean) {
         assertSupportedOption("removeBeanUnchecked");
     }
 
+    @Override
     public void preSelect() {
         assertSupportedOption("preSelect");
     }
 
     // default implementation
+    @Override
     public EJBLocalObject getEJBLocalObjectForPrimaryKey(Object pkey, EJBContext ctx) {
         assertSupportedOption("getEJBLocalObjectForPrimaryKey(pkey, ctx)");
         return null;
     }
 
     // default implementation
+    @Override
     public EJBLocalObject getEJBLocalObjectForPrimaryKey(Object pkey) {
         assertSupportedOption("getEJBLocalObjectForPrimaryKey");
         return null;
     }
 
     // default implementation
+    @Override
     public EJBObject getEJBObjectForPrimaryKey(Object pkey) {
         assertSupportedOption("getEJBObjectForPrimaryKey");
         return null;
@@ -2761,6 +2801,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * Called-back from security implementation through EjbInvocation
      * when a jacc policy provider wants an enterprise bean instance.
      */
+    @Override
     public Object getJaccEjb(EjbInvocation inv) {
         Object bean = null;
 
@@ -2810,6 +2851,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return bean;
     }
 
+    @Override
     public void assertValidLocalObject(Object o) throws EJBException
     {
         boolean valid = false;
@@ -2850,6 +2892,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * Asserts validity of RemoteHome objects.  This was defined for the
      * J2EE 1.4 implementation and is exposed through Container SPI.
      */
+    @Override
     public void assertValidRemoteObject(Object o) throws EJBException
     {
         boolean valid = false;
@@ -3484,7 +3527,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         return new String[] {
             null, "ejbCreate", "ejbRemove", "ejbPassivate", "ejbActivate"
         };
-    };
+    }
 
     private synchronized void initializeInterceptorManager() throws Exception {
         this.interceptorManager = new InterceptorManager(_logger, this,
@@ -3532,16 +3575,14 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             if ( hasRemoteHomeView ) {
                 // Process Remote intf
                 Method[] methods = remoteIntf.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_REMOTE,
                                       remoteIntf);
                 }
 
                 // Process EJBHome intf
                 methods = homeIntf.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_HOME,
                                       homeIntf);
                 }
@@ -3555,8 +3596,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                     // actual business interface as original interface.
                     Method[] methods =
                         next.generatedRemoteIntf.getMethods();
-                    for ( int i=0; i<methods.length; i++ ) {
-                        Method method = methods[i];
+                    for (Method method : methods) {
                         addInvocationInfo(method,
                                           MethodDescriptor.EJB_REMOTE,
                                           next.remoteBusinessIntf);
@@ -3565,8 +3605,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                 // Process internal EJB RemoteBusinessHome intf
                 Method[] methods = remoteBusinessHomeIntf.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_HOME,
                                       remoteBusinessHomeIntf);
                 }
@@ -3577,8 +3616,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             if ( hasLocalHomeView ) {
                 // Process Local interface
                 Method[] methods = localIntf.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     InvocationInfo info = addInvocationInfo(method, MethodDescriptor.EJB_LOCAL,
                                       localIntf);
                     postProcessInvocationInfo(info);
@@ -3586,8 +3624,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                 // Process LocalHome interface
                 methods = localHomeIntf.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method,
                                       MethodDescriptor.EJB_LOCALHOME,
                                       localHomeIntf);
@@ -3599,8 +3636,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 // Process Local Business interfaces
                 for(Class localBusinessIntf : localBusinessIntfs) {
                     Method[] methods = localBusinessIntf.getMethods();
-                    for ( int i=0; i<methods.length; i++ ) {
-                        Method method = methods[i];
+                    for (Method method : methods) {
                         addInvocationInfo(method,
                                           MethodDescriptor.EJB_LOCAL,
                                           localBusinessIntf);
@@ -3609,8 +3645,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                 // Process (internal) Local Business Home interface
                 Method[] methods = localBusinessHomeIntf.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method,
                                       MethodDescriptor.EJB_LOCALHOME,
                                       localBusinessHomeIntf);
@@ -3623,8 +3658,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 String optClassName = EJBUtils.getGeneratedOptionalInterfaceName(ejbClass.getName());
                 ejbGeneratedOptionalLocalBusinessIntfClass = optIntfClassLoader.loadClass(optClassName);
                 Method[] methods = ejbGeneratedOptionalLocalBusinessIntfClass.getMethods();
-                for ( int i=0; i<methods.length; i++ ) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method,
                                       MethodDescriptor.EJB_LOCAL,
                                       ejbGeneratedOptionalLocalBusinessIntfClass,
@@ -3633,8 +3667,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                 // Process generated Optional Local Business interface
                 Method[] optHomeMethods = ejbOptionalLocalBusinessHomeIntf.getMethods();
-                for ( int i=0; i<optHomeMethods.length; i++ ) {
-                    Method method = optHomeMethods[i];
+                for (Method method : optHomeMethods) {
                     addInvocationInfo(method,
                                       MethodDescriptor.EJB_LOCALHOME,
                                       ejbOptionalLocalBusinessHomeIntf);
@@ -3659,8 +3692,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         if ( isWebServiceEndpoint ) {
             // Process Service Endpoint interface
             Method[] methods = webServiceEndpointIntf.getMethods();
-            for ( int i=0; i<methods.length; i++ ) {
-                Method method = methods[i];
+            for (Method method : methods) {
                 addInvocationInfo(method,MethodDescriptor.EJB_WEB_SERVICE,
                                   webServiceEndpointIntf);
             }
@@ -3960,7 +3992,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
         String beanSubClassName = ejbGeneratedOptionalLocalBusinessIntfClass.getName() + "__Bean__";
 
-        ((EjbOptionalIntfGenerator) optIntfClassLoader).generateOptionalLocalInterfaceSubClass(
+        optIntfClassLoader.generateOptionalLocalInterfaceSubClass(
                 ejbClass, beanSubClassName, ejbGeneratedOptionalLocalBusinessIntfClass);
 
         optIntfClassLoader.loadClass(ejbGeneratedOptionalLocalBusinessIntfClass.getName());
@@ -4048,6 +4080,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     }
 
     // default implementation
+    @Override
     public void postCreate(EjbInvocation inv, Object primaryKey)
         throws CreateException
     {
@@ -4055,6 +4088,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     }
 
     // default implementation
+    @Override
     public Object postFind(EjbInvocation inv, Object primaryKeys,
         Object[] findParams)
         throws FinderException
@@ -4083,6 +4117,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     /**
      * Called from NamingManagerImpl during java:comp/env lookup.
      */
+    @Override
     public String getComponentId() {
         return componentId;
     }
@@ -4302,8 +4337,9 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     }
 
     private void enteringEjbContainer() {
-        if (interceptors == null)
+        if (interceptors == null) {
             return;
+        }
         for(EjbContainerInterceptor interceptor:interceptors) {
             try{
                 interceptor.preInvoke(ejbDescriptor);
@@ -4314,8 +4350,9 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     }
 
     private void leavingEjbContainer() {
-        if (interceptors == null)
+        if (interceptors == null) {
             return;
+        }
         for(EjbContainerInterceptor interceptor:interceptors) {
             try{
                 interceptor.postInvoke(ejbDescriptor);
@@ -4429,6 +4466,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * calls for the same container instance.
      *
      */
+    @Override
     public final void undeploy() {
 
         try {
@@ -4466,6 +4504,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * the same. We must be able to gracefully handle redundant
      * shutdown calls for the same container instance.
      */
+    @Override
     public final void onShutdown() {
 
         try {
@@ -4557,6 +4596,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             } else {
                 java.security.AccessController.doPrivileged(
                         new java.security.PrivilegedAction() {
+                    @Override
                     public java.lang.Object run() {
                         currentThread.setContextClassLoader(loader);
                         return null;
@@ -4631,6 +4671,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             } else {
                 java.security.AccessController.doPrivileged(
                         new java.security.PrivilegedAction() {
+                    @Override
                     public java.lang.Object run() {
                         currentThread.setContextClassLoader(previousClassLoader);
                         return null;
@@ -4678,6 +4719,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     /**
      * Called when server instance is Ready
      */
+    @Override
     public void onReady() {}
 
 
@@ -4685,6 +4727,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
      * Called when server instance is terminating. This method is the last
      * one called during server shutdown.
      */
+    @Override
     public void onTermination() {}
 
 
@@ -4774,6 +4817,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     // Implementation of Container method.
     // Called from UserTransactionImpl after the EJB started a Tx,
     // for TX_BEAN_MANAGED EJBs only.
+    @Override
     public final void doAfterBegin(ComponentInvocation ci) {
         EjbInvocation inv = (EjbInvocation)ci;
         try {
@@ -5051,7 +5095,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     protected String[] getMonitoringMethodsArray(boolean hasGeneratedClasses) {
         String[] method_sigs = null;
         if (hasGeneratedClasses) {
-            List<String> methodList = new ArrayList<String>();
+            List<String> methodList = new ArrayList<>();
             for (Class clz : monitoredGeneratedClasses) {
                 for (Method m : clz.getDeclaredMethods()) {
                     methodList.add(EjbMonitoringUtils.stringify(m));
@@ -5263,22 +5307,27 @@ final class CallFlowInfoImpl
         this.componentType = compType;
     }
 
+    @Override
     public String getApplicationName() {
         return appName;
     }
 
+    @Override
     public String getModuleName() {
         return modName;
     }
 
+    @Override
     public String getComponentName() {
         return ejbName;
     }
 
+    @Override
     public ComponentType getComponentType() {
         return componentType;
     }
 
+    @Override
     public java.lang.reflect.Method getMethod() {
         EjbInvocation inv = (EjbInvocation)
             EjbContainerUtilImpl.getInstance().getCurrentInvocation();
@@ -5286,6 +5335,7 @@ final class CallFlowInfoImpl
         return inv.method;
     }
 
+    @Override
     public String getTransactionId() {
         JavaEETransaction tx = null;
         try {
@@ -5299,6 +5349,7 @@ final class CallFlowInfoImpl
         return (tx == null) ? null : ""+tx; //TODO tx.getTransactionId();
     }
 
+    @Override
     public String getCallerPrincipal() {
         java.security.Principal principal =
                 container.getSecurityManager().getCallerPrincipal();
@@ -5306,6 +5357,7 @@ final class CallFlowInfoImpl
         return (principal != null) ? principal.getName() : null;
     }
 
+    @Override
     public Throwable getException() {
         return ((EjbInvocation) EjbContainerUtilImpl.getInstance().getCurrentInvocation()).exception;
     }
@@ -5328,18 +5380,23 @@ final class SafeProperties extends Properties {
     	"Environment properties cannot be modified";
     private static final String ejb10Prefix = "ejb10-properties/";
 
+    @Override
     public void load(java.io.InputStream inStream) {
         throw new RuntimeException(errstr);
     }
+    @Override
     public Object put(Object key, Object value) {
         throw new RuntimeException(errstr);
     }
+    @Override
     public void putAll(Map t) {
         throw new RuntimeException(errstr);
     }
+    @Override
     public Object remove(Object key) {
         throw new RuntimeException(errstr);
     }
+    @Override
     public void clear() {
         throw new RuntimeException(errstr);
     }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/EJBSecurityManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/EJBSecurityManager.java
@@ -112,7 +112,6 @@ public final class EJBSecurityManager implements SecurityManager {
     // contextId id is the same as an appname. This will be used to get
     // a PolicyConfiguration object per application.
     private String contextId;
-    private String codebase;
     private CodeSource codesource;
     private String realmName;
 
@@ -627,10 +626,8 @@ public final class EJBSecurityManager implements SecurityManager {
             }
         }
 
-        if (_logger.isLoggable(Level.FINE)) {
-            _logger.fine("JACC: Context id (id under which all EJB's in application will be created) = " + contextId);
-            _logger.fine("Codebase (module id for ejb " + ejbName + ") = " + codebase);
-        }
+        _logger.fine(() -> "JACC: EJB name = '" + ejbName
+            + "'. Context id (id under which all EJB's in application will be created) = '" + contextId + "'");
         loadPolicyConfiguration(deploymentDescriptor);
         // translate the deployment descriptor to populate the role-ref permission cache
         // addEJBRoleReferenceToCache(deploymentDescriptor);
@@ -692,10 +689,11 @@ public final class EJBSecurityManager implements SecurityManager {
                 StringBuilder pBuf = null;
                 principals = (Principal[]) principalSet.toArray(new Principal[principalSet.size()]);
                 for (int i = 0; i < principals.length; i++) {
-                    if (i == 0)
+                    if (i == 0) {
                         pBuf = new StringBuilder(principals[i].toString());
-                    else
+                    } else {
                         pBuf.append(" " + principals[i].toString());
+                    }
                 }
                 _logger.fine("JACC: returning cached ProtectionDomain - CodeSource: (" + cs + ") PrincipalSet: " + pBuf);
             }

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/notifier/DatadogMonitoringNotifierConfigurer.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/admin/notifier/DatadogMonitoringNotifierConfigurer.java
@@ -41,7 +41,7 @@ package fish.payara.jmx.monitoring.admin.notifier;
 
 
 import fish.payara.jmx.monitoring.configuration.MonitoringServiceConfiguration;
-import fish.payara.nucleus.notification.configuration.DatadogNotifier;;
+import fish.payara.nucleus.notification.configuration.DatadogNotifier;
 import org.glassfish.api.admin.ExecuteOn;
 import org.glassfish.api.admin.RestEndpoint;
 import org.glassfish.api.admin.RestEndpoints;

--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/OpenTracingRequestEventListener.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/OpenTracingRequestEventListener.java
@@ -116,7 +116,7 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
 
     @Override
     public void onEvent(final RequestEvent event) {
-        LOG.fine(() -> "onEvent(event.type=" + event.getType() + ")");
+        LOG.fine(() -> "onEvent(event.type=" + event.getType() + ", path=" + getPath(event) + ")");
 
         // onException is special, it can come in any phase of request processing.
         // early phases are simply ignored.
@@ -156,6 +156,10 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
         }
     }
 
+
+    private String getPath(final RequestEvent event) {
+        return event.getUriInfo() == null ? "<unknown>" : event.getUriInfo().getPath();
+    }
 
     private void onIncomingRequest(final RequestEvent event, final String operationName) {
         LOG.fine(() -> "onIncomingRequest(event=" + event.getType() + ", operationName=" + operationName + ")");

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -112,6 +112,7 @@ import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigBean;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.ConfigSupport;
+import org.jvnet.hk2.config.Dom;
 import org.jvnet.hk2.config.RetryableException;
 import org.jvnet.hk2.config.SingleConfigCode;
 import org.jvnet.hk2.config.Transaction;
@@ -197,9 +198,11 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     protected Logger logger = KernelLoggerInfo.getLogger();
     final private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(ApplicationLifecycle.class);
 
-    private final ThreadLocal<Deque<ExtendedDeploymentContext>> currentDeploymentContext = new ThreadLocal<Deque<ExtendedDeploymentContext>>() {
-        @Override
-        protected Deque<ExtendedDeploymentContext> initialValue() {
+    private final ThreadLocal<Deque<ExtendedDeploymentContext>> currentDeploymentContext //
+        = new ThreadLocal<Deque<ExtendedDeploymentContext>>() {
+
+            @Override
+            protected Deque<ExtendedDeploymentContext> initialValue() {
             return new ArrayDeque<>(5);
         }
     };
@@ -211,10 +214,8 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
     @Override
     public void postConstruct() {
-        deploymentLifecycleProbeProvider =
-            new DeploymentLifecycleProbeProvider();
-        alcInterceptors = habitat.getAllServices(
-            ApplicationLifecycleInterceptor.class);
+        deploymentLifecycleProbeProvider = new DeploymentLifecycleProbeProvider();
+        alcInterceptors = habitat.getAllServices(ApplicationLifecycleInterceptor.class);
     }
 
     /**
@@ -242,9 +243,12 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     @Override
     public ArchiveHandler getArchiveHandler(ReadableArchive archive, String type) throws IOException {
         if (type != null) {
-            return habitat.<ArchiveDetector>getService(ArchiveDetector.class, type).getArchiveHandler();
+            ArchiveDetector archiveDetector = habitat.<ArchiveDetector>getService(ArchiveDetector.class, type);
+            if (archiveDetector != null) {
+                return archiveDetector.getArchiveHandler();
+            }
         }
-        List<ArchiveDetector> detectors = new ArrayList<ArchiveDetector>(habitat.<ArchiveDetector>getAllServices(ArchiveDetector.class));
+        List<ArchiveDetector> detectors = new ArrayList<>(habitat.<ArchiveDetector>getAllServices(ArchiveDetector.class));
         Collections.sort(detectors, new Comparator<ArchiveDetector>() {
             // rank 2 is considered lower than rank 1, let's sort them in inceasing order
             @Override
@@ -306,7 +310,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                     ApplicationInfo appInfo = appRegistry.get(appName);
                     if (appInfo != null) {
                         // send the event to close necessary resources
-                        events.send(new Event<ApplicationInfo>(Deployment.APPLICATION_DISABLED, appInfo));
+                        events.send(new Event<>(Deployment.APPLICATION_DISABLED, appInfo));
                     }
                 } catch (Exception e) {
                     // ignore
@@ -409,7 +413,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
             context.createDeploymentClassLoader(clh, handler);
 
-            events.send(new Event<DeploymentContext>(Deployment.AFTER_DEPLOYMENT_CLASSLOADER_CREATION, context), false);
+            events.send(new Event<>(Deployment.AFTER_DEPLOYMENT_CLASSLOADER_CREATION, context), false);
 
             Thread.currentThread().setContextClassLoader(context.getClassLoader());
 
@@ -422,7 +426,9 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             span.start(DeploymentTracing.AppStage.CREATE_CLASSLOADER);
 
             if (sortedEngineInfos.isEmpty()) {
-                throw new DeploymentException(localStrings.getLocalString("unknowncontainertype", "There is no installed container capable of handling this application {0}", context.getSource().getName()));
+                throw new DeploymentException(localStrings.getLocalString("unknowncontainertype",
+                    "There is no installed container capable of handling this application {0}",
+                    context.getSource().getName()));
             }
             if (logger.isLoggable(Level.FINE)) {
                 for (EngineInfo info : sortedEngineInfos) {
@@ -454,11 +460,11 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                 return null;
             }
 
-            events.send(new Event<DeploymentContext>(Deployment.DEPLOYMENT_BEFORE_CLASSLOADER_CREATION, context), false);
+            events.send(new Event<>(Deployment.DEPLOYMENT_BEFORE_CLASSLOADER_CREATION, context), false);
 
             context.createApplicationClassLoader(clh, handler);
 
-            events.send(new Event<DeploymentContext>(Deployment.AFTER_APPLICATION_CLASSLOADER_CREATION, context), false);
+            events.send(new Event<>(Deployment.AFTER_APPLICATION_CLASSLOADER_CREATION, context), false);
 
             // this is a first time deployment as opposed as load following an unload event,
             // we need to create the application info
@@ -515,7 +521,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             context.setPhase(DeploymentContextImpl.Phase.PREPARED);
             Thread.currentThread().setContextClassLoader(context.getClassLoader());
             appInfo.setAppClassLoader(context.getClassLoader());
-            events.send(new Event<DeploymentContext>(Deployment.APPLICATION_PREPARED, context), false);
+            events.send(new Event<>(Deployment.APPLICATION_PREPARED, context), false);
 
             if (loadOnCurrentInstance(context)) {
                 appInfo.setLibraries(commandParams.libraries());
@@ -536,7 +542,9 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             tracker.actOn(logger);
             return null;
         } catch (Exception e) {
-            report.failure(logger, localStrings.getLocalString("error.deploying.app", "Exception while deploying the app [{0}]", appName), null);
+            report.failure(logger,
+                localStrings.getLocalString("error.deploying.app", "Exception while deploying the app [{0}]", appName),
+                null);
             report.setFailureCause(e);
             logger.log(Level.SEVERE, KernelLoggerInfo.lifecycleException, e);
             tracker.actOn(logger);
@@ -599,13 +607,14 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
     @Override
     public ApplicationInfo deploy(Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context) {
-        long operationStartTime = Calendar.getInstance().getTimeInMillis();
+        long operationStartTime = System.currentTimeMillis();
         ApplicationDeployment rv = prepare(sniffers, context);
         ApplicationInfo appInfo = rv != null? rv.appInfo : null;
-        if(appInfo != null) {
+        if (appInfo != null) {
             initialize(appInfo, sniffers, context);
-            long operationTime = Calendar.getInstance().getTimeInMillis() - operationStartTime;
-            deploymentLifecycleProbeProvider.applicationDeployedEvent(appInfo.getName(), getApplicationType(appInfo), String.valueOf(operationTime));
+            long operationTime = System.currentTimeMillis() - operationStartTime;
+            deploymentLifecycleProbeProvider.applicationDeployedEvent( //
+                appInfo.getName(), getApplicationType(appInfo), String.valueOf(operationTime));
         }
         return appInfo;
     }
@@ -660,9 +669,8 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         if (CommonModelRegistry.getInstance().canLoadResources()) {
             // common model registry will handle our external class dependencies
             return null;
-        } else {
-            return new ClassloaderResourceLocatorAdapter(commonClassLoaderService.getCommonClassLoader());
         }
+        return new ClassloaderResourceLocatorAdapter(commonClassLoaderService.getCommonClassLoader());
     }
 
     private void notifyLifecycleInterceptorsBefore(final ExtendedDeploymentContext.Phase phase,
@@ -681,7 +689,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
     private List<ReadableArchive> getExternalLibraries(
         DeploymentContext context) throws IOException {
-        List<ReadableArchive> externalLibArchives = new ArrayList<ReadableArchive>();
+        List<ReadableArchive> externalLibArchives = new ArrayList<>();
 
         String skipScanExternalLibProp = context.getAppProps().getProperty(
                 DeploymentProperties.SKIP_SCAN_EXTERNAL_LIB);
@@ -774,7 +782,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
         StructuredDeploymentTracing tracing = StructuredDeploymentTracing.load(context);
 
-        Map<Deployer, EngineInfo> containerInfosByDeployers = new LinkedHashMap<Deployer, EngineInfo>();
+        Map<Deployer, EngineInfo> containerInfosByDeployers = new LinkedHashMap<>();
 
         for (Sniffer sniffer : sniffers) {
             if (sniffer.getContainersNames() == null || sniffer.getContainersNames().length == 0) {
@@ -794,13 +802,13 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         // all containers that have recognized parts of the application being deployed
         // have now been successfully started. Start the deployment process.
 
-        List<ApplicationMetaDataProvider> providers = new LinkedList<ApplicationMetaDataProvider>();
+        List<ApplicationMetaDataProvider> providers = new LinkedList<>();
         providers.addAll(habitat.<ApplicationMetaDataProvider>getAllServices(ApplicationMetaDataProvider.class));
 
-        List<EngineInfo> sortedEngineInfos = new ArrayList<EngineInfo>();
+        List<EngineInfo> sortedEngineInfos = new ArrayList<>();
 
         // in reality, there is single implementation of ApplicationMetadataProvider at this point.
-        Map<Class, ApplicationMetaDataProvider> typeByProvider = new HashMap<Class, ApplicationMetaDataProvider>();
+        Map<Class, ApplicationMetaDataProvider> typeByProvider = new HashMap<>();
         for (ApplicationMetaDataProvider provider : habitat.<ApplicationMetaDataProvider>getAllServices(ApplicationMetaDataProvider.class)) {
             if (provider.getMetaData()!=null) {
                 for (Class provided : provider.getMetaData().provides()) {
@@ -823,7 +831,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             }
         }
 
-        Map<Class, Deployer> typeByDeployer = new HashMap<Class, Deployer>();
+        Map<Class, Deployer> typeByDeployer = new HashMap<>();
         for (Deployer deployer : containerInfosByDeployers.keySet()) {
             if (deployer.getMetaData()!=null) {
                 for (Class provided : deployer.getMetaData().provides()) {
@@ -852,7 +860,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         }
 
         // ok everything is satisfied, just a matter of running things in order
-        List<Deployer> orderedDeployers = new ArrayList<Deployer>();
+        List<Deployer> orderedDeployers = new ArrayList<>();
         for (Map.Entry<Deployer, EngineInfo> entry : containerInfosByDeployers.entrySet()) {
             Deployer deployer = entry.getKey();
             if (logger.isLoggable(Level.FINE)) {
@@ -989,7 +997,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                     if (provider==null) {
                         logger.log(Level.SEVERE, KernelLoggerInfo.inconsistentLifecycleState, required);
                     } else {
-                        LinkedList<ApplicationMetaDataProvider> providers = new LinkedList<ApplicationMetaDataProvider>();
+                        LinkedList<ApplicationMetaDataProvider> providers = new LinkedList<>();
 
                         addRecursively(providers, typeByProvider, provider);
                         for (ApplicationMetaDataProvider p : providers) {
@@ -1022,7 +1030,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         ProgressTracker tracker) throws Exception {
 
         ActionReport report = context.getActionReport();
-        List<EngineRef> addedEngines = new ArrayList<EngineRef>();
+        List<EngineRef> addedEngines = new ArrayList<>();
 
         StructuredDeploymentTracing tracing = StructuredDeploymentTracing.load(context);
         tracing.switchToContext(TraceContext.Level.MODULE, moduleName);
@@ -1050,8 +1058,8 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
         if (events!=null) {
             DeploymentSpan span = tracing.startSpan(TraceContext.Level.MODULE, moduleName, DeploymentTracing.AppStage.PROCESS_EVENTS, Deployment.MODULE_PREPARED.type());
-            events.send(new Event<DeploymentContext>(Deployment.MODULE_PREPARED, context), false);
-            span.close();;
+            events.send(new Event<>(Deployment.MODULE_PREPARED, context), false);
+            span.close();
         }
 
         // I need to create the application info here from the context, or something like this.
@@ -1167,7 +1175,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             notifyLifecycleInterceptorsAfter(ExtendedDeploymentContext.Phase.UNLOAD, context);
         }
 
-        events.send(new Event<ApplicationInfo>(Deployment.APPLICATION_DISABLED, info), false);
+        events.send(new Event<>(Deployment.APPLICATION_DISABLED, info), false);
 
         try {
             notifyLifecycleInterceptorsBefore(ExtendedDeploymentContext.Phase.CLEAN, context);
@@ -1223,7 +1231,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
         try {
             // prepare the application element
-            ConfigBean newBean = ((ConfigBean)ConfigBean.unwrap(applications)).allocate(Application.class);
+            ConfigBean newBean = ((ConfigBean)Dom.unwrap(applications)).allocate(Application.class);
             Application app = newBean.createProxy();
             Application app_w = t.enroll(app);
             setInitialAppAttributes(app_w, deployParams, appProps, context);
@@ -1269,7 +1277,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                     }
                 }
 
-                List<String> targets = new ArrayList<String>();
+                List<String> targets = new ArrayList<>();
                 if (!DeploymentUtils.isDomainTarget(deployParams.target)) {
                     targets.add(deployParams.target);
                 } else {
@@ -1507,24 +1515,23 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         // property element
         // trim the properties that have been written as attributes
         // the rest properties will be written as property element
-        for (Iterator itr = appProps.keySet().iterator();
-            itr.hasNext();) {
-            String propName = (String) itr.next();
-            if (!propName.equals(ServerTags.LOCATION) &&
-                !propName.equals(ServerTags.CONTEXT_ROOT) &&
-                !propName.equals(ServerTags.OBJECT_TYPE) &&
-                !propName.equals(ServerTags.DIRECTORY_DEPLOYED) &&
-                !propName.startsWith(
-                    DeploymentProperties.APP_CONFIG))
-                    {
-                if (appProps.getProperty(propName) != null) {
-                    Property prop = app.createChild(Property.class);
-                    app.getProperty().add(prop);
-                    prop.setName(propName);
-                    prop.setValue(appProps.getProperty(propName));
-                }
+        for (Object element : appProps.keySet()) {
+        String propName = (String) element;
+        if (!propName.equals(ServerTags.LOCATION) &&
+            !propName.equals(ServerTags.CONTEXT_ROOT) &&
+            !propName.equals(ServerTags.OBJECT_TYPE) &&
+            !propName.equals(ServerTags.DIRECTORY_DEPLOYED) &&
+            !propName.startsWith(
+                DeploymentProperties.APP_CONFIG))
+                {
+            if (appProps.getProperty(propName) != null) {
+                Property prop = app.createChild(Property.class);
+                app.getProperty().add(prop);
+                prop.setName(propName);
+                prop.setValue(appProps.getProperty(propName));
             }
         }
+      }
     }
 
     @Override
@@ -1538,11 +1545,12 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         final String tgt, final boolean appRefOnly)
         throws TransactionFailure {
         ConfigSupport.apply(new SingleConfigCode() {
+            @Override
             public Object run(ConfigBeanProxy param) throws PropertyVetoException, TransactionFailure {
                 // get the transaction
                 Transaction t = Transaction.getTransaction(param);
                 if (t!=null) {
-                    List<String> targets = new ArrayList<String>();
+                    List<String> targets = new ArrayList<>();
                     if (!DeploymentUtils.isDomainTarget(tgt)) {
                         targets.add(tgt);
                     } else {
@@ -1651,6 +1659,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     public void updateAppEnabledAttributeInDomainXML(final String appName,
         final String target, final boolean enabled) throws TransactionFailure {
         ConfigSupport.apply(new SingleConfigCode() {
+            @Override
             public Object run(ConfigBeanProxy param) throws PropertyVetoException, TransactionFailure {
                 // get the transaction
                 Transaction t = Transaction.getTransaction(param);
@@ -1669,7 +1678,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
                     }
 
-                    List<String> targets = new ArrayList<String>();
+                    List<String> targets = new ArrayList<>();
                     if (!DeploymentUtils.isDomainTarget(target)) {
                         targets.add(target);
                     } else {
@@ -1837,11 +1846,11 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             return build(null);
         }
         @Override
-        public Logger logger() { return logger; };
+        public Logger logger() { return logger; }
         @Override
-        public ActionReport report() { return report; };
+        public ActionReport report() { return report; }
         @Override
-        public OpsParams params() { return params; };
+        public OpsParams params() { return params; }
 
         @Override
         public ExtendedDeploymentContext build(ExtendedDeploymentContext initialContext) throws IOException {
@@ -2034,7 +2043,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     public ParameterMap prepareInstanceDeployParamMap(DeploymentContext dc)
         throws Exception {
         final DeployCommandParameters params = dc.getCommandParameters(DeployCommandParameters.class);
-        final Collection<String> excludedParams = new ArrayList<String>();
+        final Collection<String> excludedParams = new ArrayList<>();
         excludedParams.add(DeploymentProperties.PATH);
         excludedParams.add(DeploymentProperties.DEPLOYMENT_PLAN);
         excludedParams.add(DeploymentProperties.ALT_DD);
@@ -2402,7 +2411,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
 
     @Override
     public List<Sniffer> getSniffersFromApp(Application app) {
-        List<String> snifferTypes = new ArrayList<String>();
+        List<String> snifferTypes = new ArrayList<>();
         for (com.sun.enterprise.config.serverbeans.Module module : app.getModule()) {
             for (Engine engine : module.getEngines()) {
                 snifferTypes.add(engine.getSniffer());
@@ -2415,7 +2424,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             return null;
         }
 
-        List<Sniffer> sniffers = new ArrayList<Sniffer>();
+        List<Sniffer> sniffers = new ArrayList<>();
         if (app.isStandaloneModule()) {
             for (String snifferType : snifferTypes) {
                 Sniffer sniffer = snifferManager.getSniffer(snifferType);

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentProperties.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentProperties.java
@@ -59,32 +59,36 @@ import java.util.Properties;
  */
 public class DeploymentProperties extends Properties {
 
-    // Declare serialVersionUID for class versioning compatibility
-    // generated using pe build fcs-b50.
-    //
-    // This value should stay the same for all 8.x releases
-    static final long serialVersionUID = -6891581813642829148L;
+    private static final long serialVersionUID = -6891581813642829148L;
 
+    /**
+     * Construct an empty DeploymentProperties
+     */
     public DeploymentProperties() {
         super();
     }
 
-    // construct a DeploymentProperties using the props
-    // passe from client
+    /**
+     * Construct a DeploymentProperties using the props
+     *
+     * @param props
+     */
     public DeploymentProperties(Properties props) {
         super();
         putAll(props);
     }
 
-    // construct a DeploymentProperties using the map
-    // passed from client
-    // 1. For keys defined before AMX time, since different
-    // keys were defined in the DeploymentMgrMBean,
-    // we need to do conversion between the keys
-    // to keep backward compatibilities
-    // 2. For internal keys and the new keys defined after AMX
-    // time, we don't need to do any conversion
-    //
+
+    /**
+     * Construct a DeploymentProperties using the map passed from client
+     * <ol>
+     * <li>For keys defined before AMX time, since different
+     * keys were defined in the DeploymentMgrMBean,
+     * we need to do conversion between the keys
+     * to keep backward compatibilities
+     * <li>For internal keys and the new keys defined after AMX
+     * time, we don't need to do any conversion
+     */
     public DeploymentProperties(Map map) {
         super();
         if (map == null) {
@@ -111,21 +115,24 @@ public class DeploymentProperties extends Properties {
         putAll(props);
     }
 
-    // Construct a map with the keys defined in DeploymentMgrMBean this is used when the ASAPI client
-    // convert the props from the client to a map to invoke DeploymentMgrMBean API
-    
-    // 1. For keys defined before AMX time, since different keys were defined in the DeploymentMgrMBean,
-    // we need to do conversion between the keys to keep backward compatibilities
-    
-    // 2. For internal keys and the new keys defined after AMX time, we don't need to do any conversion
-    //
+
+    /**
+     * Construct a map with the keys defined in DeploymentMgrMBean this is used when the ASAPI
+     * client convert the props from the client to a map to invoke DeploymentMgrMBean API
+     * <ol>
+     * <li>For keys defined before AMX time, since different keys were defined
+     * in the DeploymentMgrMBean, we need to do conversion between the keys to keep backward
+     * compatibilities
+     * <li>For internal keys and the new keys defined after AMX time, we don't need to do any
+     * conversion
+     * </ol>
+     */
     public static Map propsToMap(Properties dProps) {
         Map map = new HashMap();
         if (dProps == null) {
             return map;
         }
-        for (Iterator<Map.Entry<Object, Object>> itr = dProps.entrySet().iterator(); itr.hasNext();) {
-            Map.Entry<Object, Object> entry = itr.next();
+        for (Map.Entry<Object, Object> entry : dProps.entrySet()) {
             String propsKey = (String) entry.getKey();
             String propsValue = (String) entry.getValue();
             String mapKey = (String) keyMap.get(propsKey);
@@ -259,8 +266,9 @@ public class DeploymentProperties extends Properties {
     }
 
     public void setName(String name) {
-        if (name != null)
+        if (name != null) {
             setProperty(NAME, name);
+        }
     }
 
     public String getDescription() {
@@ -352,7 +360,7 @@ public class DeploymentProperties extends Properties {
     }
 
     public Properties getPropertiesForInvoke() {
-        return (Properties) this;
+        return this;
     }
 
     public Properties prune() {
@@ -376,7 +384,7 @@ public class DeploymentProperties extends Properties {
         remove(RESOURCE_TARGET_LIST);
         remove(UPLOAD);
         remove(EXTERNALLY_MANAGED);
-        
+
         return this;
     }
 
@@ -478,8 +486,6 @@ public class DeploymentProperties extends Properties {
 
     // list of keys defined in DeploymentMgrMBean
     public static final String KEY_PREFIX = "X-DeploymentMgr.";
-//    public static final String DEPLOY_OPTION_REDEPLOY_KEY = 
-//        KEY_PREFIX + "Redeploy";
     public static final String DEPLOY_OPTION_FORCE_KEY = KEY_PREFIX + "Force";
     public static final String DEPLOY_OPTION_CASCADE_KEY = KEY_PREFIX + "Cascade";
     public static final String DEPLOY_OPTION_VERIFY_KEY = KEY_PREFIX + "Verify";


### PR DESCRIPTION
# Description
This is only additional PR to #4247 adding some cleanups I and my Eclipse made while working on issues with deployment-client and TCK. I didn't want to mix it with original PR.

Main differences:

1. deploy first deploys the module to the domain, then creates references (originally deployed to first target it received and created reference automatically; then developers added magic to avoid clashes on redeployments)
2. undeploy first removes all references, then undeploys the module (originally removed all references except last and for that called undeploy; existed error scenarios causing failures in undeploy phase)
3. ApplicationLifecycle.getArchiveHandler - fixed NPE

Look into individual commits for more details.

### Test suites executed
- Quicklook
- Jakarta TCKs (j2eetools)

