### PR TITLE
PAYARA-4171 Monitoring data of an Instance is not visible if it is in a Deployment Group

### DIFF
--- a/appserver/admingui/common/src/main/resources/monitor/monitoringPage.jsf
+++ b/appserver/admingui/common/src/main/resources/monitor/monitoringPage.jsf
@@ -39,7 +39,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright [2018-2019] Payara Foundation and/or affiliates -->
 
 <!initPage 
     setResourceBundle(key="common" bundle="org.glassfish.common.admingui.Strings")
@@ -51,18 +51,44 @@
 <!define name="content">
 <event>
     <!beforeCreate
-        setSessionAttribute(key="monitoringConfigTab" value="monitoringGeneralTab");
+             setSessionAttribute(key="monitoringConfigTab" value="monitoringGeneralTab");
         getRequestValue(key="configName" value=>$page{configName} default="server-config");
         urlencode(value="#{pageSession.configName}" encoding="UTF-8" result="#{pageSession.encodedConfigName}");
         setPageSessionAttribute(key="childType" value="monitoring-service");
         setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/configs/config/#{pageSession.encodedConfigName}");
         setPageSessionAttribute(key="selfUrl", value="#{pageSession.parentUrl}/#{pageSession.childType}");
-        setPageSessionAttribute(key="amxUrl", value="#{pageSession.parentUrl}/amx-configuration");
         setPageSessionAttribute(key="rest-api" value="true");
-        gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
+        
+        gf.restRequest(endpoint="#{sessionScope.REST_URL}/get-monitoring-service-configuration?target=#{pageSession.encodedConfigName}"  
+                method="GET" result="#{requestScope.resp}");
+ 
+        setPageSessionAttribute(key="valueMap", value="#{requestScope.resp.data.extraProperties.getMonitoringServiceConfiguration}");
+        mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.encodedConfigName}");       
+         
+        setPageSessionAttribute(key="convertToFalseList" value={"dtraceEnabled", "monitoringEnabled", "mbeanEnabled", "enabled", "dynamic"}); 
+        if (#{pageSession.valueMap['monitoringEnabled']}=true) {
+            setPageSessionAttribute(key="monitoringEnabledSelected", value="true");
+        }
+        
+        if (#{pageSession.valueMap['mbeanEnabled']}=true) {
+            setPageSessionAttribute(key="mbeanEnabledSelected", value="true");
+        }
+
+        if (#{pageSession.valueMap['dtraceEnabled']}=true) {
+            setPageSessionAttribute(key="dtraceEnabledSelected", value="true");
+        }
+        
+        mapRemove(map="#{pageSession.valueMap}" key="amxEnabled");
+        
+        setPageSessionAttribute(key="amxUrl", value="#{pageSession.parentUrl}/amx-configuration");
         gf.getEntityAttrs(endpoint="#{pageSession.amxUrl}", valueMap="#{pageSession.amxMap}");
-        setPageSessionAttribute(key="convertToFalseList" value={"dtraceEnabled", "monitoringEnabled", "mbeanEnabled", "enabled"});
-        setPageSessionAttribute(key="skipAttrsList" value={"amxSelected"});
+        mapPut(map="#{pageSession.amxMap}" key="target" value="#{pageSession.encodedConfigName}"); 
+        setPageSessionAttribute(key="enabledSelected", value="false");
+        if (#{pageSession.amxMap['enabled']}=true) {
+            setPageSessionAttribute(key="enabledSelected", value="true");
+        }
+        setPageSessionAttribute(key="dynamic", value="true");
+        setPageSessionAttribute(key="skipAttrsList" value={"amxEnabled"});
         gf.getMonitorLevels(endpoint="#{pageSession.parentUrl}" monitorCompList="#{requestScope.tableList}")
         
     />
@@ -75,16 +101,26 @@
     <!facet pageButtonsTop>
         <sun:panelGroup id="topButtons">
             <sun:button id="saveButton"  text="$resource{i18n.button.Save}" >
