### PR TITLE
PAYARA-4218 Add JDK11 support to JAX-WS commands

### DIFF
--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck
@@ -42,11 +42,7 @@
 
 # Checks the version of Java installed, if it is 9+ then endorsed is not available
 checkEndorsedAvailable () {
-    local ver=$("$JAVA" -version 2>&1 >/dev/null| sed -e 's/.*version "\(.*\)"\(.*\)/\1/; 1q')
-    if [ $ver = "1."* ]
-    then
-        true;
-    else
-        false;
-    fi
+    ver=$("$JAVA" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
+    return $ver
 }
+

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck
@@ -3,7 +3,7 @@
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck
@@ -3,7 +3,7 @@
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 1997-2013 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -39,28 +39,14 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2019] Payara Foundation and/or affiliates
 
-AS_INSTALL=`dirname "$0"`/..
-
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-./jdkcheck
-
-if [ checkEndorsedAvailable = true ]
-then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsGen "$@"
-else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsGen "$@"
-fi
+# Checks the version of Java installed, if it is 9+ then endorsed is not available
+checkEndorsedAvailable () {
+    local ver=$("$JAVA" -version 2>&1 >/dev/null| sed -e 's/.*version "\(.*\)"\(.*\)/\1/; 1q')
+    if [ $ver = "1."* ]
+    then
+        true;
+    else
+        false;
+    fi
+}

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/jdkcheck.bat
@@ -1,0 +1,50 @@
+@echo off
+
+REM
+REM DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+REM
+REM Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+REM
+REM The contents of this file are subject to the terms of either the GNU
+REM General Public License Version 2 only ("GPL") or the Common Development
+REM and Distribution License("CDDL") (collectively, the "License").  You
+REM may not use this file except in compliance with the License.  You can
+REM obtain a copy of the License at
+REM https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+REM or packager/legal/LICENSE.txt.  See the License for the specific
+REM language governing permissions and limitations under the License.
+REM
+REM When distributing the software, include this License Header Notice in each
+REM file and include the License file at packager/legal/LICENSE.txt.
+REM
+REM GPL Classpath Exception:
+REM Oracle designates this particular file as subject to the "Classpath"
+REM exception as provided by Oracle in the GPL Version 2 section of the License
+REM file that accompanied this code.
+REM
+REM Modifications:
+REM If applicable, add the following below the License Header, with the fields
+REM enclosed by brackets [] replaced by your own identifying information:
+REM "Portions Copyright [year] [name of copyright owner]"
+REM
+REM Contributor(s):
+REM If you wish your version of this file to be governed by only the CDDL or
+REM only the GPL Version 2, indicate your decision by adding "[Contributor]
+REM elects to include this software in this distribution under the [CDDL or GPL
+REM Version 2] license."  If you don't indicate a single choice of license, a
+REM recipient has the option to distribute your version of this file under
+REM either the CDDL, the GPL Version 2 or to extend the choice of license to
+REM its licensees as provided above.  However, if you add GPL Version 2 code
+REM and therefore, elected the GPL Version 2 license, then the option applies
+REM only if the new code is made subject to such option by the copyright
+REM holder.
+REM
+
+REM Checks the version of Java installed, if it is 9+ then endorsed is not available
+for /f tokens^=2-5^ delims^=.-_^" %%j in ('%JAVA% -fullversion 2^>^&1') do set "jver=%%j%"
+
+if %jver%==1 (
+    set ENDORSED_AVAILABLE=true
+) else (
+    set ENDORSED_AVAILABLE=false
+)

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
@@ -58,8 +58,9 @@ fi
 
 
 . $(dirname "$0")/jdkcheck
+checkEndorsedAvailable
 
-if [ checkEndorsedAvailable = true ]
+if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
 else

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
@@ -39,6 +39,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2019] Payara Foundation and/or affiliates
 
 AS_INSTALL=`dirname "$0"`/..
 
