### PR TITLE
PAYARA-4251 Woodstock cleanup (a bit of)

### DIFF
--- a/appserver/admin/backup-l10n/pom.xml
+++ b/appserver/admin/backup-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>backup-l10n</artifactId>

--- a/appserver/admin/cli-optional-l10n/pom.xml
+++ b/appserver/admin/cli-optional-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cli-optional-l10n</artifactId>
     

--- a/appserver/admin/pom.xml
+++ b/appserver/admin/pom.xml
@@ -49,7 +49,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.admin</groupId>
     <artifactId>admin</artifactId>

--- a/appserver/admin/runtime/pom.xml
+++ b/appserver/admin/runtime/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.admin.runtime</groupId>
     <artifactId>runtime</artifactId>

--- a/appserver/admingui/cdieventbus-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/cdieventbus-notifier-console-plugin-l10n/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. 
+  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates.
   All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
@@ -18,8 +18,8 @@
   file and include the License file at glassfish/legal/LICENSE.txt.
 
   GPL Classpath Exception:
-  The Payara Foundation designates this particular file as subject to the 
-  "Classpath" exception as provided by the Payara Foundation in the GPL 
+  The Payara Foundation designates this particular file as subject to the
+  "Classpath" exception as provided by the Payara Foundation in the GPL
   Version 2 section of the License file that accompanied this code.
 
   Modifications:
@@ -46,24 +46,23 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    
-    <artifactId>cdieventbus-notifier-console-plugin-l10n</artifactId>  
+
+    <artifactId>cdieventbus-notifier-console-plugin-l10n</artifactId>
     <name>Admin Console CDI Event Bus Notifier Plugin l10n</name>
     <description>CDI Event Bus Notifier Plugin bundle for Admin Console Localization</description>
-    
+
     <properties>
         <javadoc.skip>true</javadoc.skip>
         <deploy.skip>true</deploy.skip>
     </properties>
-    
-    
+
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
-                <artifactId>osgiversion-maven-plugin</artifactId>            
+                <artifactId>osgiversion-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>compute-osgi-version</id>

--- a/appserver/admingui/cluster-l10n/pom.xml
+++ b/appserver/admingui/cluster-l10n/pom.xml
@@ -47,23 +47,22 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-cluster-plugin-l10n</artifactId>
-    
+
     <name>Admin Console Clustering Support Plugin l10n</name>
     <description>Clustering support plugin bundle for Payara Admin Console Localization</description>
-    
+
     <properties>
         <javadoc.skip>true</javadoc.skip>
         <deploy.skip>true</deploy.skip>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
               <groupId>org.glassfish.hk2</groupId>
-              <artifactId>osgiversion-maven-plugin</artifactId>            
+              <artifactId>osgiversion-maven-plugin</artifactId>
               <executions>
                   <execution>
                       <id>compute-osgi-version</id>

--- a/appserver/admingui/cluster/pom.xml
+++ b/appserver/admingui/cluster/pom.xml
@@ -47,11 +47,10 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-cluster-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Clustering Support Plugin</name>
     <description>Clustering support plugin bundle for Payara Admin Console</description>
 
@@ -94,6 +93,10 @@
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/common-l10n/pom.xml
+++ b/appserver/admingui/common-l10n/pom.xml
@@ -47,24 +47,23 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>console-common-l10n</artifactId>
-    
+
     <name>Admin Console Common l10n</name>
     <description>Admin Console Common Localization</description>
-    
+
     <properties>
         <javadoc.skip>true</javadoc.skip>
         <deploy.skip>true</deploy.skip>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
               <groupId>org.glassfish.hk2</groupId>
-              <artifactId>osgiversion-maven-plugin</artifactId>            
+              <artifactId>osgiversion-maven-plugin</artifactId>
               <executions>
                   <execution>
                       <id>compute-osgi-version</id>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -48,17 +48,12 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-common</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Common</name>
     <description>This bundle contains common code that may be shared across plugins.</description>
-
-    <developers>
-        <!-- See parent POM -->
-    </developers>
 
     <build>
         <plugins>
@@ -76,7 +71,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.deployment</groupId>
@@ -85,47 +80,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.security.auth.message</groupId>
-            <artifactId>jakarta.security.auth.message-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.sun.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.servlet</groupId>
-                    <artifactId>jakarta.servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jsftemplating</groupId>
-            <artifactId>jsftemplating-dt</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet.jsp</groupId>
-            <artifactId>jakarta.servlet.jsp-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
@@ -152,6 +112,36 @@
             <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>rest-service</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating-dt</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/concurrent-l10n/pom.xml
+++ b/appserver/admingui/concurrent-l10n/pom.xml
@@ -47,23 +47,22 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-concurrent-plugin-l10n</artifactId>
-    
+
     <name>Admin Console Concurrent Plugin L10n</name>
     <description>Concurrent (JSR236) plugin bundle for Payara Admin Console L10n</description>
-    
+
     <properties>
         <javadoc.skip>true</javadoc.skip>
         <deploy.skip>true</deploy.skip>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
               <groupId>org.glassfish.hk2</groupId>
-              <artifactId>osgiversion-maven-plugin</artifactId>            
+              <artifactId>osgiversion-maven-plugin</artifactId>
               <executions>
                   <execution>
                       <id>compute-osgi-version</id>

--- a/appserver/admingui/concurrent/pom.xml
+++ b/appserver/admingui/concurrent/pom.xml
@@ -47,11 +47,10 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-concurrent-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Concurrent Plugin</name>
     <description>Concurrent (JSR236)  plugin bundle for Payara Admin Console</description>
 

--- a/appserver/admingui/corba-l10n/pom.xml
+++ b/appserver/admingui/corba-l10n/pom.xml
@@ -47,10 +47,9 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-corba-plugin-l10n</artifactId>
-    
+
     <name>Admin Console Corba Plugin l10n</name>
     <description>Corba plugin bundle for Payara Admin Console Localization</description>
 
@@ -58,12 +57,12 @@
         <javadoc.skip>true</javadoc.skip>
         <deploy.skip>true</deploy.skip>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
               <groupId>org.glassfish.hk2</groupId>
-              <artifactId>osgiversion-maven-plugin</artifactId>            
+              <artifactId>osgiversion-maven-plugin</artifactId>
               <executions>
                   <execution>
                       <id>compute-osgi-version</id>

--- a/appserver/admingui/corba/pom.xml
+++ b/appserver/admingui/corba/pom.xml
@@ -47,11 +47,10 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-corba-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Corba Plugin</name>
     <description>Corba plugin bundle for Payara Admin Console</description>
 

--- a/appserver/admingui/core-l10n/pom.xml
+++ b/appserver/admingui/core-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-core-l10n</artifactId>
     

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -51,12 +51,8 @@
     </parent>
     <artifactId>console-core</artifactId>
     <packaging>glassfish-jar</packaging>
-    
-    <name>Admin Console Core Jar</name>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
+    <name>Admin Console Core Jar</name>
 
     <build>
         <plugins>
@@ -90,83 +86,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
-            <artifactId>deployment-client</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Woodstock dependency -->
-        <dependency>
-            <groupId>com.sun.woodstock</groupId>
-            <artifactId>webui-jsf-suntheme</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.sun.woodstock</groupId>
             <artifactId>webui-jsf</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.faces.extensions</groupId>
-                    <artifactId>jsf-extensions-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.faces.extensions</groupId>
-                    <artifactId>jsf-extensions-dynamic-faces</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.woodstock.dependlibs</groupId>
-                    <artifactId>jh</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.woodstock.dependlibs</groupId>
-                    <artifactId>jhall</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.woodstock.dependlibs</groupId>
-                    <artifactId>jhbasic</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.woodstock.dependlibs</groupId>
-                    <artifactId>portlet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-beanutils</groupId>
-                    <artifactId>commons-beanutils</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-digester</groupId>
-                    <artifactId>commons-digester</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.woodstock.dependlibs</groupId>
-                    <artifactId>dataprovider</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
-            <artifactId>json</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
-            <artifactId>dojo-ajax-nodemo</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
-            <artifactId>prototype</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
@@ -179,35 +101,5 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.admingui</groupId>
-            <artifactId>dataprovider</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.admingui</groupId>
-            <artifactId>gf-admingui-connector</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency> <!-- for FindBugs -->
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency> 
-        <dependency> <!-- for FindBugs -->
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <scope>provided</scope>
-        </dependency> 
-        <dependency> <!-- for FindBugs -->
-            <groupId>com.sun.pkg</groupId>
-            <artifactId>pkg-java</artifactId>
-            <version>1.0.0-alpha-1</version>
-            <scope>provided</scope>
-        </dependency> 
-
-
     </dependencies>
 </project>

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-core</artifactId>
     <packaging>glassfish-jar</packaging>
