### PR TITLE
PAYARA-4158 Allow create-domain command to configure the Hazelcast Configuration 

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -43,7 +43,7 @@
 <!-- Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates] -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-<hazelcast-runtime-configuration></hazelcast-runtime-configuration>
+<hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
 <security-configurations>
     <authentication-service default="true" name="adminAuth" use-password-credential="true">
       <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">

--- a/appserver/admin/gf_template/src/main/resources/stringsubs.xml
+++ b/appserver/admin/gf_template/src/main/resources/stringsubs.xml
@@ -38,6 +38,8 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
+    
+    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 -->
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
@@ -45,7 +47,7 @@
         <group-ref name="glassfish-core-sub"/>
     </component>
     <group id="glassfish-core-sub" mode="forward">
-    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+        <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
         <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
         <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
         <change-pair-ref name="VERSION"/>
@@ -73,6 +75,9 @@
         <change-pair-ref name="TOKENS_HERE"/>
         <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
         <change-pair-ref name="PORT_BASE"/>
+        <change-pair-ref name="HAZELCAST_DAS_PORT"/>
+        <change-pair-ref name="HAZELCAST_START_PORT"/>
+        <change-pair-ref name="HAZELCAST_AUTO_INCREMENT"/>
     </group>
     <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
     <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
@@ -99,6 +104,9 @@
     <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
     <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
     <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <change-pair id="HAZELCAST_DAS_PORT" before="%%%HAZELCAST_DAS_PORT%%%" after="$HAZELCAST_DAS_PORT$"/>
+    <change-pair id="HAZELCAST_START_PORT" before="%%%HAZELCAST_START_PORT%%%" after="$HAZELCAST_START_PORT$"/>
+    <change-pair id="HAZELCAST_AUTO_INCREMENT" before="%%%HAZELCAST_AUTO_INCREMENT%%%" after="$HAZELCAST_AUTO_INCREMENT$"/>
     <defaults>
         <property key="ADMIN_PORT" value="4848" type="port"/>
         <property key="HTTP_SSL_PORT" value="8181" type="port"/>
@@ -110,5 +118,8 @@
         <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
         <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
         <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+        <property key="HAZELCAST_DAS_PORT" value="4900" type="port"/>
+        <property key="HAZELCAST_START_PORT" value="5900" type="port"/>
+        <property key="HAZELCAST_AUTO_INCREMENT" value="true" type="string"/>
     </defaults>
 </stringsubs-definition>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
+  
    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
@@ -39,511 +39,511 @@
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-    <hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
-    <security-configurations>
-        <authentication-service default="true" name="adminAuth" use-password-credential="true">
-            <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
-                <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
-                    <property name="config" value="server-config"></property>
-                    <property name="auth-realm" value="admin-realm"></property>
-                </login-module-config>
-            </security-provider>
-            <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
-                <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
-                    <property name="config" value="server-config"></property>
-                    <property name="auth-realm" value="admin-realm"></property>
-                </login-module-config>
-            </security-provider>
-        </authentication-service>
-        <authorization-service default="true" name="authorizationService">
-            <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
-                <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
-            </security-provider>
-        </authorization-service>
-    </security-configurations>
-    <system-applications />
-    <resources>
-        <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
-        <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
-        <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
-        <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
-            <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
-            <property value=";create=true" name="connectionAttributes" />
-        </jdbc-connection-pool>
-        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.ClientDataSource" res-type="javax.sql.DataSource">
-            <property value="1527" name="PortNumber" />
-            <property value="APP" name="Password" />
-            <property value="APP" name="User" />
-            <property value="localhost" name="serverName" />
-            <property value="sun-appserv-samples" name="DatabaseName" />
-            <property value=";create=true" name="connectionAttributes" />
-        </jdbc-connection-pool>
-        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
-            <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
-        </jdbc-connection-pool>
-    </resources>
-    <servers>
-        <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
-            <resource-ref ref="jdbc/__TimerPool" />
-            <resource-ref ref="jdbc/__default" />
-            <resource-ref ref="jdbc/__derby" />
-        </server>
-    </servers>
-    <nodes>
-        <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
-    </nodes>
-    <configs>
-        <config name="%%%CONFIG_MODEL_NAME%%%">
-            <!--%%%TOKENS_HERE%%%-->
-            <!--%%%PORT_BASE%%%-->
-            <http-service>
-                <access-log/>
-                <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
-                <virtual-server id="__asadmin" network-listeners="admin-listener"/>
-            </http-service>
-            <iiop-service>
-                <orb use-thread-pool-ids="thread-pool-1" />
-                <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
-                <ssl ssl3-enabled="false" />
-                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-                </iiop-listener>
-                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-                </iiop-listener>
-            </iiop-service>
-            <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
-                <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
-                <property value="/admin" name="adminConsoleContextRoot" />
-                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-                <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
-            </admin-service>
+<hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
+<security-configurations>
+    <authentication-service default="true" name="adminAuth" use-password-credential="true">
+      <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+        <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+      <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+        <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+    </authentication-service>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
+    <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.ClientDataSource" res-type="javax.sql.DataSource">
+      <property value="1527" name="PortNumber" />
+      <property value="APP" name="Password" />
+      <property value="APP" name="User" />
+      <property value="localhost" name="serverName" />
+      <property value="sun-appserv-samples" name="DatabaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
+      <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+      <resource-ref ref="jdbc/__derby" />
+    </server>
+  </servers>
+  <nodes>
+    <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
+  </nodes>
+ <configs>
+   <config name="%%%CONFIG_MODEL_NAME%%%">
+      <!--%%%TOKENS_HERE%%%-->
+      <!--%%%PORT_BASE%%%-->
+      <http-service>
+        <access-log/>
+        <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
+        <virtual-server id="__asadmin" network-listeners="admin-listener"/>
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
+	  <ssl ssl3-enabled="false" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+      </admin-service>
+      <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" />
+       <asadmin-recorder-configuration></asadmin-recorder-configuration>
+       <request-tracing-service-configuration>
+         <log-notifier></log-notifier>
+       </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
+      <microprofile-metrics-configuration></microprofile-metrics-configuration>
+       <diagnostic-service />
+      <security-service>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <message-security-config auth-layer="HttpServlet">
+            <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                <request-policy auth-source="sender"></request-policy>
+                <response-policy></response-policy>
+                <property name="loginPage" value="/login.jsf"></property>
+                <property name="loginErrorPage" value="/loginError.jsf"></property>
+            </provider-config>
+        </message-security-config>
+	<property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+        <jvm-options>-client</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+        <!-- Hazelcast internal package access requirement to get the best performance results. -->
+        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+        <jvm-options>-Djava.awt.headless=true</jvm-options>
+        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+        <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+        <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+        <jvm-options>-Xmx512m</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+	<jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
+        <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.shell.remote,org.apache.felix.fileinstall</jvm-options>
+        <!-- Configuration of various third-party OSGi bundles like
+             Felix Remote Shell, FileInstall, etc. -->
+        <!-- Port on which remote shell listens for connections.-->
+        <jvm-options>-Dosgi.shell.telnet.port=%%%OSGI_SHELL_TELNET_PORT%%%</jvm-options>
+        <!-- How many concurrent users can connect to this remote shell -->
+        <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+        <!-- From which hosts users can connect -->
+        <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+        <!-- Gogo shell configuration -->
+        <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+        <!-- Directory being watched by fileinstall. -->
+        <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+        <!-- Time period fileinstaller thread in ms. -->
+        <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+        <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+        <jvm-options>-Dfelix.fileinstall.log.level=2</jvm-options>
+        <!-- should new bundles be started or installed only? 
+             true => start, false => only install 
+        -->
+        <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+        <!-- should watched bundles be started transiently or persistently -->
+        <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+        <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+             If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+        -->
+        <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+        <!-- End of OSGi bundle configurations -->
+        <jvm-options>-XX:NewRatio=2</jvm-options>
+        <!-- Woodstox property needed to pass StAX TCK -->
+        <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
+        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+        <!-- Grizzly NPN Jar version -->
+        <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+        <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+        <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+        <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+        <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+        <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+        <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+      </java-config>
+      <availability-service>
+          <web-container-availability/>
+          <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+      </availability-service>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener-1">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+	    <ssl ssl3-enabled="false" />
+          </protocol>
+          <protocol security-enabled="true" name="http-listener-2">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+          <protocol name="admin-listener">
+            <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+          <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+      </thread-pools>
+    </config>
+     <config name="default-config" dynamic-reconfiguration-enabled="true" >
+         <http-service>
+             <access-log/>
+             <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
+                 <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
+             </virtual-server>
+             <virtual-server id="__asadmin" network-listeners="admin-listener" />
+         </http-service>
+         <iiop-service>
+             <orb use-thread-pool-ids="thread-pool-1" />
+             <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
+	         <ssl ssl3-enabled="false" />
+             <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+             </iiop-listener>
+             <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+             </iiop-listener>
+         </iiop-service>
+         <admin-service system-jmx-connector-name="system" type="server">
+             <!-- JSR 160  "system-jmx-connector" -->
+             <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
+             <!-- JSR 160  "system-jmx-connector" -->
+             <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+         </admin-service>
+         <web-container>
+             <session-config>
+                 <session-manager>
+                     <manager-properties/>
+                     <store-properties />
+                 </session-manager>
+                 <session-properties />
+             </session-config>
+         </web-container>
+         <ejb-container session-store="${com.sun.aas.instanceRoot}/session-store">
+             <ejb-timer-service />
+         </ejb-container>
+         <mdb-container />
+         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+             <module-log-levels />
+         </log-service>
+         <security-service>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+             <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
+                 <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
+             </jacc-provider>
+             <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
+             <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                 <property value="false" name="auditOn" />
+             </audit-module>
+             <message-security-config auth-layer="SOAP">
+                 <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+             </message-security-config>
+         </security-service>
+         <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
             <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
-            <connector-service shutdown-timeout-in-seconds="30">
-            </connector-service>
-            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" />
-            <asadmin-recorder-configuration></asadmin-recorder-configuration>
-            <request-tracing-service-configuration>
-                <log-notifier></log-notifier>
-            </request-tracing-service-configuration>
-            <notification-service-configuration enabled="true">
-                <log-notifier-configuration enabled="true"></log-notifier-configuration>
-            </notification-service-configuration>
-            <monitoring-service-configuration></monitoring-service-configuration>
-            <microprofile-metrics-configuration></microprofile-metrics-configuration>
-            <diagnostic-service />
-            <security-service>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-                    <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
-                    <property value="fileRealm" name="jaas-context" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-                    <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
-                    <property value="fileRealm" name="jaas-context" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
-                    <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
-                </jacc-provider>
-                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
-                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-                    <property value="false" name="auditOn" />
-                </audit-module>
-                <message-security-config auth-layer="SOAP">
-                    <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="dynamic.username.password" />
-                        <property value="false" name="debug" />
-                    </provider-config>
-                    <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="dynamic.username.password" />
-                        <property value="false" name="debug" />
-                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-                    </provider-config>
-                    <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="debug" />
-                    </provider-config>
-                    <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="debug" />
-                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-                    </provider-config>
-                </message-security-config>
-                <message-security-config auth-layer="HttpServlet">
-                    <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
-                        <request-policy auth-source="sender"></request-policy>
-                        <response-policy></response-policy>
-                        <property name="loginPage" value="/login.jsf"></property>
-                        <property name="loginErrorPage" value="/loginError.jsf"></property>
-                    </provider-config>
-                </message-security-config>
-                <property value="SHA-256" name="default-digest-algorithm" />
-            </security-service>
-            <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
-                <jvm-options>-client</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-                <!-- Hazelcast internal package access requirement to get the best performance results. -->
-                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-                <jvm-options>-Djava.awt.headless=true</jvm-options>
-                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-                <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
-                <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
-                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-                <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
-                <jvm-options>-Xmx512m</jvm-options>
-                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-                <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
-                <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.shell.remote,org.apache.felix.fileinstall</jvm-options>
-                <!-- Configuration of various third-party OSGi bundles like
-                Felix Remote Shell, FileInstall, etc. -->
-                <!-- Port on which remote shell listens for connections.-->
-                <jvm-options>-Dosgi.shell.telnet.port=%%%OSGI_SHELL_TELNET_PORT%%%</jvm-options>
-                <!-- How many concurrent users can connect to this remote shell -->
-                <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
-                <!-- From which hosts users can connect -->
-                <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
-                <!-- Gogo shell configuration -->
-                <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
-                <!-- Directory being watched by fileinstall. -->
-                <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
-                <!-- Time period fileinstaller thread in ms. -->
-                <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
-                <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
-                <jvm-options>-Dfelix.fileinstall.log.level=2</jvm-options>
-                <!-- should new bundles be started or installed only? 
-                     true => start, false => only install 
-                -->
-                <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
-                <!-- should watched bundles be started transiently or persistently -->
-                <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
-                <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
-                     If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
-                -->
-                <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
-                <!-- End of OSGi bundle configurations -->
-                <jvm-options>-XX:NewRatio=2</jvm-options>
-                <!-- Woodstox property needed to pass StAX TCK -->
-                <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
-                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-                <!-- Grizzly NPN Jar version -->
-                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-            </java-config>
-            <availability-service>
-                <web-container-availability/>
-                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-            </availability-service>
-            <network-config>
-                <protocols>
-                    <protocol name="http-listener-1">
-                        <http default-virtual-server="server" max-connections="250">
-                            <file-cache enabled="false"></file-cache>
-                        </http>
-                        <ssl ssl3-enabled="false" />
-                    </protocol>
-                    <protocol security-enabled="true" name="http-listener-2">
-                        <http default-virtual-server="server" max-connections="250">
-                            <file-cache enabled="false"></file-cache>
-                        </http>
-                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
-                    </protocol>
-                    <protocol name="admin-listener">
-                        <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
-                            <file-cache enabled="false"></file-cache>
-                        </http>
-                    </protocol>
-                </protocols>
-                <network-listeners>
-                    <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
-                    <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
-                    <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
-                </network-listeners>
-                <transports>
-                    <transport name="tcp"></transport>
-                </transports>
-            </network-config>
-            <thread-pools>
-                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-                <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
-                <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
-            </thread-pools>
-        </config>
-        <config name="default-config" dynamic-reconfiguration-enabled="true" >
-            <http-service>
-                <access-log/>
-                <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
-                    <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
-                </virtual-server>
-                <virtual-server id="__asadmin" network-listeners="admin-listener" />
-            </http-service>
-            <iiop-service>
-                <orb use-thread-pool-ids="thread-pool-1" />
-                <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
-                <ssl ssl3-enabled="false" />
-                <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-                </iiop-listener>
-                <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-                </iiop-listener>
-            </iiop-service>
-            <admin-service system-jmx-connector-name="system" type="server">
-                <!-- JSR 160  "system-jmx-connector" -->
-                <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
-                <!-- JSR 160  "system-jmx-connector" -->
-                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-            </admin-service>
-            <web-container>
-                <session-config>
-                    <session-manager>
-                        <manager-properties/>
-                        <store-properties />
-                    </session-manager>
-                    <session-properties />
-                </session-config>
-            </web-container>
-            <ejb-container session-store="${com.sun.aas.instanceRoot}/session-store">
-                <ejb-timer-service />
-            </ejb-container>
-            <mdb-container />
-            <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
-                <module-log-levels />
-            </log-service>
-            <security-service>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-                    <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
-                    <property name="jaas-context" value="fileRealm" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-                    <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
-                    <property name="jaas-context" value="fileRealm" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
-                    <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
-                </jacc-provider>
-                <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
-                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-                    <property value="false" name="auditOn" />
-                </audit-module>
-                <message-security-config auth-layer="SOAP">
-                    <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="dynamic.username.password" value="false" />
-                        <property name="debug" value="false" />
-                    </provider-config>
-                    <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="dynamic.username.password" value="false" />
-                        <property name="debug" value="false" />
-                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                    </provider-config>
-                    <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="debug" value="false" />
-                    </provider-config>
-                    <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="debug" value="false" />
-                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                    </provider-config>
-                </message-security-config>
-            </security-service>
-            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
-            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
-            <request-tracing-service-configuration>
-                <log-notifier></log-notifier>
-            </request-tracing-service-configuration>
-            <notification-service-configuration enabled="true">
-                <log-notifier-configuration enabled="true"></log-notifier-configuration>
-            </notification-service-configuration>
-            <monitoring-service-configuration></monitoring-service-configuration>
-            <microprofile-metrics-configuration></microprofile-metrics-configuration>
-            <diagnostic-service />
-            <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
-                <jvm-options>-server</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-                <!-- Hazelcast internal package access requirement to get the best performance results. -->
-                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-                <jvm-options>-Djava.awt.headless=true</jvm-options>
-                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-                <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
-                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-                <jvm-options>-XX:NewRatio=2</jvm-options>
-                <jvm-options>-Xmx512m</jvm-options>
-                <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names.
-                The remote shell bundle has been disabled for cluster and remote instances. -->
-                <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.fileinstall</jvm-options>
-                <!-- Port on which remote shell listens for connections.-->
-                <jvm-options>-Dosgi.shell.telnet.port=${OSGI_SHELL_TELNET_PORT}</jvm-options>
-                <!-- How many concurrent users can connect to this remote shell -->
-                <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
-                <!-- From which hosts users can connect -->
-                <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
-                <!-- Gogo shell configuration -->
-                <!--PAYARA-495-->
-                <!--<jvm-options>-Dgosh.args=nointeractive</jvm-options>-->
-                <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
-                <!-- Directory being watched by fileinstall. -->
-                <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
-                <!-- Time period fileinstaller thread in ms. -->
-                <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
-                <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
-                <jvm-options>-Dfelix.fileinstall.log.level=3</jvm-options>
-                <!-- should new bundles be started or installed only?
-                    true => start, false => only install
-                -->
-                <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
-                <!-- should watched bundles be started transiently or persistently -->
-                <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
-                <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
-                     If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
-                -->
-                <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
-                <!-- End of OSGi bundle configurations -->
-                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-                <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
-                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-                <!-- Grizzly NPN Jar version -->
-                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-            </java-config>
-            <availability-service>
-                <web-container-availability/>
-                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-            </availability-service>
-            <network-config>
-                <protocols>
-                    <protocol name="http-listener-1">
-                        <http default-virtual-server="server">
-                            <file-cache />
-                        </http>
-                        <ssl ssl3-enabled="false" />
-                    </protocol>
-                    <protocol security-enabled="true" name="http-listener-2">
-                        <http default-virtual-server="server">
-                            <file-cache />
-                        </http>
-                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
-                    </protocol>
-                    <protocol name="admin-listener">
-                        <http default-virtual-server="__asadmin" max-connections="250">
-                            <file-cache enabled="false" />
-                        </http>
-                    </protocol>
-                    <protocol security-enabled="true" name="sec-admin-listener">
-                        <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
-                            <file-cache></file-cache>
-                        </http>
-                        <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
-                    </protocol>
-                    <protocol name="admin-http-redirect">
-                        <http-redirect secure="true"></http-redirect>
-                    </protocol>
-                    <protocol name="pu-protocol">
-                        <port-unification>
-                            <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                            <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                        </port-unification>
-                    </protocol>
+         <request-tracing-service-configuration>
+             <log-notifier></log-notifier>
+         </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
+      <microprofile-metrics-configuration></microprofile-metrics-configuration>
+         <diagnostic-service />
+         <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+             <jvm-options>-server</jvm-options>
+             <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+             <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+             <!-- Hazelcast internal package access requirement to get the best performance results. -->
+             <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+             <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+             <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+             <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+             <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+             <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+             <jvm-options>-Djava.awt.headless=true</jvm-options>
+             <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+             <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+             <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+             <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+             <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+             <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+             <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+             <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+             <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+             <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+             <jvm-options>-XX:NewRatio=2</jvm-options>
+             <jvm-options>-Xmx512m</jvm-options>
+             <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names.
+                  The remote shell bundle has been disabled for cluster and remote instances. -->
+             <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.fileinstall</jvm-options>
+             <!-- Port on which remote shell listens for connections.-->
+             <jvm-options>-Dosgi.shell.telnet.port=${OSGI_SHELL_TELNET_PORT}</jvm-options>
+             <!-- How many concurrent users can connect to this remote shell -->
+             <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+             <!-- From which hosts users can connect -->
+             <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+             <!-- Gogo shell configuration -->
+             <!--PAYARA-495-->
+             <!--<jvm-options>-Dgosh.args=nointeractive</jvm-options>-->
+             <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+             <!-- Directory being watched by fileinstall. -->
+             <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+             <!-- Time period fileinstaller thread in ms. -->
+             <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+             <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+             <jvm-options>-Dfelix.fileinstall.log.level=3</jvm-options>
+             <!-- should new bundles be started or installed only?
+                 true => start, false => only install
+             -->
+             <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+             <!-- should watched bundles be started transiently or persistently -->
+             <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+             <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+                  If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+             -->
+             <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+             <!-- End of OSGi bundle configurations -->
+             <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+             <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+             <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
+             <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+             <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+             <!-- Grizzly NPN Jar version -->
+             <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+             <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+             <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+             <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+             <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+             <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+             <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+        </java-config>
+         <availability-service>
+             <web-container-availability/>
+             <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+         </availability-service>
+         <network-config>
+             <protocols>
+                 <protocol name="http-listener-1">
+                     <http default-virtual-server="server">
+                         <file-cache />
+                     </http>
+		     <ssl ssl3-enabled="false" />
+                 </protocol>
+                 <protocol security-enabled="true" name="http-listener-2">
+                     <http default-virtual-server="server">
+                         <file-cache />
+                     </http>
+                     <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
+                 </protocol>
+                 <protocol name="admin-listener">
+                     <http default-virtual-server="__asadmin" max-connections="250">
+                         <file-cache enabled="false" />
+                     </http>
+                 </protocol>
+                 <protocol security-enabled="true" name="sec-admin-listener">
+                   <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                     <file-cache></file-cache>
+                   </http>
+                   <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                 </protocol>
+                 <protocol name="admin-http-redirect">
+                   <http-redirect secure="true"></http-redirect>
+                 </protocol>
+                 <protocol name="pu-protocol">
+                   <port-unification>
+                     <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                     <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                   </port-unification>
+                 </protocol>
 
-                </protocols>
-                <network-listeners>
-                    <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
-                    <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
-                    <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
-                </network-listeners>
-                <transports>
-                    <transport name="tcp" />
-                </transports>
-            </network-config>
-            <thread-pools>
-                <thread-pool name="http-thread-pool" />
-                <thread-pool min-thread-pool-size="2" max-thread-pool-size="200" idle-thread-timeout-in-seconds="120" name="thread-pool-1" />
-                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-            </thread-pools>
-            <group-management-service/>
-            <!--%%%DEFAULT_TOKENS_HERE%%%-->
-            <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
-            <system-property name="HTTP_LISTENER_PORT" value="28080"/>
-            <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
-            <system-property name="IIOP_LISTENER_PORT" value="23700"/>
-            <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
-            <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
-            <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
-            <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
-            <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
-        </config>
-    </configs>
-    <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
-    <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
-        <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
-        <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
-    </secure-admin>
+             </protocols>
+             <network-listeners>
+                 <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                 <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                 <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+             </network-listeners>
+             <transports>
+                 <transport name="tcp" />
+             </transports>
+         </network-config>
+         <thread-pools>
+             <thread-pool name="http-thread-pool" />
+             <thread-pool min-thread-pool-size="2" max-thread-pool-size="200" idle-thread-timeout-in-seconds="120" name="thread-pool-1" />
+	     <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+         </thread-pools>
+         <group-management-service/>
+         <!--%%%DEFAULT_TOKENS_HERE%%%-->
+         <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
+         <system-property name="HTTP_LISTENER_PORT" value="28080"/>
+         <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
+         <system-property name="IIOP_LISTENER_PORT" value="23700"/>
+         <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
+         <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
+         <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
+         <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
+         <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
+     </config>
+  </configs>
+  <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
+  <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
+      <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
+      <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
+  </secure-admin>
 </domain>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
+
    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
