### PR TITLE
PAYARA-4116: Properly shutdown server on startup failure

### DIFF
--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishImpl.java
@@ -80,7 +80,16 @@ public class GlassFishImpl implements GlassFish {
             throw new IllegalStateException("Already in " + status + " state.");
         }
         status = Status.STARTING;
-        gfKernel.start();
+        try {
+            gfKernel.start();
+        } catch (RuntimeException | Error t) {
+            dispose();
+            if (t.getCause() instanceof GlassFishException) {
+                throw (GlassFishException)t.getCause();
+            } else {
+                throw t;
+            }
+        }
         status = Status.STARTED;
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -60,6 +60,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.inject.Inject;
@@ -113,6 +114,9 @@ import org.jvnet.hk2.annotations.Service;
 @Service
 @Rank(Constants.DEFAULT_IMPLEMENTATION_RANK) // This should be the default impl if no name is specified
 public class AppServerStartup implements PostConstruct, ModuleStartup {
+    enum State {
+        INITIAL, STARTING, STARTED, SHUTDOWN_REQUESTED, SHUTTING_DOWN, SHUT_DOWN;
+    }
     
     StartupContext context;
 
@@ -129,13 +133,11 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
     @Inject
     ModulesRegistry systemRegistry;
 
+    @Override
     @Inject
     public void setStartupContext(StartupContext context) {
         this.context = context;
     }
-
-    @Inject
-    ExecutorService executor;
 
     @Inject
     Events events;
@@ -166,7 +168,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
      * as long as GlassFish kernel is up.
      */
     private Thread serverThread;
-    private boolean shutdownSignal = false;
+    private AtomicReference<State> state = new AtomicReference<>(State.INITIAL);
     
     private final static String THREAD_POLICY_PROPERTY = "org.glassfish.startupThreadPolicy";
     private final static String MAX_STARTUP_THREAD_PROPERTY = "org.glassfish.maxStartupThreads";
@@ -220,10 +222,18 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             // See issue #5596 to know why we set context CL as common CL.
             Thread.currentThread().setContextClassLoader(
                     commonCLS.getCommonClassLoader());
-            doStart();
+            if (state.compareAndSet(State.INITIAL, State.STARTING) || state.compareAndSet(State.SHUT_DOWN, State.STARTING)) {
+                doStart();
+            } else {
+                throw new GlassFishException("Server cannot start, because it's in state "+state.get());
+            }
         } catch (GlassFishException ex) {
             throw new RuntimeException (ex);
         } finally {
+            if (!state.compareAndSet(State.STARTING, State.STARTED)) {
+                // the state is no longer STARTING, therefore it has to be SHUTDOWN_REQUESTED
+                stop();
+            }
             // reset the context classloader. See issue GLASSFISH-15775
             Thread.currentThread().setContextClassLoader(origCL);
         }