@@ -86,10 +85,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.woodstock</groupId>
-            <artifactId>webui-jsf</artifactId>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
@@ -100,6 +95,20 @@
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>dataprovider</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock</groupId>
+            <artifactId>webui-jsf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/core/src/main/java/org/glassfish/admingui/handlers/ThemeHandlers.java
+++ b/appserver/admingui/core/src/main/java/org/glassfish/admingui/handlers/ThemeHandlers.java
@@ -116,9 +116,8 @@ public class ThemeHandlers {
                     try {
                         Properties propertyMap = new Properties();
                         propertyMap.load(propertyFileURL.openStream());
-                        ThemeContext themeContext =
-			    AdminguiThemeContext.getInstance(ctx, propertyMap);
-			themeContext.setDefaultClassLoader(pluginCL);
+                        ThemeContext themeContext = AdminguiThemeContext.getInstance(ctx, propertyMap);
+                        themeContext.setDefaultClassLoader(pluginCL);
                         handlerCtx.setOutputValue("themeContext", themeContext);
                     } catch (Exception ex) {
                         throw new RuntimeException(

--- a/appserver/admingui/core/src/main/java/org/glassfish/admingui/theme/AdminguiThemeContext.java
+++ b/appserver/admingui/core/src/main/java/org/glassfish/admingui/theme/AdminguiThemeContext.java
@@ -36,7 +36,9 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admingui.theme;
 
@@ -44,12 +46,10 @@ import com.sun.webui.jsf.theme.JSFThemeContext;
 import com.sun.webui.theme.ServletThemeContext;
 import com.sun.webui.theme.ThemeContext;
 
-import org.glassfish.admingui.common.util.GuiUtil;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Enumeration;
+import java.util.logging.Logger;
 
 import javax.faces.context.FacesContext;
 
@@ -66,120 +66,131 @@ import javax.faces.context.FacesContext;
  */
 public class AdminguiThemeContext extends ServletThemeContext {
 
-    /**
-     *	<p> This constructor takes in the theme name and version to use by
-     *	    default.</p>
-     *
-     *	@param	themeName	The theme name (i.e. suntheme).
-     *	@param	themeVersion	The version number (i.e. 4.2).
-     */
-    protected AdminguiThemeContext(String themeName, String themeVersion) {
-	super(setThemeParams(themeName, themeVersion));
-
-	// The following ThemeContext is created to allow us to delegate our
-	// logic to it.
-	jsfThemeCtx = JSFThemeContext.getInstance(FacesContext.getCurrentInstance());
-        jsfThemeCtx.setThemeServletContext("/theme");
-    }
-
-    
-    /**
-     *	<p> Return an instance of <code>ThemeContext</code> creating one
-     *	    if necessary and persisting it in the <code>ApplicationMap</code>.
-     */
-    public synchronized static ThemeContext getInstance(FacesContext context, String themeName, String themeVersion) {
-	Map map = context.getExternalContext().getApplicationMap();
-	String themeKey = THEME_CONTEXT + themeName + themeVersion;
-	ThemeContext themeContext = (ThemeContext) map.get(themeKey);
-	if (themeContext == null) {
-	    themeContext = new AdminguiThemeContext(themeName, themeVersion);
-	    map.put(themeKey, themeContext);
-	}
-	return themeContext;
-    }
-    
-/**
-     *	<p> Return an instance of <code>ThemeContext</code> 
-     *	    using properties provided via <code>Integration point</code>.
-     */
-    public synchronized static ThemeContext getInstance(FacesContext context,  Properties propMap) {
-	Map map = context.getExternalContext().getApplicationMap();        
-        String themeName = (String)propMap.get(THEME_NAME_KEY);
-        String themeVersion = (String)propMap.get(THEME_VERSION_KEY);
-	String themeKey = THEME_CONTEXT + themeName + themeVersion;
-	ThemeContext themeContext = (ThemeContext) map.get(themeKey);
-	if (themeContext == null) {
-	    themeContext = new AdminguiThemeContext(themeName, themeVersion);
-	    map.put(themeKey, themeContext);
-	}
-	return themeContext;
-    }    
-
-    
-    /**
-     *	<p> Creates a <code>Map</code> object with the theme name and
-     *	    version.</p>
-     */
-    public static Map setThemeParams(String theme, String version) {
-	Map map = new HashMap();
-	if (theme == null) {
-	    theme = "suntheme";
-	}
-	map.put(ThemeContext.DEFAULT_THEME, theme);
-	if (version == null) {
-	    version = "4.2";
-	}
-	map.put(ThemeContext.DEFAULT_THEME_VERSION, version);
-	return map;
-    }
-    
-    
-    /**
-     *	<p> This method delegates to <code>JSFThemeContext</code>.</p>
-     */
-    public ClassLoader getDefaultClassLoader() {
-	return jsfThemeCtx.getDefaultClassLoader();
-    }
+    private static final Logger LOG = Logger.getLogger(AdminguiThemeContext.class.getName());
 
     /**
-     *	<p> This method delegates to <code>JSFThemeContext</code>.</p>
-     */
-    public void setDefaultClassLoader(ClassLoader classLoader) {
-	jsfThemeCtx.setDefaultClassLoader(classLoader);
-    }
-
-    /**
-     *	<p> This method delegates to <code>JSFThemeContext</code>.</p>
-     */
-    public String getRequestContextPath() {
-	return jsfThemeCtx.getRequestContextPath();
-    }
-
-    /**
-     *	<p> This method delegates to <code>JSFThemeContext</code>.</p>
-     */
-    public void setRequestContextPath(String path) {
-	jsfThemeCtx.setRequestContextPath(path);
-    }
-
-    /**
-     *	<p> This method delegates to <code>JSFThemeContext</code>.</p>
-     */
-    public String getResourcePath(String path) {
-	return jsfThemeCtx.getResourcePath(path);
-    }
-
-
-    /**
-     *	<p> This hold a reference to an instance of JSFThemeContext which
-     *	    will help us implement the functionality of this class.</p>
-     */
-    private ThemeContext jsfThemeCtx = null;
-    
-    /**
-     *	<p> These keys are used when getting the property values
-     *	    provided in the custom theme plugin properties file.</p>
+     * These keys are used when getting the property values
+     * provided in the custom theme plugin properties file.
      */
     public static final String THEME_NAME_KEY = "com.sun.webui.theme.DEFAULT_THEME";
     public static final String THEME_VERSION_KEY = "com.sun.webui.theme.DEFAULT_THEME_VERSION";
+
+    /**
+     * This hold a reference to an instance of JSFThemeContext which
+     * will help us implement the functionality of this class.
+     */
+    private ThemeContext jsfThemeCtx = null;
+
+
+    /**
+     * This constructor takes in the theme name and version to use by default.
+     *
+     * @param themeName The theme name (i.e. suntheme).
+     * @param themeVersion The version number (i.e. 4.2).
+     */
+    protected AdminguiThemeContext(String themeName, String themeVersion) {
+        super(setThemeParams(themeName, themeVersion));
+
+        // The following ThemeContext is created to allow us to delegate our
+        // logic to it.
+        jsfThemeCtx = JSFThemeContext.getInstance(FacesContext.getCurrentInstance());
+        jsfThemeCtx.setThemeServletContext("/theme");
+    }
+
+
+    /**
+     * @return an instance of <code>ThemeContext</code> creating one
+     * if necessary and persisting it in the <code>ApplicationMap</code>.
+     */
+    public synchronized static ThemeContext getInstance(FacesContext context, String themeName, String themeVersion) {
+        LOG.finest(() -> String.format("getInstance(context=%s, themeName=%s, themeVersion=%s)", context, themeName,
+            themeVersion));
+        Map map = context.getExternalContext().getApplicationMap();
+        String themeKey = THEME_CONTEXT + themeName + themeVersion;
+        ThemeContext themeContext = (ThemeContext) map.get(themeKey);
+        if (themeContext == null) {
+            themeContext = new AdminguiThemeContext(themeName, themeVersion);
+            map.put(themeKey, themeContext);
+        }
+        return themeContext;
+    }
+
+
+    /**
+     * @return an instance of <code>ThemeContext</code>
+     * using properties provided via <code>Integration point</code>.
+     */
+    public synchronized static ThemeContext getInstance(FacesContext context, Properties propMap) {
+        Map<String, Object> map = context.getExternalContext().getApplicationMap();
+        String themeName = (String) propMap.get(THEME_NAME_KEY);
+        String themeVersion = (String) propMap.get(THEME_VERSION_KEY);
+        String themeKey = THEME_CONTEXT + themeName + themeVersion;
+        LOG.finest(() -> "theme context key: " + themeKey);
+        ThemeContext themeContext = (ThemeContext) map.get(themeKey);
+        if (themeContext == null) {
+            themeContext = new AdminguiThemeContext(themeName, themeVersion);
+            map.put(themeKey, themeContext);
+        }
+        return themeContext;
+    }
+
+
+    /**
+     * Creates a <code>Map</code> object with the theme name and
+     * version.
+     */
+    private static Map<String, String> setThemeParams(final String theme, final String version) {
+        LOG.finest(() -> String.format("setThemeParams(theme=%s, version=%s)", theme, version));
+        final Map<String, String> map = new HashMap<>();
+        final String themeForMap = theme == null ? "suntheme" : theme;
+        map.put(ThemeContext.DEFAULT_THEME, themeForMap);
+        final String versionForMap = version == null ? "4.2" : version;
+        map.put(ThemeContext.DEFAULT_THEME_VERSION, versionForMap);
+        return map;
+    }
+
+
+    /**
+     * This method delegates to <code>JSFThemeContext</code>.
+     */
+    @Override
+    public ClassLoader getDefaultClassLoader() {
+        return jsfThemeCtx.getDefaultClassLoader();
+    }
+
+
+    /**
+     * This method delegates to <code>JSFThemeContext</code>.
+     */
+    @Override
+    public void setDefaultClassLoader(ClassLoader classLoader) {
+        jsfThemeCtx.setDefaultClassLoader(classLoader);
+    }
+
+
+    /**
+     * This method delegates to <code>JSFThemeContext</code>.
+     */
+    @Override
+    public String getRequestContextPath() {
+        return jsfThemeCtx.getRequestContextPath();
+    }
+
+
+    /**
+     * This method delegates to <code>JSFThemeContext</code>.
+     */
+    @Override
+    public void setRequestContextPath(String path) {
+        jsfThemeCtx.setRequestContextPath(path);
+    }
+
+
+    /**
+     * This method delegates to <code>JSFThemeContext</code>.
+     */
+    @Override
+    public String getResourcePath(String path) {
+        return jsfThemeCtx.getResourcePath(path);
+    }
 }

--- a/appserver/admingui/datadog-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/datadog-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>datadog-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/dataprovider/pom.xml
+++ b/appserver/admingui/dataprovider/pom.xml
@@ -43,14 +43,11 @@
 <!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>fish.payara.server</groupId>
-        <artifactId>payara-parent</artifactId>
+        <groupId>fish.payara.server.internal.admingui</groupId>
+        <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <!-- version 4.0 means this is the dataprovider used in Woodstock 4.2 release -->
-    <groupId>fish.payara.server.internal.admingui</groupId>
     <artifactId>dataprovider</artifactId>
     <name>DataProvider</name>
     <modelVersion>4.0.0</modelVersion>
@@ -118,10 +115,12 @@
         </plugins>
     </build>
     <dependencies>
+        <!-- no other artifact in Payara should depend on original dataprovider! -->
         <dependency>
             <groupId>com.sun.woodstock.dependlibs</groupId>
             <artifactId>dataprovider</artifactId>
-            <optional>true</optional>
+            <version>1.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -155,4 +154,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/appserver/admingui/devtests/pom.xml
+++ b/appserver/admingui/devtests/pom.xml
@@ -50,7 +50,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>console-devtests</artifactId>
@@ -110,12 +109,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>console-updatecenter-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency> -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>console-web-plugin</artifactId>
@@ -187,17 +180,6 @@
     </dependencies>
     <build>
         <defaultGoal>install</defaultGoal>
-        <pluginManagement>
-            <plugins>
-            <!--
-            <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>selenium-maven-plugin</artifactId>
-              <version>1.1</version>
-            </plugin>
-            -->
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -223,9 +205,6 @@
                 </dependencies>
                 <configuration>
                     <forkMode>never</forkMode>
-                    <!--
-                    <parallel>classes</parallel>
-                    -->
                 </configuration>
             </plugin>
             <plugin>

--- a/appserver/admingui/ejb-l10n/pom.xml
+++ b/appserver/admingui/ejb-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-plugin-l10n</artifactId>
     

--- a/appserver/admingui/ejb-lite-l10n/pom.xml
+++ b/appserver/admingui/ejb-lite-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-lite-plugin-l10n</artifactId>
     

--- a/appserver/admingui/ejb-lite/pom.xml
+++ b/appserver/admingui/ejb-lite/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-lite-plugin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admingui/ejb/pom.xml
+++ b/appserver/admingui/ejb/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-ejb-plugin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admingui/email-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/email-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>email-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/eventbus-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/eventbus-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>eventbus-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/full-l10n/pom.xml
+++ b/appserver/admingui/full-l10n/pom.xml
@@ -47,23 +47,22 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-common-full-plugin-l10n</artifactId>
-    
+
     <name>Admin Console Full distribution plugin l10n</name>
     <description>Plugin bundle for Payara v4 Admin Console common-full package Localization</description>
-    
+
     <properties>
         <javadoc.skip>true</javadoc.skip>
         <deploy.skip>true</deploy.skip>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
               <groupId>org.glassfish.hk2</groupId>
-              <artifactId>osgiversion-maven-plugin</artifactId>            
+              <artifactId>osgiversion-maven-plugin</artifactId>
               <executions>
                   <execution>
                       <id>compute-osgi-version</id>

--- a/appserver/admingui/full/pom.xml
+++ b/appserver/admingui/full/pom.xml
@@ -47,17 +47,12 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-common-full-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Full distribution plugin</name>
     <description>Plugin bundle for GlassFish v3 Admin Console common-full package</description>
-
-    <developers>
-        <!-- See parent POM -->
-    </developers>
 
     <build>
         <plugins>
@@ -88,6 +83,10 @@
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/healthcheck-service-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/healthcheck-service-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>healthcheck-service-console-plugin-l10n</artifactId>

--- a/appserver/admingui/hipchat-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/hipchat-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>hipchat-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/jca-l10n/pom.xml
+++ b/appserver/admingui/jca-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jca-plugin-l10n</artifactId>
     

--- a/appserver/admingui/jca/pom.xml
+++ b/appserver/admingui/jca/pom.xml
@@ -47,17 +47,12 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jca-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Connectors Plugin</name>
     <description>Connectors plugin bundle for GlassFish Admin Console</description>
-
-    <developers>
-        <!-- See parent POM -->
-    </developers>
 
     <build>
         <plugins>
@@ -88,6 +83,10 @@
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/jdbc-l10n/pom.xml
+++ b/appserver/admingui/jdbc-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jdbc-plugin-l10n</artifactId>
     

--- a/appserver/admingui/jdbc/pom.xml
+++ b/appserver/admingui/jdbc/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jdbc-plugin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admingui/jms-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/jms-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>jms-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/jms-plugin-l10n/pom.xml
+++ b/appserver/admingui/jms-plugin-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jms-plugin-l10n</artifactId>
     

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -47,16 +47,11 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jms-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
-    <name>Admin Console JMS Plugin</name>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
+    <name>Admin Console JMS Plugin</name>
 
     <build>
         <plugins>
@@ -71,9 +66,6 @@
                         <supportedProjectType>bundle</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
-                        <!-- _include does not work. See Felix-620.
-                        <_include>osgi.bundle</_include>
-                        -->
                         <Export-Package>org.glassfish.jdbc.admingui</Export-Package>
                     </instructions>
                 </configuration>
@@ -138,9 +130,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.messaging.mq</groupId>
-            <artifactId>imqjmx</artifactId>
-            <scope>provided</scope>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/jmx-monitoring-plugin-l10n/pom.xml
+++ b/appserver/admingui/jmx-monitoring-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>jmx-monitoring-plugin-l10n</artifactId>

--- a/appserver/admingui/jts-l10n/pom.xml
+++ b/appserver/admingui/jts-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jts-plugin-l10n</artifactId>
     

--- a/appserver/admingui/jts/pom.xml
+++ b/appserver/admingui/jts/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-jts-plugin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admingui/microprofile-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/microprofile-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>microprofile-console-plugin-l10n</artifactId>

--- a/appserver/admingui/newrelic-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/newrelic-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>newrelic-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/payara-console-extras-l10n/pom.xml
+++ b/appserver/admingui/payara-console-extras-l10n/pom.xml
@@ -22,7 +22,6 @@
 		<groupId>fish.payara.server.internal.admingui</groupId>
 		<artifactId>admingui</artifactId>
 		<version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>payara-console-extras-l10n</artifactId>
 	<packaging>glassfish-jar</packaging>

--- a/appserver/admingui/payara-console-extras/pom.xml
+++ b/appserver/admingui/payara-console-extras/pom.xml
@@ -50,7 +50,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
     <packaging>glassfish-jar</packaging>
     <name>Payara Console Extras</name>
     <description>Plugin containing extra configuration for the Payara console</description>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -75,8 +75,8 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             </resource>
         </resources>
     </build>
-    
-    
+
+
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
@@ -97,14 +97,19 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>weld-integration</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/admingui/payara-support/pom.xml
+++ b/appserver/admingui/payara-support/pom.xml
@@ -44,12 +44,11 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>payara-support</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>Payara Support</name>
-        
+
     <developers>
         <!-- See parent POM -->
     </developers>
@@ -120,6 +119,10 @@
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/payara-theme/pom.xml
+++ b/appserver/admingui/payara-theme/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-payara-branding-plugin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/admingui/payara-theme/pom.xml
+++ b/appserver/admingui/payara-theme/pom.xml
@@ -51,7 +51,7 @@
     </parent>
     <artifactId>console-payara-branding-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Payara Theme Plugin</name>
     <description>Custom Theme Plugin for Payara Admin Console</description>
 
@@ -144,7 +144,5 @@
             <artifactId>webui-jsf-suntheme</artifactId>
             <scope>provided</scope>
         </dependency>
-
-
     </dependencies>
 </project>

--- a/appserver/admingui/pom.xml
+++ b/appserver/admingui/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.admingui</groupId>
     <artifactId>admingui</artifactId>
@@ -168,6 +167,16 @@
         <module>microprofile-console-plugin</module>
         <module>microprofile-console-plugin-l10n</module>
     </modules>
+
+    <properties>
+        <commons-fileupload.version>1.3.3</commons-fileupload.version>
+        <woodstock-dojo-ajax-nodemo.version>0.4.4</woodstock-dojo-ajax-nodemo.version>
+        <woodstock-jsf.version>4.0.2.10.payara-p16</woodstock-jsf.version>
+        <woodstock-jsf-suntheme.version>4.0.2.10.payara-p16</woodstock-jsf-suntheme.version>
+        <woodstock-json.version>1.0</woodstock-json.version>
+        <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
+    </properties>
+
     <build>
         <plugins>
           <plugin>
@@ -202,31 +211,44 @@
         </resources>
       </build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jsftemplating</groupId>
-            <artifactId>jsftemplating-dt</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>${commons-fileupload.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.woodstock</groupId>
+                <artifactId>webui-jsf</artifactId>
+                <version>${woodstock-jsf.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.woodstock</groupId>
+                <artifactId>webui-jsf-suntheme</artifactId>
+                <version>${woodstock-jsf-suntheme.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.woodstock.dependlibs</groupId>
+                <artifactId>json</artifactId>
+                <version>${woodstock-json.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.woodstock.dependlibs</groupId>
+                <artifactId>dojo-ajax-nodemo</artifactId>
+                <version>${woodstock-dojo-ajax-nodemo.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.woodstock.dependlibs</groupId>
+                <artifactId>prototype</artifactId>
+                <version>${woodstock-prototype.version}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/appserver/admingui/pom.xml
+++ b/appserver/admingui/pom.xml
@@ -99,7 +99,7 @@
             </roles>
         </developer>
     </developers>
-    
+
     <modules>
         <module>dataprovider</module>
         <module>plugin-service</module>
@@ -148,8 +148,8 @@
         <module>eventbus-notifier-console-plugin-l10n</module>
         <module>cdieventbus-notifier-console-plugin</module>
         <module>cdieventbus-notifier-console-plugin-l10n</module>
-    	<module>email-notifier-console-plugin</module>
-    	<module>email-notifier-console-plugin-l10n</module>
+        <module>email-notifier-console-plugin</module>
+        <module>email-notifier-console-plugin-l10n</module>
         <module>snmp-notifier-console-plugin</module>
         <module>snmp-notifier-console-plugin-l10n</module>
         <module>xmpp-notifier-console-plugin</module>
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
-	    <scope>provided</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/appserver/admingui/reference-manual/pom.xml
+++ b/appserver/admingui/reference-manual/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>console-reference-manual-plugin</artifactId>

--- a/appserver/admingui/slack-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/slack-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>slack-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/snmp-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/snmp-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>snmp-notifier-console-plugin-l10n</artifactId>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -45,12 +45,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>fish.payara.server</groupId>
-        <artifactId>payara-parent</artifactId>
+        <groupId>fish.payara.server.internal.admingui</groupId>
+        <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.internal.admingui</groupId>
     <artifactId>war</artifactId>
     <packaging>war</packaging>
     <name>Admin Console WAR</name>
@@ -124,43 +122,49 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <!-- following provided scopes are to avoid maven-war-plugin's resolution of libs directory, -->
         <!-- because we need these dependencies in extra directory -->
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.3</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>dataprovider</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.sun.woodstock.dependlibs</groupId>
             <artifactId>dojo-ajax-nodemo</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.woodstock.dependlibs</groupId>
             <artifactId>json</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.woodstock.dependlibs</groupId>
             <artifactId>prototype</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.woodstock</groupId>
             <artifactId>webui-jsf</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.woodstock</groupId>
             <artifactId>webui-jsf-suntheme</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -55,61 +55,59 @@
     <packaging>war</packaging>
     <name>Admin Console WAR</name>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
+    <properties>
+        <dependencies.extra.directory>${project.build.directory}/extra-dependencies</dependencies.extra.directory>
+    </properties>
 
     <build>
         <finalName>admingui</finalName>
         <plugins>
             <plugin>
-                <artifactId>maven-war-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>prepare-extra-dependencies</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
                         <configuration>
-                            <archive>
-                                <manifestEntries>
-                                    <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
-                                    <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client  </HK2-Import-Bundles>
-                                </manifestEntries>
-                            </archive>
+                            <outputDirectory>${dependencies.extra.directory}</outputDirectory>
+                            <includeArtifactIds>
+                                commons-fileupload,commons-io,
+                                dojo-ajax-nodemo,json,prototype,
+                                webui-jsf,webui-jsf-suntheme
+                            </includeArtifactIds>
+                            <includeScope>provided</includeScope>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <unzip src="target/admingui.war" dest="target/temp" />
-                                <delete file="target/admingui.war" />
-                                <mkdir dir="target/temp/WEB-INF/extra" />
-                                <move todir="target/temp/WEB-INF/extra">
-                                    <fileset dir="target/admingui/WEB-INF/lib" includes="**/*.jar" excludes="console-core*.jar" />
-                                </move>
-                                <delete>
-                                    <fileset dir="target/temp/WEB-INF/lib" includes="**/*.jar" excludes="console-core*.jar" />
-                                </delete>
-                               <jar jarfile="target/admingui.war" basedir="target/temp">
-                                    <manifest>
-                                      <attribute name="Glassfish-require-services" value="org.glassfish.api.admingui.ConsoleProvider" />
-                                      <attribute name="HK2-Import-Bundles" value="fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client " />
-                                    </manifest>
-                                </jar>
-                                <delete dir="target/temp" />
-
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <warSourceExcludes>WEB-INF/sun-web.xml</warSourceExcludes>
+                    <webResources>
+                        <resource>
+                            <directory>src/main/webapp</directory>
+                            <filtering>true</filtering>
+                            <includes>
+                                <include>WEB-INF/sun-web.xml</include>
+                            </includes>
+                        </resource>
+                        <resource>
+                            <directory>${dependencies.extra.directory}</directory>
+                            <targetPath>WEB-INF/extra</targetPath>
+                        </resource>
+                    </webResources>
+                    <archive>
+                        <manifestEntries>
+                            <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
+                            <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client  </HK2-Import-Bundles>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -119,11 +117,50 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>console-core</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <!-- following provided scopes are to avoid maven-war-plugin's resolution of libs directory, -->
+        <!-- because we need these dependencies in extra directory -->
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <scope>runtime</scope>
+            <version>1.3.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock.dependlibs</groupId>
+            <artifactId>dojo-ajax-nodemo</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock.dependlibs</groupId>
+            <artifactId>json</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock.dependlibs</groupId>
+            <artifactId>prototype</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock</groupId>
+            <artifactId>webui-jsf</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock</groupId>
+            <artifactId>webui-jsf-suntheme</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -39,28 +39,26 @@
     only if the new code is made subject to such option by the copyright
     holder.
 -->
-<!-- Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
 
 <!DOCTYPE sun-web-app PUBLIC '-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 7.0 Servlet 2.3//EN' 'http://www.sun.com/software/sunone/appserver/dtds/sun-web-app_2_3-0.dtd'>
 
 <sun-web-app httpservlet-security-provider="GFConsoleAuthModule">
- <security-role-mapping>
-    <role-name>admin</role-name>
-    <principal-name>admin</principal-name>
-    <group-name>asadmin</group-name>
- </security-role-mapping>
- <session-config>
-     <session-manager>
-	 <manager-properties>
-	     <property name="sessionFilename" value="" />
-	 </manager-properties>
-     </session-manager>
- </session-config>
-
- <locale-charset-info>
-	<parameter-encoding default-charset="UTF-8" />
- </locale-charset-info>
-
-<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.10.payara-p16.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.4.jar:WEB-INF/extra/webui-jsf-4.0.2.10.payara-p16.jar:WEB-INF/extra/commons-fileupload-1.3.3.jar:WEB-INF/extra/commons-io-2.6.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.7.3.jar" />
-
+    <security-role-mapping>
+        <role-name>admin</role-name>
+        <principal-name>admin</principal-name>
+        <group-name>asadmin</group-name>
+    </security-role-mapping>
+    <session-config>
+        <session-manager>
+            <manager-properties>
+                <property name="sessionFilename" value="" />
+            </manager-properties>
+        </session-manager>
+    </session-config>
+    <locale-charset-info>
+        <parameter-encoding default-charset="UTF-8" />
+    </locale-charset-info>
+    <class-loader delegate="true"
+        extra-class-path="WEB-INF/extra/webui-jsf-suntheme-${woodstock-jsf-suntheme.version}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/webui-jsf-${woodstock-jsf.version}.jar:WEB-INF/extra/commons-fileupload-${commons-fileupload.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar:WEB-INF/extra/json-${woodstock-json.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar" />
 </sun-web-app>

--- a/appserver/admingui/web-l10n/pom.xml
+++ b/appserver/admingui/web-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>console-web-plugin-l10n</artifactId>
     

--- a/appserver/admingui/web/pom.xml
+++ b/appserver/admingui/web/pom.xml
@@ -50,13 +50,9 @@
     </parent>
     <artifactId>console-web-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Admin Console Web Container Plugin</name>
     <description>Web container plugin bundle for GlassFish Admin Console</description>
-
-    <developers>
-        <!-- See parent POM -->
-    </developers>
 
     <build>
         <plugins>
@@ -115,6 +111,10 @@
             <artifactId>web-gui-plugin-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/webui-jsf-plugin-l10n/pom.xml
+++ b/appserver/admingui/webui-jsf-plugin-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent> 
     <artifactId>webui-jsf-plugin-l10n</artifactId>
     <name>Woodstock webuijsf localization</name>

--- a/appserver/admingui/webui-jsf-suntheme-plugin-l10n/pom.xml
+++ b/appserver/admingui/webui-jsf-suntheme-plugin-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>  
     <artifactId>webui-jsf-suntheme-plugin-l10n</artifactId>
     <name>Woodstock webuijsf suntheme localization</name>

--- a/appserver/admingui/xmpp-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/xmpp-notifier-console-plugin-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admingui</groupId>
         <artifactId>admingui</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
  
     <artifactId>xmpp-notifier-console-plugin-l10n</artifactId>

--- a/appserver/ant-tasks/pom.xml
+++ b/appserver/ant-tasks/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>  
     
     <groupId>fish.payara.server.internal.ant-tasks</groupId>

--- a/appserver/appclient/client/jws/pom.xml
+++ b/appserver/appclient/client/jws/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.appclient</groupId>
         <artifactId>client</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gf-jws</artifactId>

--- a/appserver/appclient/server/core-l10n/pom.xml
+++ b/appserver/appclient/server/core-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.appclient</groupId>
         <artifactId>server</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.server.internal.appclient.server</groupId>

--- a/appserver/appclient/server/pom.xml
+++ b/appserver/appclient/server/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.appclient</groupId>
         <artifactId>appclient</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>server</artifactId>
     <packaging>pom</packaging>

--- a/appserver/batch/glassfish-batch-commands/pom.xml
+++ b/appserver/batch/glassfish-batch-commands/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.batch</groupId>
         <artifactId>batch</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>glassfish-batch-commands</artifactId>

--- a/appserver/batch/glassfish-batch-commands/src/main/java/fish/payara/batch/PurgeJbatchRepository.java
+++ b/appserver/batch/glassfish-batch-commands/src/main/java/fish/payara/batch/PurgeJbatchRepository.java
@@ -1,8 +1,8 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *    Copyright (c) [2017] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
  *     and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *     https://github.com/payara/Payara/blob/master/LICENSE.txt
  *     See the License for the specific
  *     language governing permissions and limitations under the License.
- * 
+ *
  *     When distributing the software, include this License Header Notice in each
  *     file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *     GPL Classpath Exception:
  *     The Payara Foundation designates this particular file as subject to the "Classpath"
  *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *     file that accompanied this code.
- * 
+ *
  *     Modifications:
  *     If applicable, add the following below the License Header, with the fields
  *     enclosed by brackets [] replaced by your own identifying information:
  *     "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *     Contributor(s):
  *     If you wish your version of this file to be governed by only the CDDL or
  *     only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -47,15 +47,15 @@ import org.glassfish.api.admin.AdminCommand;
 import org.glassfish.api.admin.AdminCommandContext;
 import org.glassfish.api.admin.CommandLock;
 import org.glassfish.api.admin.ExecuteOn;
-import org.glassfish.api.admin.RuntimeType;;
+import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.hk2.api.PerLookup;
 import org.jvnet.hk2.annotations.Service;
 
 /**
  * Purges the JBatch repository of all history of a specified apptag
- * 
+ *
  * The default apptag form is server-config:/applicationName_/applicationName
- * 
+ *
  * @since 4.1.2.173
  * @author jonathan coustick
  */
@@ -67,13 +67,13 @@ public class PurgeJbatchRepository implements AdminCommand {
 
     @Param(name="apptag", primary = true, optional = false)
     private String apptag;
-    
+
     @Override
     public void execute(AdminCommandContext context) {
         ServicesManager manager = ServicesManagerImpl.getInstance();
         IPersistenceManagerService ps = manager.getPersistenceManagerService();
         ps.purge(apptag);
-       
+
     }
-    
+
 }

--- a/appserver/batch/glassfish-batch-connector/pom.xml
+++ b/appserver/batch/glassfish-batch-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.batch</groupId>
         <artifactId>batch</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>glassfish-batch-connector</artifactId>

--- a/appserver/batch/hazelcast-jbatch-store/pom.xml
+++ b/appserver/batch/hazelcast-jbatch-store/pom.xml
@@ -44,7 +44,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <groupId>fish.payara.server.internal.batch</groupId>
         <artifactId>batch</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hazelcast-jbatch-store</artifactId>

--- a/appserver/batch/pom.xml
+++ b/appserver/batch/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>fish.payara.server.internal.batch</groupId>

--- a/appserver/common/annotation-framework-l10n/pom.xml
+++ b/appserver/common/annotation-framework-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>annotation-framework-l10n</artifactId>
     

--- a/appserver/common/container-common-l10n/pom.xml
+++ b/appserver/common/container-common-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>container-common-l10n</artifactId>

--- a/appserver/common/glassfish-naming-l10n/pom.xml
+++ b/appserver/common/glassfish-naming-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish-naming-l10n</artifactId>

--- a/appserver/common/pom.xml
+++ b/appserver/common/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.common</groupId>
     <artifactId>common</artifactId>

--- a/appserver/common/stats77-l10n/pom.xml
+++ b/appserver/common/stats77-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>stats77-l10n</artifactId>

--- a/appserver/concurrent/concurrent-connector-l10n/pom.xml
+++ b/appserver/concurrent/concurrent-connector-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.concurrent</groupId>
         <artifactId>concurrent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>concurrent-connector-l10n</artifactId>

--- a/appserver/concurrent/concurrent-impl-l10n/pom.xml
+++ b/appserver/concurrent/concurrent-impl-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.concurrent</groupId>
         <artifactId>concurrent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>concurrent-impl-l10n</artifactId>

--- a/appserver/connectors/admin-l10n/pom.xml
+++ b/appserver/connectors/admin-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>connectors-admin-l10n</artifactId>
     

--- a/appserver/connectors/connectors-inbound-runtime-l10n/pom.xml
+++ b/appserver/connectors/connectors-inbound-runtime-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connectors-inbound-runtime-l10n</artifactId>

--- a/appserver/connectors/connectors-inbound-runtime/pom.xml
+++ b/appserver/connectors/connectors-inbound-runtime/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connectors-inbound-runtime</artifactId>

--- a/appserver/connectors/connectors-internal-api-l10n/pom.xml
+++ b/appserver/connectors/connectors-internal-api-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connectors-internal-api-l10n</artifactId>

--- a/appserver/connectors/connectors-internal-api/pom.xml
+++ b/appserver/connectors/connectors-internal-api/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connectors-internal-api</artifactId>

--- a/appserver/connectors/connectors-runtime-l10n/pom.xml
+++ b/appserver/connectors/connectors-runtime-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connectors-runtime-l10n</artifactId>

--- a/appserver/connectors/connectors-runtime/pom.xml
+++ b/appserver/connectors/connectors-runtime/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.connectors</groupId>
         <artifactId>connectors</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connectors-runtime</artifactId>

--- a/appserver/core/api-exporter-fragment/pom.xml
+++ b/appserver/core/api-exporter-fragment/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.core</groupId>
         <artifactId>core</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>api-exporter-fragment</artifactId>
     <name>GlassFish API Exporter Module Fragment</name>

--- a/appserver/core/javaee-kernel/pom.xml
+++ b/appserver/core/javaee-kernel/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.core</groupId>
         <artifactId>core</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaee-kernel</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/core/pom.xml
+++ b/appserver/core/pom.xml
@@ -47,14 +47,13 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>fish.payara.server.internal.core</groupId>
     <artifactId>core</artifactId>
     <packaging>pom</packaging>
-    <name>GlassFish Core modules</name>  
+    <name>GlassFish Core modules</name>
     <modules>
-	<module>javaee-kernel</module>
-        <module>api-exporter-fragment</module>       
+        <module>javaee-kernel</module>
+        <module>api-exporter-fragment</module>
     </modules>
 </project>

--- a/appserver/deployment/client-l10n/pom.xml
+++ b/appserver/deployment/client-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>deployment-client-l10n</artifactId>
     

--- a/appserver/deployment/client/pom.xml
+++ b/appserver/deployment/client/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>deployment-client</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/deployment/dol-l10n/pom.xml
+++ b/appserver/deployment/dol-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dol-l10n</artifactId>
     

--- a/appserver/deployment/javaee-core-l10n/pom.xml
+++ b/appserver/deployment/javaee-core-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-javaee-core-l10n</artifactId>

--- a/appserver/deployment/javaee-core/pom.xml
+++ b/appserver/deployment/javaee-core/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-javaee-core</artifactId>

--- a/appserver/deployment/javaee-full-l10n/pom.xml
+++ b/appserver/deployment/javaee-full-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-javaee-full-l10n</artifactId>

--- a/appserver/deployment/javaee-full/pom.xml
+++ b/appserver/deployment/javaee-full/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-javaee-full</artifactId>

--- a/appserver/deployment/jsr88-jar/sun-as-jsr88-dm/pom.xml
+++ b/appserver/deployment/jsr88-jar/sun-as-jsr88-dm/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>jsr-88</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>sun-as-jsr88-dm</artifactId>
     <name>JSR-88 implementation declaration JAR</name>

--- a/appserver/deployment/pom.xml
+++ b/appserver/deployment/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.deployment</groupId>
     <artifactId>deployment</artifactId>

--- a/appserver/distributions/appclient/pom.xml
+++ b/appserver/distributions/appclient/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.distributions</groupId>
         <artifactId>distributions</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appclient</artifactId>

--- a/appserver/ejb/ejb-client/pom.xml
+++ b/appserver/ejb/ejb-client/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.ejb</groupId>
         <artifactId>ejb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>ejb-client</artifactId>

--- a/appserver/ejb/ejb-connector-l10n/pom.xml
+++ b/appserver/ejb/ejb-connector-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.ejb</groupId>
         <artifactId>ejb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-ejb-connector-l10n</artifactId>
     

--- a/appserver/ejb/ejb-connector/pom.xml
+++ b/appserver/ejb/ejb-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.ejb</groupId>
         <artifactId>ejb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-ejb-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/ejb/ejb-container-l10n/pom.xml
+++ b/appserver/ejb/ejb-container-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.ejb</groupId>
         <artifactId>ejb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ejb-container-l10n</artifactId>
     

--- a/appserver/ejb/ejb-full-container/pom.xml
+++ b/appserver/ejb/ejb-full-container/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.ejb</groupId>
         <artifactId>ejb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>ejb-full-container</artifactId>

--- a/appserver/ejb/ejb-internal-api/pom.xml
+++ b/appserver/ejb/ejb-internal-api/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.ejb</groupId>
         <artifactId>ejb</artifactId>
         <version>5.194-SNAPSHOT</version>
-       <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>ejb-internal-api</artifactId>

--- a/appserver/ejb/ejb-timer-service-app/pom.xml
+++ b/appserver/ejb/ejb-timer-service-app/pom.xml
@@ -47,7 +47,6 @@
        <groupId>fish.payara.server.internal.ejb</groupId>
        <artifactId>ejb</artifactId>
        <version>5.194-SNAPSHOT</version>
-       <relativePath>../pom.xml</relativePath>
    </parent>
 
    <artifactId>ejb-timer-service-app</artifactId>

--- a/appserver/extras/appserv-rt/manifest-jar/pom.xml
+++ b/appserver/extras/appserv-rt/manifest-jar/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.extras</groupId>
         <artifactId>appserv-rt-pom</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>GlassFish appserv-rt.jar</name>

--- a/appserver/extras/appserv-rt/pom.xml
+++ b/appserver/extras/appserv-rt/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <groupId>fish.payara.server.internal.extras</groupId>

--- a/appserver/extras/embedded/common/bootstrap/pom.xml
+++ b/appserver/extras/embedded/common/bootstrap/pom.xml
@@ -50,7 +50,6 @@
     <groupId>fish.payara.server.internal.extras</groupId>
     <artifactId>glassfish-embedded-common</artifactId>
     <version>4.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
     <artifactId>bootstrap</artifactId>

--- a/appserver/extras/embedded/common/installroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/installroot-builder/pom.xml
@@ -47,7 +47,6 @@
     <groupId>fish.payara.server.internal.extras</groupId>
     <artifactId>glassfish-embedded-common</artifactId>
     <version>4.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
     <artifactId>installroot-builder</artifactId>

--- a/appserver/extras/embedded/common/instanceroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/instanceroot-builder/pom.xml
@@ -48,7 +48,6 @@
     <groupId>fish.payara.server.internal.extras</groupId>
     <artifactId>glassfish-embedded-common</artifactId>
     <version>4.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
     <artifactId>instanceroot-builder</artifactId>

--- a/appserver/extras/embedded/common/osgi-main/pom.xml
+++ b/appserver/extras/embedded/common/osgi-main/pom.xml
@@ -49,7 +49,6 @@
     <groupId>fish.payara.server.internal.extras</groupId>
     <artifactId>glassfish-embedded-common</artifactId>
     <version>4.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
     <artifactId>osgi-main</artifactId>

--- a/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
+++ b/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
@@ -48,7 +48,6 @@ holder.
     <groupId>fish.payara.server.internal.extras</groupId>
     <artifactId>glassfish-embedded-common</artifactId>
     <version>4.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
     <artifactId>osgi-modules-uninstaller</artifactId>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -65,7 +65,7 @@
         <plugins>
             <!--
                 Create a text file containing the generated class path.  This
-                file is used in the ant tasks when the original Class-Path is 
+                file is used in the ant tasks when the original Class-Path is
                 augmented.  Note: we force the path separator to be a colon
                 because the plug-in will use the platform-specific separator
                 otherwise.  The ant logic replaces colons with spaces to
@@ -88,7 +88,6 @@
                           <fileSeparator>/</fileSeparator>
                           <prefix>../../modules</prefix>
                           <stripVersion>true</stripVersion>
-                          <excludeArtifactIds>jsftemplating</excludeArtifactIds>
                       </configuration>
                   </execution>
               </executions>
@@ -125,7 +124,7 @@
                                   <property name="output.dir" value="${project.build.directory}" />
                                   <property name="stage.dir" value="${project.build.directory}/stage" />
                                   <property name="classpath.file" value="${classpath.file}" />
-                                  <property name="bundlename" value="org.glassfish.embedded.static-shell" />                                  
+                                  <property name="bundlename" value="org.glassfish.embedded.static-shell" />
                               </ant>
                           </target>
                       </configuration>

--- a/appserver/extras/javaee/pom.xml
+++ b/appserver/extras/javaee/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.extras</groupId>
         <artifactId>extras</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <groupId>fish.payara.server.internal.extras</groupId>

--- a/appserver/flashlight/pom.xml
+++ b/appserver/flashlight/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>glassfish-flashlight</artifactId>

--- a/appserver/grizzly/glassfish-grizzly-extra-all/pom.xml
+++ b/appserver/grizzly/glassfish-grizzly-extra-all/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.grizzly</groupId>
         <artifactId>glassfish-grizzly</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish-grizzly-extra-all</artifactId>

--- a/appserver/grizzly/grizzly-container/pom.xml
+++ b/appserver/grizzly/grizzly-container/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.grizzly</groupId>
         <artifactId>glassfish-grizzly</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>glassfish-grizzly-container</artifactId>

--- a/appserver/grizzly/pom.xml
+++ b/appserver/grizzly/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.grizzly</groupId>
     <artifactId>glassfish-grizzly</artifactId>

--- a/appserver/ha/ha-file-store/pom.xml
+++ b/appserver/ha/ha-file-store/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.ha</groupId>
         <artifactId>ha</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ha-file-store</artifactId>

--- a/appserver/ha/ha-hazelcast-store/pom.xml
+++ b/appserver/ha/ha-hazelcast-store/pom.xml
@@ -43,7 +43,6 @@
         <groupId>fish.payara.server.internal.ha</groupId>
         <artifactId>ha</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ha-hazelcast-store</artifactId>

--- a/appserver/ha/pom.xml
+++ b/appserver/ha/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.ha</groupId>
     <artifactId>ha</artifactId>

--- a/appserver/jdbc/admin-l10n/pom.xml
+++ b/appserver/jdbc/admin-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.jdbc</groupId>
         <artifactId>jdbc</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-admin-l10n</artifactId>
     

--- a/appserver/jdbc/admin/pom.xml
+++ b/appserver/jdbc/admin/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.jdbc</groupId>
         <artifactId>jdbc</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jdbc-admin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/jdbc/jdbc-config-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-config-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jdbc</groupId>
         <artifactId>jdbc</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-config-l10n</artifactId>
     

--- a/appserver/jdbc/jdbc-config/pom.xml
+++ b/appserver/jdbc/jdbc-config/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.jdbc</groupId>
         <artifactId>jdbc</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jdbc-config</artifactId>

--- a/appserver/jdbc/jdbc-ra/jdbc-core-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jdbc.jdbc-ra</groupId>
         <artifactId>jdbc-ra</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-core-l10n</artifactId>
     

--- a/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
@@ -48,7 +48,6 @@
     <groupId>fish.payara.server.internal.jdbc.jdbc-ra</groupId>
     <artifactId>jdbc-ra</artifactId>
     <version>5.194-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>fish.payara.server.internal.jdbc.jdbc-ra.jdbc-core</groupId>

--- a/appserver/jdbc/jdbc-ra/jdbc-ra-distribution/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-ra-distribution/pom.xml
@@ -46,7 +46,6 @@
     <groupId>fish.payara.server.internal.jdbc.jdbc-ra</groupId>
     <artifactId>jdbc-ra</artifactId>
     <version>5.194-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>fish.payara.server.internal.jdbc.jdbc-ra.jdbc-ra-distribution</groupId>

--- a/appserver/jdbc/jdbc-ra/jdbc30/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc30/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.jdbc.jdbc-ra</groupId>
         <artifactId>jdbc-ra</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.server.internal.jdbc.jdbc-ra.jdbc30</groupId>

--- a/appserver/jdbc/jdbc-ra/jdbc40/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc40/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jdbc.jdbc-ra</groupId>
         <artifactId>jdbc-ra</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.server.internal.jdbc.jdbc-ra.jdbc40</groupId>

--- a/appserver/jdbc/jdbc-runtime-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-runtime-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jdbc</groupId>
         <artifactId>jdbc</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jdbc-runtime-l10n</artifactId>
     

--- a/appserver/jms/admin-l10n/pom.xml
+++ b/appserver/jms/admin-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jms-admin-l10n</artifactId>
     

--- a/appserver/jms/admin/pom.xml
+++ b/appserver/jms/admin/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jms-admin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/jms/gf-jms-connector-l10n/pom.xml
+++ b/appserver/jms/gf-jms-connector-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-jms-connector-l10n</artifactId>
     

--- a/appserver/jms/gf-jms-connector/pom.xml
+++ b/appserver/jms/gf-jms-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gf-jms-connector</artifactId>

--- a/appserver/jms/gf-jms-injection-l10n/pom.xml
+++ b/appserver/jms/gf-jms-injection-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-jms-injection-l10n</artifactId>
     

--- a/appserver/jms/gf-jms-injection/pom.xml
+++ b/appserver/jms/gf-jms-injection/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/jms/jms-core-l10n/pom.xml
+++ b/appserver/jms/jms-core-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jms-core-l10n</artifactId>
     

--- a/appserver/jms/jms-core/pom.xml
+++ b/appserver/jms/jms-core/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jms-core</artifactId>

--- a/appserver/jms/jms-handlers/pom.xml
+++ b/appserver/jms/jms-handlers/pom.xml
@@ -44,7 +44,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <groupId>fish.payara.server.internal.jms</groupId>
         <artifactId>jms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jms-handlers</artifactId>

--- a/appserver/jms/pom.xml
+++ b/appserver/jms/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.jms</groupId>
     <artifactId>jms</artifactId>

--- a/appserver/load-balancer/admin-l10n/pom.xml
+++ b/appserver/load-balancer/admin-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.load-balancer</groupId>
         <artifactId>load-balancer</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>load-balancer-admin-l10n</artifactId>

--- a/appserver/load-balancer/admin/pom.xml
+++ b/appserver/load-balancer/admin/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.load-balancer</groupId>
         <artifactId>load-balancer</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>load-balancer-admin</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/load-balancer/gf-load-balancer-connector-l10n/pom.xml
+++ b/appserver/load-balancer/gf-load-balancer-connector-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.load-balancer</groupId>
         <artifactId>load-balancer</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>gf-load-balancer-connector-l10n</artifactId>

--- a/appserver/load-balancer/gf-load-balancer-connector/pom.xml
+++ b/appserver/load-balancer/gf-load-balancer-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.load-balancer</groupId>
         <artifactId>load-balancer</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-load-balancer-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/load-balancer/pom.xml
+++ b/appserver/load-balancer/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.load-balancer</groupId>
     <artifactId>load-balancer</artifactId>

--- a/appserver/orb/orb-connector-l10n/pom.xml
+++ b/appserver/orb/orb-connector-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.orb</groupId>
         <artifactId>orb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>orb-connector-l10n</artifactId>

--- a/appserver/orb/orb-connector/pom.xml
+++ b/appserver/orb/orb-connector/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.orb</groupId>
         <artifactId>orb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>orb-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/orb/orb-enabler/pom.xml
+++ b/appserver/orb/orb-enabler/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.orb</groupId>
         <artifactId>orb</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>orb-enabler</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/orb/pom.xml
+++ b/appserver/orb/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.orb</groupId>
     <artifactId>orb</artifactId>

--- a/appserver/osgi-platforms/glassfish-osgi-console-plugin/pom.xml
+++ b/appserver/osgi-platforms/glassfish-osgi-console-plugin/pom.xml
@@ -51,7 +51,7 @@
     <groupId>fish.payara.server.internal.osgi-platforms</groupId>
     <artifactId>glassfish-osgi-console-plugin</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Payara OSGi Console Plugin</name>
     <description>OSGi Console Plugin for Payara Administration Console</description>
 
@@ -84,6 +84,10 @@
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/osgi-platforms/pom.xml
+++ b/appserver/osgi-platforms/pom.xml
@@ -48,7 +48,6 @@
       <groupId>fish.payara.server</groupId>
       <artifactId>payara-parent</artifactId>
       <version>5.194-SNAPSHOT</version>
-      <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <groupId>fish.payara.server.internal.osgi-platforms</groupId>

--- a/appserver/packager/external/dbschema/pom.xml
+++ b/appserver/packager/external/dbschema/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>external</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dbschema-repackaged</artifactId>

--- a/appserver/packager/external/schema2beans/pom.xml
+++ b/appserver/packager/external/schema2beans/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>external</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>schema2beans-repackaged</artifactId>

--- a/appserver/packager/glassfish-gui/pom.xml
+++ b/appserver/packager/glassfish-gui/pom.xml
@@ -82,7 +82,7 @@
         <profile>
             <id>ips</id>
             <activation>
-                <activeByDefault>false</activeByDefault>  
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -103,7 +103,7 @@
                                 <id>process-step5</id>
                                 <goals>
                                     <goal>exec</goal>
-                                </goals>                            
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -119,7 +119,7 @@
             </build>
         </profile>
     </profiles>
-    
+
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
@@ -132,19 +132,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--<dependency>
-            <groupId>fish.payara.server.internal.admingui</groupId>
-            <artifactId>console-updatecenter-plugin</artifactId>
-            <version>${project.version}</version>
-        </dependency> -->
         <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-payara-branding-plugin</artifactId>
@@ -155,7 +146,7 @@
             <artifactId>console-reference-manual-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>        
+        <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>dist-fragment</artifactId>
             <version>${project.version}</version>
@@ -177,12 +168,12 @@
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-jdbc-plugin</artifactId>
             <version>${project.version}</version>
-        </dependency> 
+        </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-jca-plugin</artifactId>
             <version>${project.version}</version>
-        </dependency> 
+        </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>gf-admingui-connector</artifactId>
@@ -247,6 +238,12 @@
             <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>xmpp-notifier-console-plugin</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/packager/glassfish-jms/pom.xml
+++ b/appserver/packager/glassfish-jms/pom.xml
@@ -84,7 +84,7 @@
         <profile>
             <id>ips</id>
             <activation>
-                <activeByDefault>false</activeByDefault>  
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -105,7 +105,7 @@
                                 <id>process-step5</id>
                                 <goals>
                                     <goal>exec</goal>
-                                </goals>                            
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -121,48 +121,48 @@
             </build>
         </profile>
     </profiles>
-    
+
     <dependencies>
-       <dependency>
-           <groupId>fish.payara.server.internal.admingui</groupId>
-           <artifactId>console-jms-plugin</artifactId>
+        <dependency>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>console-jms-plugin</artifactId>
             <version>${project.version}</version>
-       </dependency>
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.jms</groupId>
-	    <artifactId>jms-core</artifactId>
+            <artifactId>jms-core</artifactId>
             <version>${project.version}</version>
-       </dependency> 
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.jms</groupId>
-	    <artifactId>gf-jms-injection</artifactId>
+            <artifactId>gf-jms-injection</artifactId>
             <version>${project.version}</version>
-       </dependency> 
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.jms</groupId>
-       	    <artifactId>jms-admin</artifactId>
+            <artifactId>jms-admin</artifactId>
             <version>${project.version}</version>
-       </dependency> 
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.jms</groupId>
-       	    <artifactId>gf-jms-connector</artifactId>
+            <artifactId>gf-jms-connector</artifactId>
             <version>${project.version}</version>
-       </dependency>
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.connectors</groupId>
-       	    <artifactId>connectors-inbound-runtime</artifactId>
+            <artifactId>connectors-inbound-runtime</artifactId>
             <version>${project.version}</version>
-       </dependency>
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>jakarta.jms</groupId>
-	    <artifactId>jakarta.jms-api</artifactId>
-       </dependency>
-       <dependency>
+            <artifactId>jakarta.jms-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>jmsra</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
-       </dependency>
+        </dependency>
        <!-- JMS Annotation handlers -->
         <dependency>
             <groupId>fish.payara.server.internal.jms</groupId>

--- a/appserver/packager/monitoring-console/pom.xml
+++ b/appserver/packager/monitoring-console/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
+
    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
-  
+
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
    and Distribution License("CDDL") (collectively, the "License").  You
@@ -12,20 +12,20 @@
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
    language governing permissions and limitations under the License.
-  
+
    When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-  
+
    GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
    file that accompanied this code.
-  
+
    Modifications:
    If applicable, add the following below the License Header, with the fields
    enclosed by brackets [] replaced by your own identifying information:
    "Portions Copyright [year] [name of copyright owner]"
-  
+
    Contributor(s):
    If you wish your version of this file to be governed by only the CDDL or
    only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -38,7 +38,7 @@
    only if the new code is made subject to such option by the copyright
    holder.
 -->
-<project 
+<project
     xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,9 +54,9 @@
     <description>This pom describes how to assemble the Payara Monitoring Console package</description>
 
     <properties>
-        <temp.dir>${project.build.directory}/dependency</temp.dir>       
-    </properties> 
-    
+        <temp.dir>${project.build.directory}/dependency</temp.dir>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -81,29 +81,28 @@
                 </executions>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-dependency-plugin</artifactId>
-              <version>2.8</version>
-              <executions>
-                <execution>
-                  <id>unpack</id>
-                  <phase>generate-sources</phase>
-                  <goals>
-                    <goal>unpack</goal>
-                  </goals>
-                  <configuration>
-                    <artifactItems>
-                      <artifactItem>
-                        <groupId>fish.payara.server.monitoring-console</groupId>
-                        <artifactId>monitoring-console-webapp</artifactId>
-                        <version>${project.version}</version>
-                        <type>war</type>
-                        <outputDirectory>target/stage/payara5/glassfish/lib/install/applications/__monitoringconsole</outputDirectory>
-                      </artifactItem>
-                    </artifactItems>
-                  </configuration>
-                </execution>
-              </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>fish.payara.server.monitoring-console</groupId>
+                                    <artifactId>monitoring-console-webapp</artifactId>
+                                    <type>war</type>
+                                    <version>${project.version}</version>
+                                    <outputDirectory>target/stage/payara5/glassfish/lib/install/applications/__monitoringconsole</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/appserver/persistence/cmp-l10n/ejb-mapping-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/ejb-mapping-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-ejb-mapping-l10n</artifactId>
     

--- a/appserver/persistence/cmp-l10n/enhancer-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/enhancer-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-enhancer-l10n</artifactId>
     

--- a/appserver/persistence/cmp-l10n/generator-database-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/generator-database-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-generator-database-l10n</artifactId>
     

--- a/appserver/persistence/cmp-l10n/model-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/model-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-model-l10n</artifactId>
     

--- a/appserver/persistence/cmp-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.persistence</groupId>
         <artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.server.internal.persistence.cmp</groupId>

--- a/appserver/persistence/cmp-l10n/support-ejb-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/support-ejb-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-ejb-l10n</artifactId>
     

--- a/appserver/persistence/cmp-l10n/support-sqlstore-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/support-sqlstore-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-sqlstore-l10n</artifactId>
     

--- a/appserver/persistence/cmp-l10n/utility-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/utility-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp-l10n</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-utility-l10n</artifactId>
     

--- a/appserver/persistence/cmp/cmp-all/pom.xml
+++ b/appserver/persistence/cmp/cmp-all/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cmp-all</artifactId>

--- a/appserver/persistence/cmp/ejb-mapping/pom.xml
+++ b/appserver/persistence/cmp/ejb-mapping/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-ejb-mapping</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/enhancer/pom.xml
+++ b/appserver/persistence/cmp/enhancer/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-enhancer</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/generator-database/pom.xml
+++ b/appserver/persistence/cmp/generator-database/pom.xml
@@ -48,7 +48,6 @@
 	<groupId>fish.payara.server.internal.persistence.cmp</groupId>
     	<artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-generator-database</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/internal-api/pom.xml
+++ b/appserver/persistence/cmp/internal-api/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-internal-api</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/model/pom.xml
+++ b/appserver/persistence/cmp/model/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-model</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/support-ejb/pom.xml
+++ b/appserver/persistence/cmp/support-ejb/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-ejb</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/support-sqlstore/pom.xml
+++ b/appserver/persistence/cmp/support-sqlstore/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.persistence.cmp</groupId>
         <artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-support-sqlstore</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/cmp/utility/pom.xml
+++ b/appserver/persistence/cmp/utility/pom.xml
@@ -48,7 +48,6 @@
 	<groupId>fish.payara.server.internal.persistence.cmp</groupId>
     	<artifactId>cmp</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cmp-utility</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/common/pom.xml
+++ b/appserver/persistence/common/pom.xml
@@ -47,7 +47,6 @@
 	<groupId>fish.payara.server.internal.persistence</groupId>
     	<artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>persistence-common</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/eclipselink-wrapper/pom.xml
+++ b/appserver/persistence/eclipselink-wrapper/pom.xml
@@ -48,7 +48,6 @@
     <groupId>fish.payara.server.internal.persistence</groupId>
         <artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>eclipselink-wrapper</artifactId>
     <packaging>pom</packaging>

--- a/appserver/persistence/entitybean-container/pom.xml
+++ b/appserver/persistence/entitybean-container/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence</groupId>
         <artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>entitybean-container</artifactId>

--- a/appserver/persistence/gf-jpa-connector/pom.xml
+++ b/appserver/persistence/gf-jpa-connector/pom.xml
@@ -47,7 +47,6 @@
 	<groupId>fish.payara.server.internal.persistence</groupId>
     	<artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>gf-jpa-connector</artifactId>

--- a/appserver/persistence/jpa-container-l10n/pom.xml
+++ b/appserver/persistence/jpa-container-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.persistence</groupId>
         <artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jpa-container-l10n</artifactId>
     

--- a/appserver/persistence/jpa-container/pom.xml
+++ b/appserver/persistence/jpa-container/pom.xml
@@ -47,7 +47,6 @@
 	<groupId>fish.payara.server.internal.persistence</groupId>
     	<artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jpa-container</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/persistence/oracle-jdbc-driver-packages/pom.xml
+++ b/appserver/persistence/oracle-jdbc-driver-packages/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.persistence</groupId>
         <artifactId>persistence</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-oracle-jdbc-driver-packages</artifactId>
     <name>GlassFish Oracle JDBC Packages</name>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -125,9 +125,9 @@
         <jms-api.version>2.0.2</jms-api.version>
 
         <jna.version>5.2.0</jna.version>
-        
+
         <jline-terminal-jna>3.11.0</jline-terminal-jna>
-        
+
         <!-- 5.1.1-b02.payara-p1 -->
         <mq.version>5.1.1.final.payara-p4</mq.version>
 
@@ -183,7 +183,12 @@
 
         <jsf-ext.version>0.2</jsf-ext.version>
         <jsftemplating.version>2.1.3</jsftemplating.version>
-        <woodstock.version>4.0.2.10.payara-p16</woodstock.version>
+        <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
+        <woodstock-dojo-ajax-nodemo.version>0.4.4</woodstock-dojo-ajax-nodemo.version>
+        <woodstock-jsf.version>4.0.2.10.payara-p16</woodstock-jsf.version>
+        <woodstock-jsf-suntheme.version>4.0.2.10.payara-p16</woodstock-jsf-suntheme.version>
+        <woodstock-json.version>1.0</woodstock-json.version>
+        <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
@@ -419,7 +424,7 @@
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>1.0</specVersion>
-			                <specImplVersion>${javax.batch-api.version}</specImplVersion>
+                            <specImplVersion>${javax.batch-api.version}</specImplVersion>
                             <apiPackage>javax.batch</apiPackage>
                         </spec>
 
@@ -517,7 +522,7 @@
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>${jakarta.ejb-api.version}</specVersion>
-			                <specImplVersion>${jakarta.ejb-api.version}</specImplVersion>
+                            <specImplVersion>${jakarta.ejb-api.version}</specImplVersion>
                             <apiPackage>jakarta.ejb</apiPackage>
                         </spec>
 
@@ -531,7 +536,7 @@
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>${jakarta.interceptor-api.version}</specVersion>
-			                <specImplVersion>${jakarta.interceptor-api.version}</specImplVersion>
+                            <specImplVersion>${jakarta.interceptor-api.version}</specImplVersion>
                             <apiPackage>javax.interceptor</apiPackage>
                         </spec>
                         <spec>
@@ -543,7 +548,7 @@
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>${jakarta.resource-api.version}</specVersion>
-			                <specImplVersion>${jakarta.resource-api.version}</specImplVersion>
+                            <specImplVersion>${jakarta.resource-api.version}</specImplVersion>
                             <apiPackage>jakarta.resource</apiPackage>
                         </spec>
                         <spec>
@@ -896,16 +901,7 @@
                 <artifactId>jsf-extensions-common</artifactId>
                 <version>${jsf-ext.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock</groupId>
-                <artifactId>webui-jsf</artifactId>
-                <version>${woodstock.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock</groupId>
-                <artifactId>webui-jsf-suntheme</artifactId>
-                <version>${woodstock.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>com.sun.jsftemplating</groupId>
                 <artifactId>jsftemplating</artifactId>
@@ -931,30 +927,36 @@
                 <version>${jsftemplating.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.sun.woodstock</groupId>
+                <artifactId>webui-jsf</artifactId>
+                <version>${woodstock-jsf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.woodstock</groupId>
+                <artifactId>webui-jsf-suntheme</artifactId>
+                <version>${woodstock-jsf-suntheme.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>
                 <artifactId>json</artifactId>
-                <version>1.0</version>
+                <version>${woodstock-json.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>
                 <artifactId>dojo-ajax-nodemo</artifactId>
-                <version>0.4.4</version>
+                <version>${woodstock-dojo-ajax-nodemo.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>
                 <artifactId>prototype</artifactId>
-                <version>1.7.3</version>
+                <version>${woodstock-prototype.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>
                 <artifactId>dataprovider</artifactId>
-                <version>1.0</version>
+                <version>${woodstock-dataprovider.version}</version>
             </dependency>
-            <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>1.3.3</version>
-            </dependency>
+
             <dependency>
                 <groupId>com.sun.messaging.mq</groupId>
                 <artifactId>imqjmx</artifactId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -75,6 +75,7 @@
         <jakarta.faces-spec.version>2.3.1</jakarta.faces-spec.version>
         <jakarta.faces-api.version>2.3.1</jakarta.faces-api.version>
         <mojarra.version>2.3.9.payara-p3</mojarra.version>
+        <jsftemplating.version>2.1.3</jsftemplating.version>
 
         <!-- WebSocket -->
         <websocket-api.version>1.1.2</websocket-api.version>
@@ -180,15 +181,6 @@
         <minor_version>194-SNAPSHOT</minor_version>
         <update_version></update_version>
         <install.dir.name>payara${major_version}</install.dir.name>
-
-        <jsf-ext.version>0.2</jsf-ext.version>
-        <jsftemplating.version>2.1.3</jsftemplating.version>
-        <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
-        <woodstock-dojo-ajax-nodemo.version>0.4.4</woodstock-dojo-ajax-nodemo.version>
-        <woodstock-jsf.version>4.0.2.10.payara-p16</woodstock-jsf.version>
-        <woodstock-jsf-suntheme.version>4.0.2.10.payara-p16</woodstock-jsf-suntheme.version>
-        <woodstock-json.version>1.0</woodstock-json.version>
-        <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
@@ -703,6 +695,37 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>${woodstox.version}</version>
             </dependency>
+            <!-- shared by admingui packager and admingui modules -->
+            <dependency>
+                <groupId>com.sun.jsftemplating</groupId>
+                <artifactId>jsftemplating</artifactId>
+                <version>${jsftemplating.version}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.faces</groupId>
+                        <artifactId>javax.faces-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.el</groupId>
+                        <artifactId>el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.woodstock.dependlibs</groupId>
+                        <artifactId>dataprovider</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.jsftemplating</groupId>
+                <artifactId>jsftemplating-dt</artifactId>
+                <version>${jsftemplating.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <!-- Java EE Security API -->
             <dependency>
@@ -889,78 +912,6 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
                 <version>${jakarta.el.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.faces.extensions</groupId>
-                <artifactId>jsf-extensions-dynamic-faces</artifactId>
-                <version>${jsf-ext.version}</version>
-                <classifier>jsftemplating</classifier>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.faces.extensions</groupId>
-                <artifactId>jsf-extensions-common</artifactId>
-                <version>${jsf-ext.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jsftemplating</groupId>
-                <artifactId>jsftemplating</artifactId>
-                <version>${jsftemplating.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>javax.servlet-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.faces</groupId>
-                        <artifactId>javax.faces-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.el</groupId>
-                        <artifactId>el-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.jsftemplating</groupId>
-                <artifactId>jsftemplating-dt</artifactId>
-                <version>${jsftemplating.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock</groupId>
-                <artifactId>webui-jsf</artifactId>
-                <version>${woodstock-jsf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock</groupId>
-                <artifactId>webui-jsf-suntheme</artifactId>
-                <version>${woodstock-jsf-suntheme.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
-                <artifactId>json</artifactId>
-                <version>${woodstock-json.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
-                <artifactId>dojo-ajax-nodemo</artifactId>
-                <version>${woodstock-dojo-ajax-nodemo.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
-                <artifactId>prototype</artifactId>
-                <version>${woodstock-prototype.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
-                <artifactId>dataprovider</artifactId>
-                <version>${woodstock-dataprovider.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.messaging.mq</groupId>
-                <artifactId>imqjmx</artifactId>
-                <version>4.3</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.mq</groupId>

--- a/appserver/registration/glassfish-registration/pom.xml
+++ b/appserver/registration/glassfish-registration/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.registration</groupId>
         <artifactId>registration</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish-registration</artifactId>

--- a/appserver/registration/pom.xml
+++ b/appserver/registration/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.registration</groupId>
     <artifactId>registration</artifactId>

--- a/appserver/registration/registration-api/pom.xml
+++ b/appserver/registration/registration-api/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.registration</groupId>
         <artifactId>registration</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>registration-api</artifactId>

--- a/appserver/registration/registration-impl-l10n/pom.xml
+++ b/appserver/registration/registration-impl-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.registration</groupId>
         <artifactId>registration</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>registration-impl-l10n</artifactId>
     

--- a/appserver/registration/registration-impl/pom.xml
+++ b/appserver/registration/registration-impl/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.registration</groupId>
         <artifactId>registration</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>registration-impl</artifactId>

--- a/appserver/resources/javamail/javamail-connector-l10n/pom.xml
+++ b/appserver/resources/javamail/javamail-connector-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.resources</groupId>
         <artifactId>javamail</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>javamail-connector-l10n</artifactId>

--- a/appserver/resources/javamail/javamail-runtime/pom.xml
+++ b/appserver/resources/javamail/javamail-runtime/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.resources</groupId>
         <artifactId>javamail</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>javamail-runtime</artifactId>

--- a/appserver/resources/pom.xml
+++ b/appserver/resources/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.resources</groupId>
     <artifactId>resources</artifactId>

--- a/appserver/resources/resources-connector/pom.xml
+++ b/appserver/resources/resources-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.resources</groupId>
         <artifactId>resources</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>resources-connector</artifactId>

--- a/appserver/resources/resources-runtime/pom.xml
+++ b/appserver/resources/resources-runtime/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.resources</groupId>
         <artifactId>resources</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>resources-runtime</artifactId>

--- a/appserver/security/appclient.security/pom.xml
+++ b/appserver/security/appclient.security/pom.xml
@@ -47,11 +47,10 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
-    </parent>    
+    </parent>
     <artifactId>appclient.security</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Appclient Security Integration</name>
     <developers>
         <developer>
@@ -71,7 +70,7 @@
             </roles>
         </developer>
     </developers>
-    
+
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <resources>
@@ -89,7 +88,7 @@
             </resource>
         </resources>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/appserver/security/core-ee-l10n/pom.xml
+++ b/appserver/security/core-ee-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>security-ee-l10n</artifactId>

--- a/appserver/security/core-ee/pom.xml
+++ b/appserver/security/core-ee/pom.xml
@@ -49,7 +49,6 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>security-ee</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/security/ejb.security/pom.xml
+++ b/appserver/security/ejb.security/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ejb.security</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/security/security-all/pom.xml
+++ b/appserver/security/security-all/pom.xml
@@ -49,8 +49,7 @@
          <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
-    </parent>    
+    </parent>
     <artifactId>security-all</artifactId>
     <packaging>pom</packaging>
     <name>Security Related Implementation for GlassFish</name>

--- a/appserver/security/webservices.security-l10n/pom.xml
+++ b/appserver/security/webservices.security-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>webservices.security-l10n</artifactId>

--- a/appserver/security/webservices.security/pom.xml
+++ b/appserver/security/webservices.security/pom.xml
@@ -48,13 +48,12 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
-    </parent>    
+    </parent>
     <artifactId>webservices.security</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>WebServices Security and JSR 196 implementation</name>
-    
+
     <developers>
         <developer>
             <id>kumarjayanti</id>

--- a/appserver/tests/quicklook/admin/pom.xml
+++ b/appserver/tests/quicklook/admin/pom.xml
@@ -51,7 +51,6 @@
         <groupId>quicklook</groupId>
         <artifactId>org.glassfish.quicklook</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <description>Runs the tests on admin/asadmin code</description>
     <build>

--- a/appserver/tests/quicklook/amx/pom.xml
+++ b/appserver/tests/quicklook/amx/pom.xml
@@ -48,7 +48,6 @@
         <groupId>quicklook</groupId>
         <artifactId>org.glassfish.quicklook</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.quicklook</groupId>
     <artifactId>admin</artifactId>

--- a/appserver/transaction/internal-api-l10n/pom.xml
+++ b/appserver/transaction/internal-api-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>transaction-internal-api-l10n</artifactId>
     

--- a/appserver/transaction/internal-api/pom.xml
+++ b/appserver/transaction/internal-api/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>transaction-internal-api</artifactId>

--- a/appserver/transaction/jta-l10n/pom.xml
+++ b/appserver/transaction/jta-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jta-l10n</artifactId>
     

--- a/appserver/transaction/jta-xa/pom.xml
+++ b/appserver/transaction/jta-xa/pom.xml
@@ -50,7 +50,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>4.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jta-xa</artifactId>

--- a/appserver/transaction/jta/pom.xml
+++ b/appserver/transaction/jta/pom.xml
@@ -49,7 +49,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jta</artifactId>

--- a/appserver/transaction/jts-l10n/pom.xml
+++ b/appserver/transaction/jts-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jts-l10n</artifactId>
     

--- a/appserver/transaction/jts/pom.xml
+++ b/appserver/transaction/jts/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.transaction</groupId>
         <artifactId>transaction</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jts</artifactId>

--- a/appserver/transaction/pom.xml
+++ b/appserver/transaction/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.transaction</groupId>
     <artifactId>transaction</artifactId>

--- a/appserver/web/admin-l10n/pom.xml
+++ b/appserver/web/admin-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-cli-l10n</artifactId>
     

--- a/appserver/web/admin/pom.xml
+++ b/appserver/web/admin/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>web-cli</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/web/cdi-api-fragment/pom.xml
+++ b/appserver/web/cdi-api-fragment/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>cdi-api-fragment</artifactId>

--- a/appserver/web/gf-web-connector/pom.xml
+++ b/appserver/web/gf-web-connector/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
     	<artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gf-web-connector</artifactId>

--- a/appserver/web/gf-weld-connector/pom.xml
+++ b/appserver/web/gf-weld-connector/pom.xml
@@ -48,7 +48,6 @@
 	<groupId>fish.payara.server.internal.web</groupId>
     	<artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>gf-weld-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/web/gui-plugin-common-l10n/pom.xml
+++ b/appserver/web/gui-plugin-common-l10n/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-gui-plugin-common-l10n</artifactId>
     

--- a/appserver/web/gui-plugin-common/pom.xml
+++ b/appserver/web/gui-plugin-common/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
     	<artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>web-gui-plugin-common</artifactId>

--- a/appserver/web/jersey-mvc-connector/pom.xml
+++ b/appserver/web/jersey-mvc-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jersey-mvc-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/web/jsf-connector/pom.xml
+++ b/appserver/web/jsf-connector/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jsf-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/web/jspcaching-connector/pom.xml
+++ b/appserver/web/jspcaching-connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>jspcaching-connector</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/web/pom.xml
+++ b/appserver/web/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.web</groupId>
     <artifactId>web</artifactId>

--- a/appserver/web/war-util-l10n/pom.xml
+++ b/appserver/web/war-util-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>war-util-l10n</artifactId>
     

--- a/appserver/web/war-util/pom.xml
+++ b/appserver/web/war-util/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
     	<artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>war-util</artifactId>

--- a/appserver/web/web-core-l10n/pom.xml
+++ b/appserver/web/web-core-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-core-l10n</artifactId>
     

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -47,7 +47,7 @@
 
     <parent>
         <groupId>fish.payara.server.internal.web</groupId>
-    	  <artifactId>web</artifactId>
+        <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
     </parent>
 
@@ -157,12 +157,10 @@
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>
             <artifactId>tyrus-container-servlet</artifactId>
-            <version>${tyrus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
-            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
@@ -175,7 +173,7 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        
+
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>

--- a/appserver/web/web-embed/pom.xml
+++ b/appserver/web/web-embed/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>web-embed</artifactId>
     <packaging>pom</packaging>

--- a/appserver/web/web-glue-l10n/pom.xml
+++ b/appserver/web/web-glue-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>web-glue-l10n</artifactId>

--- a/appserver/web/web-ha/pom.xml
+++ b/appserver/web/web-ha/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>web-ha</artifactId>

--- a/appserver/web/web-naming-l10n/pom.xml
+++ b/appserver/web/web-naming-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>web-naming-l10n</artifactId>

--- a/appserver/web/web-sse/pom.xml
+++ b/appserver/web/web-sse/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>web-sse</artifactId>

--- a/appserver/web/webtier-all/pom.xml
+++ b/appserver/web/webtier-all/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
     	<artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webtier-all</artifactId>

--- a/appserver/web/weld-integration-fragment/pom.xml
+++ b/appserver/web/weld-integration-fragment/pom.xml
@@ -49,7 +49,6 @@
         <groupId>fish.payara.server.internal.web</groupId>
         <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>weld-integration-fragment</artifactId>

--- a/appserver/web/weld-integration-test-fragment/pom.xml
+++ b/appserver/web/weld-integration-test-fragment/pom.xml
@@ -48,7 +48,6 @@
 	<groupId>fish.payara.server.internal.web</groupId>
     	<artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>weld-integration-test-fragment</artifactId>
     <name>Fragment bundle for Weld related testing</name>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -49,7 +49,6 @@
 	      <groupId>fish.payara.server.internal.web</groupId>
     	  <artifactId>web</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>weld-integration</artifactId>

--- a/appserver/webservices/connector-l10n/pom.xml
+++ b/appserver/webservices/connector-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.webservices</groupId>
         <artifactId>webservices</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>webservices-connector-l10n</artifactId>
 

--- a/appserver/webservices/connector/pom.xml
+++ b/appserver/webservices/connector/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.webservices</groupId>
     	<artifactId>webservices</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webservices-connector</artifactId>

--- a/appserver/webservices/jsr109-impl-l10n/pom.xml
+++ b/appserver/webservices/jsr109-impl-l10n/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.webservices</groupId>
         <artifactId>webservices</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>jsr109-impl-l10n</artifactId>

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.webservices</groupId>
         <artifactId>webservices</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jsr109-impl</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/webservices/metro-glue/pom.xml
+++ b/appserver/webservices/metro-glue/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.webservices</groupId>
         <artifactId>webservices</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>metro-glue</artifactId>

--- a/appserver/webservices/pom.xml
+++ b/appserver/webservices/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.webservices</groupId>
     <artifactId>webservices</artifactId>

--- a/appserver/webservices/soap-tcp/pom.xml
+++ b/appserver/webservices/soap-tcp/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.webservices</groupId>
         <artifactId>webservices</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>soap-tcp</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/admin/cli-l10n/pom.xml
+++ b/nucleus/admin/cli-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>admin-cli-l10n</artifactId>

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>admin-cli</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/admin/config-api-l10n/pom.xml
+++ b/nucleus/admin/config-api-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>config-api-l10n</artifactId>

--- a/nucleus/admin/launcher-l10n/pom.xml
+++ b/nucleus/admin/launcher-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>launcher-l10n</artifactId>

--- a/nucleus/admin/monitor-l10n/pom.xml
+++ b/nucleus/admin/monitor-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>monitoring-core-l10n</artifactId>

--- a/nucleus/admin/pom.xml
+++ b/nucleus/admin/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.admin</groupId>
     <artifactId>nucleus-admin</artifactId>

--- a/nucleus/admin/rest/pom.xml
+++ b/nucleus/admin/rest/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest-service-parent</artifactId>

--- a/nucleus/admin/rest/rest-service-l10n/pom.xml
+++ b/nucleus/admin/rest/rest-service-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>rest-service-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest-service-l10n</artifactId>

--- a/nucleus/admin/server-mgmt-l10n/pom.xml
+++ b/nucleus/admin/server-mgmt-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>server-mgmt-l10n</artifactId>

--- a/nucleus/admin/util-l10n/pom.xml
+++ b/nucleus/admin/util-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>nucleus-admin</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>admin-util-l10n</artifactId>

--- a/nucleus/cluster/admin-l10n/pom.xml
+++ b/nucleus/cluster/admin-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.cluster</groupId>
         <artifactId>cluster</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cluster-admin-l10n</artifactId>

--- a/nucleus/cluster/cli-l10n/pom.xml
+++ b/nucleus/cluster/cli-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.cluster</groupId>
         <artifactId>cluster</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cluster-cli-l10n</artifactId>

--- a/nucleus/cluster/common-l10n/pom.xml
+++ b/nucleus/cluster/common-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.cluster</groupId>
         <artifactId>cluster</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cluster-common-l10n</artifactId>

--- a/nucleus/cluster/pom.xml
+++ b/nucleus/cluster/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.cluster</groupId>
     <artifactId>cluster</artifactId>

--- a/nucleus/cluster/ssh-l10n/pom.xml
+++ b/nucleus/cluster/ssh-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.cluster</groupId>
         <artifactId>cluster</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cluster-ssh-l10n</artifactId>

--- a/nucleus/cluster/uc-l10n/pom.xml
+++ b/nucleus/cluster/uc-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.cluster</groupId>
         <artifactId>cluster</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cluster-uc-l10n</artifactId>

--- a/nucleus/common/common-util-l10n/pom.xml
+++ b/nucleus/common/common-util-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>nucleus-common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 
     <artifactId>common-util-l10n</artifactId>

--- a/nucleus/common/glassfish-api-l10n/pom.xml
+++ b/nucleus/common/glassfish-api-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>nucleus-common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glassfish-api-l10n</artifactId>

--- a/nucleus/common/internal-api-l10n/pom.xml
+++ b/nucleus/common/internal-api-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>nucleus-common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>internal-api-l10n</artifactId>

--- a/nucleus/common/internal-api/pom.xml
+++ b/nucleus/common/internal-api/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>nucleus-common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>    
     <artifactId>internal-api</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/common/mbeanserver-l10n/pom.xml
+++ b/nucleus/common/mbeanserver-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.common</groupId>
         <artifactId>nucleus-common</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 
     <artifactId>glassfish-mbeanserver-l10n</artifactId>

--- a/nucleus/common/pom.xml
+++ b/nucleus/common/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.common</groupId>
     <artifactId>nucleus-common</artifactId>

--- a/nucleus/core/extra-jre-packages/pom.xml
+++ b/nucleus/core/extra-jre-packages/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.core</groupId>
         <artifactId>nucleus-core</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>glassfish-extra-jre-packages</artifactId>
     <name>GlassFish Extra JRE Packages</name>

--- a/nucleus/core/kernel-l10n/pom.xml
+++ b/nucleus/core/kernel-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.core</groupId>
         <artifactId>nucleus-core</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kernel-l10n</artifactId>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server.internal.core</groupId>
         <artifactId>nucleus-core</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>kernel</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/core/logging-l10n/pom.xml
+++ b/nucleus/core/logging-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.core</groupId>
         <artifactId>nucleus-core</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>logging-l10n</artifactId>

--- a/nucleus/core/pom.xml
+++ b/nucleus/core/pom.xml
@@ -47,12 +47,11 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>fish.payara.server.internal.core</groupId>
     <artifactId>nucleus-core</artifactId>
     <packaging>pom</packaging>
-    <name>GlassFish Nucleus Core modules</name>  
+    <name>GlassFish Nucleus Core modules</name>
     <modules>
         <module>bootstrap</module>
         <module>kernel</module>

--- a/nucleus/deployment/admin-l10n/pom.xml
+++ b/nucleus/deployment/admin-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-admin-l10n</artifactId>

--- a/nucleus/deployment/autodeploy-l10n/pom.xml
+++ b/nucleus/deployment/autodeploy-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-autodeploy-l10n</artifactId>

--- a/nucleus/deployment/common-l10n/pom.xml
+++ b/nucleus/deployment/common-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.deployment</groupId>
         <artifactId>nucleus-deployment</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>deployment-common-l10n</artifactId>

--- a/nucleus/deployment/pom.xml
+++ b/nucleus/deployment/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.deployment</groupId>
     <artifactId>nucleus-deployment</artifactId>

--- a/nucleus/flashlight/framework-l10n/pom.xml
+++ b/nucleus/flashlight/framework-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.flashlight</groupId>
         <artifactId>nucleus-flashlight</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>flashlight-framework-l10n</artifactId>

--- a/nucleus/flashlight/pom.xml
+++ b/nucleus/flashlight/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>nucleus-flashlight</artifactId>

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -49,7 +49,6 @@
         <groupId>fish.payara.server.internal.grizzly</groupId>
         <artifactId>nucleus-grizzly</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>grizzly-config</artifactId>

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -49,7 +49,6 @@
         <groupId>fish.payara.server.internal.grizzly</groupId>
         <artifactId>nucleus-grizzly</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>nucleus-grizzly-all</artifactId>

--- a/nucleus/grizzly/pom.xml
+++ b/nucleus/grizzly/pom.xml
@@ -47,12 +47,11 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
     </parent>
     <groupId>fish.payara.server.internal.grizzly</groupId>
     <artifactId>nucleus-grizzly</artifactId>
     <packaging>pom</packaging>
-    <name>GlassFish Nucleus Grizzly modules</name>  
+    <name>GlassFish Nucleus Grizzly modules</name>
     <modules>
         <module>config</module>
         <module>nucleus-grizzly-all</module>

--- a/nucleus/hk2/pom.xml
+++ b/nucleus/hk2/pom.xml
@@ -48,7 +48,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>fish.payara.server.internal.hk2</groupId>
     <artifactId>glassfish-nucleus-hk2</artifactId>

--- a/nucleus/osgi-platforms/osgi-cli-interactive-l10n/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-interactive-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 
 

--- a/nucleus/osgi-platforms/osgi-cli-remote-l10n/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.osgi-platforms</groupId>
         <artifactId>osgi-platforms</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion> 
 

--- a/nucleus/osgi-platforms/pom.xml
+++ b/nucleus/osgi-platforms/pom.xml
@@ -52,7 +52,6 @@
       <groupId>fish.payara.server</groupId>
       <artifactId>payara-nucleus-parent</artifactId>
       <version>5.194-SNAPSHOT</version>
-      <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <groupId>fish.payara.server.internal.osgi-platforms</groupId>

--- a/nucleus/packager/external/j-interop/pom.xml
+++ b/nucleus/packager/external/j-interop/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>nucleus-external</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>j-interop-repackaged</artifactId>

--- a/nucleus/packager/external/jmxremote_optional/pom.xml
+++ b/nucleus/packager/external/jmxremote_optional/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>nucleus-external</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jmxremote_optional-repackaged</artifactId>

--- a/nucleus/packager/external/ldapbp/pom.xml
+++ b/nucleus/packager/external/ldapbp/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>nucleus-external</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ldapbp-repackaged</artifactId>

--- a/nucleus/packager/external/trilead-ssh2/pom.xml
+++ b/nucleus/packager/external/trilead-ssh2/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>nucleus-external</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>trilead-ssh2-repackaged</artifactId>

--- a/nucleus/packager/external/vboxjws/pom.xml
+++ b/nucleus/packager/external/vboxjws/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>nucleus-external</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>vboxjws</artifactId>

--- a/nucleus/payara-modules/asadmin-audit/pom.xml
+++ b/nucleus/payara-modules/asadmin-audit/pom.xml
@@ -44,7 +44,6 @@
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>asadmin-audit</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/asadmin-recorder/pom.xml
+++ b/nucleus/payara-modules/asadmin-recorder/pom.xml
@@ -44,7 +44,6 @@
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>asadmin-recorder</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/hazelcast-bootstrap/pom.xml
+++ b/nucleus/payara-modules/hazelcast-bootstrap/pom.xml
@@ -43,7 +43,6 @@
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>hazelcast-bootstrap</artifactId>

--- a/nucleus/payara-modules/healthcheck-core/pom.xml
+++ b/nucleus/payara-modules/healthcheck-core/pom.xml
@@ -45,7 +45,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>healthcheck-core</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/healthcheck-cpool/pom.xml
+++ b/nucleus/payara-modules/healthcheck-cpool/pom.xml
@@ -47,7 +47,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>healthcheck-cpool</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/healthcheck-stuck/pom.xml
+++ b/nucleus/payara-modules/healthcheck-stuck/pom.xml
@@ -47,7 +47,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>healthcheck-stuck</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/notification-core/pom.xml
+++ b/nucleus/payara-modules/notification-core/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>notification-core</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/phonehome-bootstrap/pom.xml
+++ b/nucleus/payara-modules/phonehome-bootstrap/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>phonehome-bootstrap</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/payara-modules/pom.xml
+++ b/nucleus/payara-modules/pom.xml
@@ -46,7 +46,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <groupId>fish.payara.server.internal.payara-modules</groupId>

--- a/nucleus/payara-modules/requesttracing-core/pom.xml
+++ b/nucleus/payara-modules/requesttracing-core/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.payara-modules</groupId>
         <artifactId>payara-nucleus-modules</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>requesttracing-core</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -595,34 +595,6 @@
                 </executions>
             </plugin>
 
-            <!-- force cleaning of the local repository
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>purge-local-dependencies</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>purge-local-repository</goal>
-                        </goals>
-                        <configuration>
-                            <resolutionFuzziness>groupId</resolutionFuzziness>
-                            <includes>
-                                <include>jakarta.ejb</include>
-                                <include>jakarta.transaction</include>
-                                <include>javax.resource</include>
-                                <include>javax.enterprise.concurrent</include>
-                                <include>javax.ws.rs</include>
-                                <include>javax.xml.registry</include>
-                                <include>javax.websocket</include>
-                                <include>org.glassfish.jersey</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-      -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/nucleus/resources-l10n/pom.xml
+++ b/nucleus/resources-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.server.internal</groupId>

--- a/nucleus/security/core-l10n/pom.xml
+++ b/nucleus/security/core-l10n/pom.xml
@@ -46,7 +46,6 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>nucleus-security</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-l10n</artifactId>

--- a/nucleus/security/services-l10n/pom.xml
+++ b/nucleus/security/services-l10n/pom.xml
@@ -45,7 +45,6 @@
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>nucleus-security</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-services-l10n</artifactId>

--- a/nucleus/test-utils/pom.xml
+++ b/nucleus/test-utils/pom.xml
@@ -47,7 +47,6 @@
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <groupId>fish.payara.server.internal.test-utils</groupId>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -81,7 +81,6 @@ of COPY_LIB map constant.)
         <groupId>fish.payara.server.internal.tests</groupId>
         <artifactId>nucleus-tests</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.glassfish.tests</groupId>
     <artifactId>nucleus-admin</artifactId>


### PR DESCRIPTION
# Description

This is a build improvement - it is simplier and faster.

- reduced dependency management without impact (console-core)
- admingui war module
  - using Maven only, no Ant needed
  - Manifest is generated
  - no repacking, proper dependency management is faster and without mysteries
  - sun-web.xml - using Maven filtering, no hardcoded versions
- appserver/pom.xml and appserver/admingui/pom.xml
  - using properties to define versions
  - properties are used also for filtering sun-web.xml
- sources - code formatting, logging
- result: upgrade means only changing the version property, checking changes
  in artifact dependencies and testing. You can use also snapshots.

Second commit:
- no default dependencies (or less than before at least)
- dependency management uses provided scope as a default
- removed redundant relativePath elements (../pom.xml is default!)
- removed some dead code - commented out parts
- admin gui war uses admingui parent, does not skip it to payara-parent
  - it's dependencies moved here if not used in any other module outside
- console-common
  - changed order of dependencies - our first, external after that,
    classpath conflicts will prefer our implementation (but it does not
    apply to the runtime Payara Server, only for build!)
- dataprovider
  - osgi repackaging of the woodstock artifact => the original artifact
    is excluded from all dependencies and only our is used
- imqjmx vs. admingui
  - not used in admingui, even not packaged
  - packaged in other featuresets
  - tested: resulting zip file contains same 4 files with imqjmx in name as
    it contained before
- jsftemplating
  - dependency shared also by admingui plugins, that's why it is not included
    in the war file, it is included by the packager to the the admingui
    featureset

# Important Info

### Dependant PRs <!-- delete as applicable -->

Following branches/PR **do not block this PR**, but they are related (can be used to test it):
https://github.com/payara/patched-src-woodstock-suntheme/pull/16
- using maven for build.
- not required for this PR, it can be merged much later

https://github.com/dmatej/patched-src-woodstock/tree/branch-v4.0.2.10
- using maven for build.
- not required for this or the second PR
- differs from Payara/Woodstock repository, but works with that too

# Testing

### Testing Performed

Manual testing done:

- build artifacts as snapshots (ie. woodstock-jsf-suntheme)
- change version of dependency in Payara and build  (`-Dwoodstock-jsf-suntheme.version=4.0.2.10.payara-p17-SNAPSHOT`)
- install Payara and use DAS GUI on 4848
- checked output war file - same content as in previous version (except some manifest headers)
