### PR TITLE
PAYARA-4256 MP Metrics are now always unregiestred after application undeployment

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -404,6 +404,7 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
      * @return 
      */
     public MetricRegistry removeRegistry(String registryName) {
+        registryName = registryName.toLowerCase();
         return REGISTRIES.remove(registryName);
     }
     

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/MetricsServiceTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/MetricsServiceTest.java
@@ -1,0 +1,70 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test class for MetricsService
+ * @author jonathan coustick
+ */
+public class MetricsServiceTest {
+    
+    private static final String TEST = "TEST";
+    
+    @Test
+    public void registrationTest() {
+        MetricsService service = new MetricsService();
+        
+        Assert.assertTrue(service.getAllRegistryNames().isEmpty());
+        MetricRegistry registry = service.getOrAddRegistry(TEST) ;
+        Assert.assertNotNull(registry);
+        Assert.assertTrue(service.getAllRegistryNames().size() == 1);
+        MetricRegistry removed = service.removeRegistry(TEST);
+        Assert.assertEquals(registry, removed);
+        Assert.assertTrue(service.getAllRegistryNames().isEmpty());
+    }
+    
+}


### PR DESCRIPTION
# Description
This is a bug fix.

When undeploying an application that has capital letters in its name i.e. SNAPSHOT then it fails to be deregistered when it is removed.

# Important Info

# Testing

### New tests
New unit test added, see PR

### Testing Performed
Deployed the test application for PAYARA-4174, went to localhost:8080/metrics then undeployed the application and went to localhost:8080/metrics again. Before PR error thrown, afterwards no error.

### Test suites executed
- Payara Microprofile TCKs Runner

### Testing Environment
"Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.0"
