### PR TITLE
PAYARA-4253 PAYARA-4060: Replace remaining JAVA EE api artifacts with Jakarta EE's

### DIFF
--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -174,8 +174,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -81,9 +81,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-api</artifactId>
-                <version>${javaee.api.version}</version>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
+                <version>${jakartaee.api.version}</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>

--- a/appserver/admin/admin-core/pom.xml
+++ b/appserver/admin/admin-core/pom.xml
@@ -79,7 +79,7 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
+                <artifactId>jakarta.el</artifactId>
             </dependency>
     </dependencies>
 

--- a/appserver/admin/admin-core/pom.xml
+++ b/appserver/admin/admin-core/pom.xml
@@ -74,8 +74,8 @@
             <scope>test</scope>
         </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>

--- a/appserver/admin/gf_template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/default-web.xml
@@ -317,10 +317,10 @@
       <param-value>
         /lib/
         \lib\
-        javax.el.jar
-        javax.servlet-api.jar
-        javax.servlet.jsp-api.jar
-        javax.servlet.jsp.jstl-api.jar
+        jakarta.el.jar
+        jakarta.servlet-api.jar
+        jakarta.servlet.jsp-api.jar
+        jakarta.servlet.jsp.jstl-api.jar
         javax.servlet.jsp.jstl.jar
         jakarta.jms-api.jar
         jakarta.faces.jar
@@ -328,16 +328,16 @@
         jspcaching-connector.jar
         web-glue.jar
         hibernate-validator.jar
-        jakarta.ejb.jar
-        javax.enterprise.deploy-api.jar
+        jakarta.ejb-api.jar
+        jakarta.enterprise.deploy-api.jar
         jakarta.mail.jar
-        javax.management.j2ee-api.jar
+        jakarta.management.j2ee-api.jar
         jakarta.persistence.jar
-        javax.resource-api.jar
-        javax.security.auth.message.jar
-        javax.security.jacc.jar
+        jakarta.resource-api.jar
+        jakarta.security.auth.message-api.jar
+        jakarta.security.jacc-api.jar
         jakarta.transaction-api.jar
-        javax.xml.rpc-api.jar
+        jakarta.xml.rpc-api.jar
         webservices-osgi.jar
         weld-osgi-bundle.jar
         jersey-mvc-jsp.jar

--- a/appserver/admin/gf_template_web/src/main/resources/config/default-web.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/default-web.xml
@@ -314,10 +314,10 @@
       <param-value>
         /lib/
         \lib\
-        javax.el.jar
-        javax.servlet-api.jar
-        javax.servlet.jsp-api.jar
-        javax.servlet.jsp.jstl-api.jar
+        jakarta.el.jar
+        jakarta.servlet-api.jar
+        jakarta.servlet.jsp-api.jar
+        jakarta.servlet.jsp.jstl-api.jar
         javax.servlet.jsp.jstl.jar
         jakarta.jms-api.jar
         jakarta.faces.jar
@@ -325,16 +325,16 @@
         jspcaching-connector.jar
         web-glue.jar
         bean-validator.jar
-        jakarta.ejb.jar
-        javax.enterprise.deploy-api.jar
+        jakarta.ejb-api.jar
+        jakarta.enterprise.deploy-api.jar
         jakarta.mail.jar
-        javax.management.j2ee-api.jar
+        jakarta.management.j2ee-api.jar
         jakarta.persistence.jar
-        javax.resource-api.jar
-        javax.security.auth.message.jar
-        javax.security.jacc.jar
+        jakarta.resource-api.jar
+        jakarta.security.auth.message-api.jar
+        jakarta.security.jacc-api.jar
         jakarta.transaction-api.jar
-        javax.xml.rpc-api.jar
+        jakarta.xml.rpc-api.jar
         webservices-osgi.jar
         weld-osgi-bundle.jar
         jersey-mvc-jsp.jar

--- a/appserver/admin/production_domain_template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/default-web.xml
@@ -299,10 +299,10 @@
       <param-value>
         /lib/
         \lib\
-        javax.el.jar
-        javax.servlet-api.jar
-        javax.servlet.jsp-api.jar
-        javax.servlet.jsp.jstl-api.jar
+        jakarta.el.jar
+        jakarta.servlet-api.jar
+        jakarta.servlet.jsp-api.jar
+        jakarta.servlet.jsp.jstl-api.jar
         javax.servlet.jsp.jstl.jar
         jakarta.jms-api.jar
         jakarta.faces.jar
@@ -310,16 +310,16 @@
         jspcaching-connector.jar
         web-glue.jar
         hibernate-validator.jar
-        jakarta.ejb.jar
-        javax.enterprise.deploy-api.jar
+        jakarta.ejb-api.jar
+        jakarta.enterprise.deploy-api.jar
         jakarta.mail.jar
-        javax.management.j2ee-api.jar
+        jakarta.management.j2ee-api.jar
         jakarta.persistence.jar
-        javax.resource-api.jar
-        javax.security.auth.message.jar
-        javax.security.jacc.jar
+        jakarta.resource-api.jar
+        jakarta.security.auth.message-api.jar
+        jakarta.security.jacc-api.jar
         jakarta.transaction-api.jar
-        javax.xml.rpc-api.jar
+        jakarta.xml.rpc-api.jar
         webservices-osgi.jar
         weld-osgi-bundle.jar
         jersey-mvc-jsp.jar

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/default-web.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/default-web.xml
@@ -323,10 +323,10 @@
       <param-value>
         /lib/
         \lib\
-        javax.el.jar
-        javax.servlet-api.jar
-        javax.servlet.jsp-api.jar
-        javax.servlet.jsp.jstl-api.jar
+        jakarta.el.jar
+        jakarta.servlet-api.jar
+        jakarta.servlet.jsp-api.jar
+        jakarta.servlet.jsp.jstl-api.jar
         javax.servlet.jsp.jstl.jar
         jakarta.jms-api.jar
         jakarta.faces.jar
