### PR TITLE
PAYARA-4188: Put jline-jna back on asadmin cli classpath

### DIFF
--- a/appserver/admin/cli/pom.xml
+++ b/appserver/admin/cli/pom.xml
@@ -78,6 +78,9 @@
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>../../modules</classpathPrefix>
                         </manifest>
+                        <manifestEntries>
+                            <Class-Path>jna.jar jline-terminal-jna.jar</Class-Path>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->
Earlier commit fixed instability of asadmin CLI classpath by having it generated by Maven Archiver. However `jline-jna` and `jna` are not Payara modules, rather runtime dependencies.

Thankfully, manual entry can be combined with automated classpath, and the new path looks like

```
Class-Path: jna.jar jline-terminal-jna.jar ../../modules/admin-cli.jar
  ../../modules/hk2.jar ../../modules/hk2-utils.jar ../../modules/jaka
 rta.annotation-api.jar ../../modules/jakarta.inject.jar ../../modules
 /hk2-api.jar ../../modules/aopalliance-repackaged.jar ../../modules/h
 k2-core.jar ../../modules/hk2-locator.jar ../../modules/javassist.jar
  ../../modules/hk2-runlevel.jar ../../modules/class-model.jar ../../m
 odules/asm.jar ../../modules/asm-analysis.jar ../../modules/asm-commo
 ns.jar ../../modules/asm-tree.jar ../../modules/asm-util.jar ../../mo
 dules/common-util.jar ../../modules/mimepull.jar ../../modules/jakart
 a.json.jar ../../modules/launcher.jar ../../modules/logging.jar ../..
 /modules/admin-util.jar ../../modules/config-api.jar ../../modules/mi
 croprofile-config-api.jar ../../modules/org.osgi.annotation.versionin
 g.jar ../../modules/internal-api.jar ../../modules/hk2-config.jar ../
 ../modules/tiger-types.jar ../../modules/hibernate-validator.jar ../.
 ./modules/jboss-logging.jar ../../modules/classmate.jar ../../modules
 /jakarta.validation-api.jar ../../modules/config-types.jar ../../modu
 les/security-services.jar ../../modules/security.jar ../../modules/ss
 l-impl.jar ../../modules/deployment-common.jar ../../modules/ldapbp-r
 epackaged.jar ../../modules/gmbal.jar ../../modules/pfl-basic.jar ../
 ../modules/pfl-tf.jar ../../modules/pfl-asm.jar ../../modules/pfl-dyn
 amic.jar ../../modules/pfl-basic-tools.jar ../../modules/pfl-tf-tools
 .jar ../../modules/jackson-annotations.jar ../../modules/jackson-data
 bind.jar ../../modules/jackson-core.jar ../../modules/jackson-module-
 jaxb-annotations.jar ../../modules/jakarta.xml.bind-api.jar ../../mod
 ules/jakarta.activation-api.jar ../../modules/jakarta.json-api.jar ..
 /../modules/glassfish-api.jar ../../modules/scattered-archive-api.jar
  ../../modules/nucleus-grizzly-all.jar ../../modules/grizzly-framewor
 k.jar ../../modules/grizzly-portunif.jar ../../modules/grizzly-http.j
 ar ../../modules/grizzly-http2.jar ../../modules/grizzly-http-server.
 jar ../../modules/tls-sni.jar ../../modules/grizzly-config.jar ../../
 modules/management-api.jar ../../modules/glassfish-corba-omgapi.jar .
 ./../modules/simple-glassfish-api.jar ../../modules/jline.jar ../../m
 odules/jaxb-osgi.jar
```

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Testing

### Testing Performed
`asadmin` no longer complains about dumb terminal on Windows; password entry correctly switches echo off.

# Notes for Reviewers
<!-- Please give notes for any reviewers. The code should explain itself, but where should they start? Do you want feedback on anything specific? -->
<!-- Have you tagged any appropriate reviewers?-->
The bug was only present in 5.194-SNAPSHOT.