@@ -254,7 +264,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
                 latch.countDown();
 
                 synchronized (this) {
-                    while (!shutdownSignal) {
+                    while (state.get() != AppServerStartup.State.SHUT_DOWN ) {
                         try {
                             wait(); // Wait indefinitely until shutdown is requested
                         }
@@ -415,7 +425,6 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
                     if (future.get(3, TimeUnit.SECONDS).isFailure()) {
                         final Throwable t = future.get().exception();
                         logger.log(Level.SEVERE, KernelLoggerInfo.startupFatalException, t);
-                        events.send(new Event(EventTypes.SERVER_SHUTDOWN), false);
                         shutdown();
                         return false;
                     }
@@ -466,31 +475,23 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
         logger.log(level, sb.toString());
     }
 
-    // TODO(Sahoo): Revisit this method after discussing with Jerome.
     private void shutdown() {
-        CommandRunner runner = commandRunnerProvider.get();
-
-        if (runner!=null) {
-           final ParameterMap params = new ParameterMap();
-            // By default we don't want to shutdown forcefully, as that will cause the VM to exit and that's not
-            // a very good behavior for a code known to be embedded in other processes.
-        final boolean noForcedShutdown =
-                Boolean.parseBoolean(context.getArguments().getProperty(
-                        com.sun.enterprise.glassfish.bootstrap.Constants.NO_FORCED_SHUTDOWN, "true"));
-            if (noForcedShutdown) {
-                params.set("force", "false");
-            }
-            final InternalSystemAdministrator kernelIdentity = locator.getService(InternalSystemAdministrator.class);
-            if (env.isDas()) {
-                runner.getCommandInvocation("stop-domain", new DoNothingActionReporter(), kernelIdentity.getSubject()).parameters(params).execute();
-            } else {
-                runner.getCommandInvocation("_stop-instance", new DoNothingActionReporter(), kernelIdentity.getSubject()).parameters(params).execute();
-            }
+        if (    state.compareAndSet(State.STARTING, State.SHUTDOWN_REQUESTED) ||
+                state.compareAndSet(State.INITIAL, State.SHUT_DOWN)) {
+            // SHUTDOWN_REQUESTED is handled at end of START
+            // INITIAL --> SHUT_DOWN is trivial case of shutdown before we started
+            return;
+        }
+        // state doesn't change on SHUT_DOWN, SHUTTING_DOWN and SHUTDOWN_REQUESTED
+        if (state.compareAndSet(State.STARTED, State.SHUTDOWN_REQUESTED)) {
+            // directly stop only if server already completed startup sequence
+            stop();
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
     public synchronized void stop() {
+        state.set(State.SHUTTING_DOWN);
         if(env.getStatus() == ServerEnvironment.Status.stopped) {
             // During shutdown because of shutdown hooks, we can be stopped multiple times.
             // In such a case, ignore any subsequent stop operations.
@@ -527,11 +528,10 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
 
         logger.info(KernelLoggerInfo.shutdownFinished);
 
+        state.set(State.SHUT_DOWN);
         // notify the server thread that we are done, so that it can come out.
         if (serverThread!=null) {
             synchronized (serverThread) {
-                shutdownSignal = true;
-                
                 serverThread.notify();
             }
             try {
@@ -543,11 +543,9 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
     }
 
     /**
-     * Proceed to the given run level using the given {@link AppServerActivator}.
+     * Proceed to the given run level.
      *
      * @param runLevel   the run level to proceed to
-     * @param activator  an {@link AppServerActivator activator} used to
-     *                   activate/deactivate the services
      * @return false if an error occurred that required server shutdown; true otherwise
      */
     private boolean proceedTo(int runLevel) {
@@ -694,7 +692,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
     private class MasterRunLevelListener implements RunLevelListener {
         private final RunLevelController controller;
         
-        private boolean forcedShutdown = false;
+        private volatile boolean forcedShutdown = false;
         
         private MasterRunLevelListener(RunLevelController controller) {
             this.controller = controller;
@@ -729,7 +727,6 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             
             if (controller.getCurrentRunLevel() >= InitRunLevel.VAL) {
                 logger.log(Level.SEVERE, KernelLoggerInfo.startupFailure, info.getError());
-                events.send(new Event(EventTypes.SERVER_SHUTDOWN), false);
             }
             
             forcedShutdown = true;

--- a/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
+++ b/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
@@ -142,6 +142,10 @@ public class PayaraExecutorService implements ConfigListener, EventListener {
     }
 
     private void terminateThreadPools() {
+        if (threadPoolExecutor == null) {
+            // we didn't initialize yet
+            return;
+        }
         threadPoolExecutor.shutdown();
         scheduledThreadPoolExecutor.shutdown();
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix <!-- delete/modify as applicable-->

Since cca summer 2017 server would hang when startup failure occurred, thread dump would show one or two threads hanging in 
```
  java.lang.Thread.State: TIMED_WAITING
	  at java.lang.Thread.sleep(Thread.java:-1)
	  at com.sun.enterprise.v3.admin.StopServer.doExecute(StopServer.java:74)
	  at com.sun.enterprise.v3.admin.StopDomainCommand.execute(StopDomainCommand.java:96)
	  at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:558)
	  at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:554)
	  at java.security.AccessController.doPrivileged(AccessController.java:-1)
	  at javax.security.auth.Subject.doAs(Subject.java:360)
	  at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:553)
	  at org.glassfish.api.AsyncImpl$1$1.run(AsyncImpl.java:76)
```

This posed few interesting questions:
* Why there is no instance of `GlassFish` available and this command is stuck in endless loop?
* Why is there two of them?
* Why `AppServerStartup` delegates to command, which then delegates to `GlassFish` which then delegates to `AppServerStartup`?

The answers to those are:

`GlassFish` impplementations (that differ by runtime, e. g. server, embedded, micro) register themselves after kernel starts. It used to be an invariant, that kernel never throws an exception, so the registration always happened. But since 1d7999e kernel start may throw, and `StopServer` is out of luck.

There are multiple paths to `AppServerStartup#shutdown`. Failure during startup happens to hit more of them.

The mechanism of delegating shutdown to admin command, which happens to delegate back, comes from early design of Glassfish V3, where shutdown sequence was placed directly in the command. But this code very quickly moved next to startup code, and this delegation is superflous.

Therefore these changes:

* If kernel throws exception, immediately dispose the instance
* Stop kernel directly rather than delegating to stop command
* Guarantee thread safety of shutdown

Shutdown may be invoked synchronously as reaction to failed proceed, or asynchronously from RunLevelListener - it's hard to tell what the timing guarantees are, especially after startup completes.
Therefore a state machine in addition to synchronicity of `stop` now guards, that shutdown sequence in invoked only once.

PayaraExecutorService now may shutdown before it initialized.

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Testing

### New tests
<!-- Link to the test suite PR or provide info -->

### Testing Performed
Injecting failures via ByteMan to Init and Startup Runlevel services, emulating startup errors common with 5.193; Injecting failures to grizzly server binds to emulate blocked ports. Server now consistenly shuts down.
<!--- Please describe how you tested these changes.  -->

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Payara samples in remote mode

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 1.8.0_192, Windows 10,  Maven 3.6.2