@@ -334,16 +334,16 @@
         jspcaching-connector.jar
         web-glue.jar
         bean-validator.jar
-        jakarta.ejb.jar
-        javax.enterprise.deploy-api.jar
+        jakarta.ejb-api.jar
+        jakarta.enterprise.deploy-api.jar
         jakarta.mail.jar
-        javax.management.j2ee-api.jar
+        jakarta.management.j2ee-api.jar
         jakarta.persistence.jar
-        javax.resource-api.jar
-        javax.security.auth.message.jar
-        javax.security.jacc.jar
+        jakarta.resource-api.jar
+        jakarta.security.auth.message-api.jar
+        jakarta.security.jacc-api.jar
         jakarta.transaction-api.jar
-        javax.xml.rpc-api.jar
+        jakarta.xml.rpc-api.jar
         webservices-osgi.jar
         weld-osgi-bundle.jar
         jersey-mvc-jsp.jar

--- a/appserver/admin/runtime/jsr77/pom.xml
+++ b/appserver/admin/runtime/jsr77/pom.xml
@@ -55,8 +55,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.management.j2ee</groupId>
-            <artifactId>javax.management.j2ee-api</artifactId>
+            <groupId>jakarta.management.j2ee</groupId>
+            <artifactId>jakarta.management.j2ee-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.deployment</groupId>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -120,7 +120,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -100,8 +100,8 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -115,8 +115,8 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -71,7 +71,7 @@
                             <archive>
                                 <manifestEntries>
                                     <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
-                                    <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client  </HK2-Import-Bundles>
+                                    <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, jakarta.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client  </HK2-Import-Bundles>
                                 </manifestEntries>
                             </archive>
                         </configuration>
@@ -98,7 +98,7 @@
                                <jar jarfile="target/admingui.war" basedir="target/temp">
                                     <manifest>
                                       <attribute name="Glassfish-require-services" value="org.glassfish.api.admingui.ConsoleProvider" />
-                                      <attribute name="HK2-Import-Bundles" value="fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client " />
+                                      <attribute name="HK2-Import-Bundles" value="fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, jakarta.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client " />
                                     </manifest>
                                 </jar>
                                 <delete dir="target/temp" />

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -71,7 +71,7 @@
                             <archive>
                                 <manifestEntries>
                                     <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
-                                    <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, jakarta.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client  </HK2-Import-Bundles>
+                                    <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client  </HK2-Import-Bundles>
                                 </manifestEntries>
                             </archive>
                         </configuration>
@@ -98,7 +98,7 @@
                                <jar jarfile="target/admingui.war" basedir="target/temp">
                                     <manifest>
                                       <attribute name="Glassfish-require-services" value="org.glassfish.api.admingui.ConsoleProvider" />
-                                      <attribute name="HK2-Import-Bundles" value="fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, jakarta.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client " />
+                                      <attribute name="HK2-Import-Bundles" value="fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client, jakarta.servlet-api, javax.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, fish.payara.server.internal.admingui.dataprovider, com.sun.pkg.client " />
                                     </manifest>
                                 </jar>
                                 <delete dir="target/temp" />

--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -390,8 +390,8 @@
      </dependency>
 
      <dependency>
-         <groupId>javax.json.bind</groupId>
-         <artifactId>javax.json.bind-api</artifactId>
+         <groupId>jakarta.json.bind</groupId>
+         <artifactId>jakarta.json.bind-api</artifactId>
      </dependency>
 
      <dependency>
@@ -401,8 +401,8 @@
 
      <!-- JAXR -JSR-93 Support-->
      <dependency>
-         <groupId>javax.xml.registry</groupId>
-         <artifactId>javax.xml.registry-api</artifactId>
+         <groupId>jakarta.xml.registry</groupId>
+         <artifactId>jakarta.xml.registry-api</artifactId>
      </dependency>
 
         <!--
@@ -445,8 +445,8 @@
           <artifactId>weld-se-shaded</artifactId>
       </dependency>
       <dependency>
-          <groupId>javax.enterprise</groupId>
-          <artifactId>cdi-api</artifactId>
+          <groupId>jakarta.enterprise</groupId>
+          <artifactId>jakarta.enterprise.cdi-api</artifactId>
       </dependency>
 
     </dependencies>

--- a/appserver/batch/glassfish-batch-commands/pom.xml
+++ b/appserver/batch/glassfish-batch-commands/pom.xml
@@ -56,8 +56,8 @@
     <name>Batch Commands for Glassfish</name>
     <dependencies>
         <dependency>
-            <groupId>javax.batch</groupId>
-            <artifactId>javax.batch-api</artifactId>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.ibm.jbatch</groupId>

--- a/appserver/batch/glassfish-batch-connector/pom.xml
+++ b/appserver/batch/glassfish-batch-connector/pom.xml
@@ -60,8 +60,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.batch</groupId>
-            <artifactId>javax.batch-api</artifactId>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.ibm.jbatch</groupId>

