### PR TITLE
CUSTCOM-208 Suspended transaction should be resumed even when an exception is raised during commit()

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.cdi.transaction;
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
@@ -132,16 +132,16 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
                             "Managed bean with Transactional annotation and TxType of REQUIRES_NEW " +
                             "encountered exception during commit " + exception,
                             exception);
-                }
-
-                if (suspendedTransaction != null) {
-                    try {
-                        getTransactionManager().resume(suspendedTransaction);
-                    } catch (Exception exception) {
-                        throw new TransactionalException(
-                                "Managed bean with Transactional annotation and TxType of REQUIRED " +
-                                "encountered exception during resume " + exception,
-                                exception);
+                } finally {
+                    if (suspendedTransaction != null) {
+                        try {
+                            getTransactionManager().resume(suspendedTransaction);
+                        } catch (Exception exception) {
+                            throw new TransactionalException(
+                                    "Managed bean with Transactional annotation and TxType of REQUIRED " +
+                                    "encountered exception during resume " + exception,
+                                    exception);
+                        }
                     }
                 }
             }


### PR DESCRIPTION

# Description
This fixes an issues when using @Transactional(Transactional.TxType.REQUIRES_NEW).

If an exception occurs during getTransaction().commit(), then the suspended transaction is not resumed.
The code flow should be similar to EJBContainerTransactionManager.postInvokeTx (resume always called, even when commit/rollback throws an exception).

# Testing

### Testing Performed
Testing was performed on an in-house application.
