### PR TITLE
TEST-388 Update Arquillian Containers

### DIFF
--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -34,8 +34,8 @@
         <!-- Micro implementation versions (these are downloaded and installed
             in these versions by Maven for the CI profiles) -->
         <payara.version>${project.version}</payara.version>
-        <payara.container.version>1.0.Beta3</payara.container.version>
-        <payara.micro.container.version>5.Beta3-m3</payara.micro.container.version>
+        <payara.container.version>2.0</payara.container.version>
+        <payara.micro.container.version>2.0</payara.micro.container.version>
         <payara_domain>domain1</payara_domain>
 
         <micro.isActive>false</micro.isActive>
@@ -82,13 +82,13 @@
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-client-ee8</artifactId>
-                <version>1.1</version>
+                <version>${payara.container.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-client-ee7</artifactId>
-                <version>1.1</version>
+                <version>${payara.container.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -217,7 +217,7 @@
                 <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-4-managed</artifactId>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
                     <version>${payara.container.version}</version>
                     <scope>test</scope>
                 </dependency>
@@ -293,8 +293,8 @@
                 <!-- The Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-micro-5-managed</artifactId>
-                    <version>${payara.container.version}</version>
+                    <artifactId>arquillian-payara-micro-managed</artifactId>
+                    <version>${payara.micro.container.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -360,7 +360,7 @@
                 <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-4-remote</artifactId>
+                    <artifactId>arquillian-payara-server-remote</artifactId>
                     <version>${payara.container.version}</version>
                     <scope>test</scope>
                 </dependency>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -141,6 +141,7 @@
             </activation>
             <properties>
                 <payara.directory.name>payara41</payara.directory.name>
+                <payara.container.version>1.3</payara.container.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
# Description
Updates the arquillian containers used in Payara Samples tests.

Maintaining support for Payara 4 and Payara 5 within the same arquillian container version was proving too difficult, so we've split them out.

# Important Info

### Dependant PRs 
Relies upon the release of the following PRs: https://github.com/payara/ecosystem-arquillian-connectors/pull/30 https://github.com/payara/ecosystem-arquillian-connectors/pull/29

# Notes for Reviewers
If you wish to test, check out those two PRs and build them.