--- a/appserver/batch/hazelcast-jbatch-store/pom.xml
+++ b/appserver/batch/hazelcast-jbatch-store/pom.xml
@@ -80,8 +80,8 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <artifactId>hazelcast</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.batch</groupId>
-            <artifactId>javax.batch-api</artifactId>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/common/amx-javaee/pom.xml
+++ b/appserver/common/amx-javaee/pom.xml
@@ -74,8 +74,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.management.j2ee</groupId>
-            <artifactId>javax.management.j2ee-api</artifactId>
+            <groupId>jakarta.management.j2ee</groupId>
+            <artifactId>jakarta.management.j2ee-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/common/container-common/pom.xml
+++ b/appserver/common/container-common/pom.xml
@@ -93,8 +93,8 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/common/mejb/pom.xml
+++ b/appserver/common/mejb/pom.xml
@@ -68,8 +68,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.management.j2ee</groupId>
-            <artifactId>javax.management.j2ee-api</artifactId>
+            <groupId>jakarta.management.j2ee</groupId>
+            <artifactId>jakarta.management.j2ee-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/appserver/common/stats77/pom.xml
+++ b/appserver/common/stats77/pom.xml
@@ -74,8 +74,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.management.j2ee</groupId>
-            <artifactId>javax.management.j2ee-api</artifactId>
+            <groupId>jakarta.management.j2ee</groupId>
+            <artifactId>jakarta.management.j2ee-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -111,8 +111,8 @@
             <optional>true</optional>
         </dependency>
        <dependency>
-            <groupId>javax.enterprise.concurrent</groupId>
-            <artifactId>javax.enterprise.concurrent-api</artifactId>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
         </dependency>
        <dependency>
             <groupId>org.glassfish</groupId>

--- a/appserver/connectors/connectors-runtime/pom.xml
+++ b/appserver/connectors/connectors-runtime/pom.xml
@@ -200,8 +200,8 @@
 	    <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-	    <groupId>javax.interceptor</groupId>
-	    <artifactId>javax.interceptor-api</artifactId>
+	    <groupId>jakarta.interceptor</groupId>
+	    <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/deployment/client/pom.xml
+++ b/appserver/deployment/client/pom.xml
@@ -97,8 +97,8 @@
             <version>${project.version}</version>
         </dependency>   
         <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.deployment</groupId>

--- a/appserver/deployment/dol/pom.xml
+++ b/appserver/deployment/dol/pom.xml
@@ -119,16 +119,16 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/appserver/deployment/javaee-core/pom.xml
+++ b/appserver/deployment/javaee-core/pom.xml
@@ -99,8 +99,8 @@
 
     <dependencies>
        <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>

--- a/appserver/deployment/javaee-full/pom.xml
+++ b/appserver/deployment/javaee-full/pom.xml
@@ -88,8 +88,8 @@
 
     <dependencies>
        <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>

--- a/appserver/ejb/ejb-connector/pom.xml
+++ b/appserver/ejb/ejb-connector/pom.xml
@@ -90,8 +90,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -238,8 +238,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/ejb/ejb-http-remoting/admin/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/admin/pom.xml
@@ -74,9 +74,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.deployment</groupId>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -194,8 +194,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse</groupId>

--- a/appserver/ejb/ejb-http-remoting/endpoint/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/endpoint/pom.xml
@@ -66,8 +66,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/ejb/ejb-internal-api/pom.xml
+++ b/appserver/ejb/ejb-internal-api/pom.xml
@@ -99,8 +99,8 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
 	<dependency>
-	    <groupId>javax.interceptor</groupId>
-	    <artifactId>javax.interceptor-api</artifactId>
+	    <groupId>jakarta.interceptor</groupId>
+	    <artifactId>jakarta.interceptor-api</artifactId>
 	</dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>

--- a/appserver/extras/payara-micro/payara-micro-boot/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/pom.xml
@@ -70,9 +70,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/grizzly/grizzly-container/pom.xml
+++ b/appserver/grizzly/grizzly-container/pom.xml
@@ -82,8 +82,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/jdbc/jdbc-runtime/pom.xml
+++ b/appserver/jdbc/jdbc-runtime/pom.xml
@@ -98,7 +98,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
        

--- a/appserver/monitoring-console/core/pom.xml
+++ b/appserver/monitoring-console/core/pom.xml
@@ -80,9 +80,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/monitoring-console/webapp/pom.xml
+++ b/appserver/monitoring-console/webapp/pom.xml
@@ -74,8 +74,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -89,9 +89,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/orb/orb-connector/pom.xml
+++ b/appserver/orb/orb-connector/pom.xml
@@ -99,8 +99,8 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
         </dependency>
        <dependency>
             <groupId>fish.payara.server.internal.deployment</groupId>

--- a/appserver/packager/glassfish-common-full/pom.xml
+++ b/appserver/packager/glassfish-common-full/pom.xml
@@ -175,8 +175,8 @@
            <type>zip</type>
        </dependency>
         <dependency>
-            <groupId>javax.batch</groupId>
-            <artifactId>javax.batch-api</artifactId>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.batch</groupId>
@@ -190,8 +190,8 @@
          -->
 
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>  
     </dependencies>
 </project>

--- a/appserver/packager/glassfish-common-web/pom.xml
+++ b/appserver/packager/glassfish-common-web/pom.xml
@@ -309,8 +309,8 @@
             <artifactId>jakarta.resource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.management.j2ee</groupId>
-            <artifactId>javax.management.j2ee-api</artifactId>
+            <groupId>jakarta.management.j2ee</groupId>
+            <artifactId>jakarta.management.j2ee-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.security.auth.message</groupId>
@@ -342,8 +342,8 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/appserver/packager/glassfish-common/pom.xml
+++ b/appserver/packager/glassfish-common/pom.xml
@@ -156,8 +156,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise.deploy</groupId>
-            <artifactId>javax.enterprise.deploy-api</artifactId>
+            <groupId>jakarta.enterprise.deploy</groupId>
+            <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
            <groupId>fish.payara.server.internal.admingui</groupId>
@@ -175,8 +175,8 @@
            <version>${project.version}</version>
        </dependency> 
        <dependency>
-            <groupId>javax.enterprise.concurrent</groupId>
-            <artifactId>javax.enterprise.concurrent-api</artifactId>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
         </dependency>
        <dependency>
             <groupId>org.glassfish</groupId>

