### PR TITLE
PAYARA-4196 Use unit separator to split tags, rather than space

### DIFF
--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/model/Series.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/model/Series.java
@@ -52,8 +52,8 @@ import java.util.regex.Pattern;
 public final class Series implements Comparable<Series>, Serializable {
 
     public static final char TAG_ASSIGN = ':';
-    public static final char TAG_SEPARATOR = ' ';
-    private static final char[] TAG_SEPARATORS = { ' ', ',', ';' };
+    public static final char TAG_SEPARATOR = '\u001F'; //As tag values can be any valid UTF-8 character, use a control character to separate tags
+    private static final char[] TAG_SEPARATORS = { TAG_SEPARATOR, TAG_ASSIGN };
 
     private static final String SPLIT_PATTERN = "[" + Pattern.quote(new String(TAG_SEPARATORS)) + "]+";
 
@@ -130,11 +130,6 @@ public final class Series implements Comparable<Series>, Serializable {
         if (c == TAG_ASSIGN) {
             return true;
         }
-        for (char sep : TAG_SEPARATORS) {
-            if (sep == c) {
-                return true;
-            }
-        }
-        return false;
+        return TAG_SEPARATOR == c;
     }
 }

--- a/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/collect/DataSinkCollectorTest.java
+++ b/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/collect/DataSinkCollectorTest.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 
 import fish.payara.monitoring.store.MonitoringDataSink;
 import fish.payara.monitoring.store.SinkDataCollector;
+import fish.payara.monitoring.model.Series;
 
 /**
  * Component test testing the {@link SinkDataCollector} implementation semantics.
@@ -93,6 +94,7 @@ public class DataSinkCollectorTest implements MonitoringDataSource {
             .collect("plainAfterSub", 8)
             .tag("ignoredTagSinceNull", null).collect("plainIgnoredTag", 13L)
             .tag("igniredTagSinceEmpty", "").collect("plainIgnoredEmptyTag", 14L);
+        collector.tag("complex", "sp aced; str,\u1F408ange").collect("sub", 1);
 
         // testing simple value conversion
         collector
@@ -168,37 +170,42 @@ public class DataSinkCollectorTest implements MonitoringDataSource {
 
     @Test
     public void subFirstHasTag() {
-        assertDataPoint("sub:one subFirst", 4L);
+        assertDataPoint("sub:one" + Series.TAG_SEPARATOR + "subFirst", 4L);
     }
 
     @Test
     public void subChainedHasTag() {
-        assertDataPoint("sub:one subChained", 5L);
+        assertDataPoint("sub:one" + Series.TAG_SEPARATOR + "subChained", 5L);
     }
 
     @Test
     public void subRestartedHasTag() {
-        assertDataPoint("sub:one subRestarted", 6L);
+        assertDataPoint("sub:one" + Series.TAG_SEPARATOR + "subRestarted", 6L);
     }
 
     @Test
     public void sameTagDoesReplaceExistingTag() {
-        assertDataPoint("sub:two resubbed", 7L);
+        assertDataPoint("sub:two" + Series.TAG_SEPARATOR + "resubbed", 7L);
     }
 
     @Test
     public void differntTagDoesNotReplaceExistingTag() {
-        assertDataPoint("sub:two subsub:three doubleTagged", 9L);
+        assertDataPoint("sub:two" + Series.TAG_SEPARATOR + "subsub:three" + Series.TAG_SEPARATOR + "doubleTagged", 9L);
     }
 
     @Test
     public void sameSubTagDoesReplaceExistingSubTag() {
-        assertDataPoint("sub:two subsub:four doubleTaggedReplaced", 10L);
+        assertDataPoint("sub:two" + Series.TAG_SEPARATOR + "subsub:four" + Series.TAG_SEPARATOR + "doubleTaggedReplaced", 10L);
     }
 
     @Test
     public void sameTagDoesReplaceExistingTagFromThatTagOn() {
-        assertDataPoint("sub:five reset", 11L);
+        assertDataPoint("sub:five" + Series.TAG_SEPARATOR + "reset", 11L);
+    }
+    
+    @Test
+    public void tagwithUnusualCharacters() {
+        assertDataPoint("complex:sp aced; str,\u1F408ange" + Series.TAG_SEPARATOR +"sub", 1);
     }
 
     @Test
@@ -293,19 +300,19 @@ public class DataSinkCollectorTest implements MonitoringDataSource {
 
     @Test
     public void objectUsesCurrentContext() {
-        assertDataPoint("@:obj sub:SomeObject length", 10L);
-        assertDataPoint("@:obj sub:SomeObject mIsAt", 2L);
+        assertDataPoint("@:obj" + Series.TAG_SEPARATOR + "sub:SomeObject" + Series.TAG_SEPARATOR + "length", 10L);
+        assertDataPoint("@:obj" + Series.TAG_SEPARATOR + "sub:SomeObject" + Series.TAG_SEPARATOR + "mIsAt", 2L);
     }
 
     @Test
     public void objectsRunsConsumerForAllItemsInCollectionWhileUsingTheCurrentContext() {
-        assertDataPoint("@:obj sub:Foo length", 3L);
-        assertDataPoint("@:obj sub:Bar length", 3L);
+        assertDataPoint("@:obj" + Series.TAG_SEPARATOR + "sub:Foo" + Series.TAG_SEPARATOR + "length", 3L);
+        assertDataPoint("@:obj" + Series.TAG_SEPARATOR + "sub:Bar" + Series.TAG_SEPARATOR + "length", 3L);
     }
 
     @Test
     public void mapEntriesAddGroupTag() {
-        assertDataPoint("@:foo valueLength", 3L);
+        assertDataPoint("@:foo" + Series.TAG_SEPARATOR + "valueLength", 3L);
     }
 
     private void assertDataPoint(String key, long value) {


### PR DESCRIPTION
# Description
This is a bug fix

As tag values can be any valid UTF-8 character, and spaces are used frequently
i.e. in the name of the garbage collector PS Marksweep

Picked a control character to split tags as that is least likely to be split on

# Testing

### New tests
New unit test added (see PR)

### Testing Performed
Testing also performed by starting up a DAS and instance, no errors occur in logs

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Quicklook
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples
- Payara Private Tests
- Payara Microprofile TCKs Runner
- Jakarta TCKs
- Mojarra
- Cargo Tracker

### Testing Environment
"Zulu JDK 1.8_222 on Ubuntu 18.04 with Maven 3.6.0
