### PR TITLE
PAYARA-3924: Payara BOM

### DIFF
--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -43,36 +43,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>fish.payara.server</groupId>
-        <artifactId>payara-nucleus-parent</artifactId>
+        <groupId>fish.payara.api</groupId>
+        <artifactId>api-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../../nucleus/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.api</groupId>
     <artifactId>payara-api</artifactId>
     <name>Payara-API</name>
     <description>Artefact that exposes public API of Payara Application Server</description>
-
-    <developers>
-        <developer>
-            <id>smillidge</id>
-            <name>Steve Millidge</name>
-            <url>http://www.payara.fish</url>
-            <organization>Payara Foundation</organization>
-            <roles>
-                <role>lead</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <id>mulderbaba</id>
-            <name>Mert Caliskan</name>
-            <organization>Payara Foundation</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
 
     <build>
         <plugins>
@@ -157,8 +134,25 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <type>pom</type>
+                <version>${project.version}</version>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 

--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -48,15 +48,10 @@
         <version>5.194-SNAPSHOT</version>
         <relativePath>../../nucleus/pom.xml</relativePath>
     </parent>
-    
+    <groupId>fish.payara.api</groupId>
     <artifactId>payara-api</artifactId>
     <name>Payara-API</name>
     <description>Artefact that exposes public API of Payara Application Server</description>
-
-    <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-    </properties>
 
     <developers>
         <developer>
@@ -81,14 +76,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${javase.version}</source>
-                    <target>${javase.version}</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -174,6 +161,7 @@
     </build>
 
     <dependencies>
+
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
@@ -183,7 +171,6 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>${opentracing.version}</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -41,11 +41,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-   
+
     <parent>
-        <groupId>fish.payara.api</groupId>
-        <artifactId>api-parent</artifactId>
+        <groupId>fish.payara.server</groupId>
+        <artifactId>payara-nucleus-parent</artifactId>
         <version>5.194-SNAPSHOT</version>
+        <relativePath>../../nucleus/pom.xml</relativePath>
     </parent>
     
     <artifactId>payara-api</artifactId>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -55,7 +55,57 @@
     <dependencyManagement>
         <dependencies>
             <!-- Public artifacts -->
+            <dependency>
+                <groupId>fish.payara.distributions</groupId>
+                <artifactId>payara</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
 
