### PR TITLE
PAYARA-4172 Rerun add openapi schemas to allow for sub-schemas to be …

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -205,6 +205,8 @@ public class OpenApiWalker implements ApiWalker {
 
         // OpenAPI response types
         processAnnotations(RequestBody.class, visitor::visitRequestBody);
+        //redo schema, now all others have been to ensure sub-schemas work
+        processAnnotations(Schema.class, visitor::visitSchema);
     }
 
     @SafeVarargs


### PR DESCRIPTION
# Description
This is a bug fix.

If in an OpenAPI schema it references another schema then sometimes depending on loading the sub-schema is loaded yet and so it uses an empty schema definition. This adds another run of schema generation to processing so the sub-schemas (which will exist now) can be associated with where they are referenced.

# Testing

### Testing Performed
Ran provided test app (see Jira), redeploying it and going to the /openapi endpoint and checking it half a dozen times to ensure it works.

### Test suites executed
- Payara Microprofile TCKs Runner

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.0
