### PR TITLE
PAYARA-4174 MP Metrics in web profile do not throw an exception on custom metrics

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/ACLSingletonProvider.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/ACLSingletonProvider.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2018] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2019] Payara Foundation and/or affiliates
  */
 
 package org.glassfish.weld;
@@ -45,7 +45,6 @@ package org.glassfish.weld;
 import org.glassfish.web.loader.WebappClassLoader;
 import org.jboss.weld.bootstrap.api.SingletonProvider;
 import org.jboss.weld.bootstrap.api.Singleton;
-import org.glassfish.javaee.full.deployment.EarLibClassLoader;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.api.ClassLoaderHierarchy;
 
@@ -163,10 +162,7 @@ public class ACLSingletonProvider extends SingletonProvider
         // There are exceptions like hybrid app to this rule.
         // So, we have to walk upto bootstrapCL in worst case.
         while (cl != ccl && cl != bootstrapCL) {
-          if (cl instanceof EarLibClassLoader) {
-//                    System.out.println("ACLSingletonProvider.getClassLoader():\n" +
-//                            "Application Class Loader = [ " + cl + "],\n" +
-//                            "Thread Context Class Loader = [" + tccl + "]");
+          if (cl.getClass().getName().equals("org.glassfish.javaee.full.deployment.EarLibClassLoader")) {
             return cl;
           } else {
             if (cl instanceof WebappClassLoader) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/util/Util.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/util/Util.java
@@ -98,16 +98,10 @@ public class Util {
     /**
      * Starts the singleton provider for weld.
      * <p>
-     * This will be {@link ACLSingletonProvider} if there is ear support, otherwise {@link TCCLSingletonProvider}
+     * This will be {@link ACLSingletonProvider}
      */
     public static void initializeWeldSingletonProvider() {
-      boolean earSupport = false;
-      try {
-          Class.forName("org.glassfish.javaee.full.deployment.EarClassLoader");
-          earSupport = true;
-      } catch (ClassNotFoundException ignore) {
-      }
-      SingletonProvider.initialize(earSupport ? new ACLSingletonProvider() : new TCCLSingletonProvider());
+        SingletonProvider.initialize(new ACLSingletonProvider());
     }
 
 }


### PR DESCRIPTION
# Description

This is a bug fix .

The /metrics endpoint is loaded as default-web-module which is a different context to the
user's application. In Web profile previously TCCLSingleton is used to hold the classloader,
which does not allow cross-application sharing. In Full profile, and now Web, ACLSingleton
is used which while is has separate classloader for each application does allow
cross-application communication and sharing of metrics.

# Important Info

# Testing

### Testing Performed
Used reproducer in Jira, throws an error in Payara Micro and Payara Web before this PR when going to /metrics and not afterwards.

### Test suites executed
- Payara Private Tests
- Payara Microprofile TCKs Runner

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.0"-->