@@ -55,4 +56,11 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+./jdkcheck
+
+if [ checkEndorsedAvailable = true ]
+then 
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+else
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
@@ -56,7 +56,8 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-./jdkcheck
+
+. $(dirname "$0")/jdkcheck
 
 if [ checkEndorsedAvailable = true ]
 then 

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
@@ -57,7 +57,7 @@ goto run
 set JAVA=java
 
 :run
-CALL jdkcheck.bat
+CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
     %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
@@ -39,6 +39,7 @@ REM  and therefore, elected the GPL Version 2 license, then the option applies
 REM  only if the new code is made subject to such option by the copyright
 REM  holder.
 REM
+REM Portions Copyright [2019] Payara Foundation and/or affiliates
 
 VERIFY OTHER 2>nul
 setlocal ENABLEEXTENSIONS
@@ -56,4 +57,10 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+CALL jdkcheck.bat
+
+if %ENDORSED_AVAILABLE%==true (
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+) else (
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+)

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
@@ -59,4 +59,11 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" $WSCOMPILE_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
+./jdkcheck
+
+if [ checkEndorsedAvailable = true ]
+then 
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
+else
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
+fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
@@ -59,7 +59,7 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-./jdkcheck
+. $(dirname "$0")/jdkcheck
 
 if [ checkEndorsedAvailable = true ]
 then 

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
@@ -60,8 +60,9 @@ if [ ${AS_JAVA} ]; then
 fi
 
 . $(dirname "$0")/jdkcheck
+checkEndorsedAvailable
 
-if [ checkEndorsedAvailable = true ]
+if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
 else

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
@@ -58,4 +58,10 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% %WSCOMPILE_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
+CALL jdkcheck.bat
+
+if %ENDORSED_AVAILABLE%==true (
+    %JAVA% %WSCOMPILE_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
+) else (
+    %JAVA% %WSCOMPILE_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
+)

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
@@ -58,7 +58,7 @@ goto run
 set JAVA=java
 
 :run
-CALL jdkcheck.bat
+CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
     %JAVA% %WSCOMPILE_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
@@ -59,4 +59,11 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
+./jdkcheck
+
+if [ checkEndorsedAvailable = true ]
+then 
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
+else
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
+fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
@@ -59,7 +59,7 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-./jdkcheck
+. $(dirname "$0")/jdkcheck
 
 if [ checkEndorsedAvailable = true ]
 then 

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
@@ -60,8 +60,9 @@ if [ ${AS_JAVA} ]; then
 fi
 
 . $(dirname "$0")/jdkcheck
+checkEndorsedAvailable
 
-if [ checkEndorsedAvailable = true ]
+if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
 else

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
@@ -58,4 +58,10 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
+CALL jdkcheck.bat
+
+if %ENDORSED_AVAILABLE%==true (
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
+) else (
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
+)

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
@@ -58,7 +58,7 @@ goto run
 set JAVA=java
 
 :run
-CALL jdkcheck.bat
+CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
     %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
@@ -57,8 +57,9 @@ if [ ${AS_JAVA} ]; then
 fi
 
 . $(dirname "$0")/jdkcheck
+checkEndorsedAvailable
 
-if [ checkEndorsedAvailable = true ]
+if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsGen "$@"
 else

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
@@ -56,7 +56,7 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-./jdkcheck
+. $(dirname "$0")/jdkcheck
 
 if [ checkEndorsedAvailable = true ]
 then 

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
@@ -57,7 +57,7 @@ goto run
 set JAVA=java
 
 :run
-CALL jdkcheck.bat
+CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
     %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
@@ -39,6 +39,7 @@ REM  and therefore, elected the GPL Version 2 license, then the option applies
 REM  only if the new code is made subject to such option by the copyright
 REM  holder.
 REM
+REM Portions Copyright [2019] Payara Foundation and/or affiliates
 
 VERIFY OTHER 2>nul
 setlocal ENABLEEXTENSIONS
