### PR TITLE
[PAYARA-4160] - Error 500 when listing EJB Timer Count on DAS

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/ListTimers.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/ListTimers.java
@@ -48,6 +48,7 @@ import java.util.List;
 
 import com.sun.ejb.containers.EJBTimerService;
 import com.sun.ejb.containers.EjbContainerUtil;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -157,9 +158,7 @@ public class ListTimers implements AdminCommand {
             result = ejbTimerService.listTimers(serverIds);
         } else {
             result = new String[serverIds.length];
-            for (int i = 0; i < result.length; i++) {
-                result[i] = "0";
-            }
+            Arrays.fill(result, "0");
         }
 
         return result;

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/ListTimers.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/ListTimers.java
@@ -145,10 +145,7 @@ public class ListTimers implements AdminCommand {
     }
 
     private String[] listTimers(String[] serverIds) {
-        String[] result = new String[serverIds.length];
-        for(int i = 0; i < result.length; i++) {
-            result[i] = "0";
-        }
+        String[] result;
 
         EJBTimerService ejbTimerService = null;
         if (EJBTimerService.isPersistentTimerServiceLoaded()) {
@@ -158,6 +155,11 @@ public class ListTimers implements AdminCommand {
         }
         if (nonNull(ejbTimerService)) {
             result = ejbTimerService.listTimers(serverIds);
+        } else {
+            result = new String[serverIds.length];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = "0";
+            }
         }
 
         return result;

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/ListTimers.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/ListTimers.java
@@ -146,6 +146,9 @@ public class ListTimers implements AdminCommand {
 
     private String[] listTimers(String[] serverIds) {
         String[] result = new String[serverIds.length];
+        for(int i = 0; i < result.length; i++) {
+            result[i] = "0";
+        }
 
         EJBTimerService ejbTimerService = null;
         if (EJBTimerService.isPersistentTimerServiceLoaded()) {


### PR DESCRIPTION
# Description
This is a bug fix

# Testing

### Test suites executed
- Quicklook
- Java EE7 Samples
- Java EE8 Samples
- Payara Microprofile TCKs Runner
- Cargo Tracker

### Testing Environment
Ubuntu LTS 18.04, Java 1.8.0_222

# Notes for Reviewers
This is a fix for an error 500 that occurs when selecting to list timers on instances within a deployment group on the DAS. This error is the result of a null array being returned when no EJB timers are present so I've simply filled the array with 0s.

Whilst working on this, I've discovered another potential issue which will require looking into, however it needs further research and will likely be resolved in a separate issue/PR
