### PR TITLE
PAYARA-4121 Fixed Updating of Flashlight Class Instrumentation

### DIFF
--- a/appserver/web/admin/src/main/java/org/glassfish/web/admin/monitor/RequestProbeProvider.java
+++ b/appserver/web/admin/src/main/java/org/glassfish/web/admin/monitor/RequestProbeProvider.java
@@ -41,7 +41,6 @@
 package org.glassfish.web.admin.monitor;
 
 import org.glassfish.external.probe.provider.annotations.*;
-import org.glassfish.grizzly.Buffer;
 
 /**
  * Provider interface for HTTP request/response related probes.

--- a/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/StatsProviderRegistry.java
+++ b/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/StatsProviderRegistry.java
@@ -51,13 +51,13 @@ import org.glassfish.external.probe.provider.PluginPoint;
 import org.glassfish.external.probe.provider.StatsProviderInfo;
 
 public class StatsProviderRegistry {
-    private final Map<String, List<StatsProviderRegistryElement>> configToRegistryElementMap = new HashMap();
-    private final Map<Object, StatsProviderRegistryElement> statsProviderToRegistryElementMap = new HashMap();
+    private final Map<String, List<StatsProviderRegistryElement>> configToRegistryElementMap = new ConcurrentHashMap<>();
+    private final Map<Object, StatsProviderRegistryElement> statsProviderToRegistryElementMap = new ConcurrentHashMap<>();
     private boolean isAMXReady = false;
     private boolean isMBeanEnabled = true;
     
     static final String[] DEFAULT_CONFIG_LEVELS = new String[] {"LOW","HIGH"};
-    protected static final Map<String, Integer> configLevelsMap = new ConcurrentHashMap();
+    protected static final Map<String, Integer> configLevelsMap = new ConcurrentHashMap<>();
 
     public StatsProviderRegistry(MonitoringRuntimeDataRegistry mrdr) {
         for (int i = 0; i < DEFAULT_CONFIG_LEVELS.length; i++) {
@@ -84,7 +84,7 @@ public class StatsProviderRegistry {
             List<StatsProviderRegistryElement> spreList = configToRegistryElementMap.get(configStr);
             spreList.add(spre);
         } else {
-            List<StatsProviderRegistryElement> spreList = new ArrayList();
+            List<StatsProviderRegistryElement> spreList = new ArrayList<>();
             spreList.add(spre);
             configToRegistryElementMap.put(configStr, spreList);
         }

--- a/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/StatsProviderRegistry.java
+++ b/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/StatsProviderRegistry.java
@@ -118,7 +118,8 @@ public class StatsProviderRegistry {
     }
 
     List<StatsProviderRegistryElement> getStatsProviderRegistryElement(String configElement) {
-        return (this.configToRegistryElementMap.get(configElement));
+        List<StatsProviderRegistryElement> plain = configToRegistryElementMap.get(configElement);
+        return plain == null ? Collections.emptyList() : new ArrayList<>(plain);
     }
 
     Collection<StatsProviderRegistryElement> getSpreList() {

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/FlashlightProbeClientMediator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/FlashlightProbeClientMediator.java
@@ -87,7 +87,7 @@ public class FlashlightProbeClientMediator
     private AtomicInteger clientIdGenerator =
             new AtomicInteger(0);
     private static ConcurrentHashMap<Integer, Object> clients =
-            new ConcurrentHashMap<Integer, Object>();
+            new ConcurrentHashMap<>();
 
     @Override
     public void postConstruct() {
@@ -114,8 +114,8 @@ public class FlashlightProbeClientMediator
     @Override
     public Collection<ProbeClientMethodHandle> registerListener(Object listener, String invokerId) {
 
-        List<ProbeClientMethodHandle> pcms = new ArrayList<ProbeClientMethodHandle>();
-        List<FlashlightProbe> probesRequiringClassTransformation = new ArrayList<FlashlightProbe>();
+        List<ProbeClientMethodHandle> pcms = new ArrayList<>();
+        List<FlashlightProbe> probesRequiringClassTransformation = new ArrayList<>();
         if (invokerId != null) {
             invokerId = FlashlightUtils.getUniqueInvokerId(invokerId);
         }
@@ -127,8 +127,8 @@ public class FlashlightProbeClientMediator
 
     public Collection<ProbeClientMethodHandle> registerDTraceListener(FlashlightProbeProvider propro) {
 
-        List<ProbeClientMethodHandle> pcms = new ArrayList<ProbeClientMethodHandle>();
-        List<FlashlightProbe> probesRequiringClassTransformation = new ArrayList<FlashlightProbe>();
+        List<ProbeClientMethodHandle> pcms = new ArrayList<>();
+        List<FlashlightProbe> probesRequiringClassTransformation = new ArrayList<>();
 
         Object listener = registerDTraceListener(propro, pcms, probesRequiringClassTransformation);
         transformProbes(listener, probesRequiringClassTransformation);
@@ -194,7 +194,7 @@ public class FlashlightProbeClientMediator
         clients.put(clientID, listener);
 
         for (FlashlightProbe probe : probes) {
-            Class clz = probe.getProviderClazz();
+            Class<?> clz = probe.getProviderClazz();
             ProbeProviderClassFileTransformer transformer =
                     ProbeProviderClassFileTransformer.getInstance(clz);
             try {
@@ -218,7 +218,7 @@ public class FlashlightProbeClientMediator
      */
     private List<MethodProbe> handleListenerAnnotations(Class listenerClass, String invokerId) {
 
-        List<MethodProbe> mp = new LinkedList<MethodProbe>();
+        List<MethodProbe> mp = new LinkedList<>();
 
         for (Method method : listenerClass.getMethods()) {
             ProbeListener probeAnn = method.getAnnotation(ProbeListener.class);

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/FlashlightProbeClientMediator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/FlashlightProbeClientMediator.java
@@ -204,7 +204,6 @@ public class FlashlightProbeClientMediator
                 logger.log(Level.SEVERE, BAD_TRANSFORM, ex);
             }
         }
