### PR TITLE
PAYARA-4130: Workaround hidden config service dependencies

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
@@ -119,6 +119,7 @@ public class ConfigProviderResolverImpl extends ConfigProviderResolver {
     private final static String APP_METADATA_KEY = "payara.microprofile.config";
 
     static final CountDownLatch initialized = new CountDownLatch(1);
+    static volatile ConfigProviderResolver instance;
 
     @Inject
     private InvocationManager invocationManager;
@@ -146,6 +147,7 @@ public class ConfigProviderResolverImpl extends ConfigProviderResolver {
     @PostConstruct
     public void postConstruct() {
         ConfigProviderResolver.setInstance(this);
+        instance = this;
         initialized.countDown();
     }
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverSync.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverSync.java
@@ -58,7 +58,9 @@ public class ConfigProviderResolverSync extends ConfigProviderResolver {
         try {
             if (ConfigProviderResolverImpl.initialized.await(5, TimeUnit.SECONDS)) {
                 // the real resolver initialized, and have set the right instance already
-                return ConfigProviderResolver.instance();
+                // but it might have done it at unfortunate moment where it was overwritten by this instance
+                ConfigProviderResolver.setInstance(ConfigProviderResolverImpl.instance);
+                return ConfigProviderResolverImpl.instance;
             } else {
                 // we log and throw, as these exceptions might get swallowed as
                 // java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.microprofile.config.ConfigProvider


### PR DESCRIPTION


<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

`ConfigProviderResolverImpl` might provide instance to MP Config SPI at wrong moment, where its instance gets yet overwritten by instance of `ConfigProviderResolveSync` instance. This race condition manifests itself as `StackOverflowError` then, because Sync relied on Impl to set the instance.

This solution only masks a larger issue where various server internals cooperate with MP Config API to obtain configuration, however config impl is a service, that only works after proper initialization.

It would be best to use HK2 injection instead, but majority of the points of use are not HK2 services.

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Java EE7 Samples in `payara-micro-managed` profile, that manifested this behavior the most in nightly


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 10, Java 1.8.0_221, Maven 3.6.2
<!-- Have you tagged any appropriate reviewers?-->
