### PR TITLE
PAYARA-4263 Added missing dependency on MC webapp

### DIFF
--- a/appserver/packager/monitoring-console/pom.xml
+++ b/appserver/packager/monitoring-console/pom.xml
@@ -114,6 +114,13 @@
             <artifactId>monitoring-console-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.server.monitoring-console</groupId>
+            <artifactId>monitoring-console-webapp</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>
 


### PR DESCRIPTION
# Description
This is a bug fix/build fix. 

Adds the dependency on MC webapp so module build order is changed so that the webapp module is available when the packager `unpack` during `generate sources` phase finds the artefact.

# Testing

### Testing Performed
Deleted the snapshot(s) from the local repository at `fish/payara/server/monitoring-console/monitoring-console-webapp` and run a clean install. With a successful build check that 

* the webapp module was build before the package (order in list of build modules) (can also use `mvn dependency:tree` to check)
* the webapp war is **not** in the `glassfish/modules` folder of the `payara` distribution 
* the webapp was unpacked to `glassfish/lib/install/applications/__monitoringconsole`

### Test suites executed
None specific.