### PR TITLE
PAYARA-3828: Upgrade Jersey and MP Rest client version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -207,7 +207,7 @@
         <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
         <microprofile-healthcheck.version>1.0.payara-p1</microprofile-healthcheck.version>
         <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>
-        <microprofile-rest-client.version>1.2.1.payara-p1</microprofile-rest-client.version>
+        <microprofile-rest-client.version>1.3.3</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
 
         <nimbus-jose-jwt.version>5.4</nimbus-jose-jwt.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -162,7 +162,7 @@
         <!-- JAX-RS -->
         <jax-rs-api.spec.version>2.1.5</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
-        <jersey.version>2.29.payara-p5</jersey.version>
+        <jersey.version>2.29.1.payara-p1</jersey.version>
 
         <!-- Bean Validation -->
         <javax.validation.version>2.0.1.Final</javax.validation.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a feature. <!-- delete/modify as applicable-->

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->
Upgrading to latest Jersey release brings in support for Microprofile Rest Client 1.3 as well as various bugfixes.

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Important Info

### Dependant PRs <!-- delete as applicable -->
<!--- Link any related or dependant PRs here with brief description why -->
https://github.com/payara/Payara_PatchedProjects/pull/281 Binary release
https://github.com/payara/Payara_PatchedProjects/pull/282 Binary release fix

# Testing

### Testing Performed
<!--- Please describe how you tested these changes.  -->

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Java EE7 Samples
- Java EE8 Samples
- Payara Microprofile TCKs Runner (Rest Client 1.3)

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 10, Zulu 1.8_212, Maven 3.6.1