-        ProbeProviderClassFileTransformer.transformAll();
     }
 
     /**

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeClientMethodHandleImpl.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeClientMethodHandleImpl.java
@@ -75,13 +75,13 @@ public class ProbeClientMethodHandleImpl
     public synchronized void enable() {
         probe.addInvoker(clientMethodInvoker);
         enabled = true;
-        ProbeProviderClassFileTransformer.transform(probe.getProviderClazz());
+        ProbeProviderClassFileTransformer.update(probe.getProviderClazz());
     }
 
     @Override
     public synchronized void disable() {
         probe.removeInvoker(clientMethodInvoker);
         enabled = false;
-        ProbeProviderClassFileTransformer.untransform(probe.getProviderClazz());
+        ProbeProviderClassFileTransformer.update(probe.getProviderClazz());
     }
 }

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeClientMethodHandleImpl.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeClientMethodHandleImpl.java
@@ -50,10 +50,10 @@ import org.glassfish.flashlight.provider.FlashlightProbe;
 public class ProbeClientMethodHandleImpl
         implements ProbeClientMethodHandle {
 
-    private int clientMethodId;
+    private final int clientMethodId;
+    private final ProbeClientInvoker clientMethodInvoker;
+    private final FlashlightProbe probe;
     private boolean enabled = true;
-    private ProbeClientInvoker clientMethodInvoker;
-    private FlashlightProbe probe;
 
     public ProbeClientMethodHandleImpl(int id, ProbeClientInvoker invoker, FlashlightProbe probe) {
         this.clientMethodId = id;

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
@@ -52,6 +52,7 @@ import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.logging.Logger;
 import java.util.logging.Level;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -115,9 +116,13 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
         Thread t = new Thread(() -> {
             try {
                 while (true) {
-                    Thread.sleep(200); // wait first so triggering calls flag first before the update runs 
-                    for (ProbeProviderClassFileTransformer transformer : instances.values()) {
-                        if (transformer.flaggedForUpdate.get()) {
+                    Thread.sleep(200); // wait first so triggering calls flag first before the update runs
+                    Iterator<ProbeProviderClassFileTransformer> iter = instances.values().iterator();
+                    while (iter.hasNext()) {
+                        ProbeProviderClassFileTransformer transformer = iter.next();
+                        if (transformer.providerClassRef.get() == null) {
+                            iter.remove();
+                        } else if (transformer.flaggedForUpdate.get()) {
                             transformer.runUpdate();
                         }
                     }

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
@@ -81,7 +81,7 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
     private final WeakReference<Class<?>> providerClassRef;
     private final String providerClassName;
     private final Map<String, FlashlightProbe> probes = new ConcurrentHashMap<>();
-    private AtomicBoolean faggedForUpdate = new AtomicBoolean(false);
+    private AtomicBoolean flaggedForUpdate = new AtomicBoolean(false);
     private boolean transformerAdded = false;
     private int count = 0;  // Only used for debug so we can look at the before/after class dumps for each iteration
     ///////////////  static variables  //////////////////
@@ -117,7 +117,7 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
                 while (true) {
                     Thread.sleep(200); // wait first so triggering calls flag first before the update runs 
                     for (ProbeProviderClassFileTransformer transformer : instances.values()) {
-                        if (transformer.faggedForUpdate.get()) {
+                        if (transformer.flaggedForUpdate.get()) {
                             transformer.runUpdate();
                         }
                     }
@@ -133,13 +133,13 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
     }
 
     private void update() {
-        faggedForUpdate.set(true);
+        flaggedForUpdate.set(true);
         // make sure a updater is running
         updater.updateAndGet(thread -> thread != null && thread.isAlive() ? thread : newUpdater());
     }
 
     private final void runUpdate() {
-        faggedForUpdate.set(false);
+        flaggedForUpdate.set(false);
         Class<?> providerClass = providerClassRef.get();
         if (providerClass == null) {
             if (Log.getLogger().isLoggable(Level.FINER))

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/provider/ProbeRegistry.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/provider/ProbeRegistry.java
@@ -62,9 +62,9 @@ public class ProbeRegistry {
     private static volatile ProbeRegistry _me = new ProbeRegistry();
 
     private static ConcurrentHashMap<Integer, FlashlightProbe> probeMap =
-                new ConcurrentHashMap<Integer, FlashlightProbe>();
+                new ConcurrentHashMap<>();
     private static ConcurrentHashMap<String, FlashlightProbe> probeDesc2ProbeMap =
-                new ConcurrentHashMap<String, FlashlightProbe>();
+                new ConcurrentHashMap<>();
 
     public static ProbeRegistry getInstance() {
         return _me;
@@ -120,7 +120,7 @@ public class ProbeRegistry {
 
     public Collection<FlashlightProbe> getAllProbes() {
        Collection<FlashlightProbe> allProbes = probeMap.values();
-       Collection<FlashlightProbe> visibleProbes = new ArrayList<FlashlightProbe>();
+       Collection<FlashlightProbe> visibleProbes = new ArrayList<>();
        for (FlashlightProbe probe : allProbes) {
            if (!probe.isHidden())
                visibleProbes.add(probe);


### PR DESCRIPTION
### Symthom
When un-deploying and re-deploying an application the web and HTTP statistics would no longer update.

### Finding 
The reason for updates no longer reaching the statistics counters was that the connection done via class instrumentation was cut when un-deploying an app. This occurred because un-deploying an application does disable statistics providers specifically responsible for the application which wrongly triggered a removal of the class instrumentation for the probe provider class connecting the events to the statistics counters. So instead of just disconnecting the application specific statistics all statistics based on a particular class were disabled. Since the overall statistics for HTTP and web use the same class as the application specific ones this also disabled the overall statistics.

### Solution
Because the trigger for changes of class instrumentation was a static call in the innermost part of the logic there was no clear way to only trigger updates to the class instrumentation after the logic is done updating the changed probes and invokers. Another mistake was that disabling a invoker caused disabling of the class even though there might be other invokers and other probes for the same provider class. This is why both `transform` and `untransform` became just `update`. If updating would require to update the instrumentation or remove it is now evaluated based on the probes and their active invokers. If there are active invokers and the probe is enabled the instrumentation is kept and updated. Methods with no invokers are no longer instrumented.

To avoid running the update for each trigger call, which is each method times the statistics provider instances, the trigger only flags for update and a asynchronous daemon thread is used to run the actual updates with a small delay. By granting a delay the logic causing multiple triggers is likely to have completed and flagged all needed updates before the thread actually performs them. 

During shutdown the thread ends from interruption and does not perform (most of) the triggered transformation that a shutdown normally causes.

### Note to the Reviewer
Main change is in `ProbeProviderClassFileTransformer`. Besides that I only added some missing generics and made some hash maps into concurrent ones while looking for the problem.

Note that `synchronized` was largely removed where present. Synchronisation is done by now using a concurrent map and atomics. To allow reclaim of key class key was changed to `String` which alled use of concurrent map. Other methods no longer need synchronisation because only the updater thread will call them.

This also fixes PAYARA-1285 which should be checked with the reproducer given in the ticket.

### Testing
Easiest is to test this after #4274 is merged since it will be easy to verify in the monitoring console that un-deploying and re-deploying an application does no longer cause the request/sec to zero out.

With MC started enable web and HTTP monitoring until you see some request/sec in the _Core_ view of MC. Redeploy MC and check that the requests/sec are still above 0, most likely 0.5 due to data polling every 2secs.

Testing should also check that enabling and disabling the web or HTTP monitoring has the expected effect. Again this is verified easiest after #4274 already being in master. 

To check that instrumentation no longer is added or removed multiple times from provider classes I put a log output on INFO level in both cases of this if-statement https://github.com/payara/Payara/pull/4278/files#diff-16bec2e5206edbe4e95b050af4617992R193. Note that occasionally it is still possible that same class is handled twice due to unlucky async timing but not more often then that.