@@ -39,510 +39,511 @@
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-<security-configurations>
-    <authentication-service default="true" name="adminAuth" use-password-credential="true">
-      <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
-        <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
-          <property name="config" value="server-config"></property>
-          <property name="auth-realm" value="admin-realm"></property>
-        </login-module-config>
-      </security-provider>
-      <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
-        <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
-          <property name="config" value="server-config"></property>
-          <property name="auth-realm" value="admin-realm"></property>
-        </login-module-config>
-      </security-provider>
-    </authentication-service>
-    <authorization-service default="true" name="authorizationService">
-      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
-        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
-      </security-provider>
-    </authorization-service>
-  </security-configurations>
-  <system-applications />
-  <resources>
-    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
-    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
-    <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
-    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
-      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
-      <property value=";create=true" name="connectionAttributes" />
-    </jdbc-connection-pool>
-    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.ClientDataSource" res-type="javax.sql.DataSource">
-      <property value="1527" name="PortNumber" />
-      <property value="APP" name="Password" />
-      <property value="APP" name="User" />
-      <property value="localhost" name="serverName" />
-      <property value="sun-appserv-samples" name="DatabaseName" />
-      <property value=";create=true" name="connectionAttributes" />
-    </jdbc-connection-pool>
-    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
-      <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
-    </jdbc-connection-pool>
-  </resources>
-  <servers>
-    <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
-      <resource-ref ref="jdbc/__TimerPool" />
-      <resource-ref ref="jdbc/__default" />
-      <resource-ref ref="jdbc/__derby" />
-    </server>
-  </servers>
-  <nodes>
-    <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
-  </nodes>
- <configs>
-   <config name="%%%CONFIG_MODEL_NAME%%%">
-      <!--%%%TOKENS_HERE%%%-->
-      <!--%%%PORT_BASE%%%-->
-      <http-service>
-        <access-log/>
-        <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
-        <virtual-server id="__asadmin" network-listeners="admin-listener"/>
-      </http-service>
-      <iiop-service>
-        <orb use-thread-pool-ids="thread-pool-1" />
-        <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
-	  <ssl ssl3-enabled="false" />
-        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
-          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-        </iiop-listener>
-        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
-          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-        </iiop-listener>
-      </iiop-service>
-      <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
-        <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
-        <property value="/admin" name="adminConsoleContextRoot" />
-        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
-      </admin-service>
-      <connector-service shutdown-timeout-in-seconds="30">
-      </connector-service>
-       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" />
-       <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
-       <asadmin-recorder-configuration></asadmin-recorder-configuration>
-       <request-tracing-service-configuration>
-         <log-notifier></log-notifier>
-       </request-tracing-service-configuration>
-      <notification-service-configuration enabled="true">
-        <log-notifier-configuration enabled="true"></log-notifier-configuration>
-      </notification-service-configuration>
-      <monitoring-service-configuration></monitoring-service-configuration>
-      <microprofile-metrics-configuration></microprofile-metrics-configuration>
-       <diagnostic-service />
-      <security-service>
-        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
-          <property value="fileRealm" name="jaas-context" />
-        </auth-realm>
-        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
-          <property value="fileRealm" name="jaas-context" />
-        </auth-realm>
-        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
-          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
-        </jacc-provider>
-        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
-        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-          <property value="false" name="auditOn" />
-        </audit-module>
-        <message-security-config auth-layer="SOAP">
-          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="dynamic.username.password" />
-            <property value="false" name="debug" />
-          </provider-config>
-          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="dynamic.username.password" />
-            <property value="false" name="debug" />
-            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-          </provider-config>
-          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="debug" />
-          </provider-config>
-          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="debug" />
-            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-          </provider-config>
-        </message-security-config>
-        <message-security-config auth-layer="HttpServlet">
-            <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
-                <request-policy auth-source="sender"></request-policy>
-                <response-policy></response-policy>
-                <property name="loginPage" value="/login.jsf"></property>
-                <property name="loginErrorPage" value="/loginError.jsf"></property>
-            </provider-config>
-        </message-security-config>
-	<property value="SHA-256" name="default-digest-algorithm" />
-      </security-service>
-      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
-        <jvm-options>-client</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-        <!-- Hazelcast internal package access requirement to get the best performance results. -->
-        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-        <jvm-options>-Djava.awt.headless=true</jvm-options>
-        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-        <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
-        <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
-        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-        <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
-        <jvm-options>-Xmx512m</jvm-options>
-        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-	<jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-        <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
-        <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.shell.remote,org.apache.felix.fileinstall</jvm-options>
-        <!-- Configuration of various third-party OSGi bundles like
-             Felix Remote Shell, FileInstall, etc. -->
-        <!-- Port on which remote shell listens for connections.-->
-        <jvm-options>-Dosgi.shell.telnet.port=%%%OSGI_SHELL_TELNET_PORT%%%</jvm-options>
-        <!-- How many concurrent users can connect to this remote shell -->
-        <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
-        <!-- From which hosts users can connect -->
-        <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
-        <!-- Gogo shell configuration -->
-        <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
-        <!-- Directory being watched by fileinstall. -->
-        <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
-        <!-- Time period fileinstaller thread in ms. -->
-        <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
-        <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
-        <jvm-options>-Dfelix.fileinstall.log.level=2</jvm-options>
-        <!-- should new bundles be started or installed only? 
-             true => start, false => only install 
-        -->
-        <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
-        <!-- should watched bundles be started transiently or persistently -->
-        <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
-        <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
-             If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
-        -->
-        <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
-        <!-- End of OSGi bundle configurations -->
-        <jvm-options>-XX:NewRatio=2</jvm-options>
-        <!-- Woodstox property needed to pass StAX TCK -->
-        <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
-        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-        <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-        <!-- Grizzly NPN Jar version -->
-        <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-        <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-        <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-        <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-        <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-        <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-        <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-      </java-config>
-      <availability-service>
-          <web-container-availability/>
-          <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-      </availability-service>
-      <network-config>
-        <protocols>
-          <protocol name="http-listener-1">
-            <http default-virtual-server="server" max-connections="250">
-              <file-cache enabled="false"></file-cache>
-            </http>
-	    <ssl ssl3-enabled="false" />
-          </protocol>
-          <protocol security-enabled="true" name="http-listener-2">
-            <http default-virtual-server="server" max-connections="250">
-              <file-cache enabled="false"></file-cache>
-            </http>
-            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
-          </protocol>
-          <protocol name="admin-listener">
-            <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
-              <file-cache enabled="false"></file-cache>
-            </http>
-          </protocol>
-        </protocols>
-        <network-listeners>
-          <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
-          <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
-          <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
-        </network-listeners>
-        <transports>
-          <transport name="tcp"></transport>
-        </transports>
-      </network-config>
-      <thread-pools>
-          <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
-          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
-      </thread-pools>
-    </config>
-     <config name="default-config" dynamic-reconfiguration-enabled="true" >
-         <http-service>
-             <access-log/>
-             <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
-                 <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
-             </virtual-server>
-             <virtual-server id="__asadmin" network-listeners="admin-listener" />
-         </http-service>
-         <iiop-service>
-             <orb use-thread-pool-ids="thread-pool-1" />
-             <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
-	         <ssl ssl3-enabled="false" />
-             <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
-                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-             </iiop-listener>
-             <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
-                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-             </iiop-listener>
-         </iiop-service>
-         <admin-service system-jmx-connector-name="system" type="server">
-             <!-- JSR 160  "system-jmx-connector" -->
-             <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
-             <!-- JSR 160  "system-jmx-connector" -->
-             <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-         </admin-service>
-         <web-container>
-             <session-config>
-                 <session-manager>
-                     <manager-properties/>
-                     <store-properties />
-                 </session-manager>
-                 <session-properties />
-             </session-config>
-         </web-container>
-         <ejb-container session-store="${com.sun.aas.instanceRoot}/session-store">
-             <ejb-timer-service />
-         </ejb-container>
-         <mdb-container />
-         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
-             <module-log-levels />
-         </log-service>
-         <security-service>
-             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-                 <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
-                 <property name="jaas-context" value="fileRealm" />
-             </auth-realm>
-             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-                 <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
-                 <property name="jaas-context" value="fileRealm" />
-             </auth-realm>
-             <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-             <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
-                 <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
-             </jacc-provider>
-             <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
-             <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-                 <property value="false" name="auditOn" />
-             </audit-module>
-             <message-security-config auth-layer="SOAP">
-                 <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="dynamic.username.password" value="false" />
-                     <property name="debug" value="false" />
-                 </provider-config>
-                 <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="dynamic.username.password" value="false" />
-                     <property name="debug" value="false" />
-                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                 </provider-config>
-                 <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="debug" value="false" />
-                 </provider-config>
-                 <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="debug" value="false" />
-                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                 </provider-config>
-             </message-security-config>
-         </security-service>
-         <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
-         <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
-         <request-tracing-service-configuration>
-             <log-notifier></log-notifier>
-         </request-tracing-service-configuration>
-      <notification-service-configuration enabled="true">
-        <log-notifier-configuration enabled="true"></log-notifier-configuration>
-      </notification-service-configuration>
-      <monitoring-service-configuration></monitoring-service-configuration>
-      <microprofile-metrics-configuration></microprofile-metrics-configuration>
-         <diagnostic-service />
-         <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
-             <jvm-options>-server</jvm-options>
-             <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-             <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-             <!-- Hazelcast internal package access requirement to get the best performance results. -->
-             <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-             <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-             <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-             <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-             <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-             <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-             <jvm-options>-Djava.awt.headless=true</jvm-options>
-             <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-             <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-             <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-             <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-             <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
-             <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-             <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-             <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-             <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-             <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-             <jvm-options>-XX:NewRatio=2</jvm-options>
-             <jvm-options>-Xmx512m</jvm-options>
-             <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names.
-                  The remote shell bundle has been disabled for cluster and remote instances. -->
-             <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.fileinstall</jvm-options>
-             <!-- Port on which remote shell listens for connections.-->
-             <jvm-options>-Dosgi.shell.telnet.port=${OSGI_SHELL_TELNET_PORT}</jvm-options>
-             <!-- How many concurrent users can connect to this remote shell -->
-             <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
-             <!-- From which hosts users can connect -->
-             <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
-             <!-- Gogo shell configuration -->
-             <!--PAYARA-495-->
-             <!--<jvm-options>-Dgosh.args=nointeractive</jvm-options>-->
-             <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
-             <!-- Directory being watched by fileinstall. -->
-             <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
-             <!-- Time period fileinstaller thread in ms. -->
-             <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
-             <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
-             <jvm-options>-Dfelix.fileinstall.log.level=3</jvm-options>
-             <!-- should new bundles be started or installed only?
-                 true => start, false => only install
-             -->
-             <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
-             <!-- should watched bundles be started transiently or persistently -->
-             <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
-             <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
-                  If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
-             -->
-             <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
-             <!-- End of OSGi bundle configurations -->
-             <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-             <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-             <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
-             <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-             <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-             <!-- Grizzly NPN Jar version -->
-             <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-             <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-             <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-             <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-             <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-             <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-             <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        </java-config>
-         <availability-service>
-             <web-container-availability/>
-             <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-         </availability-service>
-         <network-config>
-             <protocols>
-                 <protocol name="http-listener-1">
-                     <http default-virtual-server="server">
-                         <file-cache />
-                     </http>
-		     <ssl ssl3-enabled="false" />
-                 </protocol>
-                 <protocol security-enabled="true" name="http-listener-2">
-                     <http default-virtual-server="server">
-                         <file-cache />
-                     </http>
-                     <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
-                 </protocol>
-                 <protocol name="admin-listener">
-                     <http default-virtual-server="__asadmin" max-connections="250">
-                         <file-cache enabled="false" />
-                     </http>
-                 </protocol>
-                 <protocol security-enabled="true" name="sec-admin-listener">
-                   <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
-                     <file-cache></file-cache>
-                   </http>
-                   <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
-                 </protocol>
-                 <protocol name="admin-http-redirect">
-                   <http-redirect secure="true"></http-redirect>
-                 </protocol>
-                 <protocol name="pu-protocol">
-                   <port-unification>
-                     <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                     <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                   </port-unification>
-                 </protocol>
+    <hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
+    <security-configurations>
+        <authentication-service default="true" name="adminAuth" use-password-credential="true">
+            <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+                <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+                    <property name="config" value="server-config"></property>
+                    <property name="auth-realm" value="admin-realm"></property>
+                </login-module-config>
+            </security-provider>
+            <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+                <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+                    <property name="config" value="server-config"></property>
+                    <property name="auth-realm" value="admin-realm"></property>
+                </login-module-config>
+            </security-provider>
+        </authentication-service>
+        <authorization-service default="true" name="authorizationService">
+            <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+                <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+            </security-provider>
+        </authorization-service>
+    </security-configurations>
+    <system-applications />
+    <resources>
+        <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
+        <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
+        <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
+        <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+            <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+            <property value=";create=true" name="connectionAttributes" />
+        </jdbc-connection-pool>
+        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.ClientDataSource" res-type="javax.sql.DataSource">
+            <property value="1527" name="PortNumber" />
+            <property value="APP" name="Password" />
+            <property value="APP" name="User" />
+            <property value="localhost" name="serverName" />
+            <property value="sun-appserv-samples" name="DatabaseName" />
+            <property value=";create=true" name="connectionAttributes" />
+        </jdbc-connection-pool>
+        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
+            <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
+        </jdbc-connection-pool>
+    </resources>
+    <servers>
+        <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+            <resource-ref ref="jdbc/__TimerPool" />
+            <resource-ref ref="jdbc/__default" />
+            <resource-ref ref="jdbc/__derby" />
+        </server>
+    </servers>
+    <nodes>
+        <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
+    </nodes>
+    <configs>
+        <config name="%%%CONFIG_MODEL_NAME%%%">
+            <!--%%%TOKENS_HERE%%%-->
+            <!--%%%PORT_BASE%%%-->
+            <http-service>
+                <access-log/>
+                <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
+                <virtual-server id="__asadmin" network-listeners="admin-listener"/>
+            </http-service>
+            <iiop-service>
+                <orb use-thread-pool-ids="thread-pool-1" />
+                <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
+                <ssl ssl3-enabled="false" />
+                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                </iiop-listener>
+                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+                </iiop-listener>
+            </iiop-service>
+            <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+                <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+                <property value="/admin" name="adminConsoleContextRoot" />
+                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+                <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+            </admin-service>
+            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+            <connector-service shutdown-timeout-in-seconds="30">
+            </connector-service>
+            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" />
+            <asadmin-recorder-configuration></asadmin-recorder-configuration>
+            <request-tracing-service-configuration>
+                <log-notifier></log-notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
+            <monitoring-service-configuration></monitoring-service-configuration>
+            <microprofile-metrics-configuration></microprofile-metrics-configuration>
+            <diagnostic-service />
+            <security-service>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                    <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+                    <property value="fileRealm" name="jaas-context" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                    <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+                    <property value="fileRealm" name="jaas-context" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
+                    <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+                </jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
+                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                    <property value="false" name="auditOn" />
+                </audit-module>
+                <message-security-config auth-layer="SOAP">
+                    <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="dynamic.username.password" />
+                        <property value="false" name="debug" />
+                    </provider-config>
+                    <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="dynamic.username.password" />
+                        <property value="false" name="debug" />
+                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+                    </provider-config>
+                    <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="debug" />
+                    </provider-config>
+                    <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="debug" />
+                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+                    </provider-config>
+                </message-security-config>
+                <message-security-config auth-layer="HttpServlet">
+                    <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                        <request-policy auth-source="sender"></request-policy>
+                        <response-policy></response-policy>
+                        <property name="loginPage" value="/login.jsf"></property>
+                        <property name="loginErrorPage" value="/loginError.jsf"></property>
+                    </provider-config>
+                </message-security-config>
+                <property value="SHA-256" name="default-digest-algorithm" />
+            </security-service>
+            <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+                <jvm-options>-client</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+                <!-- Hazelcast internal package access requirement to get the best performance results. -->
+                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+                <jvm-options>-Djava.awt.headless=true</jvm-options>
+                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+                <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+                <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
+                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+                <jvm-options>-Xmx512m</jvm-options>
+                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+                <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
+                <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.shell.remote,org.apache.felix.fileinstall</jvm-options>
+                <!-- Configuration of various third-party OSGi bundles like
+                Felix Remote Shell, FileInstall, etc. -->
+                <!-- Port on which remote shell listens for connections.-->
+                <jvm-options>-Dosgi.shell.telnet.port=%%%OSGI_SHELL_TELNET_PORT%%%</jvm-options>
+                <!-- How many concurrent users can connect to this remote shell -->
+                <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+                <!-- From which hosts users can connect -->
+                <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+                <!-- Gogo shell configuration -->
+                <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+                <!-- Directory being watched by fileinstall. -->
+                <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+                <!-- Time period fileinstaller thread in ms. -->
+                <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+                <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+                <jvm-options>-Dfelix.fileinstall.log.level=2</jvm-options>
+                <!-- should new bundles be started or installed only? 
+                     true => start, false => only install 
+                -->
+                <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+                <!-- should watched bundles be started transiently or persistently -->
+                <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+                <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+                     If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+                -->
+                <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+                <!-- End of OSGi bundle configurations -->
+                <jvm-options>-XX:NewRatio=2</jvm-options>
+                <!-- Woodstox property needed to pass StAX TCK -->
+                <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
+                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+                <!-- Grizzly NPN Jar version -->
+                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+            </java-config>
+            <availability-service>
+                <web-container-availability/>
+                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+            </availability-service>
+            <network-config>
+                <protocols>
+                    <protocol name="http-listener-1">
+                        <http default-virtual-server="server" max-connections="250">
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                        <ssl ssl3-enabled="false" />
+                    </protocol>
+                    <protocol security-enabled="true" name="http-listener-2">
+                        <http default-virtual-server="server" max-connections="250">
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+                    </protocol>
+                    <protocol name="admin-listener">
+                        <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                    </protocol>
+                </protocols>
+                <network-listeners>
+                    <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+                    <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+                    <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+                </network-listeners>
+                <transports>
+                    <transport name="tcp"></transport>
+                </transports>
+            </network-config>
+            <thread-pools>
+                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+                <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+                <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+            </thread-pools>
+        </config>
+        <config name="default-config" dynamic-reconfiguration-enabled="true" >
+            <http-service>
+                <access-log/>
+                <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
+                    <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
+                </virtual-server>
+                <virtual-server id="__asadmin" network-listeners="admin-listener" />
+            </http-service>
+            <iiop-service>
+                <orb use-thread-pool-ids="thread-pool-1" />
+                <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
+                <ssl ssl3-enabled="false" />
+                <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                </iiop-listener>
+                <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+                </iiop-listener>
+            </iiop-service>
+            <admin-service system-jmx-connector-name="system" type="server">
+                <!-- JSR 160  "system-jmx-connector" -->
+                <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
+                <!-- JSR 160  "system-jmx-connector" -->
+                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+            </admin-service>
+            <web-container>
+                <session-config>
+                    <session-manager>
+                        <manager-properties/>
+                        <store-properties />
+                    </session-manager>
+                    <session-properties />
+                </session-config>
+            </web-container>
+            <ejb-container session-store="${com.sun.aas.instanceRoot}/session-store">
+                <ejb-timer-service />
+            </ejb-container>
+            <mdb-container />
+            <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+                <module-log-levels />
+            </log-service>
+            <security-service>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                    <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                    <property name="jaas-context" value="fileRealm" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                    <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                    <property name="jaas-context" value="fileRealm" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+                <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
+                    <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
+                </jacc-provider>
+                <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
+                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                    <property value="false" name="auditOn" />
+                </audit-module>
+                <message-security-config auth-layer="SOAP">
+                    <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="dynamic.username.password" value="false" />
+                        <property name="debug" value="false" />
+                    </provider-config>
+                    <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="dynamic.username.password" value="false" />
+                        <property name="debug" value="false" />
+                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                    </provider-config>
+                    <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="debug" value="false" />
+                    </provider-config>
+                    <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="debug" value="false" />
+                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                    </provider-config>
+                </message-security-config>
+            </security-service>
+            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
+            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+            <request-tracing-service-configuration>
+                <log-notifier></log-notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
+            <monitoring-service-configuration></monitoring-service-configuration>
+            <microprofile-metrics-configuration></microprofile-metrics-configuration>
+            <diagnostic-service />
+            <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+                <jvm-options>-server</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+                <!-- Hazelcast internal package access requirement to get the best performance results. -->
+                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+                <jvm-options>-Djava.awt.headless=true</jvm-options>
+                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+                <jvm-options>-XX:NewRatio=2</jvm-options>
+                <jvm-options>-Xmx512m</jvm-options>
+                <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names.
+                The remote shell bundle has been disabled for cluster and remote instances. -->
+                <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.fileinstall</jvm-options>
+                <!-- Port on which remote shell listens for connections.-->
+                <jvm-options>-Dosgi.shell.telnet.port=${OSGI_SHELL_TELNET_PORT}</jvm-options>
+                <!-- How many concurrent users can connect to this remote shell -->
+                <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+                <!-- From which hosts users can connect -->
+                <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+                <!-- Gogo shell configuration -->
+                <!--PAYARA-495-->
+                <!--<jvm-options>-Dgosh.args=nointeractive</jvm-options>-->
+                <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+                <!-- Directory being watched by fileinstall. -->
+                <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+                <!-- Time period fileinstaller thread in ms. -->
+                <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+                <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+                <jvm-options>-Dfelix.fileinstall.log.level=3</jvm-options>
+                <!-- should new bundles be started or installed only?
+                    true => start, false => only install
+                -->
+                <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+                <!-- should watched bundles be started transiently or persistently -->
+                <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+                <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+                     If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+                -->
+                <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+                <!-- End of OSGi bundle configurations -->
+                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+                <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
+                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+                <!-- Grizzly NPN Jar version -->
+                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+            </java-config>
+            <availability-service>
+                <web-container-availability/>
+                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+            </availability-service>
+            <network-config>
+                <protocols>
+                    <protocol name="http-listener-1">
+                        <http default-virtual-server="server">
+                            <file-cache />
+                        </http>
+                        <ssl ssl3-enabled="false" />
+                    </protocol>
+                    <protocol security-enabled="true" name="http-listener-2">
+                        <http default-virtual-server="server">
+                            <file-cache />
+                        </http>
+                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
+                    </protocol>
+                    <protocol name="admin-listener">
+                        <http default-virtual-server="__asadmin" max-connections="250">
+                            <file-cache enabled="false" />
+                        </http>
+                    </protocol>
+                    <protocol security-enabled="true" name="sec-admin-listener">
+                        <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                            <file-cache></file-cache>
+                        </http>
+                        <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                    </protocol>
+                    <protocol name="admin-http-redirect">
+                        <http-redirect secure="true"></http-redirect>
+                    </protocol>
+                    <protocol name="pu-protocol">
+                        <port-unification>
+                            <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                            <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                        </port-unification>
+                    </protocol>
 
-             </protocols>
-             <network-listeners>
-                 <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
-                 <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
-                 <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
-             </network-listeners>
-             <transports>
-                 <transport name="tcp" />
-             </transports>
-         </network-config>
-         <thread-pools>
-             <thread-pool name="http-thread-pool" />
-             <thread-pool min-thread-pool-size="2" max-thread-pool-size="200" idle-thread-timeout-in-seconds="120" name="thread-pool-1" />
-	     <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-         </thread-pools>
-         <group-management-service/>
-         <!--%%%DEFAULT_TOKENS_HERE%%%-->
-         <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
-         <system-property name="HTTP_LISTENER_PORT" value="28080"/>
-         <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
-         <system-property name="IIOP_LISTENER_PORT" value="23700"/>
-         <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
-         <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
-         <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
-         <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
-         <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
-     </config>
-  </configs>
-  <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
-  <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
-      <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
-      <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
-  </secure-admin>
+                </protocols>
+                <network-listeners>
+                    <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                    <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                    <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+                </network-listeners>
+                <transports>
+                    <transport name="tcp" />
+                </transports>
+            </network-config>
+            <thread-pools>
+                <thread-pool name="http-thread-pool" />
+                <thread-pool min-thread-pool-size="2" max-thread-pool-size="200" idle-thread-timeout-in-seconds="120" name="thread-pool-1" />
+                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+            </thread-pools>
+            <group-management-service/>
+            <!--%%%DEFAULT_TOKENS_HERE%%%-->
+            <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
+            <system-property name="HTTP_LISTENER_PORT" value="28080"/>
+            <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
+            <system-property name="IIOP_LISTENER_PORT" value="23700"/>
+            <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
+            <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
+            <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
+            <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
+            <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
+        </config>
+    </configs>
+    <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
+    <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
+        <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
+        <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
+    </secure-admin>
 </domain>