+                 onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) {submitAndDisable(this, '$resource{i18n.button.Processing}');}; return false;" >
                 <!command
+                    mapPut(map="#{pageSession.valueMap}" key="monitoringEnabled" value="#{pageSession.monitoringEnabledSelected}");
+                    mapPut(map="#{pageSession.valueMap}" key="mbeanEnabled" value="#{pageSession.mbeanEnabledSelected}");
+                    mapPut(map="#{pageSession.valueMap}" key="dtraceEnabled" value="#{pageSession.dtraceEnabledSelected}");
+                    mapPut(map="#{pageSession.amxMap}" key="enabled" value="#{pageSession.enabledSelected}");
+                    mapPut(map="#{pageSession.amxMap}" key="dynamic" value="#{pageSession.dynamic}");
                     getUIComponent(clientId="$pageSession{tableRowGroupId}", component=>$attribute{tableRowGroup});
                     getAllSingleMapRows(TableRowGroup="${tableRowGroup}" Rows=>$attribute{allRows});
-                    updateMonitorLevels(endpoint="#{pageSession.selfUrl}/module-monitoring-levels",  allRows="#{requestScope.allRows}")
-                    gf.updateEntity(endpoint="#{pageSession.selfUrl}"  attrs="#{pageSession.valueMap}"
+                    updateMonitorLevels(allRows="#{requestScope.allRows}" config="#{pageSession.configName}");
+                    
+                    gf.updateEntity(endpoint="#{sessionScope.REST_URL}/set-monitoring-service-configuration"
                         skipAttrs="#{pageSession.skipAttrsList}"
+                        attrs="#{pageSession.valueMap}"
                         convertToFalse="#{pageSession.convertToFalseList}"
                         onlyUseAttrs="#{pageSession.onlyUseAttrs}"
                     );
-                    gf.updateEntity(endpoint="#{pageSession.amxUrl}" attrs="#{pageSession.amxMap}"
+
+                    gf.updateEntity(endpoint="#{sessionScope.REST_URL}/set-amx-enabled" 
+                        attrs="#{pageSession.amxMap}"
                         convertToFalse="#{pageSession.convertToFalseList}"
                     );
                     prepareSuccessfulMsg();
@@ -102,13 +138,19 @@
         />
 
         <sun:property id="monServiceProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.monService}"  helpText="$resource{common.monitoring.monServiceHelp}">
-            <sun:checkbox id="momServiceCheckbox"  label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['monitoringEnabled']}" selectedValue="true" />
+            <sun:checkbox id="momServiceCheckbox"  label="$resource{i18n.common.Enabled}" selected="#{pageSession.monitoringEnabledSelected}" selectedValue="true" />
         </sun:property>
         <sun:property id="monMbeansProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.monMbeans}"  helpText="$resource{common.monitoring.monMbeansHelp}">
-            <sun:checkbox id="momBbeanCheckbox" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['mbeanEnabled']}" selectedValue="true" />
+            <sun:checkbox id="momBbeanCheckbox" label="$resource{i18n.common.Enabled}" selected="#{pageSession.mbeanEnabledSelected}" selectedValue="true" />
+        </sun:property>
+        <sun:property id="monDtraceProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.monDtrace}"  helpText="$resource{common.monitoring.monDtraceHelp}">
+            <sun:checkbox id="momDtraceCheckbox" label="$resource{i18n.common.Enabled}" selected="#{pageSession.dtraceEnabledSelected}" selectedValue="true" />
         </sun:property>
         <sun:property id="amxProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.AMXEnabled}" helpText="$resource{common.monitoring.AMXEnabledHelp}">