--- a/appserver/packager/glassfish-jcdi/pom.xml
+++ b/appserver/packager/glassfish-jcdi/pom.xml
@@ -127,8 +127,8 @@
     <dependencies>
         <!-- API -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         
         <!-- Weld implementation and direct dependencies -->

--- a/appserver/packager/glassfish-web/pom.xml
+++ b/appserver/packager/glassfish-web/pom.xml
@@ -259,7 +259,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>

--- a/appserver/packager/glassfish-web/pom.xml
+++ b/appserver/packager/glassfish-web/pom.xml
@@ -133,8 +133,8 @@
                      Required in Payara 5, but optional for JDK 8+ builds in Payara 4
                 -->
                 <dependency>
-                    <groupId>javax.security.enterprise</groupId>
-                    <artifactId>javax.security.enterprise-api</artifactId>
+                    <groupId>jakarta.security.enterprise</groupId>
+                    <artifactId>jakarta.security.enterprise-api</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish.soteria</groupId>
@@ -231,16 +231,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.servlet.jsp</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
@@ -249,8 +249,8 @@
 
         <!-- Java EE Security -->
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
@@ -262,8 +262,8 @@
             <artifactId>javax.el</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>

--- a/appserver/packager/json/pom.xml
+++ b/appserver/packager/json/pom.xml
@@ -134,8 +134,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/packager/metro/pom.xml
+++ b/appserver/packager/metro/pom.xml
@@ -192,8 +192,8 @@
             <artifactId>stax2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.registry</groupId>
-            <artifactId>javax.xml.registry-api</artifactId>
+            <groupId>jakarta.xml.registry</groupId>
+            <artifactId>jakarta.xml.registry-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
@@ -95,13 +95,13 @@
             <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.soteria</groupId>

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/pom.xml
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/pom.xml
@@ -75,9 +75,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/jaspic-servlet-utils/pom.xml
+++ b/appserver/payara-appserver-modules/jaspic-servlet-utils/pom.xml
@@ -65,9 +65,9 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/config/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/config/pom.xml
@@ -74,8 +74,8 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -89,9 +89,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
@@ -94,9 +94,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
@@ -86,14 +86,14 @@
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
         </dependency>
         
         <dependency>

--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -107,9 +107,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/microprofile-common/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-common/pom.xml
@@ -73,9 +73,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
@@ -94,9 +94,9 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/appserver/payara-appserver-modules/microprofile/opentracing-jaxws/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/opentracing-jaxws/pom.xml
@@ -61,9 +61,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/appserver/payara-appserver-modules/notification-datadog-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-datadog-core/pom.xml
@@ -57,9 +57,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/notification-email-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-email-core/pom.xml
@@ -60,9 +60,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/notification-hipchat-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-hipchat-core/pom.xml
@@ -59,9 +59,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/appserver/payara-appserver-modules/notification-jms-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-jms-core/pom.xml
@@ -59,9 +59,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/notification-newrelic-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-newrelic-core/pom.xml
@@ -57,9 +57,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/notification-slack-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-slack-core/pom.xml
@@ -59,9 +59,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/notification-xmpp-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/pom.xml
@@ -57,9 +57,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/appserver/payara-appserver-modules/opentracing-cdi/pom.xml
+++ b/appserver/payara-appserver-modules/opentracing-cdi/pom.xml
@@ -59,9 +59,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/payara-jsr107/pom.xml
+++ b/appserver/payara-appserver-modules/payara-jsr107/pom.xml
@@ -98,9 +98,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.api</groupId>

--- a/appserver/payara-appserver-modules/payara-micro-cdi/pom.xml
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/pom.xml
@@ -83,9 +83,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.api</groupId>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/pom.xml
@@ -66,9 +66,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/security-oauth2/pom.xml
+++ b/appserver/payara-appserver-modules/security-oauth2/pom.xml
@@ -69,8 +69,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -91,13 +91,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/payara-appserver-modules/security-openid/pom.xml
+++ b/appserver/payara-appserver-modules/security-openid/pom.xml
@@ -76,8 +76,8 @@
         </dependency>
         
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -96,14 +96,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>8.0</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
+++ b/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
@@ -90,9 +90,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -64,11 +64,11 @@
         <jakarta.ejb-api.version>3.2.5</jakarta.ejb-api.version>
 
         <!-- JSP -->
-        <jsp-api.version>2.3.3</jsp-api.version>
+        <jsp-api.version>2.3.6</jsp-api.version>
         <jsp-impl.version>2.3.4</jsp-impl.version>
 
         <!-- JSTL -->
-        <jstl-api.version>1.2.2</jstl-api.version>
+        <jstl-api.version>1.2.7</jstl-api.version>
         <jstl-impl.version>1.2.5</jstl-impl.version>
 
         <!-- JSF -->
@@ -77,14 +77,14 @@
         <mojarra.version>2.3.9.payara-p3</mojarra.version>
 
         <!-- WebSocket -->
-        <websocket-api.version>1.1</websocket-api.version>
+        <websocket-api.version>1.1.2</websocket-api.version>
         <tyrus.version>1.15</tyrus.version>
 
         <!-- JAX-B -->
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
 
         <!-- JSON-B -->
-        <json.bind-api.version>1.0</json.bind-api.version>
+        <json.bind-api.version>1.0.2</json.bind-api.version>
         <yasson.version>1.0.4.payara-p2</yasson.version>
 
         <!-- JPA -->
@@ -95,15 +95,15 @@
         <jakarta.transaction-api.version>1.3.2</jakarta.transaction-api.version>
 
         <!-- Concurrency -->
-        <concurrent-api.version>1.0</concurrent-api.version>
+        <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.0.payara-p2</concurrent.version>
 
          <!-- Interceptor -->