--- a/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
-   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
-  
-   The contents of this file are subject to the terms of either the GNU
-   General Public License Version 2 only ("GPL") or the Common Development
-   and Distribution License("CDDL") (collectively, the "License").  You
-   may not use this file except in compliance with the License.  You can
-   obtain a copy of the License at
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+   Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
-   language governing permissions and limitations under the License.
-  
-   When distributing the software, include this License Header Notice in each
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-  
-   GPL Classpath Exception:
+
+    GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
-   file that accompanied this code.
-  
-   Modifications:
-   If applicable, add the following below the License Header, with the fields
-   enclosed by brackets [] replaced by your own identifying information:
-   "Portions Copyright [year] [name of copyright owner]"
-  
-   Contributor(s):
-   If you wish your version of this file to be governed by only the CDDL or
-   only the GPL Version 2, indicate your decision by adding "[Contributor]
-   elects to include this software in this distribution under the [CDDL or GPL
-   Version 2] license."  If you don't indicate a single choice of license, a
-   recipient has the option to distribute your version of this file under
-   either the CDDL, the GPL Version 2 or to extend the choice of license to
-   its licensees as provided above.  However, if you add GPL Version 2 code
-   and therefore, elected the GPL Version 2 license, then the option applies
-   only if the new code is made subject to such option by the copyright
-   holder.
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
 -->
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
     <component id="GlassFish Core">
         <group-ref name="glassfish-core-sub"/>
     </component>
     <group id="glassfish-core-sub" mode="forward">
-    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+        <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
         <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
         <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
         <change-pair-ref name="VERSION"/>
@@ -71,6 +71,9 @@
         <change-pair-ref name="TOKENS_HERE"/>
         <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
         <change-pair-ref name="PORT_BASE"/>
+        <change-pair-ref name="HAZELCAST_DAS_PORT"/>
+        <change-pair-ref name="HAZELCAST_START_PORT"/>
+        <change-pair-ref name="HAZELCAST_AUTO_INCREMENT"/>
     </group>
     <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
     <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
@@ -97,6 +100,9 @@
     <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
     <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
     <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <change-pair id="HAZELCAST_DAS_PORT" before="%%%HAZELCAST_DAS_PORT%%%" after="$HAZELCAST_DAS_PORT$"/>
+    <change-pair id="HAZELCAST_START_PORT" before="%%%HAZELCAST_START_PORT%%%" after="$HAZELCAST_START_PORT$"/>
+    <change-pair id="HAZELCAST_AUTO_INCREMENT" before="%%%HAZELCAST_AUTO_INCREMENT%%%" after="$HAZELCAST_AUTO_INCREMENT$"/>
     <defaults>
         <property key="ADMIN_PORT" value="4848" type="port"/>
         <property key="HTTP_SSL_PORT" value="8181" type="port"/>
@@ -108,5 +114,8 @@
         <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
         <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
         <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+        <property key="HAZELCAST_DAS_PORT" value="4900" type="port"/>
+        <property key="HAZELCAST_START_PORT" value="5900" type="port"/>
+        <property key="HAZELCAST_AUTO_INCREMENT" value="true" type="string"/>
     </defaults>
 </stringsubs-definition>

--- a/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/stringsubs.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
+  
+   GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
     <component id="GlassFish Core">
         <group-ref name="glassfish-core-sub"/>
     </component>
     <group id="glassfish-core-sub" mode="forward">
-        <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
         <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
         <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
         <change-pair-ref name="VERSION"/>

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -16,7 +16,7 @@
  -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-<hazelcast-runtime-configuration></hazelcast-runtime-configuration>
+<hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
 <security-configurations>
     <authentication-service default="true" name="adminAuth" use-password-credential="true">
       <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">

--- a/appserver/admin/production_domain_template/src/main/resources/stringsubs.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/stringsubs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- * Copyright (c) 2016 Payara Foundation. All rights reserved.
+ * Copyright (c) [2016-2019] Payara Foundation. All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (collectively, the "License").  You
@@ -20,7 +20,7 @@
         <group-ref name="glassfish-core-sub"/>
     </component>
     <group id="glassfish-core-sub" mode="forward">
-    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+        <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
         <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
         <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
         <change-pair-ref name="VERSION"/>
@@ -48,6 +48,9 @@
         <change-pair-ref name="TOKENS_HERE"/>
         <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
         <change-pair-ref name="PORT_BASE"/>
+        <change-pair-ref name="HAZELCAST_DAS_PORT"/>
+        <change-pair-ref name="HAZELCAST_START_PORT"/>
+        <change-pair-ref name="HAZELCAST_AUTO_INCREMENT"/>
     </group>
     <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
     <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
@@ -74,6 +77,9 @@
     <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
     <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
     <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <change-pair id="HAZELCAST_DAS_PORT" before="%%%HAZELCAST_DAS_PORT%%%" after="$HAZELCAST_DAS_PORT$"/>
+    <change-pair id="HAZELCAST_START_PORT" before="%%%HAZELCAST_START_PORT%%%" after="$HAZELCAST_START_PORT$"/>
+    <change-pair id="HAZELCAST_AUTO_INCREMENT" before="%%%HAZELCAST_AUTO_INCREMENT%%%" after="$HAZELCAST_AUTO_INCREMENT$"/>
     <defaults>
         <property key="ADMIN_PORT" value="4848" type="port"/>
         <property key="HTTP_SSL_PORT" value="8181" type="port"/>
@@ -85,5 +91,8 @@
         <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
         <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
         <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+        <property key="HAZELCAST_DAS_PORT" value="4900" type="port"/>
+        <property key="HAZELCAST_START_PORT" value="5900" type="port"/>
+        <property key="HAZELCAST_AUTO_INCREMENT" value="true" type="string"/>
     </defaults>
 </stringsubs-definition>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -1,8 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
+
    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
@@ -41,467 +39,468 @@
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-<security-configurations>
-    <authentication-service default="true" name="adminAuth" use-password-credential="true">
-      <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
-        <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
-          <property name="config" value="server-config"></property>
-          <property name="auth-realm" value="admin-realm"></property>
-        </login-module-config>
-      </security-provider>
-      <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
-        <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
-          <property name="config" value="server-config"></property>
-          <property name="auth-realm" value="admin-realm"></property>
-        </login-module-config>
-      </security-provider>
-    </authentication-service>
-    <authorization-service default="true" name="authorizationService">
-      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
-        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
-      </security-provider>
-    </authorization-service>
-  </security-configurations>
-  <system-applications />
-  <resources>
-    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
-    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
-    <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
-    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
-      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
-      <property value=";create=true" name="connectionAttributes" />
-    </jdbc-connection-pool>
-    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
-      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/derby_default" />
-      <property name="connectionAttributes" value=";create=true" />
-    </jdbc-connection-pool>
-    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
-      <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
-    </jdbc-connection-pool>
-  </resources>
-  <servers>
-    <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
-      <resource-ref ref="jdbc/__TimerPool" />
-      <resource-ref ref="jdbc/__default" />
-      <resource-ref ref="jdbc/__derby" />
-    </server>
-  </servers>
-  <nodes>
-    <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
-  </nodes>
- <configs>
-   <config name="%%%CONFIG_MODEL_NAME%%%">
-      <!--%%%TOKENS_HERE%%%-->
-      <!--%%%PORT_BASE%%%-->
-      <http-service>
-        <access-log/>
-        <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
-        <virtual-server id="__asadmin" network-listeners="admin-listener"/>
-      </http-service>
-      <iiop-service>
-        <orb use-thread-pool-ids="thread-pool-1" />
-        <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
-	  <ssl ssl3-enabled="false" />
-        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
-          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-        </iiop-listener>
-        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
-          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-        </iiop-listener>
-      </iiop-service>
-      <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
-        <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
-        <property value="/admin" name="adminConsoleContextRoot" />
-        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
-        <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
-      </admin-service>
-      <connector-service shutdown-timeout-in-seconds="30">
-      </connector-service>
-       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" timeout-in-seconds="300">
-         <property name="xaresource-txn-timeout" value="300"/>
-       </transaction-service>
-       <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
-       <ejb-container max-pool-size="128">
-         <ejb-timer-service />
-       </ejb-container>
-       <asadmin-recorder-configuration></asadmin-recorder-configuration>
-       <request-tracing-service-configuration>
-         <log-notifier></log-notifier>
-       </request-tracing-service-configuration>
-      <notification-service-configuration enabled="true">
-        <log-notifier-configuration enabled="true"></log-notifier-configuration>
-      </notification-service-configuration>
-       <batch-runtime-configuration data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
-       <monitoring-service-configuration></monitoring-service-configuration>
-       <microprofile-metrics-configuration></microprofile-metrics-configuration>
-       <diagnostic-service />
-      <security-service activate-default-principal-to-role-mapping="true">
-        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
-          <property value="fileRealm" name="jaas-context" />
-        </auth-realm>
-        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
-          <property value="fileRealm" name="jaas-context" />
-        </auth-realm>
-        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
-          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
-        </jacc-provider>
-        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
-        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-          <property value="false" name="auditOn" />
-        </audit-module>
-        <message-security-config auth-layer="SOAP">
-          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="dynamic.username.password" />
-            <property value="false" name="debug" />
-          </provider-config>
-          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="dynamic.username.password" />
-            <property value="false" name="debug" />
-            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-          </provider-config>
-          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="debug" />
-          </provider-config>
-          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-            <request-policy auth-source="content" />
-            <response-policy auth-source="content" />
-            <property value="s1as" name="encryption.key.alias" />
-            <property value="s1as" name="signature.key.alias" />
-            <property value="false" name="debug" />
-            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-          </provider-config>
-        </message-security-config>
-        <message-security-config auth-layer="HttpServlet">
-            <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
-                <request-policy auth-source="sender"></request-policy>
-                <response-policy></response-policy>
-                <property name="loginPage" value="/login.jsf"></property>
-                <property name="loginErrorPage" value="/loginError.jsf"></property>
-            </provider-config>
-        </message-security-config>
-	<property value="SHA-256" name="default-digest-algorithm" />
-      </security-service>
-      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
-        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-        <!-- Hazelcast internal package access requirement to get the best performance results. -->
-        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-        <jvm-options>-XX:+UseG1GC</jvm-options>
-        <jvm-options>-XX:+UseStringDeduplication</jvm-options>
-        <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
-        <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
-        <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
-        <jvm-options>-Djava.awt.headless=true</jvm-options>
-        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-        <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
-        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-        <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-        <jvm-options>-Xmx2g</jvm-options>
-        <jvm-options>-Xms2g</jvm-options>
-        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-        <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-        <!-- Grizzly NPN Jar version -->
-        <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-        <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-        <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-        <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-        <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-        <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-        <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-      </java-config>
-      <availability-service>
-          <web-container-availability/>
-          <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-          <jms-availability/>
-      </availability-service>
-      <network-config>
-        <protocols>
-          <protocol name="http-listener-1">
-            <http default-virtual-server="server" max-connections="250">
-              <file-cache enabled="true"></file-cache>
-            </http>
-	    <ssl ssl3-enabled="false" />
-          </protocol>
-          <protocol security-enabled="true" name="http-listener-2">
-            <http default-virtual-server="server" max-connections="250">
-              <file-cache enabled="true"></file-cache>
-            </http>
-            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
-          </protocol>
-          <protocol name="admin-listener">
-            <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
-              <file-cache enabled="false"></file-cache>
-            </http>
-          </protocol>
-        </protocols>
-        <network-listeners>
-          <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
-          <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
-          <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
-        </network-listeners>
-        <transports>
-          <transport name="tcp"></transport>
-        </transports>
-      </network-config>
-      <thread-pools>
-        <thread-pool max-thread-pool-size="50" name="http-thread-pool"></thread-pool>
-        <thread-pool max-thread-pool-size="250" name="thread-pool-1"></thread-pool>
-        <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-      </thread-pools>
-      <system-property name="fish.payara.classloading.delegate" value="false"/>
-      <system-property name="jersey.config.client.readTimeout" value="300000"/>
-      <system-property name="jersey.config.client.connectTimeout" value="300000"/>
-      <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
-      <system-property name="org.jboss.weld.probe.allowRemoteAddress" value="127.0.0.1|::1|::1%.+|0:0:0:0:0:0:0:1|0:0:0:0:0:0:0:1%.+"/>
-    </config>
-     <config name="default-config" dynamic-reconfiguration-enabled="true" >
-         <http-service>
-             <access-log/>
-             <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
-                 <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
-             </virtual-server>
-             <virtual-server id="__asadmin" network-listeners="admin-listener" />
-         </http-service>
-         <iiop-service>
-             <orb use-thread-pool-ids="thread-pool-1" />
-             <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
-	         <ssl ssl3-enabled="false" />
-             <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
-                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-             </iiop-listener>
-             <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
-                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-             </iiop-listener>
-         </iiop-service>
-         <admin-service system-jmx-connector-name="system" type="server">
-             <!-- JSR 160  "system-jmx-connector" -->
-             <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
-             <!-- JSR 160  "system-jmx-connector" -->
-             <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-             <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
-         </admin-service>
-         <web-container>
-             <session-config>
-                 <session-manager>
-                     <manager-properties/>
-                     <store-properties />
-                 </session-manager>
-                 <session-properties />
-             </session-config>
-         </web-container>
-         <ejb-container max-pool-size="128" session-store="${com.sun.aas.instanceRoot}/session-store">
-             <ejb-timer-service />
-         </ejb-container>
-         <mdb-container />
-         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
-             <module-log-levels />
-         </log-service>
-         <security-service activate-default-principal-to-role-mapping="true">
-             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-                 <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
-                 <property name="jaas-context" value="fileRealm" />
-             </auth-realm>
-             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-                 <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
-                 <property name="jaas-context" value="fileRealm" />
-             </auth-realm>
-             <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-             <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
-                 <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
-             </jacc-provider>
-             <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
-             <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-                 <property value="false" name="auditOn" />
-             </audit-module>
-             <message-security-config auth-layer="SOAP">
-                 <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="dynamic.username.password" value="false" />
-                     <property name="debug" value="false" />
-                 </provider-config>
-                 <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="dynamic.username.password" value="false" />
-                     <property name="debug" value="false" />
-                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                 </provider-config>
-                 <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="debug" value="false" />
-                 </provider-config>
-                 <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                     <request-policy auth-source="content" />
-                     <response-policy auth-source="content" />
-                     <property name="encryption.key.alias" value="s1as" />
-                     <property name="signature.key.alias" value="s1as" />
-                     <property name="debug" value="false" />
-                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                 </provider-config>
-             </message-security-config>
-         </security-service>
-         <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" timeout-in-seconds="300">
-           <property name="xaresource-txn-timeout" value="300"/>
-         </transaction-service>
-         <hazelcast-runtime-configuration></hazelcast-runtime-configuration>
-         <request-tracing-service-configuration>
-             <log-notifier></log-notifier>
-         </request-tracing-service-configuration>
-      <notification-service-configuration enabled="true">
-        <log-notifier-configuration enabled="true"></log-notifier-configuration>
-      </notification-service-configuration>
-      <monitoring-service-configuration></monitoring-service-configuration>
-      <microprofile-metrics-configuration></microprofile-metrics-configuration>
-         <diagnostic-service />
-      <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
-        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-        <!-- Hazelcast internal package access requirement to get the best performance results. -->
-        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-        <jvm-options>-XX:+UseG1GC</jvm-options>
-        <jvm-options>-XX:+UseStringDeduplication</jvm-options>
-        <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
-        <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
-        <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
-        <jvm-options>-Djava.awt.headless=true</jvm-options>
-        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-        <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-        <jvm-options>-Xmx2g</jvm-options>
-        <jvm-options>-Xms2g</jvm-options>
-        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>        
-        <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-        <!-- Grizzly NPN Jar version -->
-        <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-        <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-        <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-        <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-        <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-        <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-        <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-      </java-config>
-         <availability-service>
-             <web-container-availability/>
-             <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-         </availability-service>
-         <network-config>
-             <protocols>
-                 <protocol name="http-listener-1">
-                     <http default-virtual-server="server">
-                         <file-cache enabled="true" />
-                     </http>
-		     <ssl ssl3-enabled="false" />
-                 </protocol>
-                 <protocol security-enabled="true" name="http-listener-2">
-                     <http default-virtual-server="server">
-                         <file-cache enabled="true" />
-                     </http>
-                     <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
-                 </protocol>
-                 <protocol name="admin-listener">
-                     <http default-virtual-server="__asadmin" max-connections="250">
-                         <file-cache enabled="false" />
-                     </http>
-                 </protocol>
-                 <protocol security-enabled="true" name="sec-admin-listener">
-                   <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
-                     <file-cache></file-cache>
-                   </http>
-                   <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
-                 </protocol>
-                 <protocol name="admin-http-redirect">
-                   <http-redirect secure="true"></http-redirect>
-                 </protocol>
-                 <protocol name="pu-protocol">
-                   <port-unification>
-                     <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                     <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                   </port-unification>
-                 </protocol>
+    <hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
+    <security-configurations>
+        <authentication-service default="true" name="adminAuth" use-password-credential="true">
+            <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+                <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+                    <property name="config" value="server-config"></property>
+                    <property name="auth-realm" value="admin-realm"></property>
+                </login-module-config>
+            </security-provider>
+            <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+                <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+                    <property name="config" value="server-config"></property>
+                    <property name="auth-realm" value="admin-realm"></property>
+                </login-module-config>
+            </security-provider>
+        </authentication-service>
+        <authorization-service default="true" name="authorizationService">
+            <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+                <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+            </security-provider>
+        </authorization-service>
+    </security-configurations>
+    <system-applications />
+    <resources>
+        <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
+        <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
+        <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
+        <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+            <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+            <property value=";create=true" name="connectionAttributes" />
+        </jdbc-connection-pool>
+        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+            <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/derby_default" />
+            <property name="connectionAttributes" value=";create=true" />
+        </jdbc-connection-pool>
+        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
+            <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
+        </jdbc-connection-pool>
+    </resources>
+    <servers>
+        <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+            <resource-ref ref="jdbc/__TimerPool" />
+            <resource-ref ref="jdbc/__default" />
+            <resource-ref ref="jdbc/__derby" />
+        </server>
+    </servers>
+    <nodes>
+        <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
+    </nodes>
+    <configs>
+        <config name="%%%CONFIG_MODEL_NAME%%%">
+            <!--%%%TOKENS_HERE%%%-->
+            <!--%%%PORT_BASE%%%-->
+            <http-service>
+                <access-log/>
+                <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
+                <virtual-server id="__asadmin" network-listeners="admin-listener"/>
+            </http-service>
+            <iiop-service>
+                <orb use-thread-pool-ids="thread-pool-1" />
+                <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
+                <ssl ssl3-enabled="false" />
+                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                </iiop-listener>
+                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+                </iiop-listener>
+            </iiop-service>
+            <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+                <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+                <property value="/admin" name="adminConsoleContextRoot" />
+                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+                <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+                <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
+            </admin-service>
+            <connector-service shutdown-timeout-in-seconds="30">
+            </connector-service>
+            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" timeout-in-seconds="300">
+                <property name="xaresource-txn-timeout" value="300"/>
+            </transaction-service>
+            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+            <ejb-container max-pool-size="128">
+                <ejb-timer-service />
+            </ejb-container>
+            <asadmin-recorder-configuration></asadmin-recorder-configuration>
+            <request-tracing-service-configuration>
+                <log-notifier></log-notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
+            <batch-runtime-configuration data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
+            <monitoring-service-configuration></monitoring-service-configuration>
+            <microprofile-metrics-configuration></microprofile-metrics-configuration>
+            <diagnostic-service />
+            <security-service activate-default-principal-to-role-mapping="true">
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                    <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+                    <property value="fileRealm" name="jaas-context" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                    <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+                    <property value="fileRealm" name="jaas-context" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
+                    <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+                </jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
+                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                    <property value="false" name="auditOn" />
+                </audit-module>
+                <message-security-config auth-layer="SOAP">
+                    <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="dynamic.username.password" />
+                        <property value="false" name="debug" />
+                    </provider-config>
+                    <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="dynamic.username.password" />
+                        <property value="false" name="debug" />
+                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+                    </provider-config>
+                    <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="debug" />
+                    </provider-config>
+                    <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="debug" />
+                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+                    </provider-config>
+                </message-security-config>
+                <message-security-config auth-layer="HttpServlet">
+                    <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                        <request-policy auth-source="sender"></request-policy>
+                        <response-policy></response-policy>
+                        <property name="loginPage" value="/login.jsf"></property>
+                        <property name="loginErrorPage" value="/loginError.jsf"></property>
+                    </provider-config>
+                </message-security-config>
+                <property value="SHA-256" name="default-digest-algorithm" />
+            </security-service>
+            <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+                <!-- Hazelcast internal package access requirement to get the best performance results. -->
+                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+                <jvm-options>-XX:+UseG1GC</jvm-options>
+                <jvm-options>-XX:+UseStringDeduplication</jvm-options>
+                <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
+                <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
+                <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
+                <jvm-options>-Djava.awt.headless=true</jvm-options>
+                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+                <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+                <jvm-options>-Xmx2g</jvm-options>
+                <jvm-options>-Xms2g</jvm-options>
+                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+                <!-- Grizzly NPN Jar version -->
+                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+            </java-config>
+            <availability-service>
+                <web-container-availability/>
+                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+                <jms-availability/>
+            </availability-service>
+            <network-config>
+                <protocols>
+                    <protocol name="http-listener-1">
+                        <http default-virtual-server="server" max-connections="250">
+                            <file-cache enabled="true"></file-cache>
+                        </http>
+                        <ssl ssl3-enabled="false" />
+                    </protocol>
+                    <protocol security-enabled="true" name="http-listener-2">
+                        <http default-virtual-server="server" max-connections="250">
+                            <file-cache enabled="true"></file-cache>
+                        </http>
+                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+                    </protocol>
+                    <protocol name="admin-listener">
+                        <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                    </protocol>
+                </protocols>
+                <network-listeners>
+                    <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+                    <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+                    <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+                </network-listeners>
+                <transports>
+                    <transport name="tcp"></transport>
+                </transports>
+            </network-config>
+            <thread-pools>
+                <thread-pool max-thread-pool-size="50" name="http-thread-pool"></thread-pool>
+                <thread-pool max-thread-pool-size="250" name="thread-pool-1"></thread-pool>
+                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+            </thread-pools>
+            <system-property name="fish.payara.classloading.delegate" value="false"/>
+            <system-property name="jersey.config.client.readTimeout" value="300000"/>
+            <system-property name="jersey.config.client.connectTimeout" value="300000"/>
+            <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
+            <system-property name="org.jboss.weld.probe.allowRemoteAddress" value="127.0.0.1|::1|::1%.+|0:0:0:0:0:0:0:1|0:0:0:0:0:0:0:1%.+"/>
+        </config>
+        <config name="default-config" dynamic-reconfiguration-enabled="true" >
+            <http-service>
+                <access-log/>
+                <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
+                    <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
+                </virtual-server>
+                <virtual-server id="__asadmin" network-listeners="admin-listener" />
+            </http-service>
+            <iiop-service>
+                <orb use-thread-pool-ids="thread-pool-1" />
+                <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
+                <ssl ssl3-enabled="false" />
+                <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                </iiop-listener>
+                <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+                </iiop-listener>
+            </iiop-service>
+            <admin-service system-jmx-connector-name="system" type="server">
+                <!-- JSR 160  "system-jmx-connector" -->
+                <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
+                <!-- JSR 160  "system-jmx-connector" -->
+                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+                <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
+            </admin-service>
+            <web-container>
+                <session-config>
+                    <session-manager>
+                        <manager-properties/>
+                        <store-properties />
+                    </session-manager>
+                    <session-properties />
+                </session-config>
+            </web-container>
+            <ejb-container max-pool-size="128" session-store="${com.sun.aas.instanceRoot}/session-store">
+                <ejb-timer-service />
+            </ejb-container>
+            <mdb-container />
+            <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+                <module-log-levels />
+            </log-service>
+            <security-service activate-default-principal-to-role-mapping="true">
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                    <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                    <property name="jaas-context" value="fileRealm" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                    <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                    <property name="jaas-context" value="fileRealm" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+                <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
+                    <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
+                </jacc-provider>
+                <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
+                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                    <property value="false" name="auditOn" />
+                </audit-module>
+                <message-security-config auth-layer="SOAP">
+                    <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="dynamic.username.password" value="false" />
+                        <property name="debug" value="false" />
+                    </provider-config>
+                    <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="dynamic.username.password" value="false" />
+                        <property name="debug" value="false" />
+                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                    </provider-config>
+                    <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="debug" value="false" />
+                    </provider-config>
+                    <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="debug" value="false" />
+                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                    </provider-config>
+                </message-security-config>
+            </security-service>
+            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" timeout-in-seconds="300">
+                <property name="xaresource-txn-timeout" value="300"/>
+            </transaction-service>
+            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+            <request-tracing-service-configuration>
+                <log-notifier></log-notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
+            <monitoring-service-configuration></monitoring-service-configuration>
+            <microprofile-metrics-configuration></microprofile-metrics-configuration>
+            <diagnostic-service />
+            <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+                <!-- Hazelcast internal package access requirement to get the best performance results. -->
+                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+                <jvm-options>-XX:+UseG1GC</jvm-options>
+                <jvm-options>-XX:+UseStringDeduplication</jvm-options>
+                <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
+                <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
+                <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
+                <jvm-options>-Djava.awt.headless=true</jvm-options>
+                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+                <jvm-options>-Xmx2g</jvm-options>
+                <jvm-options>-Xms2g</jvm-options>
+                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+                <!-- Grizzly NPN Jar version -->
+                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+            </java-config>
+            <availability-service>
+                <web-container-availability/>
+                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+            </availability-service>
+            <network-config>
+                <protocols>
+                    <protocol name="http-listener-1">
+                        <http default-virtual-server="server">
+                            <file-cache enabled="true" />
+                        </http>
+                        <ssl ssl3-enabled="false" />
+                    </protocol>
+                    <protocol security-enabled="true" name="http-listener-2">
+                        <http default-virtual-server="server">
+                            <file-cache enabled="true" />
+                        </http>
+                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
+                    </protocol>
+                    <protocol name="admin-listener">
+                        <http default-virtual-server="__asadmin" max-connections="250">
+                            <file-cache enabled="false" />
+                        </http>
+                    </protocol>
+                    <protocol security-enabled="true" name="sec-admin-listener">
+                        <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                            <file-cache></file-cache>
+                        </http>
+                        <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                    </protocol>
+                    <protocol name="admin-http-redirect">
+                        <http-redirect secure="true"></http-redirect>
+                    </protocol>
+                    <protocol name="pu-protocol">
+                        <port-unification>
+                            <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                            <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                        </port-unification>
+                    </protocol>
 