-            <sun:checkbox id="amx" label="$resource{i18n.common.Enabled}" selected="#{pageSession.amxMap['enabled']}" selectedValue="true"/>
+            <sun:checkbox id="amx" label="$resource{i18n.common.Enabled}" selected="#{pageSession.enabledSelected}" selectedValue="true"/>
+        </sun:property>
+          <sun:property id="amxDynamicProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.AMXDynamic}" helpText="$resource{common.monitoring.AMXDynamicHelp}">
+            <sun:checkbox id="amxDynamic" label="$resource{i18n.common.Enabled}" selected="#{pageSession.dynamic}" selectedValue="true"/>
         </sun:property>
         "<br />
     </sun:propertySheetSection>

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -658,9 +658,13 @@ monitoring.monService=Monitoring Service:
 monitoring.monServiceHelp=Enable monitoring for Payara Server
 monitoring.monMbeans=Monitoring MBeans:
 monitoring.monMbeansHelp=Deploy all MBeans needed for monitoring
+monitoring.monDtrace=DTrace Monitoring:
+monitoring.monDtraceHelp=Enable or disable DTrace Monitoring
 monitoringInfo.pageHelp=View and manage the monitoring information for Payara Server instances.
-monitoring.AMXEnabled=AMX Enabled
-monitoring.AMXEnabledHelp=Whether or not AMX beans are enabled on startup
+monitoring.AMXEnabled=AMX:
+monitoring.AMXEnabledHelp=Enable or disable AMX. If enabled AMX will boot on server startup
+monitoring.AMXDynamic=AMX Dynamic:
+monitoring.AMXDynamicHelp=Amx can be enabled dynamically but disabling will require the server to be restarted.
 
 #monitoring Service page, Module  name
 monitoring.module.Jvm=Jvm

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Domain.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Domain.java
@@ -47,6 +47,15 @@ import com.sun.enterprise.util.StringUtils;
 import fish.payara.enterprise.config.serverbeans.DGServerRef;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroups;
+import java.beans.PropertyVetoException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.validation.constraints.NotNull;
 import org.glassfish.api.admin.config.ApplicationName;
 import org.glassfish.api.admin.config.PropertiesDesc;
 import org.glassfish.api.admin.config.PropertyDesc;
@@ -60,16 +69,6 @@ import org.jvnet.hk2.config.DuckTyped;
 import org.jvnet.hk2.config.Element;
 import org.jvnet.hk2.config.types.Property;
 import org.jvnet.hk2.config.types.PropertyBag;
-
-import javax.validation.constraints.NotNull;
-import java.beans.PropertyVetoException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 
 /**
@@ -917,7 +916,7 @@ public interface Domain extends ConfigBeanProxy, PropertyBag, SystemPropertyBag,
             // only add non-clustered servers as the cluster 
             // targets will be separately added
             for (Server server : d.getServers().getServer()) {
-                if (server.getCluster() == null && server.getDeploymentGroup().isEmpty()) {
+                if (server.getCluster() == null) {
                     targets.add(server.getName());
                 }
             }

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/CommandTarget.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/CommandTarget.java
@@ -41,8 +41,6 @@
 package org.glassfish.config.support;
 
 import com.sun.enterprise.config.serverbeans.*;
-
-
 import org.glassfish.hk2.api.ServiceLocator;
 
 /**
@@ -140,7 +138,7 @@ public enum CommandTarget implements TargetValidator {
         }
     },
     /**
-     * a cluster configuration change
+     * a Deployment Group configuration change
      */
     DEPLOYMENT_GROUP {
         @Override

--- a/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/Constants.java
+++ b/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/Constants.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -67,6 +67,20 @@ public final class Constants {
         "thread-pool",
         "transaction-service",
         "web-container",
-        "web-services-container"
+        "web-services-container",
+        "cloudElasticity",
+        "cloudOrchestrator",
+        "cloudTenantManager",
+        "cloudVirtAssemblyService",
+        "connectorConnectionPool",
+        "connectorService",
+        "ejbContainer",
+        "jdbcConnectionPool",
+        "jmsService",
+        "threadPool",
+        "transactionService",
+        "webContainer",
+        "webServicesContainer",
+        "httpService"
     };
 }

