### PR TITLE
Return minor version for snapshot versions of servers

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
@@ -211,7 +211,7 @@ public class Version {
      * Returns Minor version
      */
     public static String getMinorVersion() {
-        return getProperty(MINOR_VERSION_KEY, "0");
+        return getProperty(MINOR_VERSION_KEY, "0").replace("-SNAPSHOT","");
     }
 
     /**


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

Invoking `asadmin version` or reaching version endpoint returned only major version, when product was in snapshot:

`Version = Payara Server  5 #badassfish (build ${build.number})`

After the change it also reports

`Version = Payara Server  5.194 #badassfish (build ${build.number})`

The change was done during exploring posibilities of server management from inside Arquillian tests, with one of the goals of recognizing server version without additional property.

Version parsing in `Version` failed on snapshot versions, causing only major number to be reported, which is quite useless.

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Important Info

### Dependant PRs <!-- delete as applicable -->
<!--- Link any related or dependant PRs here with brief description why -->

### Blockers <!-- delete as applicable -->
<!-- Detail any blockers with links/info -->

# Testing

### Testing Performed
`asadmin version` and on build result
`curl -H 'Requested-By: me' -H "Accept: application/json" http://localhost:4848/management/domain/version`
```
{"message":"Payara Server  5.194 #badassfish (build ${build.number})",
"command":"version AdminCommand",
"exit_code":"SUCCESS",
"extraProperties":{
    "version":"Payara Server  5.194 #badassfish",
    "methods":[
      {"name":"GET"},
      {"messageParameters":{
        "verbose":{
          "acceptableValues":"",
          "defaultValue":"false",
          "optional":"true",
          "type":"boolean"}}}],
    "version-number":"5.194",
    "full-version":"Payara Server  5.194 #badassfish (build ${build.number})",
    "commandLog":["version"]}}
```


### Test suites executed
* unit tests

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

Zulu 1.8.0_222, Windows 10, Maven 3.6.2
