### PR TITLE
CI-93 PAYARA-3822: Update bundlename magic string for building embedded artifacts

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -91,7 +91,7 @@
                                 <ant dir="." antfile="../build.xml" target="create.distribution">
                                     <property name="finaljar"
                                               value="${project.build.directory}/payara-embedded-all.jar"/>
-                                    <property name="bundlename" value="fish.payara.server.internal.embedded.all"/>
+                                    <property name="bundlename" value="fish.payara.extras.embedded.all"/>
                                     <property name="install.dir.name" value="${install.dir.name}"/>
                                 </ant>
                             </tasks>

--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -52,13 +52,13 @@
 
     <target name="get.distribution.type">
         <condition property="full.distribution">
-            <equals arg1="${bundlename}" arg2="org.glassfish.main.embedded.all"/>
+            <equals arg1="${bundlename}" arg2="fish.payara.extras.embedded.all"/>
         </condition>
         <condition property="web.distribution">
-            <equals arg1="${bundlename}" arg2="org.glassfish.main.embedded.web"/>
+            <equals arg1="${bundlename}" arg2="fish.payara.extras.embedded.web"/>
         </condition>
         <condition property="nucleus.distribution">
-            <equals arg1="${bundlename}" arg2="org.glassfish.main.embedded.nucleus"/>
+            <equals arg1="${bundlename}" arg2="fish.payara.extras.embedded.nucleus"/>
         </condition>
     </target>
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -90,7 +90,7 @@
                         <configuration>
                             <tasks>
                                 <ant dir="." antfile="../build.xml" target="create.distribution">
-                                    <property name="bundlename" value="fish.payara.server.internal.embedded.web" />
+                                    <property name="bundlename" value="fish.payara.extras.embedded.web" />
                                     <property name="finaljar" value="${project.build.directory}/payara-embedded-web.jar" />
                                     <property name="install.dir.name" value="${install.dir.name}" />
                                 </ant>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

Changing the artifacts also changed parameter passed to ant file, that build embedded distribution. That ant file was changing against three fixed bundle names. Those now match again, and refer to Payara rather than Glassfish.
<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Cargo Tracker
```
 mvn "-Dpayara.version=5.194-SNAPSHOT" -Ppayara-server-embedded "-Dpayara.arquillian.container.version=1.1" "-Dmaven.surefire.debug" "-Djersey.version=2.29.payara-p5" test            
[INFO] Results:                                                                               
[INFO]                                                                                        
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0  
```
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu 8, Windows 10, Maven 3.6.1