--- a/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/GetMonitoringServiceConfiguration.java
+++ b/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/GetMonitoringServiceConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -103,16 +103,18 @@ public class GetMonitoringServiceConfiguration implements AdminCommand {
         AMXConfiguration amxConfiguration = config.getExtensionByType(AMXConfiguration.class);
 
         final ActionReport actionReport = context.getActionReport();
-        final String[] headers= {"Enabled", "AMX Enabled", "MBeans Enabled"};
+        final String[] headers= {"Monitoring Enabled", "AMX Enabled", "MBeans Enabled", "DTrace Enabled"};
 
         ColumnFormatter columnFormatter = new ColumnFormatter(headers);
-        columnFormatter.addRow(new Object[]{monitoringService.getMonitoringEnabled(), amxConfiguration.getEnabled(), monitoringService.getMbeanEnabled()});
+        columnFormatter.addRow(new Object[]{monitoringService.getMonitoringEnabled(), amxConfiguration.getEnabled(), 
+            monitoringService.getMbeanEnabled(), monitoringService.getDtraceEnabled()});
         actionReport.appendMessage(columnFormatter.toString());
 
         Map<String, Object> extraPropertiesMap = new HashMap<>();
-        extraPropertiesMap.put("enabled", monitoringService.getMonitoringEnabled());
+        extraPropertiesMap.put("monitoringEnabled", monitoringService.getMonitoringEnabled());
         extraPropertiesMap.put("amxEnabled", amxConfiguration.getEnabled());
-        extraPropertiesMap.put("mbeansEnabled", monitoringService.getMbeanEnabled());
+        extraPropertiesMap.put("mbeanEnabled", monitoringService.getMbeanEnabled());
+        extraPropertiesMap.put("dtraceEnabled", monitoringService.getDtraceEnabled());
 
         Properties extraProperties = new Properties();
         extraProperties.put("getMonitoringServiceConfiguration", extraPropertiesMap);

--- a/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/SetMonitoringLevel.java
+++ b/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/SetMonitoringLevel.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -96,7 +96,7 @@ public class SetMonitoringLevel implements AdminCommand {
     private String moduleNames;
 
     @Param(name = "level", optional = false)
-    private String moduleMonitoringLevel;
+    private String moduleMonitoringLevels;
 
     @Inject
     private Target targetUtil;
@@ -118,9 +118,11 @@ public class SetMonitoringLevel implements AdminCommand {
             actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
         }
 
-        if (moduleNames != null && moduleMonitoringLevel != null) {
-            List<String> moduleNameList = Arrays.asList(moduleNames.split(","));
-            List<String> moduleLevelList = Arrays.asList(moduleMonitoringLevel.split(","));
+        if (moduleNames != null && moduleMonitoringLevels != null) {
+            String modifiedModuleNames = moduleNames.replace(":", ",");
+            String modifiedModuleMonitoringLevels = moduleMonitoringLevels.replace(":", ",");
+            List<String> moduleNameList = Arrays.asList(modifiedModuleNames.split(","));
+            List<String> moduleLevelList = Arrays.asList(modifiedModuleMonitoringLevels.split(","));
 
             if (moduleNameList.size() == moduleLevelList.size()) {
                 for (int i = 0; i < moduleLevelList.size(); i++) {
@@ -128,7 +130,7 @@ public class SetMonitoringLevel implements AdminCommand {
                     List<String> validModuleList = new ArrayList<>(Arrays.asList(Constants.validModuleNames));
                     String moduleName = moduleNameList.get(i).trim().toLowerCase();
                     for (String module : validModuleList) {
-                        if (module.trim().equals(moduleName)) {
+                        if (module.trim().equalsIgnoreCase(moduleName)) {
                             String moduleLevel = moduleLevelList.get(i).trim().toUpperCase();
                             try {
                                 ConfigSupport.apply(new SingleConfigCode<MonitoringService>() {

--- a/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/SetMonitoringServiceConfiguration.java
+++ b/nucleus/admin/monitor/src/main/java/fish/payara/admin/monitor/cli/SetMonitoringServiceConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -87,17 +87,25 @@ import org.jvnet.hk2.config.TransactionFailure;
 })
 public class SetMonitoringServiceConfiguration implements AdminCommand {
 
-    @Param(name = "enabled", optional = true)
-    private Boolean enabled;
+    @Param(name = "enabled", optional = true, alias = "monitoringEnabled")
+    private Boolean monitoringEnabled;
 
     @Param(name = "target", optional = true, defaultValue = SystemPropertyConstants.DAS_SERVER_NAME)
     String target;
 
-    @Param(name = "mbeansenabled", optional = true, alias = "mbeansEnabled")
-    private Boolean mbeansEnabled;
+    @Param(name = "mbeansenabled", optional = true, alias = "mbeanEnabled")
+    private Boolean mbeanEnabled;
 
+    /**
+     *
+     * @deprecated Since 5.194. Use set-amx-enabled command instead.
+     */
+    @Deprecated
     @Param(name = "amxenabled", optional = true, alias = "amxEnabled")
     private Boolean amxEnabled;
+
+    @Param(name = "dtraceenabled", optional = true, alias = "dtraceEnabled")
+    private Boolean dtraceEnabled;
 
     @Inject
     protected Target targetUtil;
@@ -128,12 +136,16 @@ public class SetMonitoringServiceConfiguration implements AdminCommand {
             ConfigSupport.apply(new SingleConfigCode<MonitoringService>() {
                 @Override
                 public Object run(final MonitoringService monitoringServiceProxy) throws PropertyVetoException, TransactionFailure {
-                    if (enabled != null) {
-                        monitoringServiceProxy.setMonitoringEnabled(String.valueOf(enabled));
+                    if (monitoringEnabled != null) {
+                        monitoringServiceProxy.setMonitoringEnabled(String.valueOf(monitoringEnabled));
                     }
 
-                    if (mbeansEnabled != null) {
-                        monitoringServiceProxy.setMbeanEnabled(String.valueOf(mbeansEnabled));
+                    if (mbeanEnabled != null) {
+                        monitoringServiceProxy.setMbeanEnabled(String.valueOf(mbeanEnabled));
+                    }
+                    
+                    if (dtraceEnabled != null) {
+                         monitoringServiceProxy.setDtraceEnabled(String.valueOf(dtraceEnabled));
                     }
 
                     if (amxEnabled != null) {

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -43,14 +43,6 @@
 
 package com.sun.enterprise.admin.cli.cluster;
 
-import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
-
-import java.io.File;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.logging.Level;
-
 import com.sun.enterprise.admin.cli.CLIConstants;
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.admin.servermgmt.KeystoreManager;
@@ -60,7 +52,13 @@ import com.sun.enterprise.universal.glassfish.TokenResolver;
 import com.sun.enterprise.util.OS;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.io.FileUtils;
-
+import fish.payara.admin.cli.cluster.NamingHelper;
+import fish.payara.util.cluster.PayaraServerNameGenerator;
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.logging.Level;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
@@ -70,8 +68,7 @@ import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.security.common.FileProtectionUtility;
 import org.jvnet.hk2.annotations.Service;
 
-import fish.payara.admin.cli.cluster.NamingHelper;
-import fish.payara.util.cluster.PayaraServerNameGenerator;
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 
 
 /**
@@ -86,12 +83,16 @@ import fish.payara.util.cluster.PayaraServerNameGenerator;
 public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesystemCommand {
     private static final String CONFIG = "config";
     private static final String CLUSTER = "cluster";
+    private static final String DEPLOYMENT_GROUP = "deploymentGroup";
 
     @Param(name = CONFIG, optional = true)
     private String configName;
 
     @Param(name = CLUSTER, optional = true)
     private String clusterName;
+    
+    @Param(name = DEPLOYMENT_GROUP, optional = true)
+    private String deploymentGroup;
 
     @Param(name="lbenabled", optional = true)
     private Boolean lbEnabled;
@@ -350,6 +351,10 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
         if (clusterName != null) {
             argsList.add("--cluster");
             argsList.add(clusterName);
+        }
+        if (deploymentGroup != null) {
+            argsList.add("--deploymentgroup");
+            argsList.add(deploymentGroup);
         }
         if (lbEnabled != null) {
             argsList.add("--lbenabled");

--- a/nucleus/common/amx-core/src/main/java/fish/payara/admin/amx/AMXBootService.java
+++ b/nucleus/common/amx-core/src/main/java/fish/payara/admin/amx/AMXBootService.java
@@ -72,6 +72,7 @@ public class AMXBootService implements ConfigListener {
     ServiceLocator habitat;
     
     private boolean enabled;
+    private boolean dynamic;
     
     @PostConstruct
     public void postConstruct(){
@@ -87,32 +88,27 @@ public class AMXBootService implements ConfigListener {
         bootAMX.bootAMX();
     }
     
-    public void setEnabled(boolean enabled){
+    public void setEnabled(boolean enabled, boolean dynamic) {
         this.enabled = enabled;
-        if (enabled){
+        this.dynamic = dynamic;
+        if (enabled && dynamic) {
             startup();
-        }   
+        }
     }
 
     @Override
     public UnprocessedChangeEvents changed(PropertyChangeEvent[] events) {
         UnprocessedChangeEvents unchanged = null;
-        for (PropertyChangeEvent event: events){
-            if (event.getPropertyName().contains("enabled")){
+
+        for (PropertyChangeEvent event : events) {
+            if (event.getPropertyName().contains("enabled")) {
                 String change = (String) event.getNewValue();
-                if (change.equalsIgnoreCase("false")){
-                    unchanged = new UnprocessedChangeEvents(new UnprocessedChangeEvent(event, "Unable to stop AMX dynamically"));
-                } else if (change.equalsIgnoreCase("true")){
-                    setEnabled(true);
-                } else {
-                    throw new IllegalArgumentException("Not boolean change" + event.toString());
+                if (change.equalsIgnoreCase("false") && dynamic) {
+                    unchanged = new UnprocessedChangeEvents(new UnprocessedChangeEvent(event, "AMX can't be disabled dynamically."));
                 }
             }
         }
 
         return unchanged;
     }
-    
-    
-    
 }

--- a/nucleus/common/amx-core/src/main/java/fish/payara/admin/amx/cli/SetAmxEnabled.java
+++ b/nucleus/common/amx-core/src/main/java/fish/payara/admin/amx/cli/SetAmxEnabled.java
@@ -84,7 +84,7 @@ import static org.glassfish.config.support.CommandTarget.STANDALONE_INSTANCE;
  */
 @Service(name = "set-amx-enabled")
 @PerLookup
-@ExecuteOn({RuntimeType.DAS})
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
 @TargetType({DAS, DEPLOYMENT_GROUP, STANDALONE_INSTANCE, CLUSTER, CLUSTERED_INSTANCE, CONFIG})
 @RestEndpoints({
     @RestEndpoint(configBean = Domain.class,

--- a/nucleus/common/amx-core/src/main/java/fish/payara/admin/amx/cli/SetAmxEnabled.java
+++ b/nucleus/common/amx-core/src/main/java/fish/payara/admin/amx/cli/SetAmxEnabled.java
@@ -43,6 +43,7 @@
 package fish.payara.admin.amx.cli;
 
 import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.config.serverbeans.Domain;
 import fish.payara.admin.amx.AMXBootService;
 import fish.payara.admin.amx.config.AMXConfiguration;
 import java.beans.PropertyVetoException;
@@ -58,12 +59,6 @@ import org.glassfish.api.admin.ExecuteOn;
 import org.glassfish.api.admin.RestEndpoint;
 import org.glassfish.api.admin.RestEndpoints;
 import org.glassfish.api.admin.RuntimeType;
-import static org.glassfish.config.support.CommandTarget.CLUSTER;
-import static org.glassfish.config.support.CommandTarget.CLUSTERED_INSTANCE;
-import static org.glassfish.config.support.CommandTarget.CONFIG;
-import static org.glassfish.config.support.CommandTarget.DAS;
-import static org.glassfish.config.support.CommandTarget.DEPLOYMENT_GROUP;
-import static org.glassfish.config.support.CommandTarget.STANDALONE_INSTANCE;
 import org.glassfish.config.support.TargetType;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -72,6 +67,13 @@ import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.SingleConfigCode;
 import org.jvnet.hk2.config.TransactionFailure;
+
+import static org.glassfish.config.support.CommandTarget.CLUSTER;
+import static org.glassfish.config.support.CommandTarget.CLUSTERED_INSTANCE;
+import static org.glassfish.config.support.CommandTarget.CONFIG;
+import static org.glassfish.config.support.CommandTarget.DAS;
+import static org.glassfish.config.support.CommandTarget.DEPLOYMENT_GROUP;
+import static org.glassfish.config.support.CommandTarget.STANDALONE_INSTANCE;
 
 /**
  * Comment to enable AMX, as separate from JMX.
@@ -82,10 +84,10 @@ import org.jvnet.hk2.config.TransactionFailure;
  */
 @Service(name = "set-amx-enabled")
 @PerLookup
-@ExecuteOn({RuntimeType.ALL})
+@ExecuteOn({RuntimeType.DAS})
 @TargetType({DAS, DEPLOYMENT_GROUP, STANDALONE_INSTANCE, CLUSTER, CLUSTERED_INSTANCE, CONFIG})
 @RestEndpoints({
-    @RestEndpoint(configBean = AMXConfiguration.class,
+    @RestEndpoint(configBean = Domain.class,
             opType = RestEndpoint.OpType.POST,
             path = "set-amx-enabled",
             description = "Sets whether AMX in enabled")
@@ -94,10 +96,10 @@ public class SetAmxEnabled implements AdminCommand {
 
     private static final Logger LOGGER = AMXLoggerInfo.getLogger();
 
-    @Param(name = "enabled", optional = false, primary = true, defaultValue = "true")
+    @Param(name = "enabled", optional = true, defaultValue = "true")
     Boolean enabled;
 
-    @Param(name = "dynamic", optional = false, defaultValue = "true")
+    @Param(name = "dynamic", optional = true, defaultValue = "true")
     private Boolean dynamic;
 
     @Param(name="target", optional = true, defaultValue = "server-config")
@@ -126,10 +128,8 @@ public class SetAmxEnabled implements AdminCommand {
                 }
             }, metricsConfiguration);
 
-            if (dynamic) {
-                AMXBootService bootService = habitat.getService(AMXBootService.class);
-                bootService.setEnabled(enabled);
-            }
+            AMXBootService bootService = habitat.getService(AMXBootService.class);
+            bootService.setEnabled(enabled, dynamic);
 
         } catch (TransactionFailure ex) {
             LOGGER.log(Level.WARNING, "Exception during command set-amx-enabled: {0}", ex.getCause().getMessage());


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix to an issue where monitoring data of an Instance was not visible if it was in a Deployment Group.

# Important Info
Although the issue was identified because of the monitoring issue, the underlying issue was caused by a command not being replicated to the instances in a deployment group. 

# Testing
Created a deployment group with an instance, enabled the monitoring service and checked if the monitoring data is available. 

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Documentation
No required
