### PR TITLE
PAYARA-3796 Stop checking whether the JNDI name refers to a String ju…

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
@@ -86,9 +86,7 @@ public class JNDIConfigSource extends PayaraConfigSource implements ConfigSource
         try {
             InitialContext ctx = new InitialContext();
             Object jndiObj = ctx.lookup(propertyName);
-            if (jndiObj.getClass().isAssignableFrom(String.class)) {
-                result = String.class.cast(jndiObj);
-            }
+            result = jndiObj.toString();
         } catch (NamingException ex) {
             // ignore who cares we don;t have the property but another source may
         }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/JNDIConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
…st use toString instead if the lookup suceeds.

Fixes GH #3935

Signed-off-by: Steve Millidge <steve.millidge@payara.fish>

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a small enhancement it enables use of other types of custom JNDI resources other than Strings to be injected as ConfigProperties

<!-- fixes GitHub issue? - provide a link to that issue here -->
#3935 

<!-- Provide some context here -->
The JNDI config source was explicitly testing whether the object looked up via JNDI was assignable to a String. This is unnecessarily restrictive therefore now it just does a toString. 

# Testing

### New tests


### Testing Performed
Tested using the GH reproducer.

### Test suites executed


### Testing Environment
1.8.0_23
Ubuntu Linux version 5.0.0-31-generic (buildd@lgw01-amd64-046) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #33~18.04.1-Ubuntu SMP Tue Oct 1 10:20:39 UTC 2019

# Documentation

# Notes for Reviewers
<!-- Please give notes for any reviewers. The code should explain itself, but where should they start? Do you want feedback on anything specific? -->
<!-- Have you tagged any appropriate reviewers?-->