-        <javax.interceptor-api.version>1.2.1</javax.interceptor-api.version>
+        <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
 
         <!-- CDI -->
-        <javax.inject.version>1</javax.inject.version>
-        <cdi-api.version>2.0.SP1</cdi-api.version>
+        <jakarta.inject.version>1.0</jakarta.inject.version>
+        <cdi-api.version>2.0.2</cdi-api.version>
         <weld.version>3.1.1.Final</weld.version>
         <weld-bundle.version>3.1.1.Final</weld-bundle.version>
         <weld-api.version>3.1.Final</weld-api.version>
@@ -112,14 +112,14 @@
 
         <!-- Java EE Security API -->
         <javax.security.enterprise-spec.version>1.0</javax.security.enterprise-spec.version>
-        <javax.security.enterprise-api.version>1.0</javax.security.enterprise-api.version>
-        <javax.security.enterprise.version>1.1-b01.payara-p3</javax.security.enterprise.version>
+        <javax.security.enterprise-api.version>1.0.2</javax.security.enterprise-api.version>
+        <jakarta.security.enterprise.version>1.1-b01.payara-p3</jakarta.security.enterprise.version>
 
         <!-- JACC -->
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
 
         <!-- JASPIC -->
-        <jakarta.security.auth.message-api.version>1.1.2</jakarta.security.auth.message-api.version>
+        <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
 
         <!-- JMS -->
         <jms-api.version>2.0.2</jms-api.version>
@@ -148,16 +148,16 @@
         <!-- Woodstox Stax2 API is an extension to basic Stax 1.0 API that adds significant functionality -->
         <stax2-api.version>4.1</stax2-api.version>
 
-        <javax.xml.registry-api.version>1.0.7</javax.xml.registry-api.version>
-        <javax.xml.rpc-api.version>1.1.1</javax.xml.rpc-api.version>
+        <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>
+        <jakarta.xml.rpc-api.version>1.1.4</jakarta.xml.rpc-api.version>
 
         <jakarta.resource-api.version>1.7.3</jakarta.resource-api.version>
 
         <!-- Deployment API (JSR 88) (deprecated/pruned) -->
-        <javax.enterprise.deploy-api.version>1.6</javax.enterprise.deploy-api.version>
+        <javax.enterprise.deploy-api.version>1.7.2</javax.enterprise.deploy-api.version>
 
         <!-- Management API (JRS 77) -->
-        <javax.management.j2ee-api.version>1.1.1</javax.management.j2ee-api.version>
+        <javax.management.j2ee-api.version>1.1.4</javax.management.j2ee-api.version>
 
         <!-- JAF -->
         <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>
@@ -296,8 +296,8 @@
                         <!-- JSONB-B -->
                         <spec>
                              <artifact>
-                                 <groupId>javax.json.bind</groupId>
-                                 <artifactId>javax.json.bind-api</artifactId>
+                                 <groupId>jakarta.json.bind</groupId>
+                                 <artifactId>jakarta.json.bind-api</artifactId>
                                  <version>${json.bind-api.version}</version>
                              </artifact>
                              <nonFinal>false</nonFinal>
@@ -341,14 +341,14 @@
                         <!-- Java EE Security API -->
                         <spec>
                             <artifact>
