### PR TITLE
PAYARA-3829 MicroProfile Healthcheck 2.1 implementation

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/HealthCheckService.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/HealthCheckService.java
@@ -108,6 +108,8 @@ public class HealthCheckService implements EventListener, ConfigListener {
     private final Map<String, ClassLoader> applicationClassLoaders = new ConcurrentHashMap<>();
     private final List<String> applicationsLoaded = new CopyOnWriteArrayList<>();
 
+    private static final String BACKWARD_COMP_ENABLED_PROPERTY = "MP_HEALTH_BACKWARD_COMPATIBILITY_ENABLED";
+
     @PostConstruct
     public void postConstruct() {
         if (events == null) {
@@ -115,7 +117,7 @@ public class HealthCheckService implements EventListener, ConfigListener {
         }
         events.register(this);
         this.backwardCompEnabled = ConfigProvider.getConfig()
-                .getOptionalValue("mp.health.enable-backward-compatibility", Boolean.class)
+                .getOptionalValue(BACKWARD_COMP_ENABLED_PROPERTY, Boolean.class)
                 .orElse(false);
     }
 
@@ -209,7 +211,7 @@ public class HealthCheckService implements EventListener, ConfigListener {
         return healthChecks;
     }
     
-        private Map<String, Set<HealthCheck>> getCollectiveHealthChecks(HealthCheckType type){
+    private Map<String, Set<HealthCheck>> getCollectiveHealthChecks(HealthCheckType type) {
         final Map<String, Set<HealthCheck>> healthChecks;
         if (type == READINESS) {
             healthChecks = readiness;

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/HealthCheckType.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/HealthCheckType.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ * 
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ * 
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.microprofile.healthcheck;
+
+public enum HealthCheckType {
+
+    READINESS,
+    LIVENESS,
+    HEALTH;
+
+}

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/HealthCheckType.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/HealthCheckType.java
@@ -39,10 +39,50 @@
  */
 package fish.payara.microprofile.healthcheck;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import javax.enterprise.util.AnnotationLiteral;
+import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
+
 public enum HealthCheckType {
 
-    READINESS,
-    LIVENESS,
-    HEALTH;
+    READINESS("/ready", new AnnotationLiteral<Readiness>() {
+    }),
+    LIVENESS("/live", new AnnotationLiteral<Liveness>() {
+    }),
+    HEALTH(null, new AnnotationLiteral<Health>() {
+    });
+    
+    String path;
+    AnnotationLiteral literal;
+
+    private HealthCheckType(String path, AnnotationLiteral literal) {
+        this.path = path;
+        this.literal = literal;
+    }
+
+    public AnnotationLiteral getLiteral() {
+        return literal;
+    }
+    
+    public static HealthCheckType fromPath(String path) {
+        for (HealthCheckType value : values()) {
+            if (value.path != null && value.path.equals(path)) {
+                return value;
+            }
+        }
+        return HEALTH;
+    }
+ 
+    public static HealthCheckType fromQualifiers(Set<Annotation> qualifiers) {
+        for (HealthCheckType value : values()) {
+            if (qualifiers != null && qualifiers.contains(value.literal)) {
+                return value;
+            }
+        }
+        throw new IllegalStateException("HealthCheckType not found for : " + qualifiers);
+    }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/servlet/HealthCheckServlet.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/servlet/HealthCheckServlet.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.healthcheck.servlet;
 
 import fish.payara.microprofile.healthcheck.HealthCheckService;
+import fish.payara.microprofile.healthcheck.HealthCheckType;
 import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -53,7 +54,10 @@ import org.glassfish.internal.api.Globals;
  * @author Andrew Pielage
  */
 public class HealthCheckServlet extends HttpServlet {
-    
+
+    private static final String READINESS_ENDPOINT = "/ready";
+    private static final String LIVENESS_ENDPOINT = "/live";
+
     /**
      * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
      *
@@ -75,7 +79,15 @@ public class HealthCheckServlet extends HttpServlet {
             response.sendError(SC_FORBIDDEN, "MicroProfile Health Check Service is disabled");
             return;
         }
-        healthCheckService.performHealthChecks(response);
+
+        if (READINESS_ENDPOINT.equals(request.getPathInfo())) {
+            healthCheckService.performHealthChecks(response, HealthCheckType.READINESS);
+        } else if (LIVENESS_ENDPOINT.equals(request.getPathInfo())) {
+            healthCheckService.performHealthChecks(response, HealthCheckType.LIVENESS);
+        } else {
+            healthCheckService.performHealthChecks(response, HealthCheckType.HEALTH);
+        }
+
     }
 
     // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
@@ -114,7 +126,7 @@ public class HealthCheckServlet extends HttpServlet {
      */
     @Override
     public String getServletInfo() {
-        return "Short description";
+        return "HealthCheck Endpoint";
     }// </editor-fold>
 
 }

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/servlet/HealthCheckServlet.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/servlet/HealthCheckServlet.java
@@ -55,9 +55,6 @@ import org.glassfish.internal.api.Globals;
  */
 public class HealthCheckServlet extends HttpServlet {
 
-    private static final String READINESS_ENDPOINT = "/ready";
-    private static final String LIVENESS_ENDPOINT = "/live";
-
     /**
      * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
      *
@@ -80,13 +77,7 @@ public class HealthCheckServlet extends HttpServlet {
             return;
         }
 
-        if (READINESS_ENDPOINT.equals(request.getPathInfo())) {
-            healthCheckService.performHealthChecks(response, HealthCheckType.READINESS);
-        } else if (LIVENESS_ENDPOINT.equals(request.getPathInfo())) {
-            healthCheckService.performHealthChecks(response, HealthCheckType.LIVENESS);
-        } else {
-            healthCheckService.performHealthChecks(response, HealthCheckType.HEALTH);
-        }
+        healthCheckService.performHealthChecks(response, HealthCheckType.fromPath(request.getPathInfo()));
 
     }
 

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/servlet/HealthCheckServletContainerInitializer.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/servlet/HealthCheckServletContainerInitializer.java
@@ -39,14 +39,16 @@
  */
 package fish.payara.microprofile.healthcheck.servlet;
 
-import static fish.payara.microprofile.Constants.DEFAULT_GROUP_NAME;
 import fish.payara.microprofile.healthcheck.HealthCheckService;
 import fish.payara.microprofile.healthcheck.config.MetricsHealthCheckConfiguration;
 import static java.util.Arrays.asList;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.INFO;
 import java.util.logging.Logger;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
@@ -60,8 +62,11 @@ import javax.servlet.ServletSecurityElement;
 import static javax.servlet.annotation.ServletSecurity.TransportGuarantee.CONFIDENTIAL;
 import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
 import org.glassfish.api.invocation.InvocationManager;
 import static org.glassfish.common.util.StringHelper.isEmpty;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.Globals;
 
 /**
@@ -71,7 +76,16 @@ import org.glassfish.internal.api.Globals;
  * @author Andrew Pielage
  */
 public class HealthCheckServletContainerInitializer implements ServletContainerInitializer {
-    
+
+    private static final Logger LOGGER = Logger.getLogger(HealthCheckServletContainerInitializer.class.getName());
+
+    private static final AnnotationLiteral READINESS = new AnnotationLiteral<Readiness>() {
+    };
+    private static final AnnotationLiteral LIVENESS = new AnnotationLiteral<Liveness>() {
+    };
+    private static final AnnotationLiteral HEALTH = new AnnotationLiteral<Health>() {
+    };
+
     @Override
     public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException {
         // Check if this context is the root one ("/")
@@ -79,11 +93,11 @@ public class HealthCheckServletContainerInitializer implements ServletContainerI
             // Check if there is already a servlet for healthcheck
             Map<String, ? extends ServletRegistration> registrations = ctx.getServletRegistrations();
             MetricsHealthCheckConfiguration configuration = Globals.getDefaultHabitat().getService(MetricsHealthCheckConfiguration.class);
-            
-            if (!Boolean.parseBoolean(configuration.getEnabled())){
+
+            if (!Boolean.parseBoolean(configuration.getEnabled())) {
                 return; //MP Healthcheck disabled
             }
-            
+
             for (ServletRegistration reg : registrations.values()) {
                 if (reg.getClass().equals(HealthCheckServlet.class) || reg.getMappings().contains("/" + configuration.getEndpoint())) {
                     return;
@@ -95,52 +109,69 @@ public class HealthCheckServletContainerInitializer implements ServletContainerI
                     && !asList(virtualServers.split(",")).contains(ctx.getVirtualServerName())) {
                 return;
             }
-            
+
             // Register servlet
             ServletRegistration.Dynamic reg = ctx.addServlet("microprofile-healthcheck-servlet", HealthCheckServlet.class);
-            reg.addMapping("/" + configuration.getEndpoint());
+            reg.addMapping("/" + configuration.getEndpoint() + "/*");
             if (Boolean.parseBoolean(configuration.getSecurityEnabled())) {
                 String[] roles = configuration.getRoles().split(",");
                 reg.setServletSecurity(new ServletSecurityElement(new HttpConstraintElement(CONFIDENTIAL, roles)));
                 ctx.declareRoles(roles);
             }
         }
-        
+
         // Get the BeanManager
         BeanManager beanManager = null;
         try {
             beanManager = CDI.current().getBeanManager();
         } catch (Exception ex) {
-            Logger.getLogger(HealthCheckServletContainerInitializer.class.getName()).log(Level.FINE, 
-                    "Exception getting BeanManager; this probably isn't a CDI application. "
-                            + "No HealthChecks will be registered", ex);
+            LOGGER.log(FINE, "Exception getting BeanManager; this probably isn't a CDI application. "
+                    + "No HealthChecks will be registered", ex);
         }
-        
-        // Check for any Beans annotated with @Health
+
+        // Check for any Beans annotated with @Readiness, @Liveness or @Health
         if (beanManager != null) {
-            HealthCheckService healthCheckService = Globals.getDefaultBaseServiceLocator().getService(
-                    HealthCheckService.class);
-            InvocationManager invocationManager = Globals.getDefaultBaseServiceLocator().getService(
-                    InvocationManager.class);
-            
-            // For each bean annotated with @Health and implementing the HealthCheck interface,
+            ServiceLocator serviceLocator = Globals.getDefaultBaseServiceLocator();
+            HealthCheckService healthCheckService = serviceLocator.getService(HealthCheckService.class);
+            InvocationManager invocationManager = serviceLocator.getService(InvocationManager.class);
+            String appName = invocationManager.getCurrentInvocation().getAppName();
+
+            // For each bean annotated with @Readiness, @Liveness or @Health
+            // and implementing the HealthCheck interface,
             // register it to the HealthCheckService along with the application name
-            Set<Bean<?>> beans = beanManager.getBeans(HealthCheck.class, new AnnotationLiteral<Health>() {});
+            Set<Bean<?>> beans = new HashSet<>();
+
+            beans.addAll(beanManager.getBeans(HealthCheck.class, READINESS));
+            beans.addAll(beanManager.getBeans(HealthCheck.class, LIVENESS));
+            beans.addAll(beanManager.getBeans(HealthCheck.class, HEALTH));
+
             for (Bean<?> bean : beans) {
-                HealthCheck healthCheck = (HealthCheck) beanManager.getReference(bean, bean.getBeanClass(), 
-                        beanManager.createCreationalContext(bean));
-                
-                healthCheckService.registerHealthCheck(invocationManager.getCurrentInvocation().getAppName(),
-                        healthCheck);
-                healthCheckService.registerClassLoader(invocationManager.getCurrentInvocation().getAppName(), 
-                        healthCheck.getClass().getClassLoader());
-                
-                Logger.getLogger(HealthCheckServletContainerInitializer.class.getName()).log(Level.INFO, 
-                        "Registered {0} as a HealthCheck for app: {1}", 
-                        new Object[]{bean.getBeanClass().getCanonicalName(), 
-                                invocationManager.getCurrentInvocation().getAppName()});
+                HealthCheck healthCheck = (HealthCheck) beanManager.getReference(
+                        bean,
+                        HealthCheck.class,
+                        beanManager.createCreationalContext(bean)
+                );
+
+                if (bean.getQualifiers().contains(READINESS)) {
+                    healthCheckService.registerReadiness(appName, healthCheck);
+                }
+                if (bean.getQualifiers().contains(LIVENESS)) {
+                    healthCheckService.registerLiveness(appName, healthCheck);
+                }
+                if (bean.getQualifiers().contains(HEALTH)) {
+                    healthCheckService.registerHealth(appName, healthCheck);
+                }
+                healthCheckService.registerClassLoader(
+                        appName,
+                        healthCheck.getClass().getClassLoader()
+                );
+
+                LOGGER.log(INFO,
+                        "Registered {0} as a HealthCheck for app: {1}",
+                        new Object[]{bean.getBeanClass().getCanonicalName(), appName}
+                );
             }
         }
     }
-    
+
 }

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -205,7 +205,7 @@
         <!-- Microprofile version properties -->
         <microprofile-fault-tolerance.version>2.0.1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
-        <microprofile-healthcheck.version>1.0.payara-p1</microprofile-healthcheck.version>
+        <microprofile-healthcheck.version>2.1</microprofile-healthcheck.version>
         <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>
         <microprofile-rest-client.version>1.2.1.payara-p1</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>


### PR DESCRIPTION
# Description
MicroProfile Healthcheck 2.0 and 2.1 implementation:
- Message body of Health check response was modified, `outcome` and `state` replaced by `status` [Breaking Change]
- Introduction of Health checks for `@Liveness` and `@Readiness` on `/health/ready` and `/health/live` endpoints
- To enable the backward compatibility (`outcome` and `state` not replaced by `status` in JSON payload) of `/health` endpoint set the value of `mp.health.enable-backward-compatibility` MP config property to true.
- `/health` is deprecated and return combines Health checks data of `@Liveness` , `@Readiness` and `@Health`.

# Important Info

### Dependant PRs 
https://github.com/payara/MicroProfile-TCK-Runners/pull/59


# Testing

### New tests
Microprofile HealthCheck TCK v2.1

### Test suites executed
- Payara Microprofile TCKs Runner - HealthCheck TCK v1.0 where `mp.health.enable-backward-compatibility=true`
- Payara Microprofile TCKs Runner - HealthCheck TCK v2.1

