### PR TITLE
PAYARA-4124 Application name of deployed EAR shows unique numbers

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/archive/ArchiveHandler.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/archive/ArchiveHandler.java
@@ -37,16 +37,16 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.api.deployment.archive;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.jar.Manifest;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.jvnet.hk2.annotations.Contract;
-
-import java.io.IOException;
-import java.util.jar.Manifest;
-import java.util.List;
-import java.net.URI;
 
 /**
  * ArchiveHandlers are handling certain archive type. An archive has a unique type which is usually defines how
@@ -84,6 +84,8 @@ public interface ArchiveHandler {
     public String getDefaultApplicationName(ReadableArchive archive);
 
     public String getDefaultApplicationName(ReadableArchive archive, DeploymentContext context);
+    
+    public String getDefaultApplicationName(ReadableArchive archive, DeploymentContext context, String originalAppName);
 
     /**
      * Returns the version identifier by which the specified archive can be

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericHandler.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericHandler.java
@@ -37,35 +37,29 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.deployment;
 
-import com.sun.enterprise.module.ModulesRegistry;
+import com.sun.enterprise.util.io.FileUtils;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import javax.inject.Inject;
+import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ArchiveHandler;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.api.deployment.archive.WritableArchive;
-import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.hk2.api.ServiceLocator;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.BufferedInputStream;
-import java.io.OutputStream;
-import java.util.Enumeration;
-import java.util.jar.Manifest;
-import java.util.jar.JarFile;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.List;
-import java.util.ArrayList;
-import java.net.URI;
-import java.net.URL;
-
-import com.sun.enterprise.util.io.FileUtils;
 import org.glassfish.internal.deployment.analysis.DeploymentSpan;
 import org.glassfish.internal.deployment.analysis.StructuredDeploymentTracing;
-
-import javax.inject.Inject;
 
 /**
  * Pretty generic implementation of some ArchiveHandler methods
@@ -87,6 +81,7 @@ public abstract class GenericHandler implements ArchiveHandler {
      * @param context deployment context
      * @throws IOException when the archive is corrupted
      */
+    @Override
     public void expand(ReadableArchive source, WritableArchive target,
         DeploymentContext context) throws IOException {
 
@@ -117,6 +112,12 @@ public abstract class GenericHandler implements ArchiveHandler {
             target.closeEntry();
         }
     }
+    
+    @Override
+    public String getDefaultApplicationName(ReadableArchive archive, 
+        DeploymentContext context) {
+        return getDefaultApplicationName(archive, context, null);
+    }
 
     /**
      * Returns the default application name usable for identifying the archive.
@@ -132,8 +133,9 @@ public abstract class GenericHandler implements ArchiveHandler {
      * @param context deployment context
      * @return the default application name for the specified archive
      */
+    @Override
     public String getDefaultApplicationName(ReadableArchive archive, 
-        DeploymentContext context) {
+        DeploymentContext context, String originalAppName ) {
 
         StructuredDeploymentTracing tracing = StructuredDeploymentTracing.load(context);
         DeploymentSpan span = tracing.startSpan(DeploymentTracing.AppStage.DETERMINE_APP_NAME, "ApplicationInfoProvider");
@@ -152,6 +154,10 @@ public abstract class GenericHandler implements ArchiveHandler {
                 return appName;
             }
         }
+        
+        if (originalAppName != null) {
+            return originalAppName;
+        }
 
         // now try to get the default
         return getDefaultApplicationNameFromArchiveName(archive);
@@ -168,6 +174,7 @@ public abstract class GenericHandler implements ArchiveHandler {
         return appName;
     }
 
+    @Override
     public String getDefaultApplicationName(ReadableArchive archive) {
         return getDefaultApplicationName(archive, null);
     }

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -41,65 +41,60 @@
 
 package org.glassfish.deployment.admin;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import com.sun.enterprise.config.serverbeans.*;
 import com.sun.enterprise.deploy.shared.ArchiveFactory;
 import com.sun.enterprise.deploy.shared.FileArchive;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
-
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.DateFormat;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.inject.Inject;
 import org.glassfish.admin.payload.PayloadImpl;
 import org.glassfish.api.ActionReport;
+import org.glassfish.api.ActionReport.ExitCode;
 import org.glassfish.api.I18n;
+import org.glassfish.api.admin.AccessRequired.AccessCheck;
 import org.glassfish.api.admin.AdminCommand;
 import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.AdminCommandSecurity;
 import org.glassfish.api.admin.CommandRunner;
 import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.ParameterMap;
+import org.glassfish.api.admin.Payload;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RestParam;
 import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ArchiveHandler;
 import org.glassfish.api.deployment.archive.ReadableArchive;
+import org.glassfish.api.event.EventListener;
+import org.glassfish.api.event.Events;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
 import org.glassfish.deployment.common.*;
+import org.glassfish.deployment.versioning.VersioningService;
+import org.glassfish.deployment.versioning.VersioningSyntaxException;
+import org.glassfish.deployment.versioning.VersioningUtils;
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.deployment.*;
-import org.glassfish.config.support.TargetType;
-import org.glassfish.config.support.CommandTarget;
 import org.glassfish.internal.deployment.analysis.DeploymentSpan;
 import org.glassfish.internal.deployment.analysis.SpanSequence;
 import org.glassfish.internal.deployment.analysis.StructuredDeploymentTracing;
 import org.jvnet.hk2.annotations.Contract;
-import javax.inject.Inject;
-
 import org.jvnet.hk2.annotations.Service;
-import org.glassfish.hk2.api.PerLookup;
-import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.Transaction;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.text.DateFormat;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.glassfish.api.ActionReport.ExitCode;
-import org.glassfish.api.admin.AccessRequired.AccessCheck;
-import org.glassfish.api.admin.AdminCommandSecurity;
-import org.glassfish.api.admin.ParameterMap;
-import org.glassfish.api.admin.Payload;
-import org.glassfish.api.admin.RestEndpoint;
-import org.glassfish.api.admin.RestEndpoints;
-import org.glassfish.api.admin.RestParam;
-import org.glassfish.api.event.EventListener;
-import org.glassfish.api.event.Events;
-import org.glassfish.deployment.versioning.VersioningSyntaxException;
-import org.glassfish.deployment.versioning.VersioningUtils;
-
-import org.glassfish.deployment.versioning.VersioningService;
 
 /**
  * Deploy command
@@ -307,7 +302,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                 }
 
                 if (isModuleDescriptorAvailable) {
-                    name = archiveHandler.getDefaultApplicationName(initialContext.getSource(), initialContext);
+                    name = archiveHandler.getDefaultApplicationName(initialContext.getSource(), initialContext, name);
                 }
             }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix to an issue with application name of the deployed EAR adding unique numbers. This issue was caused by 1application.xml1 file being added by default, which causes the use of temporary application name when it can't find it.

# Testing

### New tests
None

### Testing Performed
* Deployed an EAR without an `application.xml` file and unique numbers were not added to the application name.
* Local build test

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Documentation
No required

# Notes for Reviewers
To reproduce this issue just deploy an EAR without an `application.xml` file.
