### PR TITLE
PAYARA-4147 MP Metrics now use double for MBean metrics instead of long

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanGuageImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanGuageImpl.java
@@ -47,7 +47,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  * @author jonathan coustick
  * @since 5.193
  */
-public class MBeanGuageImpl implements Gauge<Long> {
+public class MBeanGuageImpl implements Gauge<Double> {
 
     private final MBeanExpression mBean;
 
@@ -56,7 +56,7 @@ public class MBeanGuageImpl implements Gauge<Long> {
     }
 
     @Override
-    public Long getValue() {      
-        return mBean.getNumberValue().longValue();
+    public Double getValue() {      
+        return mBean.getNumberValue().doubleValue();
     }
 }


### PR DESCRIPTION
# Description
This is a bug fix 

Fixes #4230 
CPU Load was being displayed as 0 as gauge was used a long which would round off the actual cpu usage which occurs in the range [0,1]

# Testing

### Testing Performed
Started domain and admin console. Went to localhost:4848/metrics and checked system_cpu_load gauge, with this PR is is non-zero.

### Test suites executed
- Payara Microprofile TCKs Runner
- Cargo Tracker

### Testing Environment
Zulu JDK 1.8_222 on Ubuntu 19.04 with Maven 3.6.0