+            <dependency>
+                <groupId>fish.payara.distributions</groupId>
+                <artifactId>payara-web</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.distributions</groupId>
+                <artifactId>payara-ml</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.distributions</groupId>
+                <artifactId>payara-web-ml</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.extras</groupId>
+                <artifactId>ejb-http-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.extras</groupId>
+                <artifactId>payara-embedded-web</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.extras</groupId>
+                <artifactId>payara-embedded-all</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.extras</groupId>
+                <artifactId>payara-micro</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- APIs -->
             <!-- Aggregate APIs -->

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -514,6 +514,17 @@
                 <artifactId>jakarta.batch-api</artifactId>
                 <version>${jakarta.batch-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
+                <version>${websocket-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise.concurrent</groupId>
+                <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+                <version>${concurrent-api.version}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.osgi</groupId>
@@ -819,6 +830,12 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.enterprise.concurrent</artifactId>
+                <version>${concurrent.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.sun.istack</groupId>
                 <artifactId>istack-commons-runtime</artifactId>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -857,6 +857,32 @@
             </dependency>
 
             <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -56,6 +56,7 @@
         <dependencies>
             <!-- Public artifacts -->
 
+
             <!-- APIs -->
             <!-- Aggregate APIs -->
             <dependency>
@@ -140,7 +141,57 @@
                 <version>${microprofile-rest-client.version}</version>
             </dependency>
 
+            <!-- Tooling -->
+            <!-- Arquillian containers -->
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-server-remote</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
 
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-server-embedded</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-server-managed</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-micro-managed</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>payara-micro-remote</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>payara-micro-deployer</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+                <type>war</type>
+            </dependency>
+
+            <!-- These are hopefully no longer needed with this BOM, but just to be sure -->
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>payara-client-ee8</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>payara-client-ee7</artifactId>
+                <version>${payara-arquillian-container.version}</version>
+            </dependency>
 
             <!-- Individual APIs -->
             <dependency>
@@ -347,10 +398,6 @@
                 <artifactId>jakarta.jws-api</artifactId>
                 <version>${jakarta.jws-api.version}</version>
             </dependency>
-
-            <!-- Tooling -->
-            <!-- Arquillian containers -->
-
 
             <!-- Implementations -->
             <dependency>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -107,6 +107,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- APIs -->
             <!-- Aggregate APIs -->
             <dependency>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -64,7 +64,82 @@
                 <version>${jakartaee.api.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakartaee-api</artifactId>
+                <version>${jakarta-platform.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakartaee-web-api</artifactId>
+                <version>${jakarta-platform.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-bom</artifactId>
+                <version>${jakarta-platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Microprofile APIs -->
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile</artifactId>
+                <version>${microprofile-release.version}</version>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.config</groupId>
+                <artifactId>microprofile-config-api</artifactId>
+                <version>${microprofile-config.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.opentracing</groupId>
+                <artifactId>microprofile-opentracing-api</artifactId>
+                <version>${microprofile-opentracing.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+                <artifactId>microprofile-fault-tolerance-api</artifactId>
+                <version>${microprofile-fault-tolerance.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-api</artifactId>
+                <version>${microprofile-metrics.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.openapi</groupId>
+                <artifactId>microprofile-openapi-api</artifactId>
+                <version>${microprofile-openapi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.jwt</groupId>
+                <artifactId>microprofile-jwt-auth-api</artifactId>
+                <version>${microprofile-jwt-auth.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.health</groupId>
+                <artifactId>microprofile-health-api</artifactId>
+                <version>${microprofile-healthcheck.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.rest.client</groupId>
+                <artifactId>microprofile-rest-client-api</artifactId>
+                <version>${microprofile-rest-client.version}</version>
+            </dependency>
+
 
 
             <!-- Individual APIs -->

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -1,0 +1,250 @@
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.api</groupId>
+        <artifactId>api-parent</artifactId>
+        <version>5.194-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>payara-bom</artifactId>
+    <name>Payara Bill of Materials</name>
+    <packaging>pom</packaging>
+    <description>List of dependencies provided by and compatible with specific Payara Release</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Public artifacts -->
+
+            <!-- APIs -->
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
+                <version>${jakartaee.api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jax-rs-api.impl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${jakarta.el-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
+                <version>${mail.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.stream</groupId>
+                <artifactId>stax-api</artifactId>
+                <version>${stax-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>${javax.cache-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.compendium</artifactId>
+                <version>5.0.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>6.0.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.enterprise</artifactId>
+                <version>5.0.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId> <!-- OSGi Companion Code for org.osgi.dto Version 1.0.0. -->
+                <artifactId>org.osgi.dto</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+            <!-- Tooling -->
+
+            <!-- Implementations -->
+            <dependency>
+                <groupId>org.glassfish.grizzly</groupId>
+                <artifactId>grizzly-bom</artifactId>
+                <version>${grizzly.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${jersey.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate.validator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator-cdi</artifactId>
+                <version>${hibernate.validator-cdi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${jakarta.el.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>jakarta.mail</artifactId>
+                <version>${mail.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-osgi</artifactId>
+                <version>${jaxb-impl.version}</version>
+            </dependency>
+
+
+            <!-- Other libraries -->
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-bom</artifactId>
+                <version>${hk2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${hazelcast.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-kubernetes</artifactId>
+                <version>${hazelcast.kubernetes.version}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -134,21 +134,24 @@
                 <scope>provided</scope>
             </dependency>
 
+            <!-- Jakarta BOM. May be used in import scope by client instead of aggregate -->
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-bom</artifactId>
                 <version>${jakarta-platform.version}</version>
                 <type>pom</type>
-                <scope>import</scope>
             </dependency>
-            <!-- Microprofile APIs -->
+
+            <!-- Microprofile API release aggregate. Can also be used as a BOM -->
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
                 <artifactId>microprofile</artifactId>
                 <version>${microprofile-release.version}</version>
                 <type>pom</type>
+                <scope>provided</scope>
             </dependency>
 
+            <!-- Individual Microprofile APIs - Payara may implement different bugfix releases -->
             <dependency>
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-api</artifactId>
@@ -203,30 +206,35 @@
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>arquillian-payara-server-remote</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>arquillian-payara-server-embedded</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>arquillian-payara-server-managed</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>arquillian-payara-micro-managed</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-micro-remote</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -234,6 +242,7 @@
                 <artifactId>payara-micro-deployer</artifactId>
                 <version>${payara-arquillian-container.version}</version>
                 <type>war</type>
+                <scope>test</scope>
             </dependency>
 
             <!-- These are hopefully no longer needed with this BOM, but just to be sure -->
@@ -241,12 +250,14 @@
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-client-ee8</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-client-ee7</artifactId>
                 <version>${payara-arquillian-container.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Individual APIs -->
@@ -643,11 +654,6 @@
                         <artifactId>jsp-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${jakarta.el.version}</version>
             </dependency>
 
             <dependency>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -329,10 +329,17 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Payara Micro Container 1.2 is faulty. We'll likely release new version before 5.194 is out. -->
+            <!--            <dependency>-->
+            <!--                <groupId>fish.payara.arquillian</groupId>-->
+            <!--                <artifactId>arquillian-payara-micro-managed</artifactId>-->
+            <!--                <version>${payara-arquillian-container.version}</version>-->
+            <!--                <scope>test</scope>-->
+            <!--            </dependency>-->
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
-                <artifactId>arquillian-payara-micro-managed</artifactId>
-                <version>${payara-arquillian-container.version}</version>
+                <artifactId>arquillian-payara-micro-5-managed</artifactId>
+                <version>1.0.Beta3</version>
                 <scope>test</scope>
             </dependency>
 
@@ -592,11 +599,6 @@
                 <version>${jersey.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${jersey.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.validator</groupId>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -58,59 +58,59 @@
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara-web</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara-ml</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara-web-ml</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>ejb-http-client</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-embedded-web</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-embedded-all</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-micro</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-api</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
             </dependency>
 
             <!-- APIs -->
@@ -744,4 +744,20 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <properties>
+        <payara.version>${project.version}</payara.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>bom</flattenMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -123,13 +123,7 @@
             </dependency>
             <dependency>
                 <groupId>jakarta.platform</groupId>
-                <artifactId>jakartaee-api</artifactId>
-                <version>${jakarta-platform.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.platform</groupId>
-                <artifactId>jakartaee-web-api</artifactId>
+                <artifactId>jakarta.jakartaee-web-api</artifactId>
                 <version>${jakarta-platform.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -57,13 +57,17 @@
             <!-- Public artifacts -->
 
             <!-- APIs -->
+            <!-- Aggregate APIs -->
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-api</artifactId>
                 <version>${jakartaee.api.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- Microprofile APIs -->
 
+
+            <!-- Individual APIs -->
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
@@ -109,6 +113,101 @@
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jaxb-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.ejb</groupId>
+                <artifactId>jakarta.ejb-api</artifactId>
+                <version>${jakarta.ejb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${jakarta.interceptor-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${jakarta.transaction-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.transaction.cdi</groupId>
+                <artifactId>jakarta.transaction.cdi-api</artifactId>
+                <version>${jakarta.transaction.cdi-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.rpc</groupId>
+                <artifactId>jakarta.xml.rpc-api</artifactId>
+                <version>${jakarta.xml.rpc-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${cdi-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.resource</groupId>
+                <artifactId>jakarta.resource-api</artifactId>
+                <version>${jakarta.resource-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise.deploy</groupId>
+                <artifactId>jakarta.enterprise.deploy-api</artifactId>
+                <version>${jakarta.enterprise.deploy-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.faces</groupId>
+                <artifactId>jakarta.faces-api</artifactId>
+                <version>${jakarta.faces-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.security.enterprise</groupId>
+                <artifactId>jakarta.security.enterprise-api</artifactId>
+                <version>${jakarta.security.enterprise-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.security.jacc</groupId>
+                <artifactId>jakarta.security.jacc-api</artifactId>
+                <version>${jakarta.security.jacc-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.security.auth.message</groupId>
+                <artifactId>jakarta.security.auth.message-api</artifactId>
+                <version>${jakarta.security.auth.message-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>jakarta.persistence</artifactId>
+                <version>${jakarta-persistence-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.registry</groupId>
+                <artifactId>jakarta.xml.registry-api</artifactId>
+                <version>${jakarta.xml.registry-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.jms</groupId>
+                <artifactId>jakarta.jms-api</artifactId>
+                <version>${jms-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet.jsp</groupId>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
+                <version>${jsp-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                <version>${jstl-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.batch</groupId>
+                <artifactId>jakarta.batch-api</artifactId>
+                <version>${jakarta.batch-api.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.osgi</groupId>
@@ -133,7 +232,50 @@
                 <artifactId>org.osgi.dto</artifactId>
                 <version>1.0.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>stax2-api</artifactId>
+                <version>${stax2-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.jbi</groupId>
+                <artifactId>jbi</artifactId>
+                <version>${jbi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${json.bind-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${jsonp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.management.j2ee</groupId>
+                <artifactId>jakarta.management.j2ee-api</artifactId>
+                <version>${jakarta.management.j2ee-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
+                <version>${jaxws-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.jws</groupId>
+                <artifactId>jakarta.jws-api</artifactId>
+                <version>${jakarta.jws-api.version}</version>
+            </dependency>
+
             <!-- Tooling -->
+            <!-- Arquillian containers -->
+
 
             <!-- Implementations -->
             <dependency>
@@ -187,7 +329,202 @@
                 <artifactId>jaxb-osgi</artifactId>
                 <version>${jaxb-impl.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.faces</artifactId>
+                <version>${mojarra.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${woodstox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.soteria</groupId>
+                <artifactId>javax.security.enterprise</artifactId>
+                <version>${jakarta.security.enterprise.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.core</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.moxy</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.sdo</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.dbws</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.oracle</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.antlr</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.asm</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.metro</groupId>
+                <artifactId>webservices-osgi</artifactId>
+                <version>${webservices.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.metro</groupId>
+                <artifactId>webservices-extra-jdk-packages</artifactId>
+                <version>${webservices.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.metro</groupId>
+                <artifactId>webservices-api-osgi</artifactId>
+                <version>${webservices.version}</version>
+            </dependency>
 
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-extra-osgi</artifactId>
+                <version>${jaxb-extra-osgi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>wsdl4j</groupId>
+                <artifactId>wsdl4j</artifactId>
+                <version>${wsdl4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-osgi-bundle</artifactId>
+                <version>${weld.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.classfilewriter</groupId>
+                        <artifactId>jboss-classfilewriter</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-api</artifactId>
+                <version>${weld-api.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-shaded</artifactId>
+                <version>${weld.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.environment</groupId>
+                <artifactId>weld-environment-common</artifactId>
+                <version>${weld.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>javax.servlet.jsp</artifactId>
+                <version>${jsp-impl.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet.jsp</groupId>
+                        <artifactId>jsp-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${jakarta.el.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.messaging.mq</groupId>
+                <artifactId>imqjmx</artifactId>
+                <version>4.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.mq</groupId>
+                <artifactId>mq-distribution</artifactId>
+                <version>${mq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>javax.servlet.jsp.jstl</artifactId>
+                <version>${jstl-impl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse</groupId>
+                <artifactId>yasson</artifactId>
+                <version>${yasson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.json</artifactId>
+                <version>${jsonp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jsonp-jaxrs</artifactId>
+                <version>${jsonp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ibm.jbatch</groupId>
+                <artifactId>com.ibm.jbatch.container</artifactId>
+                <version>${com.ibm.jbatch.container.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ibm.jbatch</groupId>
+                <artifactId>com.ibm.jbatch.spi</artifactId>
+                <version>${com.ibm.jbatch.spi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.tyrus</groupId>
+                <artifactId>tyrus-bom</artifactId>
+                <version>${tyrus.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.istack</groupId>
+                <artifactId>istack-commons-runtime</artifactId>
+                <version>${istack-commons-runtime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>${jakarta.activation-impl.version}</version>
+            </dependency>
 
             <!-- Other libraries -->
             <dependency>
@@ -244,6 +581,14 @@
                 <artifactId>hazelcast-kubernetes</artifactId>
                 <version>${hazelcast.kubernetes.version}</version>
             </dependency>
+
+
+
+
+
+
+
+
 
         </dependencies>
     </dependencyManagement>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -708,39 +708,17 @@
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>
@@ -753,15 +731,6 @@
                 <artifactId>hazelcast-kubernetes</artifactId>
                 <version>${hazelcast.kubernetes.version}</version>
             </dependency>
-
-
-
-
-
-
-
-
-
         </dependencies>
     </dependencyManagement>
 </project>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -201,7 +201,113 @@
             </dependency>
 
             <!-- Tooling -->
-            <!-- Arquillian containers -->
+            <!-- Embedded databases available in the server -->
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2db.version}</version>
+            </dependency>
+
+            <!-- Server ships with JavaDB, but there are no client jars distributed. Instead, clients can use derby jars -->
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derby</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbynet</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyclient</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbytools</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyoptionaltools</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbywar</artifactId>
+                <version>${javadb.version}</version>
+                <type>war</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_cs</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_de_DE</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_es</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_fr</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_hu</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_it</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_ja_JP</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_ko_KR</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_pl</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_pt_BR</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_ru</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_zh_CN</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyLocale_zh_TW</artifactId>
+                <version>${javadb.version}</version>
+            </dependency>
+
+
+            <!-- Arquillian containers (test scope)-->
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>arquillian-payara-server-remote</artifactId>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -448,6 +448,11 @@
                 <artifactId>jakarta.jws-api</artifactId>
                 <version>${jakarta.jws-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-api</artifactId>
+                <version>${opentracing.version}</version>
+            </dependency>
 
             <!-- Implementations -->
             <dependency>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -691,6 +691,13 @@
                 <artifactId>org.eclipse.persistence.asm</artifactId>
                 <version>${eclipselink.version}</version>
             </dependency>
+            <!-- Annotation processor is best suited for provided scope -->
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
+                <version>${eclipselink.version}</version>
+                <scope>provided</scope>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.metro</groupId>
                 <artifactId>webservices-osgi</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -42,9 +42,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fish.payara.server</groupId>
-        <artifactId>payara-nucleus-parent</artifactId>
+        <artifactId>payara-aggregator</artifactId>
         <version>5.194-SNAPSHOT</version>
-        <relativePath>../nucleus/pom.xml</relativePath>
     </parent>
     
     <groupId>fish.payara.api</groupId>
@@ -76,17 +75,8 @@
     
     <modules>
         <module>payara-api</module>
+        <module>payara-bom</module>
     </modules>
     
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>jakarta.platform</groupId>
-                <artifactId>jakarta.jakartaee-api</artifactId>
-                <version>${jakartaee.api.version}</version>
-                <scope>provided</scope>
-                <optional>true</optional>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,27 +52,6 @@
     <packaging>pom</packaging>
     <description>Aggregator Module for Artefacts that exposes the public API of Payara Application Server</description>
 
-    <developers>
-        <developer>
-            <id>smillidge</id>
-            <name>Steve Millidge</name>
-            <url>http://www.payara.fish</url>
-            <organization>Payara Foundation</organization>
-            <roles>
-                <role>lead</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <id>mulderbaba</id>
-            <name>Mert Caliskan</name>
-            <organization>Payara Foundation</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
-    
     <modules>
         <module>payara-api</module>
         <module>payara-bom</module>

--- a/appserver/admin/gf_template/pom.xml
+++ b/appserver/admin/gf_template/pom.xml
@@ -70,7 +70,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -68,7 +68,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -69,7 +69,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/appserver/admin/production_domain_template_web/pom.xml
+++ b/appserver/admin/production_domain_template_web/pom.xml
@@ -69,7 +69,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/appserver/batch/glassfish-batch-commands/pom.xml
+++ b/appserver/batch/glassfish-batch-commands/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>com.ibm.jbatch</groupId>
             <artifactId>com.ibm.jbatch.container</artifactId>
-            <version>${com.ibm.jbatch.container.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.batch</groupId>

--- a/appserver/ejb/ejb-http-remoting/admin/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/admin/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.deployment</groupId>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -122,32 +122,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.1.0</version>
-                <configuration>
-                    <flattenMode>ossrh</flattenMode>
-                    <pomElements>
-                        <developers>resolve</developers>
-                        <build>remove</build>
-                    </pomElements>
-                </configuration>
-                <executions>
-                    <!-- enable flattening -->
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <!-- ensure proper cleanup -->
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/appserver/extras/payara-micro/payara-micro-boot/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/pom.xml
@@ -72,7 +72,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -231,7 +231,6 @@
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
-            <version>${jms-api.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/jms/gf-jms-injection/pom.xml
+++ b/appserver/jms/gf-jms-injection/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
-            <version>${jms-api.version}</version>
         </dependency>
 
          <dependency>

--- a/appserver/monitoring-console/core/pom.xml
+++ b/appserver/monitoring-console/core/pom.xml
@@ -82,8 +82,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/monitoring-console/webapp/pom.xml
+++ b/appserver/monitoring-console/webapp/pom.xml
@@ -91,8 +91,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>

--- a/appserver/packager/external/microprofile-opentracing-repackaged/pom.xml
+++ b/appserver/packager/external/microprofile-opentracing-repackaged/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
-            <version>${microprofile-opentracing.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/packager/glassfish-jpa/pom.xml
+++ b/appserver/packager/glassfish-jpa/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/appserver/packager/microprofile-package/pom.xml
+++ b/appserver/packager/microprofile-package/pom.xml
@@ -136,7 +136,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
@@ -153,7 +152,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
-            <version>${microprofile-fault-tolerance.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
@@ -165,7 +163,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>${microprofile-metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
@@ -177,7 +174,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
-            <version>${microprofile-openapi.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
@@ -189,7 +185,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
-            <version>${microprofile-jwt-auth.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
@@ -207,7 +202,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
-            <version>${microprofile-healthcheck.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
@@ -224,7 +218,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
-            <version>${microprofile-rest-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
@@ -241,7 +234,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
-            <version>${microprofile-opentracing.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>

--- a/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.security.enterprise</groupId>

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/pom.xml
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/jaspic-servlet-utils/pom.xml
+++ b/appserver/payara-appserver-modules/jaspic-servlet-utils/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/config/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/config/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -66,17 +66,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
-            <version>${microprofile-fault-tolerance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>${microprofile-metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
-            <version>${microprofile-healthcheck.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
-            <version>${microprofile-jwt-auth.version}</version>
         </dependency>
 
         <dependency>

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
@@ -87,7 +87,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
 
         <dependency>

--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -84,12 +84,10 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>${microprofile-metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>

--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -107,7 +107,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/microprofile-common/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-common/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
@@ -58,12 +58,10 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
-            <version>${microprofile-openapi.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>

--- a/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/appserver/payara-appserver-modules/microprofile/opentracing-jaxws/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/opentracing-jaxws/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/opentracing/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/pom.xml
@@ -57,6 +57,10 @@ holder.
             <artifactId>weld-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/opentracing/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/pom.xml
@@ -72,12 +72,10 @@ holder.
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
-            <version>${microprofile-opentracing.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -86,7 +84,6 @@ holder.
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
-            <version>${microprofile-rest-client.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>

--- a/appserver/payara-appserver-modules/notification-datadog-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-datadog-core/pom.xml
@@ -59,8 +59,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/notification-email-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-email-core/pom.xml
@@ -62,8 +62,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/notification-hipchat-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-hipchat-core/pom.xml
@@ -61,8 +61,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/appserver/payara-appserver-modules/notification-jms-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-jms-core/pom.xml
@@ -61,8 +61,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/notification-newrelic-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-newrelic-core/pom.xml
@@ -59,8 +59,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/notification-slack-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-slack-core/pom.xml
@@ -61,8 +61,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/notification-xmpp-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-xmpp-core/pom.xml
@@ -59,8 +59,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/appserver/payara-appserver-modules/opentracing-cdi/pom.xml
+++ b/appserver/payara-appserver-modules/opentracing-cdi/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/payara-jsr107/pom.xml
+++ b/appserver/payara-appserver-modules/payara-jsr107/pom.xml
@@ -100,7 +100,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.api</groupId>

--- a/appserver/payara-appserver-modules/payara-micro-cdi/pom.xml
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.api</groupId>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/pom.xml
@@ -68,8 +68,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     

--- a/appserver/payara-appserver-modules/security-oauth2/pom.xml
+++ b/appserver/payara-appserver-modules/security-oauth2/pom.xml
@@ -108,7 +108,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>

--- a/appserver/payara-appserver-modules/security-openid/pom.xml
+++ b/appserver/payara-appserver-modules/security-openid/pom.xml
@@ -103,8 +103,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>

--- a/appserver/payara-appserver-modules/security-openid/pom.xml
+++ b/appserver/payara-appserver-modules/security-openid/pom.xml
@@ -109,7 +109,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
         
         <dependency>

--- a/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
+++ b/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
@@ -121,7 +121,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
+++ b/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
@@ -92,8 +92,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.yubico</groupId>

--- a/appserver/persistence/eclipselink-wrapper/pom.xml
+++ b/appserver/persistence/eclipselink-wrapper/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-             <version>${eclipselink.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -741,6 +741,13 @@
                 <artifactId>maven-processor-plugin</artifactId>
                 <version>2.0.4</version>
             </dependency>
+            <!-- contrary to what BOM says, this processor is packaged with the server, and therefore needs compile scope -->
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
+                <version>${eclipselink.version}</version>
+                <scope>compile</scope>
+            </dependency>
 
             <!--
                 only used to satisfy findbugs,

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,8 +116,6 @@
         <dbschema.osgi.version>6.0</dbschema.osgi.version>
         <schema2beans.version>3.1.1</schema2beans.version>
         <schema2beans.osgi.version>5.5</schema2beans.osgi.version>
-        <javadb.version>10.13.1.1</javadb.version>
-        <h2db.version>1.4.196</h2db.version>
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
         <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -60,9 +60,6 @@
 
     <properties>
         <jakarta.faces-spec.version>2.3.1</jakarta.faces-spec.version>
-        <websocket-api.version>1.1.2</websocket-api.version>
-        <concurrent-api.version>1.1.2</concurrent-api.version>
-        <concurrent.version>1.0.payara-p2</concurrent.version>
         <jboss.classfilewriter.version>1.2.3.Final</jboss.classfilewriter.version>
         <apache.bcel.version>6.2</apache.bcel.version>
         <!-- Java EE Security API -->
@@ -686,21 +683,6 @@
                 <groupId>org.glassfish.ha</groupId>
                 <artifactId>ha-api</artifactId>
                 <version>${ha-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.websocket</groupId>
-                <artifactId>jakarta.websocket-api</artifactId>
-                <version>${websocket-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.enterprise.concurrent</groupId>
-                <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-                <version>${concurrent-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.enterprise.concurrent</artifactId>
-                <version>${concurrent.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -59,149 +59,68 @@
     <name>Payara Appserver Parent Project</name>
 
     <properties>
-
         <!-- EJB -->
-        <jakarta.ejb-api.version>3.2.5</jakarta.ejb-api.version>
-
         <!-- JSP -->
-        <jsp-api.version>2.3.6</jsp-api.version>
-        <jsp-impl.version>2.3.4</jsp-impl.version>
-
         <!-- JSTL -->
-        <jstl-api.version>1.2.7</jstl-api.version>
-        <jstl-impl.version>1.2.5</jstl-impl.version>
-
         <!-- JSF -->
         <jakarta.faces-spec.version>2.3.1</jakarta.faces-spec.version>
-        <jakarta.faces-api.version>2.3.1</jakarta.faces-api.version>
-        <mojarra.version>2.3.9.payara-p3</mojarra.version>
-
         <!-- WebSocket -->
         <websocket-api.version>1.1.2</websocket-api.version>
-        <tyrus.version>1.15</tyrus.version>
-
         <!-- JAX-B -->
-        <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
-
         <!-- JSON-B -->
-        <json.bind-api.version>1.0.2</json.bind-api.version>
-        <yasson.version>1.0.4.payara-p2</yasson.version>
-
         <!-- JPA -->
-        <javax-persistence-api.version>2.2.2</javax-persistence-api.version>
-        <eclipselink.version>2.7.4.payara-p2</eclipselink.version>
-
         <!-- JTA -->
-        <jakarta.transaction-api.version>1.3.2</jakarta.transaction-api.version>
-
         <!-- Concurrency -->
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.0.payara-p2</concurrent.version>
-
-         <!-- Interceptor -->
-        <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
-
+        <!-- Interceptor -->
         <!-- CDI -->
-        <jakarta.inject.version>1.0</jakarta.inject.version>
-        <cdi-api.version>2.0.2</cdi-api.version>
-        <weld.version>3.1.1.Final</weld.version>
         <weld-bundle.version>3.1.1.Final</weld-bundle.version>
-        <weld-api.version>3.1.Final</weld-api.version>
         <jboss.classfilewriter.version>1.2.3.Final</jboss.classfilewriter.version>
         <apache.bcel.version>6.2</apache.bcel.version>
-
         <!-- Java EE Security API -->
         <javax.security.enterprise-spec.version>1.0</javax.security.enterprise-spec.version>
-        <javax.security.enterprise-api.version>1.0.2</javax.security.enterprise-api.version>
-        <jakarta.security.enterprise.version>1.1-b01.payara-p3</jakarta.security.enterprise.version>
-
         <!-- JACC -->
-        <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
-
         <!-- JASPIC -->
-        <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
-
         <!-- JMS -->
-        <jms-api.version>2.0.2</jms-api.version>
-
         <jna.version>5.2.0</jna.version>
-        
         <jline-terminal-jna>3.11.0</jline-terminal-jna>
-        
         <!-- 5.1.1-b02.payara-p1 -->
-        <mq.version>5.1.1.final.payara-p4</mq.version>
-
         <!-- Batch -->
-        <javax.batch-api.version>1.0.1</javax.batch-api.version>
-        <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
-        <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>
-
         <!-- JAX-WS -->
-        <jaxws-api.version>2.3.2</jaxws-api.version>
-
-        <jakarta.jws-api.version>1.1.1</jakarta.jws-api.version>
-
         <!-- Metro Webservices is the JAX-WS impl -->
-        <webservices.version>2.4.3.payara-p3</webservices.version>
         <!-- Woodstox is a high-performance XML processor that implements Stax (JSR-173) and SAX2 APIs -->
-        <woodstox.version>5.1.0</woodstox.version>
         <!-- Woodstox Stax2 API is an extension to basic Stax 1.0 API that adds significant functionality -->
-        <stax2-api.version>4.1</stax2-api.version>
-
-        <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>
-        <jakarta.xml.rpc-api.version>1.1.4</jakarta.xml.rpc-api.version>
-
-        <jakarta.resource-api.version>1.7.3</jakarta.resource-api.version>
-
         <!-- Deployment API (JSR 88) (deprecated/pruned) -->
-        <javax.enterprise.deploy-api.version>1.7.2</javax.enterprise.deploy-api.version>
-
         <!-- Management API (JRS 77) -->
-        <javax.management.j2ee-api.version>1.1.4</javax.management.j2ee-api.version>
-
         <!-- JAF -->
-        <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>
-        <jakarta.activation-impl.version>1.2.1</jakarta.activation-impl.version>
-
-        <istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
-
         <!-- Application Server / Implementation -->
         <product.name>Payara Server</product.name>
         <brief_product_name>Payara Server</brief_product_name>
         <abbrev_product_name>Payara</abbrev_product_name>
-
         <admin_client_command_name>asadmin</admin_client_command_name>
         <default_domain_template>appserver-domain.jar</default_domain_template>
         <production_domain_template>production-domain.jar</production_domain_template>
         <version_prefix />
-
         <version_suffix>#badassfish</version_suffix>
         <major_version>5</major_version>
         <minor_version>194-SNAPSHOT</minor_version>
         <update_version></update_version>
         <install.dir.name>payara${major_version}</install.dir.name>
-
         <jsf-ext.version>0.2</jsf-ext.version>
         <jsftemplating.version>2.1.3</jsftemplating.version>
         <woodstock.version>4.0.2.10.payara-p16</woodstock.version>
-
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
-
         <dbschema.version>3.1.1</dbschema.version>
         <dbschema.osgi.version>6.0</dbschema.osgi.version>
         <schema2beans.version>3.1.1</schema2beans.version>
         <schema2beans.osgi.version>5.5</schema2beans.osgi.version>
-
         <javadb.version>10.13.1.1</javadb.version>
         <h2db.version>1.4.196</h2db.version>
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
-
-        <wsdl4j.version>1.6.3</wsdl4j.version>
-
         <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
-
         <!-- Microprofile version properties -->
         <microprofile-fault-tolerance.version>2.0.1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
@@ -209,14 +128,12 @@
         <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>
         <microprofile-rest-client.version>1.3.3</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
-
         <nimbus-jose-jwt.version>5.4</nimbus-jose-jwt.version>
         <accessors-smart.version>1.2.payara-p2</accessors-smart.version>
         <json-smart.version>2.3</json-smart.version>
         <jcip-annotations.version>1.0-1</jcip-annotations.version>
         <!-- Yubico client validation version property -->
         <yubico-validation-client2.version>3.0.2.payara-p1</yubico-validation-client2.version>
-
         <dockerfile-maven-plugin.version>1.4.10</dockerfile-maven-plugin.version>
     </properties>
 
@@ -637,227 +554,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>jakarta.ejb</groupId>
-                <artifactId>jakarta.ejb-api</artifactId>
-                <version>${jakarta.ejb-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.interceptor</groupId>
-                <artifactId>jakarta.interceptor-api</artifactId>
-                <version>${jakarta.interceptor-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.transaction</groupId>
-                <artifactId>jakarta.transaction-api</artifactId>
-                <version>${jakarta.transaction-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.transaction.cdi</groupId>
-                <artifactId>jakarta.transaction.cdi-api</artifactId>
-                <version>${jakarta.transaction.cdi-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.rpc</groupId>
-                <artifactId>jakarta.xml.rpc-api</artifactId>
-                <version>${jakarta.xml.rpc-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.enterprise</groupId>
-                <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${cdi-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.inject</groupId>
-                <artifactId>jakarta.inject-api</artifactId>
-                <version>${jakarta.inject.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.resource</groupId>
-                <artifactId>jakarta.resource-api</artifactId>
-                <version>${jakarta.resource-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.enterprise.deploy</groupId>
-                <artifactId>jakarta.enterprise.deploy-api</artifactId>
-                <version>${javax.enterprise.deploy-api.version}</version>
-            </dependency>
-
-            <!-- JSF - JavaServer Faces -->
-            <dependency>
-                <groupId>jakarta.faces</groupId>
-                <artifactId>jakarta.faces-api</artifactId>
-                <version>${jakarta.faces-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.faces</artifactId>
-                <version>${mojarra.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.woodstox</groupId>
-                <artifactId>woodstox-core</artifactId>
-                <version>${woodstox.version}</version>
-            </dependency>
-
-            <!-- Java EE Security API -->
-            <dependency>
-                <groupId>jakarta.security.enterprise</groupId>
-                <artifactId>jakarta.security.enterprise-api</artifactId>
-                <version>${javax.security.enterprise-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.soteria</groupId>
-                <artifactId>javax.security.enterprise</artifactId>
-                <version>${jakarta.security.enterprise.version}</version>
-            </dependency>
-
-            <!-- JACC -->
-            <dependency>
-                <groupId>jakarta.security.jacc</groupId>
-                <artifactId>jakarta.security.jacc-api</artifactId>
-                <version>${jakarta.security.jacc-api.version}</version>
-            </dependency>
-
-            <!-- JASPIC -->
-            <dependency>
-                <groupId>jakarta.security.auth.message</groupId>
-                <artifactId>jakarta.security.auth.message-api</artifactId>
-                <version>${jakarta.security.auth.message-api.version}</version>
-            </dependency>
-
-            <!-- JPA -->
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>jakarta.persistence</artifactId>
-                <version>${javax-persistence-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.core</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.jpa</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.moxy</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.sdo</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.dbws</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.oracle</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.antlr</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.asm</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.metro</groupId>
-                <artifactId>webservices-osgi</artifactId>
-                <version>${webservices.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.metro</groupId>
-                <artifactId>webservices-extra-jdk-packages</artifactId>
-                <version>${webservices.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.metro</groupId>
-                <artifactId>webservices-api-osgi</artifactId>
-                <version>${webservices.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-extra-osgi</artifactId>
-                <version>${jaxb-extra-osgi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.registry</groupId>
-                <artifactId>jakarta.xml.registry-api</artifactId>
-                <version>${jakarta.xml.registry-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.woodstox</groupId>
-                <artifactId>stax2-api</artifactId>
-                <version>${stax2-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.jbi</groupId>
-                <artifactId>jbi</artifactId>
-                <version>${jbi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>wsdl4j</groupId>
-                <artifactId>wsdl4j</artifactId>
-                <version>${wsdl4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-osgi-bundle</artifactId>
-                <version>${weld.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.classfilewriter</groupId>
-                        <artifactId>jboss-classfilewriter</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.bcel</groupId>
                 <artifactId>bcel</artifactId>
                 <version>${apache.bcel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-api</artifactId>
-                <version>${weld-api.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.enterprise</groupId>
-                        <artifactId>cdi-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.classfilewriter</groupId>
                 <artifactId>jboss-classfilewriter</artifactId>
                 <version>${jboss.classfilewriter.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld.se</groupId>
-                <artifactId>weld-se-shaded</artifactId>
-                <version>${weld.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld.environment</groupId>
-                <artifactId>weld-environment-common</artifactId>
-                <version>${weld.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.pkg</groupId>
@@ -868,22 +572,6 @@
                 <groupId>com.sun.pkg</groupId>
                 <artifactId>pkg-bootstrap</artifactId>
                 <version>${uc-pkg-bootstrap.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.web</groupId>
-                <artifactId>javax.servlet.jsp</artifactId>
-                <version>${jsp-impl.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.servlet.jsp</groupId>
-                        <artifactId>jsp-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.faces.extensions</groupId>
@@ -954,81 +642,6 @@
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.3.3</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.messaging.mq</groupId>
-                <artifactId>imqjmx</artifactId>
-                <version>4.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.mq</groupId>
-                <artifactId>mq-distribution</artifactId>
-                <version>${mq.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.jms</groupId>
-                <artifactId>jakarta.jms-api</artifactId>
-                <version>${jms-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.servlet.jsp</groupId>
-                <artifactId>jakarta.servlet.jsp-api</artifactId>
-                <version>${jsp-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.servlet.jsp.jstl</groupId>
-                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-                <version>${jstl-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.web</groupId>
-                <artifactId>javax.servlet.jsp.jstl</artifactId>
-                <version>${jstl-impl.version}</version>
-            </dependency>
-
-            <!-- JSON-B -->
-            <dependency>
-                <groupId>jakarta.json.bind</groupId>
-                <artifactId>jakarta.json.bind-api</artifactId>
-                <version>${json.bind-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse</groupId>
-                <artifactId>yasson</artifactId>
-                <version>${yasson.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.json.bind</groupId>
-                        <artifactId>jakarta.json.bind-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.glassfish</groupId>
-                        <artifactId>jakarta.json</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- JSON-P -->
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.json</artifactId>
-                <version>${jsonp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.json</groupId>
-                <artifactId>jakarta.json-api</artifactId>
-                <version>${jsonp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jsonp-jaxrs</artifactId>
-                <version>${jsonp.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.management.j2ee</groupId>
-                <artifactId>jakarta.management.j2ee-api</artifactId>
-                <version>${javax.management.j2ee-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
@@ -1136,21 +749,7 @@
                 <artifactId>maven-processor-plugin</artifactId>
                 <version>2.0.4</version>
             </dependency>
-            <dependency>
-                <groupId>jakarta.batch</groupId>
-                <artifactId>jakarta.batch-api</artifactId>
-                <version>${javax.batch-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.ibm.jbatch</groupId>
-                <artifactId>com.ibm.jbatch.container</artifactId>
-                <version>${com.ibm.jbatch.container.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.ibm.jbatch</groupId>
-                <artifactId>com.ibm.jbatch.spi</artifactId>
-                <version>${com.ibm.jbatch.spi.version}</version>
-            </dependency>
+
             <!--
                 only used to satisfy findbugs,
                 can be removed once GLASSFISH-20835 is resolved
@@ -1160,44 +759,12 @@
                 <artifactId>ddl</artifactId>
                 <version>RELEASE65</version>
             </dependency>
-            <dependency>
-                <groupId>org.glassfish.tyrus</groupId>
-                <artifactId>tyrus-bom</artifactId>
-                <version>${tyrus.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
+
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>${jboss.logging.version}</version>
                 <optional>true</optional>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${jaxws-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-runtime</artifactId>
-                <version>${istack-commons-runtime.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.activation</groupId>
-                <artifactId>jakarta.activation-api</artifactId>
-                <version>${jakarta.activation-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.activation</groupId>
-                <artifactId>jakarta.activation</artifactId>
-                <version>${jakarta.activation-impl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.jws</groupId>
-                <artifactId>jakarta.jws-api</artifactId>
-                <version>${jakarta.jws-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -59,41 +59,17 @@
     <name>Payara Appserver Parent Project</name>
 
     <properties>
-        <!-- EJB -->
-        <!-- JSP -->
-        <!-- JSTL -->
-        <!-- JSF -->
         <jakarta.faces-spec.version>2.3.1</jakarta.faces-spec.version>
-        <!-- WebSocket -->
         <websocket-api.version>1.1.2</websocket-api.version>
-        <!-- JAX-B -->
-        <!-- JSON-B -->
-        <!-- JPA -->
-        <!-- JTA -->
-        <!-- Concurrency -->
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.0.payara-p2</concurrent.version>
-        <!-- Interceptor -->
-        <!-- CDI -->
-        <weld-bundle.version>3.1.1.Final</weld-bundle.version>
         <jboss.classfilewriter.version>1.2.3.Final</jboss.classfilewriter.version>
         <apache.bcel.version>6.2</apache.bcel.version>
         <!-- Java EE Security API -->
         <javax.security.enterprise-spec.version>1.0</javax.security.enterprise-spec.version>
-        <!-- JACC -->
-        <!-- JASPIC -->
-        <!-- JMS -->
         <jna.version>5.2.0</jna.version>
         <jline-terminal-jna>3.11.0</jline-terminal-jna>
-        <!-- 5.1.1-b02.payara-p1 -->
-        <!-- Batch -->
-        <!-- JAX-WS -->
-        <!-- Metro Webservices is the JAX-WS impl -->
-        <!-- Woodstox is a high-performance XML processor that implements Stax (JSR-173) and SAX2 APIs -->
-        <!-- Woodstox Stax2 API is an extension to basic Stax 1.0 API that adds significant functionality -->
-        <!-- Deployment API (JSR 88) (deprecated/pruned) -->
-        <!-- Management API (JRS 77) -->
-        <!-- JAF -->
+
         <!-- Application Server / Implementation -->
         <product.name>Payara Server</product.name>
         <brief_product_name>Payara Server</brief_product_name>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -122,12 +122,6 @@
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
         <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
         <!-- Microprofile version properties -->
-        <microprofile-fault-tolerance.version>2.0.1</microprofile-fault-tolerance.version>
-        <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
-        <microprofile-healthcheck.version>2.1</microprofile-healthcheck.version>
-        <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>
-        <microprofile-rest-client.version>1.3.3</microprofile-rest-client.version>
-        <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
         <nimbus-jose-jwt.version>5.4</nimbus-jose-jwt.version>
         <accessors-smart.version>1.2.payara-p2</accessors-smart.version>
         <json-smart.version>2.3</json-smart.version>
@@ -260,7 +254,7 @@
                             <artifact>
                                 <groupId>jakarta.security.enterprise</groupId>
                                 <artifactId>jakarta.security.enterprise-api</artifactId>
-                                <version>${javax.security-api.version}</version>
+                                <version>${javax.security.enterprise-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -96,7 +96,6 @@
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
                 <artifactId>microprofile</artifactId>
-                <version>3.0</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>

--- a/appserver/web/gf-web-connector/pom.xml
+++ b/appserver/web/gf-web-connector/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-api</artifactId>
-            <version>${weld-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -157,12 +157,10 @@
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>
             <artifactId>tyrus-container-servlet</artifactId>
-            <version>${tyrus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
-            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>

--- a/appserver/web/weld-integration-fragment/pom.xml
+++ b/appserver/web/weld-integration-fragment/pom.xml
@@ -83,7 +83,7 @@
                         </goals>
                         <configuration>
                             <instructions>
-                                <Fragment-Host>org.jboss.weld.osgi-bundle;bundle-version=${weld-bundle.version}</Fragment-Host>
+                                <Fragment-Host>org.jboss.weld.osgi-bundle;bundle-version=${weld.version}</Fragment-Host>
                                 <!-- The export of javassist.util.proxy is done to ensure that the weld-generated proxy has access to the ProxyFactory class
                                in that package. This "partial" export of the javassist package would not cause the problem described in IT 12368, because
                                javassist has fixed the issue in JASSIST-104, and as part of WELD-570, the new javassist version is integrated in Weld 1.1.Beta2

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -143,7 +143,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -159,8 +159,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
     

--- a/nucleus/admin/rest/rest-client/pom.xml
+++ b/nucleus/admin/rest/rest-client/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -125,7 +125,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.flashlight</groupId>
@@ -166,7 +165,6 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/nucleus/admin/rest/rest-testing/pom.xml
+++ b/nucleus/admin/rest/rest-testing/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/admin/template/pom.xml
+++ b/nucleus/admin/template/pom.xml
@@ -81,7 +81,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/nucleus/admin/util/pom.xml
+++ b/nucleus/admin/util/pom.xml
@@ -159,7 +159,6 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jline</groupId>

--- a/nucleus/common/amx-core/pom.xml
+++ b/nucleus/common/amx-core/pom.xml
@@ -103,7 +103,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2</artifactId>
-            <version>${hk2.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -91,7 +91,6 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-utils</artifactId>
-            <version>${hk2.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.hk2</groupId>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -136,7 +136,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-core</artifactId>
-            <version>${hk2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet</groupId>
@@ -146,7 +145,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.validator.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>

--- a/nucleus/packager/external/opentracing-repackaged/pom.xml
+++ b/nucleus/packager/external/opentracing-repackaged/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>${opentracing.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/nucleus/packager/nucleus-jersey/pom.xml
+++ b/nucleus/packager/nucleus-jersey/pom.xml
@@ -145,7 +145,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-            <version>${jsonp.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/notification-cdi-eventbus-core/pom.xml
+++ b/nucleus/payara-modules/notification-cdi-eventbus-core/pom.xml
@@ -66,8 +66,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/notification-core/pom.xml
+++ b/nucleus/payara-modules/notification-core/pom.xml
@@ -103,8 +103,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/nucleus/payara-modules/notification-eventbus-core/pom.xml
+++ b/nucleus/payara-modules/notification-eventbus-core/pom.xml
@@ -64,8 +64,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/pom.xml
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/pom.xml
@@ -102,7 +102,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${microprofile-config.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/requesttracing-core/pom.xml
+++ b/nucleus/payara-modules/requesttracing-core/pom.xml
@@ -116,13 +116,11 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-            <version>${jsonp.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee.api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -96,7 +96,6 @@
             <id>payara-patched-externals</id>
             <name>Payara Patched Externals</name>
             <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url> -->
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -110,7 +109,6 @@
         <!-- on Hudson and RE, ${build.number} gets replaced by real build ID -->
         <build.id>${build.number}</build.id>
         <jdk.version>1.8.0</jdk.version>
-        <javase.version>1.8</javase.version>
         <javadoc.skip>false</javadoc.skip>
 
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
@@ -122,7 +120,6 @@
         <maven.war.plugin.version>3.2.2</maven.war.plugin.version>
         <maven.makepkgs.plugin.version>0.6.2</maven.makepkgs.plugin.version>
         <maven.jaxb2.plugin.version>0.14.0</maven.jaxb2.plugin.version>
-        <maven.bundle.plugin.version>4.1.0</maven.bundle.plugin.version>
         <maven.antlr.plugin.version>2.2</maven.antlr.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
         <maven.jaxws.plugin.version>2.5</maven.jaxws.plugin.version>
@@ -268,22 +265,6 @@
                     <version>${maven.clean.plugin.version}</version>
                </plugin>
 
-               <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven.compiler.plugin.version}</version>
-                    <configuration>
-                        <source>${javase.version}</source>
-                        <target>${javase.version}</target>
-                        <excludes>
-                            <exclude>**/.ade_path/**</exclude>
-                        </excludes>
-                        <testExcludes>
-                            <testExclude>**/.ade_path/**</testExclude>
-                        </testExcludes>
-                    </configuration>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
@@ -303,17 +284,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${maven.source.plugin.version}</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>${maven.javadoc.plugin.version}</version>
-                    <configuration>
-                        <additionalOptions>
-                            <additionalOption>${javadoc.options}</additionalOption>
-                        </additionalOptions>
-                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -429,12 +399,6 @@
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
                     <artifactId>maven-jaxb2-plugin</artifactId>
                     <version>${maven.jaxb2.plugin.version}</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>${maven.bundle.plugin.version}</version>
                 </plugin>
 
                 <plugin>
@@ -627,21 +591,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <!-- By default, we don't export anything. -->
-                    <Export-Package />
-                    <instructions>
-                        <!--
-                            Read all the configuration from osgi.bundle file, if it exists.
-                        -->
-                        <_include>-osgi.bundle</_include>
-                    </instructions>
-                    <excludeDependencies>tools-jar</excludeDependencies>
-                    <supportedProjectTypes>
-                        <supportedProjectType>glassfish-jar</supportedProjectType>
-                        <supportedProjectType>jar</supportedProjectType>
-                    </supportedProjectTypes>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -787,14 +736,6 @@ Parent is ${project.parent}</echo>
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                    <skip>${deploy.skip}</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -185,9 +185,6 @@
         <commons-io.version>2.6</commons-io.version>
 
         <mimepull.version>1.9.11</mimepull.version>
-
-        <opentracing.version>0.31.0</opentracing.version>
-
         <jline.version>3.11.0</jline.version>
 
         <!-- Apache Felix is an open source implementation of the OSGi Core Release 6 framework specification. -->

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -89,19 +89,6 @@
             </snapshots>
         </repository>
 
-        <repository>
-           <id>payara-patched-externals</id>
-             <name>Payara Patched Externals</name>
-             <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-             <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url>-->
-             <releases>
-                 <enabled>true</enabled>
-             </releases>
-              <snapshots>
-                  <enabled>false</enabled>
-              </snapshots>
-        </repository>
-
     </repositories>
 
     <pluginRepositories>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -145,13 +145,7 @@
 
         <deploy.skip>true</deploy.skip>
 
-        <!-- Java EE -->
-        <jakartaee.api.version>8.0.0</jakartaee.api.version>
-
         <!-- Servlet -->
-        <servlet-api.version>4.0.2</servlet-api.version>
-        <grizzly.version>2.4.3.payara-p9</grizzly.version>
-
         <!-- Requires JDK8u161 or above-->
         <grizzly.npn.version>1.8</grizzly.npn.version>
 
@@ -161,41 +155,19 @@
 
         <!-- JAX-RS -->
         <jax-rs-api.spec.version>2.1.5</jax-rs-api.spec.version>
-        <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
-        <jersey.version>2.29.1.payara-p1</jersey.version>
-
-        <!-- Bean Validation -->
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
-        <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
-        <hibernate.validator-cdi.version>6.0.16.Final</hibernate.validator-cdi.version>
-
-        <!-- Expression language -->
-        <jakarta.el.version>3.0.3</jakarta.el.version>
-        <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
 
         <!-- JAX-B -->
-        <jaxb-api.version>2.3.2</jaxb-api.version>
         <jaxb.version>2.3.2</jaxb.version>
-
-        <!-- Cache -->
-        <javax.cache-api.version>1.1.0</javax.cache-api.version>
-
-        <!-- JavaMail -->
-        <mail.version>1.6.4.payara-p1</mail.version>
 
         <management-api.version>1.1-rev-1</management-api.version>
 
-        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-
-
         <!-- Other -->
 
-        <hk2.version>2.6.1.payara-p1</hk2.version>
         <hk2.plugin.version>2.6.1.payara-p1</hk2.plugin.version>
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
 
         <glassfish-corba.version>4.1.1.payara-p3</glassfish-corba.version>
-        <stax-api.version>1.0-2</stax-api.version>
         <saaj-api.version>1.4.0</saaj-api.version>
 
         <!-- Library for introspecting types with full generic information including resolving of field and method types. -->
@@ -214,11 +186,6 @@
         <antlr.version>2.7.7</antlr.version>
 
         <commons-io.version>2.6</commons-io.version>
-
-        <!-- Jackson is a high-performance JSON processor (parser, generator) -->
-        <jackson.version>2.10.0</jackson.version>
-        <!-- SnakeYAML is required for the YAML conversion in Jackson -->
-        <snakeyaml.version>1.24</snakeyaml.version>
 
         <jsonp.version>1.1.5</jsonp.version>
 
@@ -249,15 +216,11 @@
         <l10n.version>3.1-b41</l10n.version>
         <asm.version>7.2</asm.version>
         <ha-api.version>3.1.12</ha-api.version>
-        <hazelcast.version>3.12</hazelcast.version>
-        <hazelcast.kubernetes.version>1.3.1</hazelcast.kubernetes.version>
         <smack.version>4.1.9</smack.version>
         <jxmpp.version>0.4.2</jxmpp.version>
         <xpp3.version>1.1.4c_7</xpp3.version>
         <snmp4j.version>2.5.3-payara.p1</snmp4j.version>
         <mockito.version>2.2.6</mockito.version>
-        <jaxb-api.version>2.3.2</jaxb-api.version>
-        <jaxb-impl.version>2.3.2</jaxb-impl.version>
 
         <!-- Build -->
 
@@ -859,104 +822,14 @@ Parent is ${project.parent}</echo>
 
     <dependencyManagement>
         <dependencies>
-
-            <!-- Servlet -->
             <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>${servlet-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.grizzly</groupId>
-                <artifactId>grizzly-bom</artifactId>
-                <version>${grizzly.version}</version>
-                <scope>import</scope>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <!-- A workaround for case when module redefines its version (rest-monitoring-war) -->
+                <version>${project.parent.version}</version>
                 <type>pom</type>
-            </dependency>
-
-            <!-- JAX-RS -->
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>${jax-rs-api.impl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey</groupId>
-                <artifactId>jersey-bom</artifactId>
-                <version>${jersey.version}</version>
                 <scope>import</scope>
-                <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-
-
-            <!-- Bean Validation (BVal) -->
-            <dependency>
-                <groupId>jakarta.validation</groupId>
-                <artifactId>jakarta.validation-api</artifactId>
-                <version>${jakarta.validation.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.validator</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>${hibernate.validator.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.validation</groupId>
-                        <artifactId>validation-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.validator</groupId>
-                <artifactId>hibernate-validator-cdi</artifactId>
-                <version>${hibernate.validator-cdi.version}</version>
-            </dependency>
-
-
-            <!-- Expression Language (EL) -->
-            <dependency>
-                <groupId>jakarta.el</groupId>
-                <artifactId>jakarta.el-api</artifactId>
-                <version>${jakarta.el-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${jakarta.el.version}</version>
-            </dependency>
-
-
-            <!-- JavaMail -->
-            <dependency>
-                <groupId>jakarta.mail</groupId>
-                <artifactId>jakarta.mail-api</artifactId>
-                <version>${mail.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>jakarta.mail</artifactId>
-                <version>${mail.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.annotation</groupId>
-                <artifactId>jakarta.annotation-api</artifactId>
-                <version>${jakarta.annotation-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.glassfish.hk2</groupId>
-                <artifactId>hk2-bom</artifactId>
-                <version>${hk2.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
             <dependency>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>osgi-resource-locator</artifactId>
@@ -967,11 +840,6 @@ Parent is ${project.parent}</echo>
                 <groupId>com.sun.xml.stream</groupId>
                 <artifactId>sjsxp</artifactId>
                 <version>1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.stream</groupId>
-                <artifactId>stax-api</artifactId>
-                <version>${stax-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>antlr</groupId>
@@ -993,31 +861,6 @@ Parent is ${project.parent}</echo>
                 <artifactId>gmbal</artifactId>
                 <version>${gmbal.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.compendium</artifactId>
-                <version>5.0.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.core</artifactId>
-                <version>6.0.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.enterprise</artifactId>
-                <version>5.0.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId> <!-- OSGi Companion Code for org.osgi.dto Version 1.0.0. -->
-                <artifactId>org.osgi.dto</artifactId>
-                <version>1.0.0</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.main</artifactId>
@@ -1054,8 +897,8 @@ Parent is ${project.parent}</echo>
                 <version>${org.apache.felix.gogo.command.version}</version>
             </dependency>
             <dependency> <!-- A utility to automatically install bundles from a directory.-->
-               <groupId>org.apache.felix</groupId>
-               <artifactId>org.apache.felix.fileinstall</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.fileinstall</artifactId>
                 <version>${org.apache.felix.fileinstall.version}</version>
             </dependency>
             <dependency>
@@ -1064,51 +907,14 @@ Parent is ${project.parent}</echo>
                 <version>${org.apache.felix.configadmin.version}</version>
             </dependency>
             <dependency>
-               <groupId>org.apache.felix</groupId> <!-- Implementation of the Declarative Services specification 1.3 -->
-               <artifactId>org.apache.felix.scr</artifactId>
-               <version>${org.apache.felix.scr.version}</version>
+                <groupId>org.apache.felix</groupId> <!-- Implementation of the Declarative Services specification 1.3 -->
+                <artifactId>org.apache.felix.scr</artifactId>
+                <version>${org.apache.felix.scr.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId> <!-- Bundle repository service. -->
                 <artifactId>org.apache.felix.bundlerepository</artifactId>
                 <version>${org.apache.felix.bundlerepository.version}</version>
-            </dependency>
-
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>
@@ -1294,32 +1100,6 @@ Parent is ${project.parent}</echo>
                 <artifactId>javassist</artifactId>
                 <version>${javassist.version}</version>
             </dependency>
-            <dependency>
-                <groupId>javax.cache</groupId>
-                <artifactId>cache-api</artifactId>
-                <version>${javax.cache-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.hazelcast</groupId>
-                <artifactId>hazelcast</artifactId>
-                <version>${hazelcast.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.hazelcast</groupId>
-                <artifactId>hazelcast-kubernetes</artifactId>
-                <version>${hazelcast.kubernetes.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${jaxb-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-osgi</artifactId>
-                <version>${jaxb-impl.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -189,7 +189,6 @@
         <btrace.version>1.2.3</btrace.version>
         <opendmk.version>1.0-b01-ea</opendmk.version>
         <l10n.version>3.1-b41</l10n.version>
-        <asm.version>7.2</asm.version>
         <ha-api.version>3.1.12</ha-api.version>
         <smack.version>4.1.9</smack.version>
         <jxmpp.version>0.4.2</jxmpp.version>
@@ -957,31 +956,6 @@ Parent is ${project.parent}</echo>
                 <groupId>com.sun</groupId>
                 <artifactId>ldapbp</artifactId>
                 <version>1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-commons</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-analysis</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-tree</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-util</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jvnet.hudson</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -150,9 +150,6 @@
         <grizzly.npn.version>1.8</grizzly.npn.version>
 
         <!-- Microprofile -->
-        <microprofile-config.version>1.3</microprofile-config.version>
-        <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
-
         <!-- JAX-RS -->
         <jax-rs-api.spec.version>2.1.5</jax-rs-api.spec.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -187,8 +187,6 @@
 
         <commons-io.version>2.6</commons-io.version>
 
-        <jsonp.version>1.1.5</jsonp.version>
-
         <mimepull.version>1.9.11</mimepull.version>
 
         <opentracing.version>0.31.0</opentracing.version>
@@ -209,7 +207,6 @@
         <org.apache.felix.bundlerepository.version>2.0.10</org.apache.felix.bundlerepository.version>
 
         <!-- Java Business Integration (JBI) is a specification for an approach to implementing a service-oriented architecture (SOA).  -->
-        <jbi.version>1.0</jbi.version>
         <glassfish-management-api.version>3.2.1-b002.payara-p1</glassfish-management-api.version>
         <btrace.version>1.2.3</btrace.version>
         <opendmk.version>1.0-b01-ea</opendmk.version>

--- a/nucleus/test-utils/utils-ng/pom.xml
+++ b/nucleus/test-utils/utils-ng/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.3.1</version>
         </dependency>
     </dependencies>    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
         <microprofile-rest-client.version>1.3.4</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
         <payara-arquillian-container.version>1.2</payara-arquillian-container.version>
+        <opentracing.version>0.31.0</opentracing.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,50 @@
         <hazelcast.kubernetes.version>1.3.1</hazelcast.kubernetes.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>
         <jaxb-impl.version>2.3.2</jaxb-impl.version>
+        <jakarta.ejb-api.version>3.2.5</jakarta.ejb-api.version>
+        <jsp-api.version>2.3.6</jsp-api.version>
+        <jsp-impl.version>2.3.4</jsp-impl.version>
+        <jstl-api.version>1.2.7</jstl-api.version>
+        <jstl-impl.version>1.2.5</jstl-impl.version>
+        <jakarta.faces-api.version>2.3.1</jakarta.faces-api.version>
+        <mojarra.version>2.3.9.payara-p3</mojarra.version>
+        <tyrus.version>1.15</tyrus.version>
+        <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
+        <json.bind-api.version>1.0.2</json.bind-api.version>
+        <yasson.version>1.0.4.payara-p2</yasson.version>
+        <jakarta-persistence-api.version>2.2.2</jakarta-persistence-api.version>
+        <eclipselink.version>2.7.4.payara-p2</eclipselink.version>
+        <jakarta.transaction-api.version>1.3.2</jakarta.transaction-api.version>
+        <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
+        <jakarta.inject.version>1.0</jakarta.inject.version>
+        <cdi-api.version>2.0.2</cdi-api.version>
+        <weld.version>3.1.1.Final</weld.version>
+        <weld-api.version>3.1.Final</weld-api.version>
+        <jakarta.security.enterprise-api.version>1.0.2</jakarta.security.enterprise-api.version>
+        <jakarta.security.enterprise.version>1.1-b01.payara-p3</jakarta.security.enterprise.version>
+        <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
+        <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
+        <jms-api.version>2.0.2</jms-api.version>
+        <mq.version>5.1.1.final.payara-p4</mq.version>
+        <jakarta.batch-api.version>1.0.1</jakarta.batch-api.version>
+        <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
+        <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>
+        <jaxws-api.version>2.3.2</jaxws-api.version>
+        <jakarta.jws-api.version>1.1.1</jakarta.jws-api.version>
+        <webservices.version>2.4.3.payara-p3</webservices.version>
+        <woodstox.version>5.1.0</woodstox.version>
+        <stax2-api.version>4.1</stax2-api.version>
+        <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>
+        <jakarta.xml.rpc-api.version>1.1.4</jakarta.xml.rpc-api.version>
+        <jakarta.resource-api.version>1.7.3</jakarta.resource-api.version>
+        <jakarta.enterprise.deploy-api.version>1.7.2</jakarta.enterprise.deploy-api.version>
+        <jakarta.management.j2ee-api.version>1.1.4</jakarta.management.j2ee-api.version>
+        <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>
+        <jakarta.activation-impl.version>1.2.1</jakarta.activation-impl.version>
+        <istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
+        <wsdl4j.version>1.6.3</wsdl4j.version>
+        <jsonp.version>1.1.5</jsonp.version>
+        <jbi.version>1.0</jbi.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -112,10 +112,12 @@
         <maven.source.plugin.version>3.1.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
         <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
+        <maven.bundle.plugin.version>4.1.0</maven.bundle.plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
+        <javase.version>1.8</javase.version>
+        <deploy.skip>false</deploy.skip>
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
@@ -354,8 +356,14 @@
                     <version>${maven.source.plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven.javadoc.plugin.version}</version>
+                    <configuration>
+                        <additionalOptions>
+                            <additionalOption>-Xdoclint:none</additionalOption>
+                        </additionalOptions>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
@@ -372,6 +380,50 @@
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven.release.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.plugin.version}</version>
+                    <configuration>
+                        <source>${javase.version}</source>
+                        <target>${javase.version}</target>
+                        <excludes>
+                            <exclude>**/.ade_path/**</exclude>
+                        </excludes>
+                        <testExcludes>
+                            <testExclude>**/.ade_path/**</testExclude>
+                        </testExcludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+                        <skip>${deploy.skip}</skip>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven.bundle.plugin.version}</version>
+                    <configuration>
+                        <!-- By default, we don't export anything. -->
+                        <Export-Package />
+                        <instructions>
+                            <!--
+                                Read all the configuration from osgi.bundle file, if it exists.
+                            -->
+                            <_include>-osgi.bundle</_include>
+                        </instructions>
+                        <excludeDependencies>tools-jar</excludeDependencies>
+                        <supportedProjectTypes>
+                            <supportedProjectType>glassfish-jar</supportedProjectType>
+                            <supportedProjectType>jar</supportedProjectType>
+                        </supportedProjectTypes>
+                    </configuration>
                 </plugin>
                 <!-- Flatten plugin for use in public artifacts. -->
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,21 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>payara-patched-externals</id>
+            <name>Payara Patched Externals</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+    </repositories>
+
     <properties>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
@@ -352,6 +367,30 @@
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven.release.plugin.version}</version>
+                </plugin>
+                <!-- Flatten plugin for use in public artifacts. -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.1.0</version>
+                    <configuration>
+                        <flattenMode>ossrh</flattenMode>
+                        <pomElements>
+                            <developers>resolve</developers>
+                            <build>remove</build>
+                        </pomElements>
+                        <flattenedPomFilename>target/flattened-pom.xml</flattenedPomFilename>
+                    </configuration>
+                    <executions>
+                        <!-- enable flattening -->
+                        <execution>
+                            <id>flatten</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,9 @@
         <opentracing.version>0.31.0</opentracing.version>
         <javadb.version>10.13.1.1</javadb.version>
         <h2db.version>1.4.196</h2db.version>
+        <websocket-api.version>1.1.2</websocket-api.version>
+        <concurrent-api.version>1.1.2</concurrent-api.version>
+        <concurrent.version>1.0.payara-p2</concurrent.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
         <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>
         <microprofile-rest-client.version>1.3.4</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
+        <payara-arquillian-container.version>1.2</payara-arquillian-container.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
         <websocket-api.version>1.1.2</websocket-api.version>
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.0.payara-p2</concurrent.version>
+        <asm.version>7.2</asm.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,30 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <!-- BOM-referenced versions -->
+        <jakartaee.api.version>8.0.0</jakartaee.api.version>
+        <servlet-api.version>4.0.2</servlet-api.version>
+        <grizzly.version>2.4.3.payara-p9</grizzly.version>
+        <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
+        <jersey.version>2.29.1.payara-p1</jersey.version>
+        <jakarta.validation.version>2.0.2</jakarta.validation.version>
+        <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
+        <hibernate.validator-cdi.version>6.0.16.Final</hibernate.validator-cdi.version>
+        <jakarta.el.version>3.0.3</jakarta.el.version>
+        <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
+        <jaxb-api.version>2.3.2</jaxb-api.version>
+        <javax.cache-api.version>1.1.0</javax.cache-api.version>
+        <mail.version>1.6.4.payara-p1</mail.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <hk2.version>2.6.1.payara-p1</hk2.version>
+        <stax-api.version>1.0-2</stax-api.version>
+        <jackson.version>2.10.0</jackson.version>
+        <snakeyaml.version>1.24</snakeyaml.version>
+        <hazelcast.version>3.12</hazelcast.version>
+        <hazelcast.kubernetes.version>1.3.1</hazelcast.kubernetes.version>
+        <jaxb-api.version>2.3.2</jaxb-api.version>
+        <jaxb-impl.version>2.3.2</jaxb-impl.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,18 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <jsonp.version>1.1.5</jsonp.version>
         <jbi.version>1.0</jbi.version>
+        <jakarta-platform.version>8.0.0</jakarta-platform.version>
+        <microprofile-release.version>3.0</microprofile-release.version>
+        <microprofile-config.version>1.3</microprofile-config.version>
+        <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
+        <microprofile-config.version>1.3</microprofile-config.version>
+        <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
+        <microprofile-fault-tolerance.version>2.0.1</microprofile-fault-tolerance.version>
+        <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
+        <microprofile-healthcheck.version>2.1</microprofile-healthcheck.version>
+        <microprofile-metrics.version>2.0.1.payara-p1</microprofile-metrics.version>
+        <microprofile-rest-client.version>1.3.4</microprofile-rest-client.version>
+        <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,8 @@
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
         <payara-arquillian-container.version>1.2</payara-arquillian-container.version>
         <opentracing.version>0.31.0</opentracing.version>
+        <javadb.version>10.13.1.1</javadb.version>
+        <h2db.version>1.4.196</h2db.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a feature. <!-- delete/modify as applicable-->

Bill of material module lists all the APIs, third-party libraries and Arquillian containers fit for particular release. The goal is to enable downstream users (and e. g. our test projects) to always have proper dependencies for microprofile APIs, third-party libraries like Jackson and Jersey and up-to-date container implementations driven by single input - the version of target Payara server.

General structure is following:

* Top-level module (`payara-aggregator`) defines the versions as properties
* `payara-bom` inherits those via `api-parent` ⇾ `payara-aggregator`
* BOM defines the dependencies in `dependencyManagement` section
* It is imported in `payara-nucleus-parent` to make these entries available for the rest of the build

An artifact is put in BOM when:
* It is Jakarta EE, Microprofile, OSGi or Java EE API that is compatible with the release
* It is public artifact of the release (distribution, arquillian container)
* It is major implementation component with many optional artifacts users may use (HK2, Jersey, Jackson, Hazelcast), or is frequently used separately in application e.g. for tests.
* When BOM is available for such third-party component, entire BOM is imported

A BOM is to be used:
* By the build itself 
* By users to refer to APIs, and e.g. Jackon and Jersey components that are not part of server
  * In import scope
  * It can be useful to support BOM as a parent to
    * Bring patched-externals repository into the project
    * Allow user to use version properties to import related artifacts
    * Control the versions by redefining properties (if they're feeling lucky)

Scopes are defined as `provided` for major aggregation apis - `javaee-api`, `jakarta.jakartaee-api`, `microprofile`. Arquillian containers are defined as `test`. Anything else is left at `compile` to keep user surprises at minimum (and to prevent the need at redefining scopes within main codebase).

The POM file is flattened to contain all relevant information from parent poms and be standalone -- check version in `target/flattened-pom.xml` or the one that gets installed into your local repo.

# Testing

### Testing Performed
[x] Clean build with empty repository
[x] compare dependency trees of the project before and after the change (see 
[deptree-diff.patch.gz](https://github.com/payara/Payara/files/3841974/deptree-diff.patch.gz))
[x] make test application that imports a BOM and utilizes Arquillian (all containers) https://github.com/payara/Payara-Examples/pull/115
[ ] make test application that uses BOM as parent to utilize properties (i. e. TCK runner)


### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. MIght come later
- Quicklook
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples
- Payara Private Tests
- Payara Microprofile TCKs Runner
- Jakarta TCKs
- Mojarra
- Cargo Tracker  

-->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 1.8_222 on Windows 10 with Maven 3.6.2 and constantly cleaned `fish.payara.server.internal` group in local Maven repo.

# Documentation
[ ] T. B. D.