-             </protocols>
-             <network-listeners>
-                 <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
-                 <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
-                 <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
-             </network-listeners>
-             <transports>
-                 <transport name="tcp" />
-             </transports>
-         </network-config>
-         <thread-pools>
-             <thread-pool name="http-thread-pool" />
-             <thread-pool max-thread-pool-size="250" idle-thread-timeout-in-seconds="120" name="thread-pool-1" min-thread-pool-size="2"/>
-	     <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-         </thread-pools>
-         <group-management-service/>
-         <!--%%%DEFAULT_TOKENS_HERE%%%-->
-         <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
-         <system-property name="HTTP_LISTENER_PORT" value="28080"/>
-         <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
-         <system-property name="IIOP_LISTENER_PORT" value="23700"/>
-         <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
-         <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
-         <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
-         <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
-         <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
-         <system-property name="fish.payara.classloading.delegate" value="false"/>
-         <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
-     </config>
-  </configs>
-  <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
-  <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
-      <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
-      <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
-  </secure-admin>
+                </protocols>
+                <network-listeners>
+                    <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                    <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                    <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+                </network-listeners>
+                <transports>
+                    <transport name="tcp" />
+                </transports>
+            </network-config>
+            <thread-pools>
+                <thread-pool name="http-thread-pool" />
+                <thread-pool max-thread-pool-size="250" idle-thread-timeout-in-seconds="120" name="thread-pool-1" min-thread-pool-size="2"/>
+                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+            </thread-pools>
+            <group-management-service/>
+            <!--%%%DEFAULT_TOKENS_HERE%%%-->
+            <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
+            <system-property name="HTTP_LISTENER_PORT" value="28080"/>
+            <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
+            <system-property name="IIOP_LISTENER_PORT" value="23700"/>
+            <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
+            <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
+            <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
+            <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
+            <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
+            <system-property name="fish.payara.classloading.delegate" value="false"/>
+            <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
+        </config>
+    </configs>
+    <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
+    <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
+        <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
+        <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
+    </secure-admin>
 </domain>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -1,6 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
+  
    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
@@ -39,468 +41,468 @@
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-    <hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
-    <security-configurations>
-        <authentication-service default="true" name="adminAuth" use-password-credential="true">
-            <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
-                <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
-                    <property name="config" value="server-config"></property>
-                    <property name="auth-realm" value="admin-realm"></property>
-                </login-module-config>
-            </security-provider>
-            <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
-                <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
-                    <property name="config" value="server-config"></property>
-                    <property name="auth-realm" value="admin-realm"></property>
-                </login-module-config>
-            </security-provider>
-        </authentication-service>
-        <authorization-service default="true" name="authorizationService">
-            <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
-                <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
-            </security-provider>
-        </authorization-service>
-    </security-configurations>
-    <system-applications />
-    <resources>
-        <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
-        <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
-        <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
-        <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
-            <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
-            <property value=";create=true" name="connectionAttributes" />
-        </jdbc-connection-pool>
-        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
-            <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/derby_default" />
-            <property name="connectionAttributes" value=";create=true" />
-        </jdbc-connection-pool>
-        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
-            <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
-        </jdbc-connection-pool>
-    </resources>
-    <servers>
-        <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
-            <resource-ref ref="jdbc/__TimerPool" />
-            <resource-ref ref="jdbc/__default" />
-            <resource-ref ref="jdbc/__derby" />
-        </server>
-    </servers>
-    <nodes>
-        <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
-    </nodes>
-    <configs>
-        <config name="%%%CONFIG_MODEL_NAME%%%">
-            <!--%%%TOKENS_HERE%%%-->
-            <!--%%%PORT_BASE%%%-->
-            <http-service>
-                <access-log/>
-                <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
-                <virtual-server id="__asadmin" network-listeners="admin-listener"/>
-            </http-service>
-            <iiop-service>
-                <orb use-thread-pool-ids="thread-pool-1" />
-                <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
-                <ssl ssl3-enabled="false" />
-                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-                </iiop-listener>
-                <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-                </iiop-listener>
-            </iiop-service>
-            <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
-                <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
-                <property value="/admin" name="adminConsoleContextRoot" />
-                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-                <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
-                <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
-            </admin-service>
-            <connector-service shutdown-timeout-in-seconds="30">
-            </connector-service>
-            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" timeout-in-seconds="300">
-                <property name="xaresource-txn-timeout" value="300"/>
-            </transaction-service>
-            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
-            <ejb-container max-pool-size="128">
-                <ejb-timer-service />
-            </ejb-container>
-            <asadmin-recorder-configuration></asadmin-recorder-configuration>
-            <request-tracing-service-configuration>
-                <log-notifier></log-notifier>
-            </request-tracing-service-configuration>
-            <notification-service-configuration enabled="true">
-                <log-notifier-configuration enabled="true"></log-notifier-configuration>
-            </notification-service-configuration>
-            <batch-runtime-configuration data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
-            <monitoring-service-configuration></monitoring-service-configuration>
-            <microprofile-metrics-configuration></microprofile-metrics-configuration>
-            <diagnostic-service />
-            <security-service activate-default-principal-to-role-mapping="true">
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-                    <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
-                    <property value="fileRealm" name="jaas-context" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-                    <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
-                    <property value="fileRealm" name="jaas-context" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
-                    <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
-                </jacc-provider>
-                <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
-                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-                    <property value="false" name="auditOn" />
-                </audit-module>
-                <message-security-config auth-layer="SOAP">
-                    <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="dynamic.username.password" />
-                        <property value="false" name="debug" />
-                    </provider-config>
-                    <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="dynamic.username.password" />
-                        <property value="false" name="debug" />
-                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-                    </provider-config>
-                    <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="debug" />
-                    </provider-config>
-                    <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property value="s1as" name="encryption.key.alias" />
-                        <property value="s1as" name="signature.key.alias" />
-                        <property value="false" name="debug" />
-                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
-                    </provider-config>
-                </message-security-config>
-                <message-security-config auth-layer="HttpServlet">
-                    <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
-                        <request-policy auth-source="sender"></request-policy>
-                        <response-policy></response-policy>
-                        <property name="loginPage" value="/login.jsf"></property>
-                        <property name="loginErrorPage" value="/loginError.jsf"></property>
-                    </provider-config>
-                </message-security-config>
-                <property value="SHA-256" name="default-digest-algorithm" />
-            </security-service>
-            <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
-                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-                <!-- Hazelcast internal package access requirement to get the best performance results. -->
-                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-                <jvm-options>-XX:+UseG1GC</jvm-options>
-                <jvm-options>-XX:+UseStringDeduplication</jvm-options>
-                <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
-                <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
-                <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
-                <jvm-options>-Djava.awt.headless=true</jvm-options>
-                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-                <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
-                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-                <jvm-options>-Xmx2g</jvm-options>
-                <jvm-options>-Xms2g</jvm-options>
-                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-                <!-- Grizzly NPN Jar version -->
-                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-            </java-config>
-            <availability-service>
-                <web-container-availability/>
-                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-                <jms-availability/>
-            </availability-service>
-            <network-config>
-                <protocols>
-                    <protocol name="http-listener-1">
-                        <http default-virtual-server="server" max-connections="250">
-                            <file-cache enabled="true"></file-cache>
-                        </http>
-                        <ssl ssl3-enabled="false" />
-                    </protocol>
-                    <protocol security-enabled="true" name="http-listener-2">
-                        <http default-virtual-server="server" max-connections="250">
-                            <file-cache enabled="true"></file-cache>
-                        </http>
-                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
-                    </protocol>
-                    <protocol name="admin-listener">
-                        <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
-                            <file-cache enabled="false"></file-cache>
-                        </http>
-                    </protocol>
-                </protocols>
-                <network-listeners>
-                    <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
-                    <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
-                    <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
-                </network-listeners>
-                <transports>
-                    <transport name="tcp"></transport>
-                </transports>
-            </network-config>
-            <thread-pools>
-                <thread-pool max-thread-pool-size="50" name="http-thread-pool"></thread-pool>
-                <thread-pool max-thread-pool-size="250" name="thread-pool-1"></thread-pool>
-                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-            </thread-pools>
-            <system-property name="fish.payara.classloading.delegate" value="false"/>
-            <system-property name="jersey.config.client.readTimeout" value="300000"/>
-            <system-property name="jersey.config.client.connectTimeout" value="300000"/>
-            <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
-            <system-property name="org.jboss.weld.probe.allowRemoteAddress" value="127.0.0.1|::1|::1%.+|0:0:0:0:0:0:0:1|0:0:0:0:0:0:0:1%.+"/>
-        </config>
-        <config name="default-config" dynamic-reconfiguration-enabled="true" >
-            <http-service>
-                <access-log/>
-                <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
-                    <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
-                </virtual-server>
-                <virtual-server id="__asadmin" network-listeners="admin-listener" />
-            </http-service>
-            <iiop-service>
-                <orb use-thread-pool-ids="thread-pool-1" />
-                <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
-                <ssl ssl3-enabled="false" />
-                <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
-                </iiop-listener>
-                <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
-                    <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
-                </iiop-listener>
-            </iiop-service>
-            <admin-service system-jmx-connector-name="system" type="server">
-                <!-- JSR 160  "system-jmx-connector" -->
-                <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
-                <!-- JSR 160  "system-jmx-connector" -->
-                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
-                <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
-            </admin-service>
-            <web-container>
-                <session-config>
-                    <session-manager>
-                        <manager-properties/>
-                        <store-properties />
-                    </session-manager>
-                    <session-properties />
-                </session-config>
-            </web-container>
-            <ejb-container max-pool-size="128" session-store="${com.sun.aas.instanceRoot}/session-store">
-                <ejb-timer-service />
-            </ejb-container>
-            <mdb-container />
-            <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
-                <module-log-levels />
-            </log-service>
-            <security-service activate-default-principal-to-role-mapping="true">
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
-                    <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
-                    <property name="jaas-context" value="fileRealm" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
-                    <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
-                    <property name="jaas-context" value="fileRealm" />
-                </auth-realm>
-                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
-                    <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
-                </jacc-provider>
-                <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
-                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
-                    <property value="false" name="auditOn" />
-                </audit-module>
-                <message-security-config auth-layer="SOAP">
-                    <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="dynamic.username.password" value="false" />
-                        <property name="debug" value="false" />
-                    </provider-config>
-                    <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="dynamic.username.password" value="false" />
-                        <property name="debug" value="false" />
-                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                    </provider-config>
-                    <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="debug" value="false" />
-                    </provider-config>
-                    <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
-                        <request-policy auth-source="content" />
-                        <response-policy auth-source="content" />
-                        <property name="encryption.key.alias" value="s1as" />
-                        <property name="signature.key.alias" value="s1as" />
-                        <property name="debug" value="false" />
-                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
-                    </provider-config>
-                </message-security-config>
-            </security-service>
-            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" timeout-in-seconds="300">
-                <property name="xaresource-txn-timeout" value="300"/>
-            </transaction-service>
-            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
-            <request-tracing-service-configuration>
-                <log-notifier></log-notifier>
-            </request-tracing-service-configuration>
-            <notification-service-configuration enabled="true">
-                <log-notifier-configuration enabled="true"></log-notifier-configuration>
-            </notification-service-configuration>
-            <monitoring-service-configuration></monitoring-service-configuration>
-            <microprofile-metrics-configuration></microprofile-metrics-configuration>
-            <diagnostic-service />
-            <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
-                <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-                <!-- Hazelcast internal package access requirement to get the best performance results. -->
-                <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-                <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-                <jvm-options>-XX:+UseG1GC</jvm-options>
-                <jvm-options>-XX:+UseStringDeduplication</jvm-options>
-                <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
-                <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
-                <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
-                <jvm-options>-Djava.awt.headless=true</jvm-options>
-                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
-                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
-                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
-                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
-                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-                <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
-                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
-                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
-                <jvm-options>-Xmx2g</jvm-options>
-                <jvm-options>-Xms2g</jvm-options>
-                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
-                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
-                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
-                <!-- Grizzly NPN Jar version -->
-                <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
-                <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
-                <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
-                <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-                <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-                <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-                <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-            </java-config>
-            <availability-service>
-                <web-container-availability/>
-                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
-            </availability-service>
-            <network-config>
-                <protocols>
-                    <protocol name="http-listener-1">
-                        <http default-virtual-server="server">
-                            <file-cache enabled="true" />
-                        </http>
-                        <ssl ssl3-enabled="false" />
-                    </protocol>
-                    <protocol security-enabled="true" name="http-listener-2">
-                        <http default-virtual-server="server">
-                            <file-cache enabled="true" />
-                        </http>
-                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
-                    </protocol>
-                    <protocol name="admin-listener">
-                        <http default-virtual-server="__asadmin" max-connections="250">
-                            <file-cache enabled="false" />
-                        </http>
-                    </protocol>
-                    <protocol security-enabled="true" name="sec-admin-listener">
-                        <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
-                            <file-cache></file-cache>
-                        </http>
-                        <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
-                    </protocol>
-                    <protocol name="admin-http-redirect">
-                        <http-redirect secure="true"></http-redirect>
-                    </protocol>
-                    <protocol name="pu-protocol">
-                        <port-unification>
-                            <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                            <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
-                        </port-unification>
-                    </protocol>
+<hazelcast-runtime-configuration start-port="%%%HAZELCAST_DAS_PORT%%%" das-port="%%%HAZELCAST_START_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
+<security-configurations>
+    <authentication-service default="true" name="adminAuth" use-password-credential="true">
+      <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+        <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+      <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+        <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+          <property name="config" value="server-config"></property>
+          <property name="auth-realm" value="admin-realm"></property>
+        </login-module-config>
+      </security-provider>
+    </authentication-service>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__derby" object-type="system-all" />
+    <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/derby_default" />
+      <property name="connectionAttributes" value=";create=true" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
+      <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+      <resource-ref ref="jdbc/__derby" />
+    </server>
+  </servers>
+  <nodes>
+    <node name="localhost-%%%DOMAIN_NAME%%%" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}"/>
+  </nodes>
+ <configs>
+   <config name="%%%CONFIG_MODEL_NAME%%%">
+      <!--%%%TOKENS_HERE%%%-->
+      <!--%%%PORT_BASE%%%-->
+      <http-service>
+        <access-log/>
+        <virtual-server id="server" network-listeners="http-listener-1,http-listener-2"/>
+        <virtual-server id="__asadmin" network-listeners="admin-listener"/>
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="%%%ORB_LISTENER_PORT%%%" id="orb-listener-1" lazy-init="true"/>
+	  <ssl ssl3-enabled="false" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_SSL_PORT%%%" id="SSL">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="%%%ORB_MUTUALAUTH_PORT%%%" id="SSL_MUTUALAUTH">
+          <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+        <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" timeout-in-seconds="300">
+         <property name="xaresource-txn-timeout" value="300"/>
+       </transaction-service>
+       <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+       <ejb-container max-pool-size="128">
+         <ejb-timer-service />
+       </ejb-container>
+       <asadmin-recorder-configuration></asadmin-recorder-configuration>
+       <request-tracing-service-configuration>
+         <log-notifier></log-notifier>
+       </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+       <batch-runtime-configuration data-source-lookup-name="jdbc/__default"></batch-runtime-configuration>
+       <monitoring-service-configuration></monitoring-service-configuration>
+       <microprofile-metrics-configuration></microprofile-metrics-configuration>
+       <diagnostic-service />
+      <security-service activate-default-principal-to-role-mapping="true">
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl" policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <message-security-config auth-layer="HttpServlet">
+            <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                <request-policy auth-source="sender"></request-policy>
+                <response-policy></response-policy>
+                <property name="loginPage" value="/login.jsf"></property>
+                <property name="loginErrorPage" value="/loginError.jsf"></property>
+            </provider-config>
+        </message-security-config>
+	<property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+        <!-- Hazelcast internal package access requirement to get the best performance results. -->
+        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+        <jvm-options>-XX:+UseG1GC</jvm-options>
+        <jvm-options>-XX:+UseStringDeduplication</jvm-options>
+        <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
+        <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
+        <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
+        <jvm-options>-Djava.awt.headless=true</jvm-options>
+        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+        <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+        <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <jvm-options>-Xmx2g</jvm-options>
+        <jvm-options>-Xms2g</jvm-options>
+        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+        <!-- Grizzly NPN Jar version -->
+        <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+        <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+        <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+        <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+        <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+        <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+        <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+      </java-config>
+      <availability-service>
+          <web-container-availability/>
+          <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+          <jms-availability/>
+      </availability-service>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener-1">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="true"></file-cache>
+            </http>
+	    <ssl ssl3-enabled="false" />
+          </protocol>
+          <protocol security-enabled="true" name="http-listener-2">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="true"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+          <protocol name="admin-listener">
+            <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true" >
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="%%%HTTP_PORT%%%" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%HTTP_SSL_PORT%%%" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+          <network-listener port="%%%ADMIN_PORT%%%" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+        <thread-pool max-thread-pool-size="50" name="http-thread-pool"></thread-pool>
+        <thread-pool max-thread-pool-size="250" name="thread-pool-1"></thread-pool>
+        <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+      </thread-pools>
+      <system-property name="fish.payara.classloading.delegate" value="false"/>
+      <system-property name="jersey.config.client.readTimeout" value="300000"/>
+      <system-property name="jersey.config.client.connectTimeout" value="300000"/>
+      <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
+      <system-property name="org.jboss.weld.probe.allowRemoteAddress" value="127.0.0.1|::1|::1%.+|0:0:0:0:0:0:0:1|0:0:0:0:0:0:0:1%.+"/>
+    </config>
+     <config name="default-config" dynamic-reconfiguration-enabled="true" >
+         <http-service>
+             <access-log/>
+             <virtual-server id="server" network-listeners="http-listener-1, http-listener-2" >
+                 <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml"/>
+             </virtual-server>
+             <virtual-server id="__asadmin" network-listeners="admin-listener" />
+         </http-service>
+         <iiop-service>
+             <orb use-thread-pool-ids="thread-pool-1" />
+             <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" address="0.0.0.0" />
+	         <ssl ssl3-enabled="false" />
+             <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+             </iiop-listener>
+             <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                 <ssl ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+             </iiop-listener>
+         </iiop-service>
+         <admin-service system-jmx-connector-name="system" type="server">
+             <!-- JSR 160  "system-jmx-connector" -->
+             <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false"/>
+             <!-- JSR 160  "system-jmx-connector" -->
+             <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+             <das-config dynamic-reload-enabled="false" autodeploy-enabled="false"/>
+         </admin-service>
+         <web-container>
+             <session-config>
+                 <session-manager>
+                     <manager-properties/>
+                     <store-properties />
+                 </session-manager>
+                 <session-properties />
+             </session-config>
+         </web-container>
+         <ejb-container max-pool-size="128" session-store="${com.sun.aas.instanceRoot}/session-store">
+             <ejb-timer-service />
+         </ejb-container>
+         <mdb-container />
+         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+             <module-log-levels />
+         </log-service>
+         <security-service activate-default-principal-to-role-mapping="true">
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                 <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                 <property name="jaas-context" value="fileRealm" />
+             </auth-realm>
+             <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+             <jacc-provider policy-provider="com.sun.enterprise.security.provider.PolicyWrapper" name="default" policy-configuration-factory-provider="com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl">
+                 <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy" />
+             </jacc-provider>
+             <jacc-provider policy-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory" />
+             <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                 <property value="false" name="auditOn" />
+             </audit-module>
+             <message-security-config auth-layer="SOAP">
+                 <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="dynamic.username.password" value="false" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                 </provider-config>
+                 <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                     <request-policy auth-source="content" />
+                     <response-policy auth-source="content" />
+                     <property name="encryption.key.alias" value="s1as" />
+                     <property name="signature.key.alias" value="s1as" />
+                     <property name="debug" value="false" />
+                     <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                 </provider-config>
+             </message-security-config>
+         </security-service>
+         <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" timeout-in-seconds="300">
+           <property name="xaresource-txn-timeout" value="300"/>
+         </transaction-service>
+         <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+         <request-tracing-service-configuration>
+             <log-notifier></log-notifier>
+         </request-tracing-service-configuration>
+      <notification-service-configuration enabled="true">
+        <log-notifier-configuration enabled="true"></log-notifier-configuration>
+      </notification-service-configuration>
+      <monitoring-service-configuration></monitoring-service-configuration>
+      <microprofile-metrics-configuration></microprofile-metrics-configuration>
+         <diagnostic-service />
+      <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+        <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+        <!-- Hazelcast internal package access requirement to get the best performance results. -->
+        <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+        <jvm-options>-XX:+UseG1GC</jvm-options>
+        <jvm-options>-XX:+UseStringDeduplication</jvm-options>
+        <jvm-options>-XX:MetaspaceSize=256m</jvm-options>
+        <jvm-options>-XX:MaxMetaspaceSize=2g</jvm-options>
+        <jvm-options>-XX:MaxGCPauseMillis=500</jvm-options>
+        <jvm-options>-Djava.awt.headless=true</jvm-options>
+        <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+        <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <jvm-options>-Xmx2g</jvm-options>
+        <jvm-options>-Xms2g</jvm-options>
+        <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+        <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+        <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>        
+        <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+        <!-- Grizzly NPN Jar version -->
+        <jvm-options>[1.8.0|1.8.0u120]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.6.jar</jvm-options>
+        <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
+        <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
+        <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
+        <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+        <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+        <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+      </java-config>
+         <availability-service>
+             <web-container-availability/>
+             <ejb-container-availability sfsb-store-pool-name="jdbc/hastore"/>
+         </availability-service>
+         <network-config>
+             <protocols>
+                 <protocol name="http-listener-1">
+                     <http default-virtual-server="server">
+                         <file-cache enabled="true" />
+                     </http>
+		     <ssl ssl3-enabled="false" />
+                 </protocol>
+                 <protocol security-enabled="true" name="http-listener-2">
+                     <http default-virtual-server="server">
+                         <file-cache enabled="true" />
+                     </http>
+                     <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as" />
+                 </protocol>
+                 <protocol name="admin-listener">
+                     <http default-virtual-server="__asadmin" max-connections="250">
+                         <file-cache enabled="false" />
+                     </http>
+                 </protocol>
+                 <protocol security-enabled="true" name="sec-admin-listener">
+                   <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                     <file-cache></file-cache>
+                   </http>
+                   <ssl client-auth="want" ssl3-enabled="false" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                 </protocol>
+                 <protocol name="admin-http-redirect">
+                   <http-redirect secure="true"></http-redirect>
+                 </protocol>
+                 <protocol name="pu-protocol">
+                   <port-unification>
+                     <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                     <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                   </port-unification>
+                 </protocol>
 