@@ -56,4 +57,10 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% %WSGEN_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*
+CALL jdkcheck.bat
+
+if %ENDORSED_AVAILABLE%==true (
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*
+) else (
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.xml.ws-api.jar" com.sun.tools.ws.WsGen %*
+)

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -39,6 +39,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2019] Payara Foundation and/or affiliates
 
 AS_INSTALL=`dirname "$0"`/..
 
@@ -55,4 +56,11 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
+./jdkcheck
+
+if [ checkEndorsedAvailable = true ]
+then 
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
+else
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsImport "$@"
+fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -57,8 +57,9 @@ if [ ${AS_JAVA} ]; then
 fi
 
 . $(dirname "$0")/jdkcheck
+checkEndorsedAvailable
 
-if [ checkEndorsedAvailable = true ]
+if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
 else

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -56,7 +56,7 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-./jdkcheck
+. $(dirname "$0")/jdkcheck
 
 if [ checkEndorsedAvailable = true ]
 then 

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
@@ -39,6 +39,7 @@ REM  and therefore, elected the GPL Version 2 license, then the option applies
 REM  only if the new code is made subject to such option by the copyright
 REM  holder.
 REM
+REM Portions Copyright [2019] Payara Foundation and/or affiliates
 
 VERIFY OTHER 2>nul
 setlocal ENABLEEXTENSIONS
@@ -55,5 +56,12 @@ goto run
 :UsePath
 set JAVA=java
 
+
 :run
-%JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*
+CALL jdkcheck.bat
+
+if %ENDORSED_AVAILABLE%==true (
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*
+) else (
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.xml.ws-api.jar" com.sun.tools.ws.WsImport %*
+)

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
@@ -58,7 +58,7 @@ set JAVA=java
 
 
 :run
-CALL jdkcheck.bat
+CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
     %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
@@ -57,8 +57,9 @@ if [ ${AS_JAVA} ]; then
 fi
 
 . $(dirname "$0")/jdkcheck
+checkEndorsedAvailable
 
-if [ checkEndorsedAvailable = true ]
+if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
 else

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
@@ -39,6 +39,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2019] Payara Foundation and/or affiliates
 
 AS_INSTALL=`dirname "$0"`/..
 
@@ -55,4 +56,11 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
+./jdkcheck
+
+if [ checkEndorsedAvailable = true ]
+then 
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
+else
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
+fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
@@ -56,7 +56,7 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-./jdkcheck
+. $(dirname "$0")/jdkcheck
 
 if [ checkEndorsedAvailable = true ]
 then 

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
@@ -57,7 +57,7 @@ goto run
 set JAVA=java
 
 :run
-CALL jdkcheck.bat
+CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
     %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
@@ -39,6 +39,7 @@ REM  and therefore, elected the GPL Version 2 license, then the option applies
 REM  only if the new code is made subject to such option by the copyright
 REM  holder.
 REM
+REM Portions Copyright [2019] Payara Foundation and/or affiliates
 
 VERIFY OTHER 2>nul
 setlocal ENABLEEXTENSIONS
@@ -56,4 +57,10 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
+CALL jdkcheck.bat
+
+if %ENDORSED_AVAILABLE%==true (
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
+) else (
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
+)


### PR DESCRIPTION
# Description
This is a bug fix

This allows running of the JAX-WS commands i.e. `wsimport`, `wscompile` on both JDKs 8 and 11, since the endorsed has been removed in JDK9+ and required classes were removed from Java SE in JDK11.

# Testing

### Testing Performed
Ran all changed commands on JDKs 8 and 11 on Windows and Linux

### Testing Environment
Zulu JDK 1.8_222 on Ubuntu 19.04
Zulu JDK 11.0.5 on Ubuntu 19.04
IBM JDK 1.8_221 on Ubuntu 19.04
Zulu JDK 1.8_181 on Windows 10
Zulu JDK 11.0.3 on Windows 10
