### PR TITLE
PAYARA-4150: Retain compatibility with Payara Micro ARQ container

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/pom.xml
@@ -51,6 +51,17 @@
     <packaging>glassfish-jar</packaging>
     <name>Payara Micro Boot</name>
     <description>Payara Micro Edition Boot</description>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources-filtered/META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources-filtered/META-INF/maven/fish.payara.micro/payara-micro-boot/pom.properties
@@ -1,0 +1,42 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+#
+
+# Kept for compatibility reasons with arquillian container <= 1.2
+version=${project.version}


### PR DESCRIPTION
# Description
This is a bug fix / feature. A feature to workaround bug in Arquillian container.

arquillian-micro-managed container looks specifically for `pom.properties` of artifact `payara-micro-boot` in old groupId, and fails with unhelpful error message when it doesn't find one:

```
[ERROR] org.javaee7.cdi.vetoed.GreetingTest  Time elapsed: 74.975 s  <<< ERROR!
java.lang.NullPointerException: entry
```

# Testing

### Test suites executed
- Java EE7 Samples in profile `payara-micro-managed`

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu 8, Maven 3.6.1, Windows 10