-                </protocols>
-                <network-listeners>
-                    <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
-                    <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
-                    <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
-                </network-listeners>
-                <transports>
-                    <transport name="tcp" />
-                </transports>
-            </network-config>
-            <thread-pools>
-                <thread-pool name="http-thread-pool" />
-                <thread-pool max-thread-pool-size="250" idle-thread-timeout-in-seconds="120" name="thread-pool-1" min-thread-pool-size="2"/>
-                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
-            </thread-pools>
-            <group-management-service/>
-            <!--%%%DEFAULT_TOKENS_HERE%%%-->
-            <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
-            <system-property name="HTTP_LISTENER_PORT" value="28080"/>
-            <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
-            <system-property name="IIOP_LISTENER_PORT" value="23700"/>
-            <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
-            <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
-            <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
-            <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
-            <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
-            <system-property name="fish.payara.classloading.delegate" value="false"/>
-            <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
-        </config>
-    </configs>
-    <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
-    <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
-        <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
-        <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
-    </secure-admin>
+             </protocols>
+             <network-listeners>
+                 <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                 <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                 <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+             </network-listeners>
+             <transports>
+                 <transport name="tcp" />
+             </transports>
+         </network-config>
+         <thread-pools>
+             <thread-pool name="http-thread-pool" />
+             <thread-pool max-thread-pool-size="250" idle-thread-timeout-in-seconds="120" name="thread-pool-1" min-thread-pool-size="2"/>
+	     <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+         </thread-pools>
+         <group-management-service/>
+         <!--%%%DEFAULT_TOKENS_HERE%%%-->
+         <system-property name="ASADMIN_LISTENER_PORT" value="24848"/>
+         <system-property name="HTTP_LISTENER_PORT" value="28080"/>
+         <system-property name="HTTP_SSL_LISTENER_PORT" value="28181"/>
+         <system-property name="IIOP_LISTENER_PORT" value="23700"/>
+         <system-property name="IIOP_SSL_LISTENER_PORT" value="23820"/>
+         <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920"/>
+         <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686"/>
+         <system-property name="OSGI_SHELL_TELNET_PORT" value="26666"/>
+         <system-property name="JAVA_DEBUGGER_PORT" value="29009"/>
+         <system-property name="fish.payara.classloading.delegate" value="false"/>
+         <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".."/>
+     </config>
+  </configs>
+  <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%"/>
+  <secure-admin special-admin-indicator="%%%SECURE_ADMIN_IDENTIFIER%%%">
+      <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
+      <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
+  </secure-admin>
 </domain>

--- a/appserver/admin/production_domain_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/stringsubs.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
-
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
-    language governing permissions and limitations under the License.
-
-    When distributing the software, include this License Header Notice in each
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-
-    GPL Classpath Exception:
+  
+   GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
-    file that accompanied this code.
-
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
-
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
 -->
 
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
@@ -45,7 +45,7 @@
         <group-ref name="glassfish-core-sub"/>
     </component>
     <group id="glassfish-core-sub" mode="forward">
-        <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
         <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
         <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
         <change-pair-ref name="VERSION"/>

--- a/appserver/admin/production_domain_template_web/src/main/resources/stringsubs.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/stringsubs.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
-   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
-  
-   The contents of this file are subject to the terms of either the GNU
-   General Public License Version 2 only ("GPL") or the Common Development
-   and Distribution License("CDDL") (collectively, the "License").  You
-   may not use this file except in compliance with the License.  You can
-   obtain a copy of the License at
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+   Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
-   language governing permissions and limitations under the License.
-  
-   When distributing the software, include this License Header Notice in each
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-  
-   GPL Classpath Exception:
+
+    GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
-   file that accompanied this code.
-  
-   Modifications:
-   If applicable, add the following below the License Header, with the fields
-   enclosed by brackets [] replaced by your own identifying information:
-   "Portions Copyright [year] [name of copyright owner]"
-  
-   Contributor(s):
-   If you wish your version of this file to be governed by only the CDDL or
-   only the GPL Version 2, indicate your decision by adding "[Contributor]
-   elects to include this software in this distribution under the [CDDL or GPL
-   Version 2] license."  If you don't indicate a single choice of license, a
-   recipient has the option to distribute your version of this file under
-   either the CDDL, the GPL Version 2 or to extend the choice of license to
-   its licensees as provided above.  However, if you add GPL Version 2 code
-   and therefore, elected the GPL Version 2 license, then the option applies
-   only if the new code is made subject to such option by the copyright
-   holder.
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
 -->
 
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
@@ -45,7 +45,7 @@
         <group-ref name="glassfish-core-sub"/>
     </component>
     <group id="glassfish-core-sub" mode="forward">
-    <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
+        <file-entry name="$DOMAIN_DIR$/config/domain.xml"/>
         <file-entry name="$DOMAIN_DIR$/config/glassfish-acc.xml"/>
         <file-entry name="$DOMAIN_DIR$/docroot/index.html"/>
         <change-pair-ref name="VERSION"/>
@@ -73,6 +73,9 @@
         <change-pair-ref name="TOKENS_HERE"/>
         <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
         <change-pair-ref name="PORT_BASE"/>
+        <change-pair-ref name="HAZELCAST_DAS_PORT"/>
+        <change-pair-ref name="HAZELCAST_START_PORT"/>
+        <change-pair-ref name="HAZELCAST_AUTO_INCREMENT"/>
     </group>
     <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
     <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
@@ -99,6 +102,9 @@
     <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
     <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
     <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <change-pair id="HAZELCAST_DAS_PORT" before="%%%HAZELCAST_DAS_PORT%%%" after="$HAZELCAST_DAS_PORT$"/>
+    <change-pair id="HAZELCAST_START_PORT" before="%%%HAZELCAST_START_PORT%%%" after="$HAZELCAST_START_PORT$"/>
+    <change-pair id="HAZELCAST_AUTO_INCREMENT" before="%%%HAZELCAST_AUTO_INCREMENT%%%" after="$HAZELCAST_AUTO_INCREMENT$"/>
     <defaults>
         <property key="ADMIN_PORT" value="4848" type="port"/>
         <property key="HTTP_SSL_PORT" value="8181" type="port"/>
@@ -110,5 +116,8 @@
         <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
         <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
         <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+        <property key="HAZELCAST_DAS_PORT" value="4900" type="port"/>
+        <property key="HAZELCAST_START_PORT" value="5900" type="port"/>
+        <property key="HAZELCAST_AUTO_INCREMENT" value="true" type="string"/>
     </defaults>
 </stringsubs-definition>

--- a/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-domain.html
+++ b/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-domain.html
@@ -235,6 +235,12 @@
                                         <p>JPDA debugger port: portbase + 9</p>
                                     </li>
                                     <li>
+                                        <p>Hazelcast DAS port: portbase + 49</p>
+                                    </li>
+                                    <li>
+                                        <p>Hazelcast Start port: portbase + 59</p>
+                                    </li> 
+                                    <li>
                                         <p>Felix shell service port for OSGi module management: portbase + 66<br>
                                             When the <code>--portbase</code> option is specified, the output of this
                                             subcommand includes a complete list of used ports.<br>

--- a/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-domain.html
+++ b/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-domain.html
@@ -19,672 +19,783 @@
 -->
 <!-- Portions Copyright [2019] [Payara Foundation and/or its affiliates] -->
 <html lang="en">
-  <head>
-    <meta charset="utf-8"/>
-    <title>create-domain</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="css/style.css" rel="stylesheet">
-    <script src="https://use.fontawesome.com/96c4d89611.js"></script>
-  </head>
-  <body>
-<table id="doc-title" cellspacing="0" cellpadding="0">
-  <tr>
-  <td align="left" valign="top">
-  <b>create-domain</b><br />
-  </td>
-  </tr>
-</table>
-<hr />
+    <head>
+        <meta charset="utf-8"/>
+        <title>create-domain</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href="css/style.css" rel="stylesheet">
+        <script src="https://use.fontawesome.com/96c4d89611.js"></script>
+    </head>
+    <body>
+        <table id="doc-title" cellspacing="0" cellpadding="0">
+            <tr>
+                <td align="left" valign="top">
+                    <b>create-domain</b><br />
+                </td>
+            </tr>
+        </table>
+        <hr />
 
-<table width="90%" id="top-nav" cellspacing="0" cellpadding="0">
-	<colgroup>
-		<col width="12%"/>
-		<col width="12%"/>
-		<col width="*"/>
-	</colgroup>
-	<tr>
-		<td align="left">
-		<a href="create-custom-resource.html">
-			<span class="vector-font"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></span>
-			<span style="position:relative;top:-2px;">Previous</span>
-		</a>
-		</td>
+        <table width="90%" id="top-nav" cellspacing="0" cellpadding="0">
+            <colgroup>
+                <col width="12%"/>
+                <col width="12%"/>
+                <col width="*"/>
+            </colgroup>
+            <tr>
+                <td align="left">
+                    <a href="create-custom-resource.html">
+                        <span class="vector-font"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></span>
+                        <span style="position:relative;top:-2px;">Previous</span>
+                    </a>
+                </td>
 
-		<td align="left">
-		<a href="create-file-user.html">
-			<span class=" vector-font"><i class="fa fa-arrow-circle-right vector-font" aria-hidden="true"></i></span>
-			<span style="position:relative;top:-2px;">Next</span>
-		</a>
-		</td>
+                <td align="left">
+                    <a href="create-file-user.html">
+                        <span class=" vector-font"><i class="fa fa-arrow-circle-right vector-font" aria-hidden="true"></i></span>
+                        <span style="position:relative;top:-2px;">Next</span>
+                    </a>
+                </td>
 
