### PR TITLE
PAYARA-4196 Replace spaces in tag values with an underscore

### DIFF
--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/store/InMemoryMonitoringDataRepository.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/store/InMemoryMonitoringDataRepository.java
@@ -75,6 +75,8 @@ import fish.payara.monitoring.model.Series;
 import fish.payara.monitoring.model.SeriesDataset;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import fish.payara.nucleus.hazelcast.HazelcastCore;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A simple in-memory store for a fixed size sliding window for each {@link Series}.
@@ -194,6 +196,7 @@ public class InMemoryMonitoringDataRepository implements MonitoringDataRepositor
                 collectedSources++;
                 source.collect(collector);
             } catch (RuntimeException e) {
+                Logger.getLogger("monitoring-console-core").log(Level.FINE, "Error collecting metrics", e);
                 failedSources++;
                 // ignore and continue with next
             }

--- a/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/collect/DataSinkCollectorTest.java
+++ b/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/collect/DataSinkCollectorTest.java
@@ -93,6 +93,7 @@ public class DataSinkCollectorTest implements MonitoringDataSource {
             .collect("plainAfterSub", 8)
             .tag("ignoredTagSinceNull", null).collect("plainIgnoredTag", 13L)
             .tag("igniredTagSinceEmpty", "").collect("plainIgnoredEmptyTag", 14L);
+        collector.tag("complex", "sp aced; str,\u1F408ange").collect("sub", 1);
 
         // testing simple value conversion
         collector
@@ -199,6 +200,11 @@ public class DataSinkCollectorTest implements MonitoringDataSource {
     @Test
     public void sameTagDoesReplaceExistingTagFromThatTagOn() {
         assertDataPoint("sub:five reset", 11L);
+    }
+    
+    @Test
+    public void tagwithUnusualCharacters() {
+        assertDataPoint("complex:sp_aced__str_\u1F408ange sub", 1);
     }
 
     @Test

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -207,7 +207,7 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
        StringBuilder tag = new StringBuilder();
        tag.append(metric.getName());
        for (Entry<String, String> e : metric.getTags().entrySet()) {
-           tag.append('.').append(e.getKey()).append('.').append(e.getValue());
+           tag.append('.').append(e.getKey()).append('.').append(e.getValue().replaceAll(" ", "_"));
        }
        return tag;
     }


### PR DESCRIPTION
# Description

This is a bug fix

As tag values can be any valid UTF-8 character, and spaces are used frequently
i.e. in the name of the garbage collector PS Marksweep

Picked a control character to split tags as that is least likely to be split on
 # Testing
### New tests

New unit test added (see PR)
### Testing Performed

Testing also performed by starting up a DAS and instance, no errors occur in logs

# Testing Environment

Zulu JDK 1.8_222 on Ubuntu 18.04 with Maven 3.6.0