-                                <groupId>javax.security.enterprise</groupId>
-                                <artifactId>javax.security.enterprise-api</artifactId>
+                                <groupId>jakarta.security.enterprise</groupId>
+                                <artifactId>jakarta.security.enterprise-api</artifactId>
                                 <version>${javax.security-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>${javax.security.enterprise-spec.version}</specVersion>
-                            <specImplVersion>${javax.security.enterprise.version}</specImplVersion>
+                            <specImplVersion>${jakarta.security.enterprise.version}</specImplVersion>
                             <apiPackage>javax.security.enterprise</apiPackage>
                             <implNamespace>org.glassfish.soteria</implNamespace>
                         </spec>
@@ -384,8 +384,8 @@
                         <!-- JSTL -->
                         <spec>
                             <artifact>
-                                <groupId>javax.servlet.jsp.jstl</groupId>
-                                <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+                                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
                                 <version>${jstl-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -412,8 +412,8 @@
                         <!-- BATCH -->
                         <spec>
                             <artifact>
-                                <groupId>javax.batch</groupId>
-                                <artifactId>javax.batch-api</artifactId>
+                                <groupId>jakarta.batch</groupId>
+                                <artifactId>jakarta.batch-api</artifactId>
                                 <version>${javax.batch-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -440,8 +440,8 @@
                         <!-- Concurrency Utils -->
                         <spec>
                             <artifact>
-                                <groupId>javax.enterprise.concurrent</groupId>
-                                <artifactId>javax.enterprise.concurrent-api</artifactId>
+                                <groupId>jakarta.enterprise.concurrent</groupId>
+                                <artifactId>jakarta.enterprise.concurrent-api</artifactId>
                                 <version>${concurrent-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -482,8 +482,8 @@
                         <!-- WebSocket -->
                         <spec>
                             <artifact>
-                                <groupId>javax.websocket</groupId>
-                                <artifactId>javax.websocket-api</artifactId>
+                                <groupId>jakarta.websocket</groupId>
+                                <artifactId>jakarta.websocket-api</artifactId>
                                 <version>${websocket-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -524,14 +524,14 @@
                         <!-- Interceptor -->
                         <spec>
                             <artifact>
-                                <groupId>javax.interceptor</groupId>
-                                <artifactId>javax.interceptor-api</artifactId>
-                                <version>${javax.interceptor-api.version}</version>
+                                <groupId>jakarta.interceptor</groupId>
+                                <artifactId>jakarta.interceptor-api</artifactId>
+                                <version>${jakarta.interceptor-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
-                            <specVersion>${javax.interceptor-api.version}</specVersion>
-			                <specImplVersion>${javax.interceptor-api.version}</specImplVersion>
+                            <specVersion>${jakarta.interceptor-api.version}</specVersion>
+			                <specImplVersion>${jakarta.interceptor-api.version}</specImplVersion>
                             <apiPackage>javax.interceptor</apiPackage>
                         </spec>
                         <spec>
@@ -548,32 +548,32 @@
                         </spec>
                         <spec>
                             <artifact>
-                                <groupId>javax.xml.registry</groupId>
-                                <artifactId>javax.xml.registry-api</artifactId>
-                                <version>${javax.xml.registry-api.version}</version>
+                                <groupId>jakarta.xml.registry</groupId>
+                                <artifactId>jakarta.xml.registry-api</artifactId>
+                                <version>${jakarta.xml.registry-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>1.0</specVersion>
-                            <specImplVersion>${javax.xml.registry-api.version}</specImplVersion>
+                            <specImplVersion>${jakarta.xml.registry-api.version}</specImplVersion>
                             <apiPackage>javax.xml.registry</apiPackage>
                         </spec>
                         <spec>
                             <artifact>
-                                <groupId>javax.xml.rpc</groupId>
-                                <artifactId>javax.xml.rpc-api</artifactId>
-                                <version>${javax.xml.rpc-api.version}</version>
+                                <groupId>jakarta.xml.rpc</groupId>
+                                <artifactId>jakarta.xml.rpc-api</artifactId>
+                                <version>${jakarta.xml.rpc-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>1.1</specVersion>
-                            <specImplVersion>${javax.xml.rpc-api.version}</specImplVersion>
+                            <specImplVersion>${jakarta.xml.rpc-api.version}</specImplVersion>
                             <apiPackage>javax.xml.rpc</apiPackage>
                         </spec>
                         <spec>
                             <artifact>
-                                <groupId>javax.enterprise.deploy</groupId>
-                                <artifactId>javax.enterprise.deploy-api</artifactId>
+                                <groupId>jakarta.enterprise.deploy</groupId>
+                                <artifactId>jakarta.enterprise.deploy-api</artifactId>
                                 <version>${javax.enterprise.deploy-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -584,8 +584,8 @@
                         </spec>
                         <spec>
                             <artifact>
-                                <groupId>javax.management.j2ee</groupId>
-                                <artifactId>javax.management.j2ee-api</artifactId>
+                                <groupId>jakarta.management.j2ee</groupId>
+                                <artifactId>jakarta.management.j2ee-api</artifactId>
                                 <version>${javax.management.j2ee-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -596,8 +596,8 @@
                         </spec>
                         <spec>
                             <artifact>
-                                <groupId>javax.servlet.jsp</groupId>
-                                <artifactId>javax.servlet.jsp-api</artifactId>
+                                <groupId>jakarta.servlet.jsp</groupId>
+                                <artifactId>jakarta.servlet.jsp-api</artifactId>
                                 <version>${jsp-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
@@ -610,11 +610,11 @@
                             <artifact>
                                 <groupId>org.glassfish</groupId>
                                 <artifactId>javax.el</artifactId>
-                                <version>${javax.el.version}</version>
+                                <version>${jakarta.el.version}</version>
                             </artifact>
                             <jarType>impl</jarType>
                             <specVersion>3.0</specVersion>
-                            <implVersion>${javax.el.version}</implVersion>
+                            <implVersion>${jakarta.el.version}</implVersion>
                             <apiPackage>javax.el</apiPackage>
                             <implNamespace>com.sun.el</implNamespace>
                         </spec>
@@ -642,9 +642,9 @@
                 <version>${jakarta.ejb-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.interceptor</groupId>
-                <artifactId>javax.interceptor-api</artifactId>
-                <version>${javax.interceptor-api.version}</version>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${jakarta.interceptor-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.transaction</groupId>
@@ -657,19 +657,19 @@
                 <version>${jakarta.transaction.cdi-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.rpc</groupId>
-                <artifactId>javax.xml.rpc-api</artifactId>
-                <version>${javax.xml.rpc-api.version}</version>
+                <groupId>jakarta.xml.rpc</groupId>
+                <artifactId>jakarta.xml.rpc-api</artifactId>
+                <version>${jakarta.xml.rpc-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${cdi-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>${javax.inject.version}</version>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.resource</groupId>
@@ -677,8 +677,8 @@
                 <version>${jakarta.resource-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise.deploy</groupId>
-                <artifactId>javax.enterprise.deploy-api</artifactId>
+                <groupId>jakarta.enterprise.deploy</groupId>
+                <artifactId>jakarta.enterprise.deploy-api</artifactId>
                 <version>${javax.enterprise.deploy-api.version}</version>
             </dependency>
 
@@ -701,14 +701,14 @@
 
             <!-- Java EE Security API -->
             <dependency>
-                <groupId>javax.security.enterprise</groupId>
-                <artifactId>javax.security.enterprise-api</artifactId>
+                <groupId>jakarta.security.enterprise</groupId>
+                <artifactId>jakarta.security.enterprise-api</artifactId>
                 <version>${javax.security.enterprise-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
                 <artifactId>javax.security.enterprise</artifactId>
-                <version>${javax.security.enterprise.version}</version>
+                <version>${jakarta.security.enterprise.version}</version>
             </dependency>
 
             <!-- JACC -->
@@ -798,9 +798,9 @@
                 <version>${jaxb-extra-osgi.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.registry</groupId>
-                <artifactId>javax.xml.registry-api</artifactId>
-                <version>${javax.xml.registry-api.version}</version>
+                <groupId>jakarta.xml.registry</groupId>
+                <artifactId>jakarta.xml.registry-api</artifactId>
+                <version>${jakarta.xml.registry-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
@@ -837,6 +837,12 @@
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-api</artifactId>
                 <version>${weld-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.classfilewriter</groupId>
@@ -867,11 +873,17 @@
                 <groupId>org.glassfish.web</groupId>
                 <artifactId>javax.servlet.jsp</artifactId>
                 <version>${jsp-impl.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet.jsp</groupId>
+                        <artifactId>jsp-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
-                <version>${javax.el.version}</version>
+                <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.faces.extensions</groupId>
@@ -898,6 +910,20 @@
                 <groupId>com.sun.jsftemplating</groupId>
                 <artifactId>jsftemplating</artifactId>
                 <version>${jsftemplating.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.faces</groupId>
+                        <artifactId>javax.faces-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.el</groupId>
+                        <artifactId>el-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.sun.jsftemplating</groupId>
@@ -945,13 +971,13 @@
                 <version>${jms-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>javax.servlet.jsp-api</artifactId>
+                <groupId>jakarta.servlet.jsp</groupId>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
                 <version>${jsp-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet.jsp.jstl</groupId>
-                <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
                 <version>${jstl-api.version}</version>
             </dependency>
             <dependency>
@@ -962,8 +988,8 @@
 
             <!-- JSON-B -->
             <dependency>
-                <groupId>javax.json.bind</groupId>
-                <artifactId>javax.json.bind-api</artifactId>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
                 <version>${json.bind-api.version}</version>
             </dependency>
             <dependency>
@@ -1000,8 +1026,8 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.management.j2ee</groupId>
-                <artifactId>javax.management.j2ee-api</artifactId>
+                <groupId>jakarta.management.j2ee</groupId>
+                <artifactId>jakarta.management.j2ee-api</artifactId>
                 <version>${javax.management.j2ee-api.version}</version>
             </dependency>
             <dependency>
@@ -1081,13 +1107,13 @@
                 <version>${ha-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.websocket</groupId>
-                <artifactId>javax.websocket-api</artifactId>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
                 <version>${websocket-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise.concurrent</groupId>
-                <artifactId>javax.enterprise.concurrent-api</artifactId>
+                <groupId>jakarta.enterprise.concurrent</groupId>
+                <artifactId>jakarta.enterprise.concurrent-api</artifactId>
                 <version>${concurrent-api.version}</version>
             </dependency>
             <dependency>
@@ -1111,8 +1137,8 @@
                 <version>2.0.4</version>
             </dependency>
             <dependency>
-                <groupId>javax.batch</groupId>
-                <artifactId>javax.batch-api</artifactId>
+                <groupId>jakarta.batch</groupId>
+                <artifactId>jakarta.batch-api</artifactId>
                 <version>${javax.batch-api.version}</version>
             </dependency>
             <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -609,7 +609,7 @@
                         <spec>
                             <artifact>
                                 <groupId>org.glassfish</groupId>
-                                <artifactId>javax.el</artifactId>
+                                <artifactId>jakarta.el</artifactId>
                                 <version>${jakarta.el.version}</version>
                             </artifact>
                             <jarType>impl</jarType>
@@ -882,7 +882,7 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
+                <artifactId>jakarta.el</artifactId>
                 <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>

--- a/appserver/resources/javamail/javamail-runtime/pom.xml
+++ b/appserver/resources/javamail/javamail-runtime/pom.xml
@@ -110,8 +110,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency> <!-- for FindBugs -->
             <groupId>com.sun.mail</groupId>

--- a/appserver/resources/resources-connector/pom.xml
+++ b/appserver/resources/resources-connector/pom.xml
@@ -87,8 +87,8 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -61,8 +61,8 @@
         <dependencies>
             <!-- Java EE -->
             <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-api</artifactId>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
                 <version>8.0</version>
                 <scope>provided</scope>
             </dependency>
@@ -294,8 +294,8 @@
 
                 <dependencies>
                     <dependency>
-                        <groupId>javax.annotation</groupId>
-                        <artifactId>javax.annotation-api</artifactId>
+                        <groupId>jakarta.annotation</groupId>
+                        <artifactId>jakarta.annotation-api</artifactId>
                         <version>1.3.2</version>
                     </dependency>
                 </dependencies>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
@@ -77,8 +77,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <version>8.0.1</version>
             <scope>provided</scope>
         </dependency>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
@@ -66,8 +66,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <version>8.0.1</version>
             <scope>provided</scope>
         </dependency>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -36,8 +36,8 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.samples</groupId>

--- a/appserver/transaction/jta/pom.xml
+++ b/appserver/transaction/jta/pom.xml
@@ -96,8 +96,8 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.resource</groupId>

--- a/appserver/web/cdi-api-fragment/pom.xml
+++ b/appserver/web/cdi-api-fragment/pom.xml
@@ -75,7 +75,7 @@
                         <manifestEntries>
                             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                             <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
-                            <Fragment-Host>javax.enterprise.cdi-api</Fragment-Host>
+                            <Fragment-Host>jakarta.enterprise.cdi-api</Fragment-Host>
                             <Import-Package>org.glassfish.weld</Import-Package>
                             <Bundle-Description>${project.description}</Bundle-Description>
                         </manifestEntries>

--- a/appserver/web/gf-weld-connector/pom.xml
+++ b/appserver/web/gf-weld-connector/pom.xml
@@ -72,8 +72,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/web/jstl-connector/pom.xml
+++ b/appserver/web/jstl-connector/pom.xml
@@ -77,8 +77,8 @@
             <artifactId>javax.servlet.jsp.jstl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/web/war-util/pom.xml
+++ b/appserver/web/war-util/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/appserver/web/war-util/pom.xml
+++ b/appserver/web/war-util/pom.xml
@@ -80,8 +80,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/appserver/web/web-glue/pom.xml
+++ b/appserver/web/web-glue/pom.xml
@@ -173,7 +173,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -104,8 +104,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -145,6 +145,10 @@
                 <exclusion>
                     <groupId>javax.enterprise</groupId>
                     <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.enterprise</groupId>
+                    <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>javassist</groupId>

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -106,8 +106,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -147,8 +147,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -153,7 +153,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -83,8 +83,8 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.core</groupId>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -251,8 +251,8 @@
             <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -256,7 +256,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -56,7 +56,7 @@
     <packaging>glassfish-jar</packaging>
 
     <properties>
-        <javax.validation.version.upperbound>3</javax.validation.version.upperbound>
+        <jakarta.validation.version.upperbound>3</jakarta.validation.version.upperbound>
         <hibernate.validator.version.upperbound>7</hibernate.validator.version.upperbound>
     </properties>
     
@@ -110,7 +110,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            javax.validation.*;resolution:=optional;version="${range;[==,${javax.validation.version.upperbound});${javax.validation.version}}
+                            javax.validation.*;resolution:=optional;version="${range;[==,${jakarta.validation.version.upperbound});${jakarta.validation.version}}
 ",
                             org.hibernate.validator.*;resolution:=optional;version="${range;[==,${hibernate.validator.version.upperbound});${hibernate.validator.version}}",
                             *
@@ -151,8 +151,8 @@
 
         <!-- hk2-config tests use hibernate-validator which requires javax.el-api -->
         <dependency>
-          <groupId>javax.el</groupId>
-          <artifactId>javax.el-api</artifactId>
+          <groupId>jakarta.el</groupId>
+          <artifactId>jakarta.el-api</artifactId>
           <scope>test</scope>
        </dependency>
         <dependency>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -157,7 +157,7 @@
        </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -148,6 +148,10 @@
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate.validator.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
 
         <!-- hk2-config tests use hibernate-validator which requires javax.el-api -->
         <dependency>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -126,7 +126,7 @@
         <!-- Expression Language -->
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         
         <dependency>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -115,8 +115,8 @@
         
         <!-- Bean Validation -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/nucleus/payara-modules/notification-cdi-eventbus-core/pom.xml
+++ b/nucleus/payara-modules/notification-cdi-eventbus-core/pom.xml
@@ -64,9 +64,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/nucleus/payara-modules/notification-core/pom.xml
+++ b/nucleus/payara-modules/notification-core/pom.xml
@@ -101,9 +101,9 @@
             <version>${hk2.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/nucleus/payara-modules/notification-eventbus-core/pom.xml
+++ b/nucleus/payara-modules/notification-eventbus-core/pom.xml
@@ -62,9 +62,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -64,9 +64,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/requesttracing-core/pom.xml
+++ b/nucleus/payara-modules/requesttracing-core/pom.xml
@@ -120,9 +120,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.api.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -904,6 +904,12 @@ Parent is ${project.parent}</echo>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate.validator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.validator</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -146,7 +146,7 @@
         <deploy.skip>true</deploy.skip>
 
         <!-- Java EE -->
-        <javaee.api.version>8.0</javaee.api.version>
+        <jakartaee.api.version>8.0.0</jakartaee.api.version>
 
         <!-- Servlet -->
         <servlet-api.version>4.0.2</servlet-api.version>
@@ -165,13 +165,13 @@
         <jersey.version>2.29.1.payara-p1</jersey.version>
 
         <!-- Bean Validation -->
-        <javax.validation.version>2.0.1.Final</javax.validation.version>
+        <jakarta.validation.version>2.0.2</jakarta.validation.version>
         <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>6.0.16.Final</hibernate.validator-cdi.version>
 
         <!-- Expression language -->
-        <javax.el.version>3.0.1-b11</javax.el.version>
-        <javax.el-api.version>3.0.1-b06</javax.el-api.version>
+        <jakarta.el.version>3.0.1-b11</jakarta.el.version>
+        <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
 
         <!-- JAX-B -->
         <jaxb-api.version>2.3.2</jaxb-api.version>
@@ -896,9 +896,9 @@ Parent is ${project.parent}</echo>
 
             <!-- Bean Validation (BVal) -->
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${javax.validation.version}</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
@@ -914,14 +914,14 @@ Parent is ${project.parent}</echo>
 
             <!-- Expression Language (EL) -->
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-                <version>${javax.el-api.version}</version>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${jakarta.el-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
-                <version>${javax.el.version}</version>
+                <version>${jakarta.el.version}</version>
             </dependency>
 
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -170,7 +170,7 @@
         <hibernate.validator-cdi.version>6.0.16.Final</hibernate.validator-cdi.version>
 
         <!-- Expression language -->
-        <jakarta.el.version>3.0.1-b11</jakarta.el.version>
+        <jakarta.el.version>3.0.3</jakarta.el.version>
         <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
 
         <!-- JAX-B -->
@@ -920,7 +920,7 @@ Parent is ${project.parent}</echo>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
+                <artifactId>jakarta.el</artifactId>
                 <version>${jakarta.el.version}</version>
             </dependency>
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a feature. <!-- delete/modify as applicable-->

All remaining `javax` API classes were replaced with their jakarta counterparts. Since some of the third party implementations still depend on original APIs, they may appear on classpath here and there, but the resulting distribution is javax-free.

After changes in module names, jsp compilation paths in `default-web.xml` had to be updated. Hibernate Validator pulling Java EE validation API resulted in wrong classpath of `asadmin`, and therefore that dependency needed be excluded.

# Testing

### Testing Performed
Full run of Jakarta EE TCK (and then focused tests for failures until fixed)
Click through asadmin ui

### Test suites executed
- Jakarta TCK - full run

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 1.8_222 on Ubuntu 18.04 with Maven 3.6.0