-		<td align="right">
-		<a href="toc.html">
-			<span class=" vector-font"><i class="fa fa-list vector-font" aria-hidden="true"></i></span>
-			<span style="position:relative;top:-2px;">Contents</span>
-		</a>
-		</td>
-	</tr>
-</table>
+                <td align="right">
+                    <a href="toc.html">
+                        <span class=" vector-font"><i class="fa fa-list vector-font" aria-hidden="true"></i></span>
+                        <span style="position:relative;top:-2px;">Contents</span>
+                    </a>
+                </td>
+            </tr>
+        </table>
 
 
-<div id="preamble">
-<div class="sectionbody">
-<div class="paragraph">
-<p><a id="create-domain-1"></a><a id="GSRFM00023"></a><a id="create-domain"></a></p>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_create_domain">create-domain</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>creates a domain</p>
-</div>
-<div id="sthref208" class="paragraph">
-<p>Synopsis</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin [asadmin-options] create-domain [--help]
-[--adminport adminport]
-[--instanceport instanceport]
-[--portbase portbase]
-[--profile profile-name]
-[--template template-name]
-[--domaindir domaindir]
-[--savemasterpassword={false|true}]
-[--usemasterpassword={false|true}]
-[--domainproperties (name=value)[:name=value]*]
-[--keytooloptions (name=value)[:name=value]*]
-[--savelogin={false|true}]
-[--checkports={true|false}]
-[--nopassword={false|true}]
-domain-name</code></pre>
-</div>
-</div>
-<div id="sthref209" class="paragraph">
-<p>Description</p>
-</div>
-<div class="paragraph">
-<p>The <code>create-domain</code> subcommand creates a \{product---name} domain. A
-domain in \{product---name} is an administrative namespace that complies
-with the Java Platform, Enterprise Edition (Java EE) standard. Every
-domain has a configuration, which is stored in a set of files. Any
-number of domains, each of which has a distinct administrative identity,
-can be created in a given installation of \{product---name}. A domain
-can exist independently of other domains.</p>
-</div>
-<div class="paragraph">
-<p>Any user who has access to the <code>asadmin</code> utility on a given system can
-create a domain and store its configuration in a folder of the user&#8217;s
-choosing. By default, the domain configuration is created in the default
-directory for domains. You can override this location to store the
-configuration elsewhere.</p>
-</div>
-<div class="paragraph">
-<p>If domain customizers are found in JAR files in the as-install`/modules`
-directory when the <code>create-domain</code> subcommand is run, the customizers
-are processed. A domain customizer is a class that implements the
-<code>DomainInitializer</code> interface.</p>
-</div>
-<div class="paragraph">
-<p>The <code>create-domain</code> subcommand creates a domain with a single
-administrative user specified by the <code>asadmin</code> utility option <code>--user</code>.
-If the <code>--user</code> option is not specified, and the <code>--nopassword</code> option
-is set to true, the default administrative user, <code>admin</code>, is used. If
-the <code>--nopassword</code> option is set to false (the default), a username is
-required. In this case, if you have not specified the user name by using
-the <code>--user</code> option, you are prompted to do so.</p>
-</div>
-<div class="paragraph">
-<p>You choose an appropriate profile for the domain, depending on the
-applications that you want to run on your new domain. You can choose the
-developer, cluster, or enterprise profile for the domain you create.</p>
-</div>
-<div class="paragraph">
-<p>This subcommand is supported in local mode only.</p>
-</div>
-<div id="sthref210" class="paragraph">
-<p>Options</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">asadmin-options</dt>
-<dd>
-<p>Options for the <code>asadmin</code> utility. For information about these
-options, see the <a href="asadmin.html#asadmin-1m"><code>asadmin</code>(1M)</a> help page.</p>
-</dd>
-<dt class="hdlist1"><code>--help</code></dt>
-<dt class="hdlist1"><code>-?</code></dt>
-<dd>
-<p>Displays the help text for the subcommand.</p>
-</dd>
-<dt class="hdlist1"><code>--adminport</code></dt>
-<dd>
-<p>The HTTP port or the HTTPS port for administration. This port is the
-port in the URL that you specify in your web browser to manage the
-domain, for example, <code>http://localhost:4949</code>. The <code>--adminport</code> option
-cannot be used with the <code>--portbase</code> option. The default value is</p>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>+
-The <code>--adminport</code> option overrides the <code>domain.adminPort</code> property of
-the <code>--domainproperties</code> option.</p>
-</li>
-</ol>
-</div>
-</dd>
-<dt class="hdlist1"><code>--instanceport</code></dt>
-<dd>
-<p>The domain provides services so that applications can run when
-deployed. This HTTP port specifies where the web application context
-roots are available for a web browser to connect to. This port is a
-positive integer and must be available at the time of domain creation.
-The <code>--instanceport</code> option cannot be used with the <code>--portbase</code>
-option. The default value is 8080.<br>
-The <code>--instanceport</code> option overrides the <code>domain.instancePort</code>
-property of the <code>--domainproperties</code> option.</p>
-</dd>
-<dt class="hdlist1"><code>--portbase</code></dt>
-<dd>
-<p>Determines the number with which port assignments should start. A
-domain uses a certain number of ports that are statically assigned.
-The portbase value determines where the assignment should start. The
-values for the ports are calculated as follows:<br></p>
-<div class="ulist">
-<ul>
-<li>
-<p>Administration port: portbase + 48</p>
-</li>
-<li>
-<p>HTTP listener port: portbase + 80</p>
-</li>
-<li>
-<p>HTTPS listener port: portbase + 81</p>
-</li>
-<li>
-<p>JMS port: portbase + 76</p>
-</li>
-<li>
-<p>IIOP listener port: portbase + 37</p>
-</li>
-<li>
-<p>Secure IIOP listener port: portbase + 38</p>
-</li>
-<li>
-<p>Secure IIOP with mutual authentication port: portbase + 39</p>
-</li>
-<li>
-<p>JMX port: portbase + 86</p>
-</li>
-<li>
-<p>JPDA debugger port: portbase + 9</p>
-</li>
-<li>
-<p>Felix shell service port for OSGi module management: portbase + 66<br>
-When the <code>--portbase</code> option is specified, the output of this
-subcommand includes a complete list of used ports.<br>
-The <code>--portbase</code> option cannot be used with the <code>--adminport</code>,
-<code>--instanceport</code>, or the <code>--domainproperties</code> option.</p>
-</li>
-</ul>
-</div>
-</dd>
-<dt class="hdlist1"><code>--profile</code></dt>
-<dd>
-<p>Do not specify this option. This option is retained for compatibility
-with earlier releases. If you specify this option, a syntax error does
-not occur. Instead, the subcommand runs successfully and displays a
-warning message that the option is ignored.</p>
-</dd>
-<dt class="hdlist1"><code>--template</code></dt>
-<dd>
-<p>The file name, including a relative or absolute path, of a domain
-configuration template to use for creating the domain. If a relative
-path is specified, the subcommand appends the path to the
-as-install`/lib/templates` directory to locate the file. If it is an
-absolute pathname, the subcommand locates the file in the specified
-path.<br>
-This option enables domains of different types to be created and
-custom domain templates to be defined.</p>
-</dd>
-<dt class="hdlist1"><code>--domaindir</code></dt>
-<dd>
-<p>The directory where the domain is to be created. If specified, the
-path must be accessible in the filesystem. If not specified, the
-domain is created in the default domain directory,
-as-install`/domains`.</p>
-</dd>
-<dt class="hdlist1"><code>--savemasterpassword</code></dt>
-<dd>
-<p>Setting this option to <code>true</code> allows the master password to be written
-to the file system. If this option is <code>true</code>, the
-<code>--usemasterpassword</code> option is also true, regardless of the value
-that is specified on the command line. The default value is <code>false</code>.<br>
-A master password is really a password for the secure key store. A
-domain is designed to keep its own certificate (created at the time of
-domain creation) in a safe place in the configuration location. This
-certificate is called the domain&#8217;s SSL server certificate. When the
-domain is contacted by a web browser over a secure channel (HTTPS),
-this certificate is presented by the domain. The master password is
-supposed to protect the store (a file) that contains this certificate.
-This file is called <code>keystore.jks</code> and is created in the configuration
-directory of the domain created. If however, this option is chosen,
-the master password is saved on the disk in the domain&#8217;s configuration
-location. The master password is stored in a file called
-<code>master-password</code>, which is a Java JCEKS type keystore. The reason for
-using the <code>--savemasterpassword</code> option is for unattended system
-boots. In this case, the master password is not prompted for when the
-domain starts because the password will be extracted from this file.<br>
-It is best to create a master password when creating a domain, because
-the master password is used by the <code>start-domain</code> subcommand. For
-security purposes, the default setting should be false, because saving
-the master password on the disk is an insecure practice, unless file
-system permissions are properly set. If the master password is saved,
-then <code>start-domain</code> does not prompt for it. The master password gives
-an extra level of security to the environment.</p>
-</dd>
-<dt class="hdlist1"><code>--usemasterpassword</code></dt>
-<dd>
-<p>Specifies whether the key store is encrypted with a master password
-that is built into the system or a user-defined master password.<br>
-If <code>false</code> (default), the keystore is encrypted with a well-known
-password that is built into the system. Encrypting the keystore with a
-password that is built into the system provides no additional
-security.<br>
-If <code>true</code>, the subcommand obtains the master password from the
-<code>AS_ADMIN_MASTERPASSWORD</code> entry in the password file or prompts for
-the master password. The password file is specified in the
-<code>--passwordfile</code> option of the
-<a href="asadmin.html#asadmin-1m"><code>asadmin</code>(1M)</a>utility.<br>
-If the <code>--savemasterpassword</code> option is <code>true</code>, this option is also
-true, regardless of the value that is specified on the command line.</p>
-</dd>
-<dt class="hdlist1"><code>--domainproperties</code></dt>
-<dd>
-<p>Setting the optional name/value pairs overrides the default values for
-the properties of the domain to be created. The list must be separated
-by the colon (:) character. The <code>--portbase</code> options cannot be used
-with the <code>--domainproperties</code> option. The following properties are
-available:<br></p>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>domain.adminPort</code></dt>
-<dd>
-<p>This property specifies the port number of the HTTP port or the
-HTTPS port for administration. This port is the port in the URL that
-you specify in your web browser to manage the instance, for example,
-<code>http://localhost:4949</code>. Valid values are 1-65535. On UNIX, creating
-sockets that listen on ports 1-1024 requires superuser privileges.<br>
-The <code>domain.adminPort</code> property is overridden by the <code>--adminport</code>
-option.</p>
-</dd>
-<dt class="hdlist1"><code>domain.instancePort</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used to
-listen for HTTP requests. Valid values are 1-65535. On UNIX,
-creating sockets that listen on ports 1-1024 requires superuser
-privileges.<br>
-The <code>domain.instancePort</code> property is overridden by <code>--instanceport</code>
-option.</p>
-</dd>
-<dt class="hdlist1"><code>domain.jmxPort</code></dt>
-<dd>
-<p>This property specifies the port number on which the JMX connector
-listens. Valid values are 1-65535. On UNIX, creating sockets that
-listen on ports 1-1024 requires superuser privileges.</p>
-</dd>
-<dt class="hdlist1"><code>http.ssl.port</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used to
-listen for HTTPS requests. Valid values are 1-65535. On UNIX,
-creating sockets that listen on ports 1-1024 requires superuser
-privileges.</p>
-</dd>
-<dt class="hdlist1"><code>java.debugger.port</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used for
-connections to the Java Platform Debugger Architecture (JPDA)
-debugger. Valid values are 1-65535. On UNIX, creating sockets that
-listen on ports 1-1024 requires superuser privileges.</p>
-</dd>
-<dt class="hdlist1"><code>jms.port</code></dt>
-<dd>
-<p>This property specifies the port number for the Java Message Service
-provider. Valid values are 1-65535. On UNIX, creating sockets that
-listen on ports 1-1024 requires superuser privileges.</p>
-</dd>
-<dt class="hdlist1"><code>orb.listener.port</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used for
-IIOP connections. Valid values are 1-65535. On UNIX, creating
-sockets that listen on ports 1-1024 requires superuser privileges.</p>
-</dd>
-<dt class="hdlist1"><code>orb.mutualauth.port</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used for
-secure IIOP connections with client authentication. Valid values are
-1-65535. On UNIX, creating sockets that listen on ports 1-1024
-requires superuser privileges.</p>
-</dd>
-<dt class="hdlist1"><code>orb.ssl.port</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used for
-secure IIOP connections. Valid values are 1-65535. On UNIX, creating
-sockets that listen on ports 1-1024 requires superuser privileges.</p>
-</dd>
-<dt class="hdlist1"><code>osgi.shell.telnet.port</code></dt>
-<dd>
-<p>This property specifies the port number of the port that is used for
-connections to the
-<a href="http://felix.apache.org/site/apache-felix-remote-shell.html">Apache
-Felix Remote Shell</a>
-(<a href="http://felix.apache.org/site/apache-felix-remote-shell.html" class="bare">http://felix.apache.org/site/apache-felix-remote-shell.html</a>). This
-shell uses the Felix shell service to interact with the OSGi module
-management subsystem. Valid values are 1-65535. On UNIX, creating
-sockets that listen on ports 1-1024 requires superuser privileges.</p>
-</dd>
-</dl>
-</div>
-</dd>
-<dt class="hdlist1"><code>--keytooloptions</code></dt>
-<dd>
-<p>Specifies an optional list of name-value pairs of keytool options for
-a self-signed server certificate. The certificate is generated during
-the creation of the domain. Each pair in the list must be separated by
-the colon (:) character.<br>
-Allowed options are as follows:<br></p>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>CN</code></dt>
-<dd>
-<p>Specifies the common name of the host that is to be used for the
-self-signed certificate. This option name is case insensitive.<br>
-By default, the name is the fully-qualified name of the host where
-the <code>create-domain</code> subcommand is run.</p>
-</dd>
-</dl>
-</div>
-</dd>
-<dt class="hdlist1"><code>--savelogin</code></dt>
-<dd>
-<p>If set to true, this option saves the administration user name and
-password. Default value is false. The username and password are stored
-in the <code>.asadminpass</code> file in user&#8217;s home directory. A domain can only
-be created locally. Therefore, when using the <code>--savelogin</code> option,
-the host name saved in <code>.asadminpass</code> is always <code>localhost</code>. If the
-user has specified default administration port while creating the
-domain, there is no need to specify <code>--user</code>, <code>--passwordfile</code>,
-<code>--host</code>, or <code>--port</code> on any of the subsequent <code>asadmin</code> remote
-commands. These values will be obtained automatically.<br></p>
-</dd>
-</dl>
-</div>
-<table class="tableblock frame-all grid-all spread">
-<colgroup>
-<col style="width: 100%;">
-</colgroup>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><div><div class="paragraph">
-<p>Note:</p>
-</div>
-<div class="paragraph">
-<p>When the same user creates multiple domains that have the same
-administration port number on the same or different host (where the
-home directory is NFS mounted), the subcommand does not ask if the
-password should be overwritten. The password will always be
-overwritten.</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>--checkports</code></dt>
-<dd>
-<p>Specifies whether to check for the availability of the administration,
-HTTP, JMS, JMX, and IIOP ports. The default value is true.</p>
-</dd>
-<dt class="hdlist1"><code>--nopassword</code></dt>
-<dd>
-<p>Specifies whether the administrative user will have a password. If
-false (the default), the password is specified by the
-<code>AS_ADMIN_PASSWORD</code> entry in the <code>asadmin</code> password file (set by using
-the <code>--passwordfile</code> option). If false and the <code>AS_ADMIN_PASSWORD</code> is
-not set, you are prompted for the password.<br>
-If true, the administrative user is created without a password. If a
-user name for the domain is not specified by using the <code>--user</code>
-option, and the <code>--nopassword</code> option is set to true, the default user
-name, <code>admin</code>, is used.</p>
-</dd>
-</dl>
-</div>
-<div id="sthref211" class="paragraph">
-<p>Operands</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">domain-name</dt>
-<dd>
-<p>The name of the domain to be created. The name may contain only ASCII
-characters and must be a valid directory name for the operating system
-on the host where the domain is created.</p>
-</dd>
-</dl>
-</div>
-<div id="sthref212" class="paragraph">
-<p>Examples</p>
-</div>
-<div class="paragraph">
-<p><a id="GSRFM471"></a><a id="sthref213"></a></p>
-</div>
-<div class="paragraph">
-<p>Example 1   Creating a Domain</p>
-</div>
-<div class="paragraph">
-<p>This example creates a domain named <code>domain4</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt;create-domain --adminport 4848 domain4
-Enter admin user name [Enter to accept default "admin" / no password]&gt;
-Using port 4848 for Admin.
-Using default port 8080 for HTTP Instance.
-Using default port 7676 for JMS.
-Using default port 3700 for IIOP.
-Using default port 8181 for HTTP_SSL.
-Using default port 3820 for IIOP_SSL.
-Using default port 3920 for IIOP_MUTUALAUTH.
-Using default port 8686 for JMX_ADMIN.
-Using default port 6666 for OSGI_SHELL.
-Distinguished Name of the self-signed X.509 Server Certificate is:
-[CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
-No domain initializers found, bypassing customization step
-Domain domain4 created.
-Domain domain4 admin port is 4848.
-Domain domain4 allows admin login as user "admin" with no password.
-Command create-domain executed successfully.</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p><a id="GSRFM472"></a><a id="sthref214"></a></p>
-</div>
-<div class="paragraph">
-<p>Example 2   Creating a Domain in an Alternate Directory</p>
-</div>
-<div class="paragraph">
-<p>This example creates a domain named <code>sampleDomain</code> in the
-<code>/home/someuser/domains</code> directory.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-domain --domaindir /home/someuser/domains --adminport 7070
---instanceport 7071 sampleDomain
-Enter admin user name [Enter to accept default "admin" / no password]&gt;
-Using port 7070 for Admin.
-Using port 7071 for HTTP Instance.
-Using default port 7676 for JMS.
-Using default port 3700 for IIOP.
-Using default port 8181 for HTTP_SSL.
-Using default port 3820 for IIOP_SSL.
-Using default port 3920 for IIOP_MUTUALAUTH.
-Using default port 8686 for JMX_ADMIN.
-Using default port 6666 for OSGI_SHELL.
-Enterprise ServiceDistinguished Name of the self-signed X.509 Server Certificate is:
-[CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
-No domain initializers found, bypassing customization step
-Domain sampleDomain created.
-Domain sampleDomain admin port is 7070.
-Domain sampleDomain allows admin login as user "admin" with no password.
-Command create-domain executed successfully.</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p><a id="GSRFM473"></a><a id="sthref215"></a></p>
-</div>
-<div class="paragraph">
-<p>Example 3   Creating a Domain and Saving the Administration User Name
-and Password</p>
-</div>
-<div class="paragraph">
-<p>This example creates a domain named <code>myDomain</code> and saves the
-administration username and password.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-domain --adminport 8282 --savelogin=true myDomain
-Enter the admin password [Enter to accept default of no password]&gt;
-Enter the master password [Enter to accept default password "changeit"]&gt;
-Using port 8282 for Admin.
-Using default port 8080 for HTTP Instance.
-Using default port 7676 for JMS.
-Using default port 3700 for IIOP.
-Using default port 8181 for HTTP_SSL.
-Using default port 3820 for IIOP_SSL.
-Using default port 3920 for IIOP_MUTUALAUTH.
-Using default port 8686 for JMX_ADMIN.
-Using default port 6666 for OSGI_SHELL.
-Enterprise ServiceDistinguished Name of the self-signed X.509 Server Certificate is:
-[CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
-No domain initializers found, bypassing customization step
-Domain myDomain created.
-Domain myDomain admin port is 8282.
-Domain myDomain allows admin login as user "admin" with no password.
-Login information relevant to admin user name [admin]
-for this domain [myDomain] stored at
-[/home/someuser/.asadminpass] successfully.
-Make sure that this file remains protected.
-Information stored in this file will be used by
-asadmin commands to manage this domain.
-Command create-domain executed successfully.</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p><a id="GSRFM474"></a><a id="sthref216"></a></p>
-</div>
-<div class="paragraph">
-<p>Example 4   Creating a Domain and Designating the Certificate Host</p>
-</div>
-<div class="paragraph">
-<p>This example creates a domain named <code>domain5</code>. The common name of the
-host that is to be used for the self-signed certificate is <code>trio</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-domain --adminport 9898 --keytooloptions CN=trio domain5
-Enter the admin password [Enter to accept default of no password]&gt;
-Enter the master password [Enter to accept default password "changeit"]&gt;
-Using port 9898 for Admin.
-Using default port 8080 for HTTP Instance.
-Using default port 7676 for JMS.
-Using default port 3700 for IIOP.
-Using default port 8181 for HTTP_SSL.
-Using default port 3820 for IIOP_SSL.
-Using default port 3920 for IIOP_MUTUALAUTH.
-Using default port 8686 for JMX_ADMIN.
-Using default port 6666 for OSGI_SHELL.
-Distinguished Name of the self-signed X.509 Server Certificate is:
-[CN=trio,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
-No domain initializers found, bypassing customization step
-Domain domain5 created.
-Domain domain5 admin port is 9898.
-Domain domain5 allows admin login as user "admin" with no password.
-Command create-domain executed successfully.</code></pre>
-</div>
-</div>
-<div id="sthref217" class="paragraph">
-<p>Exit Status</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">0</dt>
-<dd>
-<p>subcommand executed successfully</p>
-</dd>
-<dt class="hdlist1">1</dt>
-<dd>
-<p>error in executing the subcommand</p>
-</dd>
-</dl>
-</div>
-<div id="sthref218" class="paragraph">
-<p>See Also</p>
-</div>
-<div class="paragraph">
-<p><a href="asadmin.html#asadmin-1m"><code>asadmin</code>(1M)</a></p>
-</div>
-<div class="paragraph">
-<p><a href="delete-domain.html#delete-domain-1"><code>delete-domain</code>(1)</a>,
-<a href="list-domains.html#list-domains-1"><code>list-domains</code>(1)</a>,
-<a href="login.html#login-1"><code>login</code>(1)</a>,
-<a href="start-domain.html#start-domain-1"><code>start-domain</code>(1)</a>,
-<a href="stop-domain.html#stop-domain-1"><code>stop-domain</code>(1)</a></p>
-</div>
-<div class="paragraph">
-<p>Apache Felix Remote Shell
-(<code>http://felix.apache.org/site/apache-felix-remote-shell.html</code>)</p>
-</div>
-</div>
-</div>
+        <div id="preamble">
+            <div class="sectionbody">
+                <div class="paragraph">
+                    <p><a id="create-domain-1"></a><a id="GSRFM00023"></a><a id="create-domain"></a></p>
+                </div>
+            </div>
+        </div>
+        <div class="sect1">
+            <h2 id="_create_domain">create-domain</h2>
+            <div class="sectionbody">
+                <div class="paragraph">
+                    <p>creates a domain</p>
+                </div>
+                <div id="sthref208" class="paragraph">
+                    <p>Synopsis</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="prettyprint highlight">
+                            <code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin [asadmin-options] create-domain [--help]
+                                [--adminport adminport]
+                                [--instanceport instanceport]
+                                [--portbase portbase]
+                                [--profile profile-name]
+                                [--template template-name]
+                                [--domaindir domaindir]
+                                [--savemasterpassword={false|true}]
+                                [--usemasterpassword={false|true}]
+                                [--hazelcastdasport hazelcastdasport]
+                                [--hazelcaststartport hazelcaststartport]
+                                [--hazelcastautoincrement={false|true}]
+                                [--domainproperties (name=value)[:name=value]*]
+                                [--keytooloptions (name=value)[:name=value]*]
+                                [--savelogin={false|true}]
+                                [--checkports={true|false}]
+                                [--nopassword={false|true}]
+                                domain-name
+                            </code>
+                        </pre>
+                    </div>
+                </div>
+                <div id="sthref209" class="paragraph">
+                    <p>Description</p>
+                </div>
+                <div class="paragraph">
+                    <p>The <code>create-domain</code> subcommand creates a \{product---name} domain. A
+                        domain in \{product---name} is an administrative namespace that complies
+                        with the Java Platform, Enterprise Edition (Java EE) standard. Every
+                        domain has a configuration, which is stored in a set of files. Any
+                        number of domains, each of which has a distinct administrative identity,
+                        can be created in a given installation of \{product---name}. A domain
+                        can exist independently of other domains.</p>
+                </div>
+                <div class="paragraph">
+                    <p>Any user who has access to the <code>asadmin</code> utility on a given system can
+                        create a domain and store its configuration in a folder of the user&#8217;s
+                        choosing. By default, the domain configuration is created in the default
+                        directory for domains. You can override this location to store the
+                        configuration elsewhere.</p>
+                </div>
+                <div class="paragraph">
+                    <p>If domain customizers are found in JAR files in the as-install`/modules`
+                        directory when the <code>create-domain</code> subcommand is run, the customizers
+                        are processed. A domain customizer is a class that implements the
+                        <code>DomainInitializer</code> interface.</p>
+                </div>
+                <div class="paragraph">
+                    <p>The <code>create-domain</code> subcommand creates a domain with a single
+                        administrative user specified by the <code>asadmin</code> utility option <code>--user</code>.
+                        If the <code>--user</code> option is not specified, and the <code>--nopassword</code> option
+                        is set to true, the default administrative user, <code>admin</code>, is used. If
+                        the <code>--nopassword</code> option is set to false (the default), a username is
+                        required. In this case, if you have not specified the user name by using
+                        the <code>--user</code> option, you are prompted to do so.</p>
+                </div>
+                <div class="paragraph">
+                    <p>You choose an appropriate profile for the domain, depending on the
+                        applications that you want to run on your new domain. You can choose the
+                        developer, cluster, or enterprise profile for the domain you create.</p>
+                </div>
+                <div class="paragraph">
+                    <p>This subcommand is supported in local mode only.</p>
+                </div>
+                <div id="sthref210" class="paragraph">
+                    <p>Options</p>
+                </div>
+                <div class="dlist">
+                    <dl>
+                        <dt class="hdlist1">asadmin-options</dt>
+                        <dd>
+                            <p>Options for the <code>asadmin</code> utility. For information about these
+                                options, see the <a href="asadmin.html#asadmin-1m"><code>asadmin</code>(1M)</a> help page.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--help</code></dt>
+                        <dt class="hdlist1"><code>-?</code></dt>
+                        <dd>
+                            <p>Displays the help text for the subcommand.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--adminport</code></dt>
+                        <dd>
+                            <p>The HTTP port or the HTTPS port for administration. This port is the
+                                port in the URL that you specify in your web browser to manage the
+                                domain, for example, <code>http://localhost:4949</code>. The <code>--adminport</code> option
+                                cannot be used with the <code>--portbase</code> option. The default value is 4848</p>
+                            <div class="olist arabic">
+                                <ol class="arabic">
+                                    <li>
+                                        <p>+
+                                            The <code>--adminport</code> option overrides the <code>domain.adminPort</code> property of
+                                            the <code>--domainproperties</code> option.</p>
+                                    </li>
+                                </ol>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--instanceport</code></dt>
+                        <dd>
+                            <p>The domain provides services so that applications can run when
+                                deployed. This HTTP port specifies where the web application context
+                                roots are available for a web browser to connect to. This port is a
+                                positive integer and must be available at the time of domain creation.
+                                The <code>--instanceport</code> option cannot be used with the <code>--portbase</code>
+                                option. The default value is 8080.
+                            <div class="olist arabic">
+                                <ol class="arabic">
+                                    <li>
+                                        <p>+
+                                            The <code>--instanceport</code> option overrides the <code>domain.instancePort</code>
+                                            property of the <code>--domainproperties</code> option.</p>
+                                    </li>
+                                </ol>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--portbase</code></dt>
+                        <dd>
+                            <p>Determines the number with which port assignments should start. A
+                                domain uses a certain number of ports that are statically assigned.
+                                The portbase value determines where the assignment should start. The
+                                values for the ports are calculated as follows:<br></p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p>Administration port: portbase + 48</p>
+                                    </li>
+                                    <li>
+                                        <p>HTTP listener port: portbase + 80</p>
+                                    </li>
+                                    <li>
+                                        <p>HTTPS listener port: portbase + 81</p>
+                                    </li>
+                                    <li>
+                                        <p>JMS port: portbase + 76</p>
+                                    </li>
+                                    <li>
+                                        <p>IIOP listener port: portbase + 37</p>
+                                    </li>
+                                    <li>
+                                        <p>Secure IIOP listener port: portbase + 38</p>
+                                    </li>
+                                    <li>
+                                        <p>Secure IIOP with mutual authentication port: portbase + 39</p>
+                                    </li>
+                                    <li>
+                                        <p>JMX port: portbase + 86</p>
+                                    </li>
+                                    <li>
+                                        <p>JPDA debugger port: portbase + 9</p>
+                                    </li>
+                                    <li>
+                                        <p>Felix shell service port for OSGi module management: portbase + 66<br>
+                                            When the <code>--portbase</code> option is specified, the output of this
+                                            subcommand includes a complete list of used ports.<br>
+                                            The <code>--portbase</code> option cannot be used with the <code>--adminport</code>,
+                                            <code>--instanceport</code>, or the <code>--domainproperties</code> option.</p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--profile</code></dt>
+                        <dd>
+                            <p>Do not specify this option. This option is retained for compatibility
+                                with earlier releases. If you specify this option, a syntax error does
+                                not occur. Instead, the subcommand runs successfully and displays a
+                                warning message that the option is ignored.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--template</code></dt>
+                        <dd>
+                            <p>The file name, including a relative or absolute path, of a domain
+                                configuration template to use for creating the domain. If a relative
+                                path is specified, the subcommand appends the path to the
+                                as-install`/lib/templates` directory to locate the file. If it is an
+                                absolute pathname, the subcommand locates the file in the specified
+                                path.<br>
+                                This option enables domains of different types to be created and
+                                custom domain templates to be defined.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--domaindir</code></dt>
+                        <dd>
+                            <p>The directory where the domain is to be created. If specified, the
+                                path must be accessible in the filesystem. If not specified, the
+                                domain is created in the default domain directory,
+                                as-install`/domains`.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--savemasterpassword</code></dt>
+                        <dd>
+                            <p>Setting this option to <code>true</code> allows the master password to be written
+                                to the file system. If this option is <code>true</code>, the
+                                <code>--usemasterpassword</code> option is also true, regardless of the value
+                                that is specified on the command line. The default value is <code>false</code>.<br>
+                                A master password is really a password for the secure key store. A
+                                domain is designed to keep its own certificate (created at the time of
+                                domain creation) in a safe place in the configuration location. This
+                                certificate is called the domain&#8217;s SSL server certificate. When the
+                                domain is contacted by a web browser over a secure channel (HTTPS),
+                                this certificate is presented by the domain. The master password is
+                                supposed to protect the store (a file) that contains this certificate.
+                                This file is called <code>keystore.jks</code> and is created in the configuration
+                                directory of the domain created. If however, this option is chosen,
+                                the master password is saved on the disk in the domain&#8217;s configuration
+                                location. The master password is stored in a file called
+                                <code>master-password</code>, which is a Java JCEKS type keystore. The reason for
+                                using the <code>--savemasterpassword</code> option is for unattended system
+                                boots. In this case, the master password is not prompted for when the
+                                domain starts because the password will be extracted from this file.<br>
+                                It is best to create a master password when creating a domain, because
+                                the master password is used by the <code>start-domain</code> subcommand. For
+                                security purposes, the default setting should be false, because saving
+                                the master password on the disk is an insecure practice, unless file
+                                system permissions are properly set. If the master password is saved,
+                                then <code>start-domain</code> does not prompt for it. The master password gives
+                                an extra level of security to the environment.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--usemasterpassword</code></dt>
+                        <dd>
+                            <p>Specifies whether the key store is encrypted with a master password
+                                that is built into the system or a user-defined master password.<br>
+                                If <code>false</code> (default), the keystore is encrypted with a well-known
+                                password that is built into the system. Encrypting the keystore with a
+                                password that is built into the system provides no additional
+                                security.<br>
+                                If <code>true</code>, the subcommand obtains the master password from the
+                                <code>AS_ADMIN_MASTERPASSWORD</code> entry in the password file or prompts for
+                                the master password. The password file is specified in the
+                                <code>--passwordfile</code> option of the
+                                <a href="asadmin.html#asadmin-1m"><code>asadmin</code>(1M)</a>utility.<br>
+                                If the <code>--savemasterpassword</code> option is <code>true</code>, this option is also
+                                true, regardless of the value that is specified on the command line.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--hazelcastdasport</code></dt>
+                        <dd>
+                            <p>The port to run Hazelcast on for the DAS. If this port is busy, 
+                                the port specified will be incremented until a valid port is found.
+                                The <code>--hazelcastdasport</code> option cannot be used with the <code>--portbase</code> 
+                                option. The default value is 4900.</p>
+                            <div class="olist arabic">
+                                <ol class="arabic">
+                                    <li>
+                                        <p>+
+                                            The <code>--hazelcastdasport</code> option overrides the <code>hazelcast.das.port</code> property of
+                                            the <code>--domainproperties</code> option.</p>
+                                    </li>
+                                </ol>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--hazelcaststartport</code></dt>
+                        <dd>
+                            <p>The port the other Payara Server instances use to run Hazelcast on. 
+                                If this port is busy, the port specified will be incremented until 
+                                a valid port is found.
+                                The <code>--hazelcaststartport</code> option cannot be used with the <code>--portbase</code> 
+                                option. The default value is 5900.</p>
+                            <div class="olist arabic">
+                                <ol class="arabic">
+                                    <li>
+                                        <p>+
+                                            The <code>--hazelcaststartport</code> option overrides the <code>hazelcast.start.port</code> property of
+                                            the <code>--domainproperties</code> option.</p>
+                                    </li>
+                                </ol>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--hazelcastautoincrement</code></dt>
+                        <dd>
+                            <p>By default the cluster uses the next unoccupied port that is 
+                                available starting with the start port. When auto-increment is 
+                                turned off an occupied start port results in a startup failure 
+                                instead.</p>
+                            <div class="olist arabic">
+                                <ol class="arabic">
+                                    <li>
+                                        <p>+
+                                            The <code>--hazelcastautoincrement</code> option overrides the <code>hazelcast.auto.increment</code> property of
+                                            the <code>--domainproperties</code> option.</p>
+                                    </li>
+                                </ol>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--domainproperties</code></dt>
+                        <dd>
+                            <p>Setting the optional name/value pairs overrides the default values for
+                                the properties of the domain to be created. The list must be separated
+                                by the colon (:) character. The <code>--portbase</code> options cannot be used
+                                with the <code>--domainproperties</code> option. The following properties are
+                                available:<br></p>
+                            <div class="dlist">
+                                <dl>
+                                    <dt class="hdlist1"><code>domain.adminPort</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the HTTP port or the
+                                            HTTPS port for administration. This port is the port in the URL that
+                                            you specify in your web browser to manage the instance, for example,
+                                            <code>http://localhost:4949</code>. Valid values are 1-65535. On UNIX, creating
+                                            sockets that listen on ports 1-1024 requires superuser privileges.<br>
+                                            The <code>domain.adminPort</code> property is overridden by the <code>--adminport</code>
+                                            option.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>domain.instancePort</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used to
+                                            listen for HTTP requests. Valid values are 1-65535. On UNIX,
+                                            creating sockets that listen on ports 1-1024 requires superuser
+                                            privileges.<br>
+                                            The <code>domain.instancePort</code> property is overridden by <code>--instanceport</code>
+                                            option.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>domain.jmxPort</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number on which the JMX connector
+                                            listens. Valid values are 1-65535. On UNIX, creating sockets that
+                                            listen on ports 1-1024 requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>http.ssl.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used to
+                                            listen for HTTPS requests. Valid values are 1-65535. On UNIX,
+                                            creating sockets that listen on ports 1-1024 requires superuser
+                                            privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>java.debugger.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used for
+                                            connections to the Java Platform Debugger Architecture (JPDA)
+                                            debugger. Valid values are 1-65535. On UNIX, creating sockets that
+                                            listen on ports 1-1024 requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>jms.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number for the Java Message Service
+                                            provider. Valid values are 1-65535. On UNIX, creating sockets that
+                                            listen on ports 1-1024 requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>orb.listener.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used for
+                                            IIOP connections. Valid values are 1-65535. On UNIX, creating
+                                            sockets that listen on ports 1-1024 requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>orb.mutualauth.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used for
+                                            secure IIOP connections with client authentication. Valid values are
+                                            1-65535. On UNIX, creating sockets that listen on ports 1-1024
+                                            requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>orb.ssl.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used for
+                                            secure IIOP connections. Valid values are 1-65535. On UNIX, creating
+                                            sockets that listen on ports 1-1024 requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>osgi.shell.telnet.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is used for
+                                            connections to the
+                                            <a href="http://felix.apache.org/site/apache-felix-remote-shell.html">Apache
+                                                Felix Remote Shell</a>
+                                            (<a href="http://felix.apache.org/site/apache-felix-remote-shell.html" class="bare">http://felix.apache.org/site/apache-felix-remote-shell.html</a>). This
+                                            shell uses the Felix shell service to interact with the OSGi module
+                                            management subsystem. Valid values are 1-65535. On UNIX, creating
+                                            sockets that listen on ports 1-1024 requires superuser privileges.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>hazelcast.das.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port that is 
+                                            used to run Hazelcast on for the DAS. If this port is busy, the 
+                                            port specified will be incremented until a valid port is found. 
+                                            Valid values are 1-65535. On UNIX, creating sockets that listen 
+                                            on ports 1-1024 requires superuser privileges.<br>
+                                            The <code>hazelcast.das.port</code> property is overridden by the <code>--hazelcastdasport</code>
+                                            option.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>hazelcast.start.port</code></dt>
+                                    <dd>
+                                        <p>This property specifies the port number of the port the other 
+                                            Payara Server instances use to run Hazelcast on. If this port is 
+                                            busy, the port specified will be incremented until a valid port 
+                                            is found. Valid values are 1-65535. On UNIX, creating sockets 
+                                            that listen on ports 1-1024 requires superuser privileges.<br>
+                                            The <code>hazelcast.start.port</code> property is overridden by the <code>--hazelcaststartport</code>
+                                            option.</p>
+                                    </dd>
+                                    <dt class="hdlist1"><code>hazelcast.auto.increment</code></dt>
+                                    <dd>
+                                        <p>This property specifies whether or not to use the next unoccupied
+                                            port that is available starting with the start port. When 
+                                            auto-increment is turned off an occupied start port results in a 
+                                            startup failure instead.<br>
+                                            The <code>hazelcast.auto.increment</code> property is overridden by the <code>--hazelcastautoincrement</code>
+                                            option.</p>
+                                    </dd>
+                                </dl>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--keytooloptions</code></dt>
+                        <dd>
+                            <p>Specifies an optional list of name-value pairs of keytool options for
+                                a self-signed server certificate. The certificate is generated during
+                                the creation of the domain. Each pair in the list must be separated by
+                                the colon (:) character.<br>
+                                Allowed options are as follows:<br></p>
+                            <div class="dlist">
+                                <dl>
+                                    <dt class="hdlist1"><code>CN</code></dt>
+                                    <dd>
+                                        <p>Specifies the common name of the host that is to be used for the
+                                            self-signed certificate. This option name is case insensitive.<br>
+                                            By default, the name is the fully-qualified name of the host where
+                                            the <code>create-domain</code> subcommand is run.</p>
+                                    </dd>
+                                </dl>
+                            </div>
+                        </dd>
+                        <dt class="hdlist1"><code>--savelogin</code></dt>
+                        <dd>
+                            <p>If set to true, this option saves the administration user name and
+                                password. Default value is false. The username and password are stored
+                                in the <code>.asadminpass</code> file in user&#8217;s home directory. A domain can only
+                                be created locally. Therefore, when using the <code>--savelogin</code> option,
+                                the host name saved in <code>.asadminpass</code> is always <code>localhost</code>. If the
+                                user has specified default administration port while creating the
+                                domain, there is no need to specify <code>--user</code>, <code>--passwordfile</code>,
+                                <code>--host</code>, or <code>--port</code> on any of the subsequent <code>asadmin</code> remote
+                                commands. These values will be obtained automatically.<br></p>
+                        </dd>
+                    </dl>
+                </div>
+                <table class="tableblock frame-all grid-all spread">
+                    <colgroup>
+                        <col style="width: 100%;">
+                    </colgroup>
+                    <tbody>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><div><div class="paragraph">
+                                        <p>Note:</p>
+                                    </div>
+                                    <div class="paragraph">
+                                        <p>When the same user creates multiple domains that have the same
+                                            administration port number on the same or different host (where the
+                                            home directory is NFS mounted), the subcommand does not ask if the
+                                            password should be overwritten. The password will always be
+                                            overwritten.</p>
+                                    </div></div></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="dlist">
+                    <dl>
+                        <dt class="hdlist1"><code>--checkports</code></dt>
+                        <dd>
+                            <p>Specifies whether to check for the availability of the administration,
+                                HTTP, JMS, JMX, and IIOP ports. The default value is true.</p>
+                        </dd>
+                        <dt class="hdlist1"><code>--nopassword</code></dt>
+                        <dd>
+                            <p>Specifies whether the administrative user will have a password. If
+                                false (the default), the password is specified by the
+                                <code>AS_ADMIN_PASSWORD</code> entry in the <code>asadmin</code> password file (set by using
+                                the <code>--passwordfile</code> option). If false and the <code>AS_ADMIN_PASSWORD</code> is
+                                not set, you are prompted for the password.<br>
+                                If true, the administrative user is created without a password. If a
+                                user name for the domain is not specified by using the <code>--user</code>
+                                option, and the <code>--nopassword</code> option is set to true, the default user
+                                name, <code>admin</code>, is used.</p>
+                        </dd>
+                    </dl>
+                </div>
+                <div id="sthref211" class="paragraph">
+                    <p>Operands</p>
+                </div>
+                <div class="dlist">
+                    <dl>
+                        <dt class="hdlist1">domain-name</dt>
+                        <dd>
+                            <p>The name of the domain to be created. The name may contain only ASCII
+                                characters and must be a valid directory name for the operating system
+                                on the host where the domain is created.</p>
+                        </dd>
+                    </dl>
+                </div>
+                <div id="sthref212" class="paragraph">
+                    <p>Examples</p>
+                </div>
+                <div class="paragraph">
+                    <p><a id="GSRFM471"></a><a id="sthref213"></a></p>
+                </div>
+                <div class="paragraph">
+                    <p>Example 1   Creating a Domain</p>
+                </div>
+                <div class="paragraph">
+                    <p>This example creates a domain named <code>domain4</code>.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="prettyprint highlight">
+                            <code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt;create-domain --adminport 4848 domain4
+                                Enter admin user name [Enter to accept default "admin" / no password]&gt;
+                                Using port 4848 for Admin.
+                                Using default port 8080 for HTTP Instance.
+                                Using default port 7676 for JMS.
+                                Using default port 3700 for IIOP.
+                                Using default port 8181 for HTTP_SSL.
+                                Using default port 3820 for IIOP_SSL.
+                                Using default port 3920 for IIOP_MUTUALAUTH.
+                                Using default port 8686 for JMX_ADMIN.
+                                Using default port 6666 for OSGI_SHELL.
+                                Using default port 4900 for Hazelcast DAS.
+                                Using default port 5900 for Hazelcast Start.
+                                Distinguished Name of the self-signed X.509 Server Certificate is:
+                                [CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
+                                No domain initializers found, bypassing customization step
+                                Domain domain4 created.
+                                Domain domain4 admin port is 4848.
+                                Domain domain4 allows admin login as user "admin" with no password.
+                                Command create-domain executed successfully.
+                            </code>
+                        </pre>
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p><a id="GSRFM472"></a><a id="sthref214"></a></p>
+                </div>
+                <div class="paragraph">
+                    <p>Example 2   Creating a Domain in an Alternate Directory</p>
+                </div>
+                <div class="paragraph">
+                    <p>This example creates a domain named <code>sampleDomain</code> in the
+                        <code>/home/someuser/domains</code> directory.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="prettyprint highlight">
+                            <code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-domain --domaindir /home/someuser/domains --adminport 7070
+                                --instanceport 7071 sampleDomain
+                                Enter admin user name [Enter to accept default "admin" / no password]&gt;
+                                Using port 7070 for Admin.
+                                Using port 7071 for HTTP Instance.
+                                Using default port 7676 for JMS.
+                                Using default port 3700 for IIOP.
+                                Using default port 8181 for HTTP_SSL.
+                                Using default port 3820 for IIOP_SSL.
+                                Using default port 3920 for IIOP_MUTUALAUTH.
+                                Using default port 8686 for JMX_ADMIN.
+                                Using default port 6666 for OSGI_SHELL.
+                                Using default port 4900 for Hazelcast DAS.
+                                Using default port 5900 for Hazelcast Start.
+                                Enterprise ServiceDistinguished Name of the self-signed X.509 Server Certificate is:
+                                [CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
+                                No domain initializers found, bypassing customization step
+                                Domain sampleDomain created.
+                                Domain sampleDomain admin port is 7070.
+                                Domain sampleDomain allows admin login as user "admin" with no password.
+                                Command create-domain executed successfully.
+                            </code>
+                        </pre>
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p><a id="GSRFM473"></a><a id="sthref215"></a></p>
+                </div>
+                <div class="paragraph">
+                    <p>Example 3   Creating a Domain and Saving the Administration User Name
+                        and Password</p>
+                </div>
+                <div class="paragraph">
+                    <p>This example creates a domain named <code>myDomain</code> and saves the
+                        administration username and password.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="prettyprint highlight">
+                            <code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-domain --adminport 8282 --savelogin=true myDomain
+                                Enter the admin password [Enter to accept default of no password]&gt;
+                                Enter the master password [Enter to accept default password "changeit"]&gt;
+                                Using port 8282 for Admin.
+                                Using default port 8080 for HTTP Instance.
+                                Using default port 7676 for JMS.
+                                Using default port 3700 for IIOP.
+                                Using default port 8181 for HTTP_SSL.
+                                Using default port 3820 for IIOP_SSL.
+                                Using default port 3920 for IIOP_MUTUALAUTH.
+                                Using default port 8686 for JMX_ADMIN.
+                                Using default port 6666 for OSGI_SHELL.
+                                Using default port 4900 for Hazelcast DAS.
+                                Using default port 5900 for Hazelcast Start.
+                                Enterprise ServiceDistinguished Name of the self-signed X.509 Server Certificate is:
+                                [CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
+                                No domain initializers found, bypassing customization step
+                                Domain myDomain created.
+                                Domain myDomain admin port is 8282.
+                                Domain myDomain allows admin login as user "admin" with no password.
+                                Login information relevant to admin user name [admin]
+                                for this domain [myDomain] stored at
+                                [/home/someuser/.asadminpass] successfully.
+                                Make sure that this file remains protected.
+                                Information stored in this file will be used by
+                                asadmin commands to manage this domain.
+                                Command create-domain executed successfully.
+                            </code>
+                        </pre>
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p><a id="GSRFM474"></a><a id="sthref216"></a></p>
+                </div>
+                <div class="paragraph">
+                    <p>Example 4   Creating a Domain and Designating the Certificate Host</p>
+                </div>
+                <div class="paragraph">
+                    <p>This example creates a domain named <code>domain5</code>. The common name of the
+                        host that is to be used for the self-signed certificate is <code>trio</code>.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="prettyprint highlight">
+                            <code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-domain --adminport 9898 --keytooloptions CN=trio domain5
+                                Enter the admin password [Enter to accept default of no password]&gt;
+                                Enter the master password [Enter to accept default password "changeit"]&gt;
+                                Using port 9898 for Admin.
+                                Using default port 8080 for HTTP Instance.
+                                Using default port 7676 for JMS.
+                                Using default port 3700 for IIOP.
+                                Using default port 8181 for HTTP_SSL.
+                                Using default port 3820 for IIOP_SSL.
+                                Using default port 3920 for IIOP_MUTUALAUTH.
+                                Using default port 8686 for JMX_ADMIN.
+                                Using default port 6666 for OSGI_SHELL.
+                                Using default port 4900 for Hazelcast DAS.
+                                Using default port 5900 for Hazelcast Start.
+                                Distinguished Name of the self-signed X.509 Server Certificate is:
+                                [CN=trio,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
+                                No domain initializers found, bypassing customization step
+                                Domain domain5 created.
+                                Domain domain5 admin port is 9898.
+                                Domain domain5 allows admin login as user "admin" with no password.
+                                Command create-domain executed successfully.
+                            </code>
+                        </pre>
+                    </div>
+                </div>
+                <div id="sthref217" class="paragraph">
+                    <p>Exit Status</p>
+                </div>
+                <div class="dlist">
+                    <dl>
+                        <dt class="hdlist1">0</dt>
+                        <dd>
+                            <p>subcommand executed successfully</p>
+                        </dd>
+                        <dt class="hdlist1">1</dt>
+                        <dd>
+                            <p>error in executing the subcommand</p>
+                        </dd>
+                    </dl>
+                </div>
+                <div id="sthref218" class="paragraph">
+                    <p>See Also</p>
+                </div>
+                <div class="paragraph">
+                    <p><a href="asadmin.html#asadmin-1m"><code>asadmin</code>(1M)</a></p>
+                </div>
+                <div class="paragraph">
+                    <p><a href="delete-domain.html#delete-domain-1"><code>delete-domain</code>(1)</a>,
+                        <a href="list-domains.html#list-domains-1"><code>list-domains</code>(1)</a>,
+                        <a href="login.html#login-1"><code>login</code>(1)</a>,
+                        <a href="start-domain.html#start-domain-1"><code>start-domain</code>(1)</a>,
+                        <a href="stop-domain.html#stop-domain-1"><code>stop-domain</code>(1)</a></p>
+                </div>
+                <div class="paragraph">
+                    <p>Apache Felix Remote Shell
+                        (<code>http://felix.apache.org/site/apache-felix-remote-shell.html</code>)</p>
+                </div>
+            </div>
+        </div>
 
-<hr />
+        <hr />
 
-<table width="90%" id="bottom-nav" cellspacing="0" cellpadding="0">
-	<colgroup>
-		<col width="12%"/>
-		<col width="12%"/>
-		<col width="*"/>
-	</colgroup>
-	<tr>		
-		<td align="left">
-		<a href="create-custom-resource.html">
-			<span class=" vector-font"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></span>
-			<span style="position:relative;top:-2px;">Previous</span>
-		</a>
-		</td>
+        <table width="90%" id="bottom-nav" cellspacing="0" cellpadding="0">
+            <colgroup>
+                <col width="12%"/>
+                <col width="12%"/>
+                <col width="*"/>
+            </colgroup>
+            <tr>		
+                <td align="left">
+                    <a href="create-custom-resource.html">
+                        <span class=" vector-font"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></span>
+                        <span style="position:relative;top:-2px;">Previous</span>
+                    </a>
+                </td>
 
-		<td align="left">
-		<a href="create-file-user.html">
-			<span class="vector-font"><i class="fa fa-arrow-circle-right vector-font" aria-hidden="true"></i></span>
-			<span style="position:relative;top:-2px;">Next</span>
-		</a>
-		</td>
+                <td align="left">
+                    <a href="create-file-user.html">
+                        <span class="vector-font"><i class="fa fa-arrow-circle-right vector-font" aria-hidden="true"></i></span>
+                        <span style="position:relative;top:-2px;">Next</span>
+                    </a>
+                </td>
 
-		<td align="right">
-		<a href="toc.html">
-			<span class="vector-font"><i class="fa fa-list vector-font" aria-hidden="true"></i></span>
-			<span style="position:relative;top:-2px;">Contents</span>
-		</a>
-		</td>
-	</tr>
-</table>
+                <td align="right">
+                    <a href="toc.html">
+                        <span class="vector-font"><i class="fa fa-list vector-font" aria-hidden="true"></i></span>
+                        <span style="position:relative;top:-2px;">Contents</span>
+                    </a>
+                </td>
+            </tr>
+        </table>
 
-<span id="copyright">
-        <img src="/resource/reference/img/eclipse_foundation_logo_tiny.png" height="20px" alt="Eclipse Foundation Logo" align="top"/>&nbsp;            
-        <span >Copyright&nbsp;&copy;&nbsp;2019,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</span>
-</span>
+        <span id="copyright">
+            <img src="/resource/reference/img/eclipse_foundation_logo_tiny.png" height="20px" alt="Eclipse Foundation Logo" align="top"/>&nbsp;            
+            <span >Copyright&nbsp;&copy;&nbsp;2019,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</span>
+        </span>
 
-</body>
+    </body>
 </html>

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/util/PortConstants.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/util/PortConstants.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+
 package com.sun.enterprise.config.util;
 
 import java.util.*;
@@ -62,6 +64,8 @@ public final class PortConstants {
     public static final int DEFAULT_JMX_PORT = 8686;
     public static final int DEFAULT_OSGI_SHELL_TELNET_PORT = 6666;
     public static final int DEFAULT_JAVA_DEBUGGER_PORT = 9009;
+    public static final int DEFAULT_HAZELCAST_DAS_PORT = 4900;
+    public static final int DEFAULT_HAZELCAST_START_PORT = 5900;
 
     public static final int PORTBASE_ADMINPORT_SUFFIX = 48;
     public static final int PORTBASE_HTTPSSL_SUFFIX = 81;
@@ -73,6 +77,8 @@ public final class PortConstants {
     public static final int PORTBASE_JMX_SUFFIX = 86;
     public static final int PORTBASE_OSGI_SUFFIX = 66;
     public static final int PORTBASE_DEBUG_SUFFIX = 9;
+    public static final int PORTBASE_HAZELCAST_DAS_PORT_SUFFIX = 49;
+    public static final int PORTBASE_HAZELCAST_START_PORT_SUFFIX = 59;
     
     // these are the ports that we support handling conflicts for...
     public static final String ADMIN = "ASADMIN_LISTENER_PORT";

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/DomainConfig.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/DomainConfig.java
@@ -37,18 +37,16 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt;
 
-import java.util.HashMap;
-import java.util.Properties;
-
-import java.util.Map;
-
 import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
 import com.sun.enterprise.util.SystemPropertyConstants;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * This class defines the keys that are used to create the domain config object.
@@ -96,6 +94,10 @@ public class DomainConfig extends RepositoryConfig {
     public static final String K_INSTANCE_CERT_DN = "domain.instance.cert.dn";
     public static final String K_SECURE_ADMIN_IDENTIFIER = "domain.indicator";
     public static final String K_INITIAL_ADMIN_USER_GROUPS="domain.admin.groups";
+    
+    public static final String K_HAZELCAST_DAS_PORT = "hazelcast.das.port";
+    public static final String K_HAZELCAST_START_PORT = "hazelcast.start.port";
+    public static final String K_HAZELCAST_AUTO_INCREMENT = "hazelcast.auto.increment";
 
     private Properties _domainProperties;
 
@@ -166,6 +168,7 @@ public class DomainConfig extends RepositoryConfig {
     public DomainConfig(String domainName, String domainRoot,
             String adminUser, String adminPassword, String masterPassword,
             Boolean saveMasterPassword, String adminPort, String instancePort,
+            String hazelcastDasPort, String hazelcastStartPort, String hazelcastAutoIncrement,
             Properties domainProperties) throws DomainException {
         this(domainName, domainRoot);
         put(K_ADMIN_PORT, adminPort);
@@ -174,6 +177,9 @@ public class DomainConfig extends RepositoryConfig {
         put(K_SAVE_MASTER_PASSWORD, saveMasterPassword);
         put(K_USER, adminUser);
         put(K_INSTANCE_PORT, instancePort);
+        put(K_HAZELCAST_DAS_PORT, hazelcastDasPort);
+        put(K_HAZELCAST_START_PORT, hazelcastStartPort);
+        put(K_HAZELCAST_AUTO_INCREMENT, hazelcastAutoIncrement);
         _domainProperties = domainProperties;
     }
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -95,7 +95,7 @@ public class DomainBuilder {
     private final DomainConfig domainConfig;
     private JarFile templateJar;
     private DomainTemplate domainTemplate;
-    private final Properties defaultProertiesValue = new Properties();
+    private final Properties defaultPropertiesValue = new Properties();
     private byte[]  keystoreBytes = null;
     private final Set<String> _extractedEntries = new HashSet<String>();
 
@@ -152,11 +152,11 @@ public class DomainBuilder {
                 stringSubstitutor = StringSubstitutionFactory.createStringSubstitutor(templateJar.getInputStream(je));
                 List<Property> defaultPortSubstituteProperties = stringSubstitutor.getDefaultProperties(PropertyType.PORT);
                 for (Property property : defaultPortSubstituteProperties) {
-                    defaultProertiesValue.setProperty(property.getKey(), property.getValue());
+                    defaultPropertiesValue.setProperty(property.getKey(), property.getValue());
                 }
                 List<Property> defaultStringSubstituteProperties = stringSubstitutor.getDefaultProperties(PropertyType.STRING);
                 for (Property property : defaultStringSubstituteProperties) {
-                    defaultProertiesValue.setProperty(property.getKey(), property.getValue());
+                    defaultPropertiesValue.setProperty(property.getKey(), property.getValue());
                 }
                 _extractedEntries.add(je.getName());
             } else {
@@ -202,7 +202,7 @@ public class DomainBuilder {
             repoManager.checkRepository(domainConfig, false);
 
             // Validate the port values.
-            DomainPortValidator portValidator = new DomainPortValidator(domainConfig, defaultProertiesValue);
+            DomainPortValidator portValidator = new DomainPortValidator(domainConfig, defaultPropertiesValue);
             portValidator.validateAndSetPorts();
             setProperties();
             
@@ -218,7 +218,7 @@ public class DomainBuilder {
         Properties domainProperties = domainConfig.getDomainProperties();
         String hazelcastAutoIncrement = getProperty(domainProperties, DomainConfig.K_HAZELCAST_AUTO_INCREMENT,  
                 (String) domainConfig.get(DomainConfig.K_HAZELCAST_AUTO_INCREMENT),
-                defaultProertiesValue.getProperty(SubstitutableTokens.HAZELCAST_AUTO_INCREMENT_TOKEN_NAME));
+                defaultPropertiesValue.getProperty(SubstitutableTokens.HAZELCAST_AUTO_INCREMENT_TOKEN_NAME));
         domainConfig.add(DomainConfig.K_HAZELCAST_AUTO_INCREMENT, Boolean.valueOf(hazelcastAutoIncrement));
 
     }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -41,24 +41,6 @@
 
 package com.sun.enterprise.admin.servermgmt.domain;
 
-import static com.sun.enterprise.admin.servermgmt.SLogger.UNHANDLED_EXCEPTION;
-import static com.sun.enterprise.admin.servermgmt.SLogger.getLogger;
-
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.sun.appserv.server.util.Version;
 import com.sun.enterprise.admin.servermgmt.DomainConfig;
 import com.sun.enterprise.admin.servermgmt.DomainException;
@@ -76,7 +58,24 @@ import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
 import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.io.FileUtils;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.sun.enterprise.admin.servermgmt.SLogger.UNHANDLED_EXCEPTION;
+import static com.sun.enterprise.admin.servermgmt.SLogger.getLogger;
 
 /**
  * Domain builder class.
@@ -96,7 +95,7 @@ public class DomainBuilder {
     private final DomainConfig domainConfig;
     private JarFile templateJar;
     private DomainTemplate domainTemplate;
-    private final Properties defaultPortValues = new Properties();
+    private final Properties defaultProertiesValue = new Properties();
     private byte[]  keystoreBytes = null;
     private final Set<String> _extractedEntries = new HashSet<String>();
 
@@ -151,9 +150,13 @@ public class DomainBuilder {
             StringSubstitutor stringSubstitutor = null;
             if (je != null) {
                 stringSubstitutor = StringSubstitutionFactory.createStringSubstitutor(templateJar.getInputStream(je));
-                List<Property> defaultStringSubsProps = stringSubstitutor.getDefaultProperties(PropertyType.PORT);
-                for (Property prop : defaultStringSubsProps) {
-                    defaultPortValues.setProperty(prop.getKey(), prop.getValue());
+                List<Property> defaultPortSubstituteProperties = stringSubstitutor.getDefaultProperties(PropertyType.PORT);
+                for (Property property : defaultPortSubstituteProperties) {
+                    defaultProertiesValue.setProperty(property.getKey(), property.getValue());
+                }
+                List<Property> defaultStringSubstituteProperties = stringSubstitutor.getDefaultProperties(PropertyType.STRING);
+                for (Property property : defaultStringSubstituteProperties) {
+                    defaultProertiesValue.setProperty(property.getKey(), property.getValue());
                 }
                 _extractedEntries.add(je.getName());
             } else {
@@ -199,15 +202,42 @@ public class DomainBuilder {
             repoManager.checkRepository(domainConfig, false);
 
             // Validate the port values.
-            DomainPortValidator portValidator = new DomainPortValidator(domainConfig, defaultPortValues);
+            DomainPortValidator portValidator = new DomainPortValidator(domainConfig, defaultProertiesValue);
             portValidator.validateAndSetPorts();
-
+            setProperties();
+            
             // Validate other domain config parameters.
             new PEDomainConfigValidator().validate(domainConfig);
 
         } catch (Exception ex) {
             throw new DomainException(ex);
         }
+    }
+     
+    public void setProperties() {
+        Properties domainProperties = domainConfig.getDomainProperties();
+        String hazelcastAutoIncrement = getProperty(domainProperties, DomainConfig.K_HAZELCAST_AUTO_INCREMENT,  
+                (String) domainConfig.get(DomainConfig.K_HAZELCAST_AUTO_INCREMENT),
+                defaultProertiesValue.getProperty(SubstitutableTokens.HAZELCAST_AUTO_INCREMENT_TOKEN_NAME));
+        domainConfig.add(DomainConfig.K_HAZELCAST_AUTO_INCREMENT, Boolean.valueOf(hazelcastAutoIncrement));
+
+    }
+
+    public String getProperty(Properties properties, String key, String currentValue, String defaultPorperty) {
+
+        if (currentValue != null && !currentValue.equals("")) {
+            return currentValue;
+
+        }
+
+        if (properties != null) {
+            String property = properties.getProperty(key);
+            if ((property != null) && !property.equals("")) {
+                return property;
+            }
+        }
+
+        return defaultPorperty;
     }
 
     /**

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainPortValidator.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainPortValidator.java
@@ -37,13 +37,9 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.servermgmt.domain;
-
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import com.sun.enterprise.admin.servermgmt.DomainConfig;
 import com.sun.enterprise.admin.servermgmt.DomainException;
@@ -51,6 +47,9 @@ import com.sun.enterprise.admin.servermgmt.SLogger;
 import com.sun.enterprise.config.util.PortConstants;
 import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.util.net.NetUtils;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Checks that port is free and that the current user has permission to use it
@@ -84,64 +83,87 @@ public class DomainPortValidator {
             // Validate and gets the port values.
             final Integer adminPortInt = getPort(domainProperties,
                     DomainConfig.K_ADMIN_PORT,
-                    (String)domainConfig.get(DomainConfig.K_ADMIN_PORT),
+                    (String) domainConfig.get(DomainConfig.K_ADMIN_PORT),
                     defaultProps.getProperty(SubstitutableTokens.ADMIN_PORT_TOKEN_NAME),
                     "Admin");
             domainConfig.add(DomainConfig.K_ADMIN_PORT, adminPortInt);
 
             final Integer instancePortInt = getPort(domainProperties,
                     DomainConfig.K_INSTANCE_PORT,
-                    (String)domainConfig.get(DomainConfig.K_INSTANCE_PORT),
+                    (String) domainConfig.get(DomainConfig.K_INSTANCE_PORT),
                     defaultProps.getProperty(SubstitutableTokens.HTTP_PORT_TOKEN_NAME),
                     "HTTP Instance");
             domainConfig.add(DomainConfig.K_INSTANCE_PORT, instancePortInt);
 
             final Integer jmsPort = getPort(domainProperties,
                     DomainConfig.K_JMS_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.JMS_PROVIDER_PORT_TOKEN_NAME), "JMS");
+                    defaultProps.getProperty(SubstitutableTokens.JMS_PROVIDER_PORT_TOKEN_NAME), 
+                    "JMS");
             domainConfig.add(DomainConfig.K_JMS_PORT, jmsPort);
             domainProperties.setProperty(PortConstants.JMS, jmsPort.toString());
 
             final Integer orbPort = getPort(domainProperties,
                     DomainConfig.K_ORB_LISTENER_PORT,
                     null,
-                    defaultProps.getProperty(SubstitutableTokens.ORB_LISTENER_PORT_TOKEN_NAME), "IIOP");
+                    defaultProps.getProperty(SubstitutableTokens.ORB_LISTENER_PORT_TOKEN_NAME),
+                    "IIOP");
             domainConfig.add(DomainConfig.K_ORB_LISTENER_PORT, orbPort);
 
             final Integer httpSSLPort = getPort(domainProperties,
                     DomainConfig.K_HTTP_SSL_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.HTTP_SSL_PORT_TOKEN_NAME), "HTTP_SSL");
+                    defaultProps.getProperty(SubstitutableTokens.HTTP_SSL_PORT_TOKEN_NAME),
+                    "HTTP_SSL");
             domainConfig.add(DomainConfig.K_HTTP_SSL_PORT, httpSSLPort);
 
             final Integer iiopSSLPort = getPort(domainProperties,
                     DomainConfig.K_IIOP_SSL_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.ORB_SSL_PORT_TOKEN_NAME), "IIOP_SSL");
+                    defaultProps.getProperty(SubstitutableTokens.ORB_SSL_PORT_TOKEN_NAME),
+                    "IIOP_SSL");
             domainConfig.add(DomainConfig.K_IIOP_SSL_PORT, iiopSSLPort);
 
             final Integer iiopMutualAuthPort = getPort(domainProperties,
                     DomainConfig.K_IIOP_MUTUALAUTH_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.ORB_MUTUALAUTH_PORT_TOKEN_NAME), "IIOP_MUTUALAUTH");
+                    defaultProps.getProperty(SubstitutableTokens.ORB_MUTUALAUTH_PORT_TOKEN_NAME),
+                    "IIOP_MUTUALAUTH");
             domainConfig.add(DomainConfig.K_IIOP_MUTUALAUTH_PORT, iiopMutualAuthPort);
 
             final Integer jmxPort = getPort(domainProperties,
                     DomainConfig.K_JMX_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.JMX_SYSTEM_CONNECTOR_PORT_TOKEN_NAME), "JMX_ADMIN");
+                    defaultProps.getProperty(SubstitutableTokens.JMX_SYSTEM_CONNECTOR_PORT_TOKEN_NAME),
+                    "JMX_ADMIN");
             domainConfig.add(DomainConfig.K_JMX_PORT, jmxPort);
 
             final Integer osgiShellTelnetPort = getPort(domainProperties,
                     DomainConfig.K_OSGI_SHELL_TELNET_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.OSGI_SHELL_TELNET_PORT_TOKEN_NAME), "OSGI_SHELL");
+                    defaultProps.getProperty(SubstitutableTokens.OSGI_SHELL_TELNET_PORT_TOKEN_NAME),
+                    "OSGI_SHELL");
             domainConfig.add(DomainConfig.K_OSGI_SHELL_TELNET_PORT, osgiShellTelnetPort);
 
             final Integer javaDebuggerPort = getPort(domainProperties,
                     DomainConfig.K_JAVA_DEBUGGER_PORT, null,
-                    defaultProps.getProperty(SubstitutableTokens.JAVA_DEBUGGER_PORT_TOKEN_NAME), "JAVA_DEBUGGER");
+                    defaultProps.getProperty(SubstitutableTokens.JAVA_DEBUGGER_PORT_TOKEN_NAME),
+                    "JAVA_DEBUGGER");
             domainConfig.add(DomainConfig.K_JAVA_DEBUGGER_PORT, javaDebuggerPort);
 
+            final Integer hazelcastDasPortInt = getPort(domainProperties,
+                    DomainConfig.K_HAZELCAST_DAS_PORT,
+                    (String) domainConfig.get(DomainConfig.K_HAZELCAST_DAS_PORT),
+                    defaultProps.getProperty(SubstitutableTokens.HAZELCAST_DAS_PORT_TOKEN_NAME),
+                    "Hazelcast DAS");
+            domainConfig.add(DomainConfig.K_HAZELCAST_DAS_PORT, hazelcastDasPortInt);
+
+            final Integer hazelcastStartPortInt = getPort(domainProperties,
+                    DomainConfig.K_HAZELCAST_START_PORT,
+                    (String) domainConfig.get(DomainConfig.K_HAZELCAST_START_PORT),
+                    defaultProps.getProperty(SubstitutableTokens.HAZELCAST_START_PORT_TOKEN_NAME),
+                    "Hazelcast Start");
+            domainConfig.add(DomainConfig.K_HAZELCAST_START_PORT, hazelcastStartPortInt);
+
             checkPortPrivilege(new Integer[]{
-                    adminPortInt, instancePortInt, jmsPort, orbPort, httpSSLPort,
-                    jmsPort, orbPort, httpSSLPort, iiopSSLPort,
-                    iiopMutualAuthPort, jmxPort, osgiShellTelnetPort, javaDebuggerPort
+                adminPortInt, instancePortInt, jmsPort, orbPort, httpSSLPort,
+                jmsPort, orbPort, httpSSLPort, iiopSSLPort,
+                iiopMutualAuthPort, jmxPort, osgiShellTelnetPort, javaDebuggerPort,
+                hazelcastDasPortInt, hazelcastStartPortInt
             });
         } catch (Exception ex) {
             throw new DomainException(ex);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/SubstitutableTokens.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/SubstitutableTokens.java
@@ -37,18 +37,18 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.servermgmt.domain;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
 
 import com.sun.appserv.server.util.Version;
 import com.sun.enterprise.admin.servermgmt.DomainConfig;
 import com.sun.enterprise.admin.servermgmt.pe.PEFileLayout;
 import com.sun.enterprise.util.io.FileUtils;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 public class SubstitutableTokens {
 
@@ -84,6 +84,10 @@ public class SubstitutableTokens {
     public static final String ORB_LISTENER1_PORT = "ORB_LISTENER1_PORT"; 
 
     private static final String DOMAIN_DIR = "DOMAIN_DIR";
+    
+    public static final String HAZELCAST_DAS_PORT_TOKEN_NAME = "HAZELCAST_DAS_PORT";
+    public static final String HAZELCAST_START_PORT_TOKEN_NAME = "HAZELCAST_START_PORT";
+    public static final String HAZELCAST_AUTO_INCREMENT_TOKEN_NAME = "HAZELCAST_AUTO_INCREMENT";
 
     public static Map<String, String> getSubstitutableTokens(DomainConfig domainConfig) {
         Map<String, String> substitutableTokens = new HashMap<String, String>();
@@ -99,7 +103,7 @@ public class SubstitutableTokens {
         substitutableTokens.put(CONFIG_MODEL_NAME_TOKEN_NAME, CONFIG_MODEL_NAME_TOKEN_VALUE);
         substitutableTokens.put(HOST_NAME_TOKEN_NAME, (String) domainConfig.get(DomainConfig.K_HOST_NAME));
 
-        substitutableTokens.put(ADMIN_PORT_TOKEN_NAME, domainConfig.get(DomainConfig.K_ADMIN_PORT).toString());
+        substitutableTokens.put(ADMIN_PORT_TOKEN_NAME, domainConfig.get(DomainConfig.K_ADMIN_PORT).toString());   
         substitutableTokens.put(HTTP_PORT_TOKEN_NAME, domainConfig.get(DomainConfig.K_INSTANCE_PORT).toString());
         substitutableTokens.put(ORB_LISTENER_PORT_TOKEN_NAME,  domainConfig.get(DomainConfig.K_ORB_LISTENER_PORT).toString());
         substitutableTokens.put(JMS_PROVIDER_PORT_TOKEN_NAME, domainConfig.get(DomainConfig.K_JMS_PORT).toString());
@@ -122,6 +126,10 @@ public class SubstitutableTokens {
         substitutableTokens.put(ORB_LISTENER1_PORT,  domainConfig.get(DomainConfig.K_ORB_LISTENER_PORT).toString());
         String domainLocation =  new File(domainConfig.getRepositoryRoot(), domainConfig.getRepositoryName()).getAbsolutePath();
         substitutableTokens.put(DOMAIN_DIR, domainLocation);
+        
+        substitutableTokens.put(HAZELCAST_DAS_PORT_TOKEN_NAME, domainConfig.get(DomainConfig.K_HAZELCAST_DAS_PORT).toString());
+        substitutableTokens.put(HAZELCAST_START_PORT_TOKEN_NAME, domainConfig.get(DomainConfig.K_HAZELCAST_START_PORT).toString());
+        substitutableTokens.put(HAZELCAST_AUTO_INCREMENT_TOKEN_NAME, domainConfig.get(DomainConfig.K_HAZELCAST_AUTO_INCREMENT).toString());
 
         for (String pname : domainProperties.stringPropertyNames()) {
             if (!substitutableTokens.containsKey(pname)) {

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
@@ -110,9 +110,9 @@ OPTIONS
            *   Felix shell service port for OSGi module management: portbase +
                66
            
-           *   Hazelcast DAS port: portbase + 0
+           *   Hazelcast DAS port: portbase + 49
            
-           *   Hazelcast Start port: portbase + 0
+           *   Hazelcast Start port: portbase + 59
 
            When the --portbase option is specified, the output of this
            subcommand includes a complete list of used ports.

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
@@ -13,6 +13,9 @@ SYNOPSIS
            [--domaindir domaindir]
            [--savemasterpassword={false|true}]
            [--usemasterpassword={false|true}]
+           [--hazelcastdasport hazelcastdasport]
+           [--hazelcaststartport hazelcaststartport]
+           [--hazelcastautoincrement={false|true}]
            [--domainproperties (name=value)[:name=value]*]
            [--keytooloptions (name=value)[:name=value]*]
            [--savelogin={false|true}]
@@ -106,6 +109,10 @@ OPTIONS
 
            *   Felix shell service port for OSGi module management: portbase +
                66
+           
+           *   Hazelcast DAS port: portbase + 0
+           
+           *   Hazelcast Start port: portbase + 0
 
            When the --portbase option is specified, the output of this
            subcommand includes a complete list of used ports.
@@ -186,6 +193,33 @@ OPTIONS
            If the --savemasterpassword option is true, this option is also
            true, regardless of the value that is specified on the command
            line.
+        
+       --hazelcastdasport
+           The port to run Hazelcast on for the DAS. If this port is busy, 
+           the port specified will be incremented until a valid port is found.
+           The --hazelcastdasport option cannot be used with the --portbase 
+           option. The default value is 4900.
+
+           The --hazelcastdasport option overrides the hazelcast.das.port 
+           property of the --domainproperties option.
+        
+       --hazelcaststartport
+           The port the other Payara Server instances use to run Hazelcast on. 
+           If this port is busy, the port specified will be incremented until 
+           a valid port is found. The --hazelcaststartport option cannot be 
+           used with the --portbase option. The default value is 5900.
+
+           The --hazelcaststartport option overrides the hazelcast.start.port 
+           property of the --domainproperties option.
+
+       --hazelcastautoincrement
+           By default the cluster uses the next unoccupied port that is 
+           available starting with the start port. When auto-increment is 
+           turned off an occupied start port results in a startup failure 
+           instead.
+
+           The --hazelcastautoincrement option overrides the 
+           hazelcast.auto.increment property of the --domainproperties option.
 
        --domainproperties
            Setting the optional name/value pairs overrides the default values
@@ -270,6 +304,36 @@ OPTIONS
                UNIX, creating sockets that listen on ports 1-1024 requires
                superuser privileges.
 
+           hazelcast.das.port
+               This property specifies the port number of the port that is 
+               used to run Hazelcast on for the DAS. If this port is busy, the 
+               port specified will be incremented until a valid port is found. 
+               Valid values are 1-65535. On UNIX, creating sockets that listen 
+               on ports 1-1024 requires superuser privileges.
+           
+               The hazelcast.das.port property is overridden by the 
+               --hazelcastdasport option.
+
+           hazelcast.start.port
+               This property specifies the port number of the port the other 
+               Payara Server instances use to run Hazelcast on. If this port is 
+               busy, the port specified will be incremented until a valid port 
+               is found. Valid values are 1-65535. On UNIX, creating sockets 
+               that listen on ports 1-1024 requires superuser privileges.
+           
+               The hazelcast.start.port property is overridden by the 
+               --hazelcaststartport option.
+
+           hazelcast.auto.increment
+               This property specifies whether or not to use the next unoccupied
+               port that is available starting with the start port. When 
+               auto-increment is turned off an occupied start port results in a 
+               startup failure instead.
+               
+               
+               The hazelcast.auto.increment property is overridden by the 
+               --hazelcastautoincrement option.
+
        --keytooloptions
            Specifies an optional list of name-value pairs of keytool options
            for a self-signed server certificate. The certificate is generated
@@ -347,6 +411,8 @@ EXAMPLES
                Using default port 3920 for IIOP_MUTUALAUTH.
                Using default port 8686 for JMX_ADMIN.
                Using default port 6666 for OSGI_SHELL.
+               Using default port 4900 for Hazelcast DAS.
+               Using default port 5900 for Hazelcast Start.
                Distinguished Name of the self-signed X.509 Server Certificate is:
                [CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
                No domain initializers found, bypassing customization step
@@ -371,6 +437,8 @@ EXAMPLES
                Using default port 3920 for IIOP_MUTUALAUTH.
                Using default port 8686 for JMX_ADMIN.
                Using default port 6666 for OSGI_SHELL.
+               Using default port 4900 for Hazelcast DAS.
+               Using default port 5900 for Hazelcast Start.
                Enterprise ServiceDistinguished Name of the self-signed X.509 Server Certificate is:
                [CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
                No domain initializers found, bypassing customization step
@@ -396,6 +464,8 @@ EXAMPLES
                Using default port 3920 for IIOP_MUTUALAUTH.
                Using default port 8686 for JMX_ADMIN.
                Using default port 6666 for OSGI_SHELL.
+               Using default port 4900 for Hazelcast DAS.
+               Using default port 5900 for Hazelcast Start.
                Enterprise ServiceDistinguished Name of the self-signed X.509 Server Certificate is:
                [CN=sr1-usca-22,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
                No domain initializers found, bypassing customization step
@@ -426,6 +496,8 @@ EXAMPLES
                Using default port 3920 for IIOP_MUTUALAUTH.
                Using default port 8686 for JMX_ADMIN.
                Using default port 6666 for OSGI_SHELL.
+               Using default port 4900 for Hazelcast DAS.
+               Using default port 5900 for Hazelcast Start.
                Distinguished Name of the self-signed X.509 Server Certificate is:
                [CN=trio,OU=GlassFish,O=Oracle Corp.,L=Redwood Shores,ST=California,C=US]
                No domain initializers found, bypassing customization step

--- a/nucleus/admin/template/src/main/resources/stringsubs.xml
+++ b/nucleus/admin/template/src/main/resources/stringsubs.xml
@@ -38,6 +38,8 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
+    
+    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 -->
 <stringsubs-definition name="em" version="1.0.0.0" xmlns="http://xmlns.oracle.com/cie/glassfish/stringsubs">
@@ -69,10 +71,16 @@
         <change-pair-ref name="TOKENS_HERE"/>
         <change-pair-ref name="DEFAULT_TOKENS_HERE"/>
         <change-pair-ref name="PORT_BASE"/>
+        <change-pair-ref name="HAZELCAST_DAS_PORT"/>
+        <change-pair-ref name="HAZELCAST_START_PORT"/>
+        <change-pair-ref name="HAZELCAST_AUTO_INCREMENT"/>
     </group>
     <change-pair id="VERSION" before="%%%VERSION%%%" after="$VERSION$"/>
     <change-pair id="INSTALL_ROOT" before="%%%INSTALL_ROOT%%%" after="$INSTALL_ROOT$"/>
     <change-pair id="SERVER_ID" before="%%%SERVER_ID%%%" after="$SERVER_ID$"/>
+    <change-pair id="SERVER_ROOT" before="%%%SERVER_ROOT%%%" after="$SERVER_ROOT$"/>
+    <change-pair id="SERVER_NAME" before="%%%SERVER_NAME%%%" after="$SERVER_NAME$"/>
+    <change-pair id="ORB_LISTENER1_PORT" before="%%%ORB_LISTENER1_PORT%%%" after="$ORB_LISTENER_PORT$"/>
     <change-pair id="CONFIG_MODEL_NAME" before="%%%CONFIG_MODEL_NAME%%%" after="$CONFIG_MODEL_NAME$"/>
     <change-pair id="DOMAIN_NAME" before="%%%DOMAIN_NAME%%%" after="$DOMAIN_NAME$"/>
     <change-pair id="JMS_PROVIDER_PORT" before="%%%JMS_PROVIDER_PORT%%%" after="$JMS_PROVIDER_PORT$"/>
@@ -92,6 +100,9 @@
     <change-pair id="TOKENS_HERE" before="&lt;!--%%%TOKENS_HERE%%%--&gt;" after="$TOKENS_HERE$"/>
     <change-pair id="DEFAULT_TOKENS_HERE" before="&lt;!--%%%DEFAULT_TOKENS_HERE%%%--&gt;" after="$DEFAULT_TOKENS_HERE$"/>
     <change-pair id="PORT_BASE" before="&lt;!--%%%PORT_BASE%%%--&gt;" after="$PORT_BASE$"/>
+    <change-pair id="HAZELCAST_DAS_PORT" before="%%%HAZELCAST_DAS_PORT%%%" after="$HAZELCAST_DAS_PORT$"/>
+    <change-pair id="HAZELCAST_START_PORT" before="%%%HAZELCAST_START_PORT%%%" after="$HAZELCAST_START_PORT$"/>
+    <change-pair id="HAZELCAST_AUTO_INCREMENT" before="%%%HAZELCAST_AUTO_INCREMENT%%%" after="$HAZELCAST_AUTO_INCREMENT$"/>
     <defaults>
         <property key="ADMIN_PORT" value="4848" type="port"/>
         <property key="HTTP_SSL_PORT" value="8181" type="port"/>
@@ -103,5 +114,8 @@
         <property key="JMX_SYSTEM_CONNECTOR_PORT" value="8686" type="port"/>
         <property key="OSGI_SHELL_TELNET_PORT" value="6666" type="port"/>
         <property key="JAVA_DEBUGGER_PORT" value="9009" type="port"/>
+        <property key="HAZELCAST_DAS_PORT" value="4900" type="port"/>
+        <property key="HAZELCAST_START_PORT" value="5900" type="port"/>
+        <property key="HAZELCAST_AUTO_INCREMENT" value="true" type="string"/>
     </defaults>
 </stringsubs-definition>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a feature to allow `create-domain` command to configure the Hazelcast Configuration. This makes it possible to configure the Hazelcast Configuration before starting the domain.
 
**Following new command options have been added to the `create-domain` command:**

* **`--hazelcastdasport`** The port to run Hazelcast on for the DAS. If this port is busy, the port specified will be incremented until a valid port is found. The `--hazelcastdasport` option cannot be used with the --portbase option. The default value is 4900. The `--hazelcastdasport` option overrides the `hazelcast.das.port` property of the `--domainproperties` option.

* **`--hazelcaststartport`** The port the other Payara Server instances use to run Hazelcast on. If this port is busy, the port specified will be incremented until a valid port is found. The `--hazelcaststartport` option cannot be used with the `--portbase` option. The default value is 5900. The `--hazelcaststartport` option overrides the `hazelcast.start.port` property of the `--domainproperties` option.

**Following domain properties have been added to the `create-domain` command:**
* **`--hazelcastautoincrement`** By default the cluster uses the next unoccupied port that is available starting with the start port. When auto-increment is turned off an occupied start port results in a startup failure instead. The `--hazelcastautoincrement` option overrides the hazelcast.auto.increment property of the `--domainproperties` option. 


* **` hazelcast.das.port`** This property specifies the port number of the port that is used to run. Hazelcast on for the DAS. If this port is busy, the port specified will be incremented until a valid port is found.  Valid values are 1-65535. On UNIX, creating sockets that listen on ports 1-1024 requires superuser privileges. The hazelcast.das.port property is overridden by the `--hazelcastdasport` option.

* **`hazelcast.start.port`** This property specifies the port number of the port the other Payara Server instances use to run Hazelcast on. If this port is busy, the port specified will be incremented until a valid port is found. Valid values are 1-65535. On UNIX, creating sockets that listen on ports 1-1024 requires superuser privileges. The hazelcast.start.port property is overridden by the  `--hazelcaststartport` option.

* **`hazelcast.auto.increment`** This property specifies whether or not to use the next unoccupied port that is available starting with the start port. When auto-increment is turned off an occupied start port results in a startup failure instead. The `hazelcast.auto.increment` property is overridden by the `--hazelcastautoincrement` option.

It also shifts the Hazelcast DAS and the Start port according to the value of `--portbase` command option, similar to the other port values.

# Testing

### New tests
None

### Testing Performed
* Running the `create-domain` command to test the functionality of the newly implemented command options. E.g. running `asadmin create-domain --hazelcastdasport 7900 --hazelcaststartport 8900 --hazelcastautoincrement true testDomain` command. Gave following output:

```
Using default port 4848 for Admin.
Using default port 8080 for HTTP Instance.
Using default port 7676 for JMS.
Using default port 3700 for IIOP.
Using default port 8181 for HTTP_SSL.
Using default port 3820 for IIOP_SSL.
Using default port 3920 for IIOP_MUTUALAUTH.
Using default port 8686 for JMX_ADMIN.
Using default port 6666 for OSGI_SHELL.
Using default port 9009 for JAVA_DEBUGGER.
Using port 7900 for Hazelcast DAS.
Using port 8900 for Hazelcast Start.
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dev,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dev-instance,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Domain testDomain created.
Domain testDomain admin port is 4848.
Domain testDomain allows admin login as user "admin" with no password.
Command create-domain executed successfully.
```
* Or running `create-domain --domainproperties hazelcast.das.port=7900:hazelcast.auto.increment=false:hazelcast.start.port=8900 testDomain` command. Gave following output:

```
Using default port 8080 for HTTP Instance.
Using default port 7676 for JMS.
Using default port 3700 for IIOP.
Using default port 8181 for HTTP_SSL.
Using default port 3820 for IIOP_SSL.
Using default port 3920 for IIOP_MUTUALAUTH.
Using default port 8686 for JMX_ADMIN.
Using default port 6666 for OSGI_SHELL.
Using default port 9009 for JAVA_DEBUGGER.
Using port 7900 for Hazelcast DAS.
Using port 8900 for Hazelcast Start.
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dev,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dev-instance,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Domain testDomain created.
Domain testDomain admin port is 4848.
Domain testDomain allows admin login as user "admin" with no password.
Command create-domain executed successfully.
```
* Local Build Test

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Documentation
TODO