### PR TITLE
PAYARA-4197 Minor but large cleanup in ejb-container and related things

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EjbInvocation.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EjbInvocation.java
@@ -41,17 +41,27 @@
 
 package com.sun.ejb;
 
-//XXX: import javax.xml.rpc.handler.MessageContext;
-/* HARRY : JACC Changes */
-
-import com.sun.ejb.containers.*;
+import com.sun.ejb.containers.BaseContainer;
+import com.sun.ejb.containers.EJBContextImpl;
+import com.sun.ejb.containers.EJBLocalRemoteObject;
+import com.sun.ejb.containers.EjbContainerUtilImpl;
+import com.sun.ejb.containers.EjbFutureTask;
+import com.sun.ejb.containers.SimpleEjbResourceHandlerImpl;
 import com.sun.ejb.containers.interceptors.InterceptorManager;
+import com.sun.ejb.containers.interceptors.InterceptorManager.AroundInvokeContext;
 import com.sun.ejb.containers.interceptors.InterceptorUtil;
 import com.sun.enterprise.deployment.EjbBundleDescriptor;
 import com.sun.enterprise.deployment.MethodDescriptor;
 import com.sun.enterprise.transaction.spi.TransactionOperationsManager;
-import org.glassfish.api.invocation.ComponentInvocation;
-import org.glassfish.api.invocation.ResourceHandler;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.rmi.UnmarshalException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import javax.ejb.EJBContext;
 import javax.ejb.Timer;
@@ -61,11 +71,10 @@ import javax.transaction.Transaction;
 import javax.xml.rpc.handler.MessageContext;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.WebServiceContext;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.rmi.UnmarshalException;
-import java.util.HashMap;
-import java.util.Map;
+
+import org.glassfish.api.invocation.ComponentInvocation;
+import org.glassfish.api.invocation.ResourceHandler;
+import org.glassfish.ejb.api.EJBInvocation;
 
 /**
  * The EjbInvocation object contains state associated with an invocation
@@ -75,32 +84,14 @@ import java.util.Map;
  * EJB(Local)Object/EJB(Local)Home before and after an invocation.
  */
 
-public class EjbInvocation
-    extends ComponentInvocation
-    implements InvocationContext, TransactionOperationsManager,
-         org.glassfish.ejb.api.EJBInvocation, InterceptorManager.AroundInvokeContext
-{
-
+public class EjbInvocation //
+    extends ComponentInvocation //
+    implements InvocationContext, TransactionOperationsManager, EJBInvocation, AroundInvokeContext {
 
     public ComponentContext context;
 
     private TransactionOperationsManager transactionOperationsManager;
 
-    EjbInvocation(String compEnvId, Container container) {
-        super.componentId = compEnvId;
-        super.container = container;
-        super.setComponentInvocationType(ComponentInvocation.ComponentInvocationType.EJB_INVOCATION);
-
-        EjbBundleDescriptor ejbBundleDesc = container.getEjbDescriptor().getEjbBundleDescriptor();
-        moduleName = ejbBundleDesc.getModuleName();
-        appName = ejbBundleDesc.getApplication().getAppName();
-        registrationName = ejbBundleDesc.getApplication().getRegistrationName();
-
-        //By default we enable TransactionOperationsManager checks. But EjbInvocation.clone()
-        //  clears transactionOperationsManager so that, be default, cloned invocations
-        //  doesn't enforce Transaction Operations checks.
-        transactionOperationsManager = this;
-    }
 
     /**
      * The EJBObject/EJBLocalObject which created this EjbInvocation object.
@@ -112,13 +103,13 @@ public class EjbInvocation
      * Local flag: true if this invocation was through the 2.x (or earlier)
      * Local client view, the 3.x local client view or a no-interface client view.
      */
-    public boolean isLocal=false;
+    public boolean isLocal = false;
 
     /**
      * True if this invocation was made through the 2.x (or earlier) Remote
      * client view or the 3.x remote client view.
      */
-    public boolean isRemote=false;
+    public boolean isRemote = false;
 
     /**
      * InvocationInfo object caches information about the current method
@@ -134,29 +125,29 @@ public class EjbInvocation
     /**
      * true if this is a web service invocation
      */
-    public boolean isWebService=false;
+    public boolean isWebService = false;
 
     /**
      * true if this is an ejb timeout method invocation
      */
-    public boolean isTimerCallback=false;
+    public boolean isTimerCallback = false;
 
     /**
      * true if this is a message-driven bean invocation
      */
-    public boolean isMessageDriven=false;
+    public boolean isMessageDriven = false;
 
     /**
      * true if this is an invocation on the home object
      * this is required for jacc.
      */
-    public boolean isHome=false;
+    public boolean isHome = false;
 
     /**
      * Home, Remote, LocalHome, Local, WebService, or business interface
      * through which a synchronous ejb invocation was made.
      */
-    public Class clientInterface;
+    public Class<?> clientInterface;
 
     /**
      * Method to be invoked. This is a method of the EJB's local/remote
@@ -189,21 +180,12 @@ public class EjbInvocation
      */
     public Throwable exceptionFromBeanMethod;
 
-
     /**
      * The client's transaction if any.
      * Set by the Container during preInvoke() and used by the Container
      * during postInvoke().
      */
     public Transaction clientTx;
-
-    /**
-     * The EJBContext object of the bean instance being invoked.
-     * Set by the Container during preInvoke() and used by the Container
-     * during postInvoke().
-     */
-    // Moved to com/sun/enterprise/ComponentInvocation
-    // public ComponentContext context;
 
     /**
      * The transaction attribute of the bean method. Set in generated
@@ -282,6 +264,38 @@ public class EjbInvocation
     // True if lock is currently held for this invocation
     private boolean holdingSFSBSerializedLock = false;
 
+    private int interceptorIndex;
+
+    public Method beanMethod;
+
+    // Only set for web service invocations.
+    private WebServiceContext webServiceContext;
+
+    // Only set for EJB JAXWS
+    // FIXME: private Message message = null;
+    private Object message;
+
+    private SOAPMessage soapMessage = null;
+
+    private Map<String, Object> contextData;
+
+
+    EjbInvocation(String compEnvId, Container container) {
+        super.componentId = compEnvId;
+        super.container = container;
+        super.setComponentInvocationType(ComponentInvocation.ComponentInvocationType.EJB_INVOCATION);
+
+        EjbBundleDescriptor ejbBundleDesc = container.getEjbDescriptor().getEjbBundleDescriptor();
+        moduleName = ejbBundleDesc.getModuleName();
+        appName = ejbBundleDesc.getApplication().getAppName();
+        registrationName = ejbBundleDesc.getApplication().getRegistrationName();
+
+        //By default we enable TransactionOperationsManager checks. But EjbInvocation.clone()
+        //  clears transactionOperationsManager so that, be default, cloned invocations
+        //  doesn't enforce Transaction Operations checks.
+        transactionOperationsManager = this;
+    }
+
     public ClassLoader getOriginalContextClassLoader() {
         return originalContextClassLoader;
     }
@@ -330,6 +344,7 @@ public class EjbInvocation
         this.doTxProcessingInPostInvoke = doTxProcessingInPostInvoke;
     }
 
+    @Override
     public EjbInvocation clone() {
         EjbInvocation newInv = (EjbInvocation) super.clone();
 
@@ -366,6 +381,7 @@ public class EjbInvocation
      * implementation should use this method rather than directly
      * accessing the ejb field.
      */
+    @Override
     public Object getJaccEjb() {
         Object bean = null;
         if( container != null ) {
@@ -392,17 +408,17 @@ public class EjbInvocation
     }
 
     /**
-     * Returns CachedPermission associated with this invocation, or
+     * @return CachedPermission associated with this invocation, or
      * null if not available.
      */
     public Object getCachedPermission() {
-        return (invocationInfo != null) ? invocationInfo.cachedPermission :
-            null;
+        return invocationInfo == null ? null : invocationInfo.cachedPermission;
     }
 
     /**
      * @return Returns the ejbCtx.
      */
+    @Override
     public EJBContext getEJBContext() {
         return (EJBContext) this.context;
     }
@@ -438,17 +454,16 @@ public class EjbInvocation
     }
 
     public void setTransactionOperationsManager(TransactionOperationsManager transactionOperationsManager) {
-        //Note: clone() clears transactionOperationsManager so that, be default, cloned invocations
-        //  doesn't enforce Transaction Operations checks.
+        // Note: clone() clears transactionOperationsManager so that, be default, cloned invocations
+        // doesn't enforce Transaction Operations checks.
         this.transactionOperationsManager = transactionOperationsManager;
     }
-
-    //Implementation of TransactionOperationsManager methods
 
     /**
      * Called by the UserTransaction implementation to verify
      * access to the UserTransaction methods.
      */
+    @Override
     public boolean userTransactionMethodsAllowed() {
         return ((Container) container).userTransactionMethodsAllowed(this);
     }
@@ -457,6 +472,7 @@ public class EjbInvocation
      * Called by the UserTransaction lookup to verify
      * access to the UserTransaction itself.
      */
+    @Override
     public void userTransactionLookupAllowed() throws NameNotFoundException {
         ((BaseContainer) container).checkUserTransactionLookup(this);
     }
@@ -464,35 +480,19 @@ public class EjbInvocation
     /**
      * Called by the UserTransaction when transaction is started.
      */
+    @Override
     public void doAfterUtxBegin() {
         ((Container) container).doAfterBegin(this);
     }
 
-    //Implementation of InvocationContext methods
-
-    private int interceptorIndex;
-
-    public Method   beanMethod;
-
-    // Only set for web service invocations.
-    private WebServiceContext webServiceContext;
-
-    // Only set for EJB JAXWS
-    //FIXME: private Message message = null;
-    private Object message;
-
-    private SOAPMessage soapMessage = null;
-
-    private Map      contextData;
-
     public InterceptorManager.InterceptorChain getInterceptorChain() {
-        return (invocationInfo == null)
-            ? null : invocationInfo.interceptorChain;
+        return (invocationInfo == null) ? null : invocationInfo.interceptorChain;
     }
 
     /**
      * @return Returns the bean instance.
      */
+    @Override
     public Object getTarget() {
         return this.ejb;
     }
@@ -500,6 +500,7 @@ public class EjbInvocation
     /**
      * @return Returns the timer instance.
      */
+    @Override
     public Object getTimer() {
         return timer;
     }
@@ -510,13 +511,16 @@ public class EjbInvocation
      *         method being invoked.  For lifecycle callback methods,
      *         returns null.
      */
+    @Override
     public Method getMethod() {
         return getBeanMethod();
     }
+
     public Method getBeanMethod() {
         return this.beanMethod;
     }
 
+    @Override
     public Constructor getConstructor() {
         return null;
     }
@@ -527,6 +531,7 @@ public class EjbInvocation
      * getParameters() returns the values to which the parameters
      * have been set.
      */
+    @Override
     public Object[] getParameters() {
         return this.methodParams;
     }
@@ -535,15 +540,17 @@ public class EjbInvocation
      * Set the parameters that will be used to invoke the business method.
      *
      */
+    @Override
     public void setParameters(Object[] params) {
         InterceptorUtil.checkSetParameters(params, getMethod());
         this.methodParams = params;
     }
 
-    /*
-     * Method takes Object to decouple EJBInvocation interface
+    /**
+     * Method takes Object to decouple {@link EJBInvocation} interface
      * from jaxws (which isn't available in all profiles).
      */
+    @Override
     public void setWebServiceContext(Object webServiceContext) {
         // shouldn't be necessary, but to be safe
         if (webServiceContext instanceof WebServiceContext) {
@@ -554,12 +561,14 @@ public class EjbInvocation
     /**
      * @return Returns the contextMetaData.
      */
+    @Override
     public Map<String, Object> getContextData() {
         if (this.contextData == null) {
-            if (webServiceContext != null)
+            if (webServiceContext != null) {
                 this.contextData = webServiceContext.getMessageContext();
-            else
-                this.contextData = new HashMap<String, Object>();
+            } else {
+                this.contextData = new HashMap<>();
+            }
         }
         return contextData;
     }
@@ -568,6 +577,7 @@ public class EjbInvocation
      * This is for EJB JAXWS only.
      * @param message  an unconsumed message
      */
+    @Override
     public <T> void setMessage(T message) {
         this.message = message;
     }
@@ -576,6 +586,7 @@ public class EjbInvocation
      * This is for EJB JAXWS only.
      * @return the JAXWS message
      */
+    @Override
     public Object getMessage() {
         return this.message;
     }
@@ -597,12 +608,8 @@ public class EjbInvocation
         return soapMessage;
     }
 
-    /* (non-Javadoc)
-     * @see javax.interceptor.InvocationContext#proceed()
-     */
-    public Object proceed()
-        throws Exception
-    {
+    @Override
+    public Object proceed() throws Exception {
         try {
             //TODO: Internal error if getInterceptorChain() is null
             interceptorIndex++;
@@ -623,8 +630,8 @@ public class EjbInvocation
     /**
      * Print most useful fields.  Don't do all of them (yet) since there
      * are a large number.
-     * @return
      */
+    @Override
     public String toString() {
 
         StringBuilder sbuf = new StringBuilder();
@@ -649,94 +656,100 @@ public class EjbInvocation
     }
 
     // Implementation of AroundInvokeContext
+    @Override
     public Object[] getInterceptorInstances() {
         return  ((EJBContextImpl)context).getInterceptorInstances();
     }
 
+    @Override
     public  Object invokeBeanMethod() throws Throwable {
         return ((BaseContainer) container).invokeBeanMethod(this);
     }
-
-    /*********************************************************/
-
-
 
     public com.sun.enterprise.security.SecurityManager getEjbSecurityManager() {
         return ((BaseContainer)container).getSecurityManager();
     }
 
+    @Override
     public boolean isAWebService() {
         return this.isWebService;
     }
 
+    @Override
     public Object[] getMethodParams() {
         return this.methodParams;
     }
 
+    @Override
     public boolean authorizeWebService(Method m) throws Exception {
-        Exception ie = null;
-        if (isAWebService()) {
-            try {
-                this.method = m;
-                if (!((com.sun.ejb.Container)container).authorize(this)) {
-                    ie = new Exception
-                    ("Client not authorized for invocation of method {" + method + "}");
-                } else {
-                    // Record the method on which the successful
-                    // authorization check was performed.
-                    setWebServiceMethod(m);
-                }
-            } catch(Exception e) {
-                String errorMsg = "Error unmarshalling method {" + method + "} for ejb ";
-                ie = new UnmarshalException(errorMsg);
-                ie.initCause(e);
+        if (!isAWebService()) {
+            setWebServiceMethod(null);
+            return true;
+        }
+        Exception ie;
+        try {
+            this.method = m;
+            if (((com.sun.ejb.Container) container).authorize(this)) {
+                // Record the method on which the successful
+                // authorization check was performed.
+                setWebServiceMethod(m);
+                ie = null;
+            } else {
+                ie = new Exception("Client not authorized for invocation of method {" + method + "}");
             }
-            if ( ie != null ) {
-                exception = ie;
-                throw ie;
-            }
-	    } else {
-		    setWebServiceMethod(null);
-	    }
-        return true;
+        } catch (Exception e) {
+            String errorMsg = "Error unmarshalling method {" + method + "} for ejb ";
+            ie = new UnmarshalException(errorMsg, e);
+        }
+        if (ie == null) {
+            return true;
+        }
+        // ie was only created or catched, it does not matter here
+        exception = ie;
+        throw ie;
 	}
 
-/**
-    * Implements the  method in org.glassfish.ejb.api.EJBInvocation
-    * @return true if the SecurityManager reports that the caller is in role
-    */
-   public boolean isCallerInRole(String role) {
-       return getEjbSecurityManager().isCallerInRole(role);
-   }
+    /**
+     * @return true if the SecurityManager reports that the caller is in role
+     */
+    @Override
+    public boolean isCallerInRole(String role) {
+        return getEjbSecurityManager().isCallerInRole(role);
+    }
 
+    @Override
     public void setWebServiceTie(Object tie) {
         webServiceTie = tie;
     }
 
+    @Override
     public Object getWebServiceTie() {
         return webServiceTie;
     }
 
+    @Override
     public void setWebServiceMethod(Method method) {
         webServiceMethod = method;
     }
 
+    @Override
     public Method getWebServiceMethod() {
         return webServiceMethod;
     }
 
+    @Override
     public void setMessageContext(MessageContext msgContext) {
        messageContext = msgContext;
     }
 
-   public ResourceHandler getResourceHandler() {
-       ResourceHandler rh = super.getResourceHandler();
-       if (rh == null) {
-           rh = context;
-       }
-
-       return rh;
-   }
+    @Override
+    public ResourceHandler getResourceHandler() {
+        ResourceHandler rh = super.getResourceHandler();
+        if (rh == null) {
+            rh = context;
+        }
+        return rh;
+    }
 
     public boolean isContainerStartsTx() {
         return containerStartsTx;
@@ -745,6 +758,14 @@ public class EjbInvocation
     public void setContainerStartsTx(boolean containerStartsTx) {
         this.containerStartsTx = containerStartsTx;
     }
+
+    /**
+     * @param classes must not be null
+     * @return true if the client interface is assignable to at least one of classes in parameter
+     */
+    public boolean isClientInterfaceAssignableToOneOf(final Class<?>... classes) {
+        Objects.requireNonNull(classes, "classes");
+        final Predicate<Class<?>> predicate = c -> c.isAssignableFrom(this.clientInterface);
+        return Arrays.stream(classes).anyMatch(predicate);
+    }
 }
-
-

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
@@ -37,8 +37,15 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates.]
 package com.sun.ejb.containers;
+
+import com.sun.ejb.Container;
+import com.sun.ejb.EjbInvocation;
+import com.sun.enterprise.deployment.MethodDescriptor;
+import com.sun.enterprise.transaction.api.JavaEETransaction;
+import com.sun.enterprise.transaction.api.JavaEETransactionManager;
+import com.sun.enterprise.util.LocalStringManagerImpl;
 
 import java.util.Map;
 import java.util.logging.Level;
@@ -47,26 +54,18 @@ import java.util.logging.Logger;
 import javax.ejb.EJBException;
 import javax.ejb.NoSuchEntityException;
 import javax.ejb.NoSuchObjectLocalException;
-import javax.ejb.TransactionRolledbackLocalException;
 import javax.ejb.TransactionRequiredLocalException;
+import javax.ejb.TransactionRolledbackLocalException;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.UserTransaction;
 
-import com.sun.ejb.Container;
-import com.sun.ejb.EjbInvocation;
-import com.sun.ejb.InvocationInfo;
-import com.sun.enterprise.deployment.MethodDescriptor;
 import org.glassfish.ejb.deployment.descriptor.ContainerTransaction;
 import org.glassfish.ejb.deployment.descriptor.EjbApplicationExceptionInfo;
 import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
 import org.glassfish.ejb.deployment.descriptor.runtime.IASEjbExtraDescriptors;
-
-import com.sun.enterprise.transaction.api.JavaEETransaction;
-import com.sun.enterprise.transaction.api.JavaEETransactionManager;
-import com.sun.enterprise.util.LocalStringManagerImpl;
 
 /**
  * Container support for handling transactions
@@ -75,19 +74,14 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
  */
 public class EJBContainerTransactionManager {
 
-    private static final Logger _logger = EjbContainerUtilImpl.getLogger();
-
-    private static LocalStringManagerImpl localStrings =
-            new LocalStringManagerImpl(EJBContainerTransactionManager.class);
-
+    private static final Logger LOG = EjbContainerUtilImpl.getLogger();
     private static final String USER_TX = "java:comp/UserTransaction";
 
-    private EjbContainerUtil ejbContainerUtilImpl = EjbContainerUtilImpl.getInstance();
-
-    private JavaEETransactionManager transactionManager;
-    private BaseContainer container;
-    private EjbDescriptor ejbDescriptor;
-    private int cmtTimeoutInSeconds = 0;
+    private final EjbContainerUtil ejbContainerUtilImpl = EjbContainerUtilImpl.getInstance();
+    private final JavaEETransactionManager transactionManager;
+    private final BaseContainer container;
+    private final EjbDescriptor ejbDescriptor;
+    private final int cmtTimeoutInSeconds;
 
     /**
      * Construct new instance and set basic references
@@ -96,12 +90,8 @@ public class EJBContainerTransactionManager {
         container = (BaseContainer)c;
         ejbDescriptor = ejbDesc;
         transactionManager = ejbContainerUtilImpl.getTransactionManager();
-
-        IASEjbExtraDescriptors iased = ejbDesc.getIASEjbExtraDescriptors();
-
-        if(iased.getCmtTimeoutInSeconds() != 0){
-        	cmtTimeoutInSeconds = iased.getCmtTimeoutInSeconds();
-        }
+        final IASEjbExtraDescriptors iased = ejbDesc.getIASEjbExtraDescriptors();
+        cmtTimeoutInSeconds = iased.getCmtTimeoutInSeconds();
     }
 
     /**
@@ -110,55 +100,55 @@ public class EJBContainerTransactionManager {
      * tx attributes can be looked up with variations of getTxAttr()
      */
     int findTxAttr(MethodDescriptor md) {
-        int txAttr = -1;
-
-        if ( container.isBeanManagedTran ) {
+        if (container.isBeanManagedTran) {
             return Container.TX_BEAN_MANAGED;
         }
-
-        ContainerTransaction ct = ejbDescriptor.getContainerTransactionFor(md);
-
-        if ( ct != null ) {
-            String attr = ct.getTransactionAttribute();
-            if ( attr.equals(ContainerTransaction.NOT_SUPPORTED) )
-                txAttr = Container.TX_NOT_SUPPORTED;
-            else if ( attr.equals(ContainerTransaction.SUPPORTS) )
-                txAttr = Container.TX_SUPPORTS;
-            else if ( attr.equals(ContainerTransaction.REQUIRED) )
-                txAttr = Container.TX_REQUIRED;
-            else if ( attr.equals(ContainerTransaction.REQUIRES_NEW) )
-                txAttr = Container.TX_REQUIRES_NEW;
-            else if ( attr.equals(ContainerTransaction.MANDATORY) )
-                txAttr = Container.TX_MANDATORY;
-            else if ( attr.equals(ContainerTransaction.NEVER) )
-                txAttr = Container.TX_NEVER;
+        final int txAttr = getTransactionAttribute(md);
+        if (txAttr < 0) {
+            throw new EJBException("Transaction Attribute not found for method " + md.prettyPrint());
         }
-
-        if ( txAttr == -1 ) {
-            throw new EJBException("Transaction Attribute not found for method "
-                + md.prettyPrint());
-        }
-
         container.validateTxAttr(md, txAttr);
-
         return txAttr;
+    }
+
+    private int getTransactionAttribute(final MethodDescriptor md) {
+        final ContainerTransaction containerTx = ejbDescriptor.getContainerTransactionFor(md);
+        if (containerTx == null) {
+            return -1;
+        }
+        final String attr = containerTx.getTransactionAttribute();
+        if (attr.equals(ContainerTransaction.NOT_SUPPORTED)) {
+            return Container.TX_NOT_SUPPORTED;
+        } else if (attr.equals(ContainerTransaction.SUPPORTS)) {
+            return Container.TX_SUPPORTS;
+        } else if (attr.equals(ContainerTransaction.REQUIRED)) {
+            return Container.TX_REQUIRED;
+        } else if (attr.equals(ContainerTransaction.REQUIRES_NEW)) {
+            return Container.TX_REQUIRES_NEW;
+        } else if (attr.equals(ContainerTransaction.MANDATORY)) {
+            return Container.TX_MANDATORY;
+        } else if (attr.equals(ContainerTransaction.NEVER)) {
+            return Container.TX_NEVER;
+        } else {
+            return -2;
+        }
     }
 
     /**
      * Handle transaction requirements, if any, before invoking bean method
      */
     final void preInvokeTx(EjbInvocation inv) throws Exception {
+        LOG.finest(() -> String.format("preInvokeTx(inv=%s)", inv));
         // Get existing Tx status: this tells us if the client
         // started a transaction which was propagated on this invocation.
-        Integer preInvokeTxStatus = inv.getPreInvokeTxStatus();
-        int status = (preInvokeTxStatus != null) ?
-            preInvokeTxStatus.intValue() : transactionManager.getStatus();
+        final Integer preInvokeTxStatus = inv.getPreInvokeTxStatus();
+        final int status = (preInvokeTxStatus != null) ? preInvokeTxStatus.intValue() : transactionManager.getStatus();
 
         // For MessageDrivenBeans,ejbCreate/ejbRemove must be called without a Tx.
         // For StatelessSessionBeans, ejbCreate/ejbRemove must be called without a Tx.
         // For StatefullSessionBeans ejbCreate/ejbRemove/ejbFind can be called with or without a Tx.
         // For EntityBeans, ejbCreate/ejbRemove/ejbFind must be called with a Tx so no special work needed.
-        if ( container.suspendTransaction(inv) ) {
+        if (container.suspendTransaction(inv)) {
             // EJB2.0 section 7.5.7 says that ejbCreate/ejbRemove etc are called
             // without a Tx. So suspend the client's Tx if any.
 
@@ -166,7 +156,7 @@ public class EJBContainerTransactionManager {
             // a Tx, according to EJB2.0 section 7.6.4. This check is done in
             // the container's implementation of removeBean().
 
-            if ( status != Status.STATUS_NO_TRANSACTION ) {
+            if (status != Status.STATUS_NO_TRANSACTION) {
                 // client request is associated with a Tx
                 try {
                     inv.clientTx = transactionManager.suspend();
@@ -181,32 +171,33 @@ public class EJBContainerTransactionManager {
         // (i.e. a tx context with a null Coordinator objref)
         // or if this server's tx interop mode flag is false.
         // Follow the tables in EJB2.0 sections 19.6.2.2.1 and 19.6.2.2.2.
-        boolean isNullTx = false;
+        final boolean isNullTx;
         if (inv.isRemote) {
             isNullTx = transactionManager.isNullTransaction();
+        } else {
+            isNullTx = false;
         }
 
-        int txAttr = container.getTxAttr(inv);
-
-        EJBContextImpl context = (EJBContextImpl)inv.context;
+        final int txAttr = container.getTxAttr(inv);
+        final EJBContextImpl context = (EJBContextImpl)inv.context;
 
         // Note: in the code below, inv.clientTx is set ONLY if the
         // client's Tx is actually suspended.
 
         // get the Tx associated with the EJB from previous invocation,
         // if any.
-        Transaction prevTx = context.getTransaction();
+        final Transaction prevTx = context.getTransaction();
 
         switch (txAttr) {
             case Container.TX_BEAN_MANAGED:
                 // TX_BEAN_MANAGED rules from EJB2.0 Section 17.6.1, Table 13
                 // Note: only MDBs and SessionBeans can be TX_BEAN_MANAGED
-                if ( status != Status.STATUS_NO_TRANSACTION ) {
+                if (status != Status.STATUS_NO_TRANSACTION) {
                     // client request associated with a Tx, always suspend
                     inv.clientTx = transactionManager.suspend();
                 }
-                if ( container.isStatefulSession && prevTx != null
-                        && prevTx.getStatus() != Status.STATUS_NO_TRANSACTION ) {
+                if (container.isStatefulSession && prevTx != null
+                    && prevTx.getStatus() != Status.STATUS_NO_TRANSACTION ) {
                     // Note: if prevTx != null , then it means
                     // afterCompletion was not called yet for the
                     // previous transaction on the EJB.
@@ -225,7 +216,7 @@ public class EJBContainerTransactionManager {
                 break;
 
             case Container.TX_NOT_SUPPORTED:
-                if ( status != Status.STATUS_NO_TRANSACTION ) {
+                if (status != Status.STATUS_NO_TRANSACTION) {
                     inv.clientTx = transactionManager.suspend();
                 }
                 container.checkUnfinishedTx(prevTx, inv);
@@ -233,7 +224,7 @@ public class EJBContainerTransactionManager {
                 break;
 
             case Container.TX_MANDATORY:
-                if ( isNullTx || status == Status.STATUS_NO_TRANSACTION ) {
+                if (isNullTx || status == Status.STATUS_NO_TRANSACTION) {
                     throw new TransactionRequiredLocalException();
                 }
 
@@ -241,11 +232,11 @@ public class EJBContainerTransactionManager {
                 break;
 
             case Container.TX_REQUIRED:
-                if ( isNullTx ) {
+                if (isNullTx) {
                     throw new TransactionRequiredLocalException();
                 }
 
-                if ( status == Status.STATUS_NO_TRANSACTION ) {
+                if (status == Status.STATUS_NO_TRANSACTION) {
                     inv.clientTx = null;
                     startNewTx(prevTx, inv);
                 } else { // There is a client Tx
@@ -255,18 +246,18 @@ public class EJBContainerTransactionManager {
                 break;
 
             case Container.TX_REQUIRES_NEW:
-                if ( status != Status.STATUS_NO_TRANSACTION ) {
+                if (status != Status.STATUS_NO_TRANSACTION) {
                     inv.clientTx = transactionManager.suspend();
                 }
                 startNewTx(prevTx, inv);
                 break;
 
             case Container.TX_SUPPORTS:
-                if ( isNullTx ) {
+                if (isNullTx) {
                     throw new TransactionRequiredLocalException();
                 }
 
-                if ( status != Status.STATUS_NO_TRANSACTION ) {
+                if (status != Status.STATUS_NO_TRANSACTION) {
                     useClientTx(prevTx, inv);
                 } else { // we need to invoke the EJB with no Tx.
                     container.checkUnfinishedTx(prevTx, inv);
@@ -275,13 +266,11 @@ public class EJBContainerTransactionManager {
                 break;
 
             case Container.TX_NEVER:
-                if ( isNullTx || status != Status.STATUS_NO_TRANSACTION ) {
+                if (isNullTx || status != Status.STATUS_NO_TRANSACTION) {
                     throw new EJBException("EJB cannot be invoked in global transaction");
-
-                } else { // we need to invoke the EJB with no Tx.
-                    container.checkUnfinishedTx(prevTx, inv);
-                    container.preInvokeNoTx(inv);
                 }
+                container.checkUnfinishedTx(prevTx, inv);
+                container.preInvokeNoTx(inv);
                 break;
 
             default:
@@ -294,7 +283,7 @@ public class EJBContainerTransactionManager {
      * no-op in those containers that do not need this callback
      */
     private void startNewTx(Transaction prevTx, EjbInvocation inv) throws Exception {
-
+        LOG.finest(() -> String.format("startNewTx(prevTx=%s, inv=%s)", prevTx, inv));
         container.checkUnfinishedTx(prevTx, inv);
 
         if (cmtTimeoutInSeconds > 0) {
@@ -303,9 +292,9 @@ public class EJBContainerTransactionManager {
             transactionManager.begin();
         }
 
-        EJBContextImpl context = (EJBContextImpl)inv.context;
+        EJBContextImpl context = (EJBContextImpl) inv.context;
         Transaction tx = transactionManager.getTransaction();
-        if (! container.isSingleton) {
+        if (!container.isSingleton) {
             context.setTransaction(tx);
         }
 
@@ -314,7 +303,7 @@ public class EJBContainerTransactionManager {
         transactionManager.enlistComponentResources();
 
         // register synchronization for methods other than finders/home methods
-        if ( !inv.invocationInfo.isHomeFinder ) {
+        if (!inv.invocationInfo.isHomeFinder) {
             // Register for Synchronization notification
             ejbContainerUtilImpl.getContainerSync(tx).addBean(context);
         }
@@ -331,42 +320,45 @@ public class EJBContainerTransactionManager {
      * Use caller transaction to execute a bean method
      */
     protected void useClientTx(Transaction prevTx, EjbInvocation inv) {
-        Transaction clientTx;
-        int status=-1;
-        int prevStatus=-1;
+        LOG.finest(() -> String.format("useClientTx(prevTx=%s, inv=%s)", prevTx, inv));
+        final Transaction clientTx;
+        final int status;
+        final int prevStatus;
         try {
             // Note: inv.clientTx will not be set at this point.
             clientTx = transactionManager.getTransaction();
             status = clientTx.getStatus();  // clientTx cant be null
-            if ( prevTx != null ) {
+            if (prevTx == null) {
+                prevStatus = -1;
+            } else {
                 prevStatus = prevTx.getStatus();
             }
         } catch (Exception ex) {
+            final TransactionRolledbackLocalException toThrow = new TransactionRolledbackLocalException(ex.getMessage(), ex);
             try {
                 transactionManager.setRollbackOnly();
-            } catch ( Exception e ) {
-		//FIXME: Use LogStrings.properties
-		_logger.log(Level.FINEST, "", e);
-	    }
-            throw new TransactionRolledbackLocalException("", ex);
+            } catch (Exception e) {
+                toThrow.addSuppressed(ex);
+            }
+            throw toThrow;
         }
 
         // If the client's tx is going to rollback, it is fruitless
         // to invoke the EJB, so throw an exception back to client.
-        if ( status == Status.STATUS_MARKED_ROLLBACK
-                || status == Status.STATUS_ROLLEDBACK
-                || status == Status.STATUS_ROLLING_BACK ) {
+        if (status == Status.STATUS_MARKED_ROLLBACK //
+            || status == Status.STATUS_ROLLEDBACK //
+            || status == Status.STATUS_ROLLING_BACK) {
             throw new TransactionRolledbackLocalException("Client's transaction aborted");
         }
 
         container.validateEMForClientTx(inv, (JavaEETransaction) clientTx);
 
-        if ( prevTx == null || prevStatus == Status.STATUS_NO_TRANSACTION ) {
+        if (prevTx == null || prevStatus == Status.STATUS_NO_TRANSACTION) {
             // First time the bean is running in this new client Tx
             EJBContextImpl context = (EJBContextImpl)inv.context;
 
             //Must change this for singleton
-            if (! container.isSingleton) {
+            if (!container.isSingleton) {
                 context.setTransaction(clientTx);
             }
             try {
@@ -388,23 +380,22 @@ public class EJBContainerTransactionManager {
                     container.afterBegin(context);
                 }
             } catch (Exception ex) {
+                final TransactionRolledbackLocalException toThrow = new TransactionRolledbackLocalException("", ex);
                 try {
                     transactionManager.setRollbackOnly();
-                } catch ( Exception e ) {
-					//FIXME: Use LogStrings.properties
-					_logger.log(Level.FINEST, "", e);
+                } catch (Exception e) {
+                    toThrow.addSuppressed(e);
 				}
-                throw new TransactionRolledbackLocalException("", ex);
+                throw toThrow;
             }
         } else { // Bean already has a transaction associated with it.
-            if ( !prevTx.equals(clientTx) ) {
+            if (!prevTx.equals(clientTx)) {
                 // There is already a different Tx in progress !!
                 // Note: this can only happen for stateful SessionBeans.
                 // EntityBeans will get a different context for every Tx.
-                if ( container.isSession ) {
+                if (container.isSession) {
                     // Row 2 in Table E
-                    throw new IllegalStateException(
-                    "EJB is already associated with an incomplete transaction");
+                    throw new IllegalStateException("EJB is already associated with an incomplete transaction");
                 }
             } else { // Bean was invoked again with the same transaction
                 // This allows the TM to enlist resources used by the EJB
@@ -412,13 +403,13 @@ public class EJBContainerTransactionManager {
                 try {
                     transactionManager.enlistComponentResources();
                 } catch (Exception ex) {
+                    final TransactionRolledbackLocalException toThrow = new TransactionRolledbackLocalException("", ex);
                     try {
                         transactionManager.setRollbackOnly();
                     } catch ( Exception e ) {
-                        //FIXME: Use LogStrings.properties
-                        _logger.log(Level.FINEST, "", e);
+                        toThrow.addSuppressed(e);
 					}
-                    throw new TransactionRolledbackLocalException("", ex);
+                    throw toThrow;
                 }
             }
         }
@@ -428,8 +419,7 @@ public class EJBContainerTransactionManager {
      * Handle transaction requirements, if any, after invoking bean method
      */
     protected void postInvokeTx(EjbInvocation inv) throws Exception {
-
-        Throwable exception = inv.exception;
+        LOG.finest(() -> String.format("postInvokeTx(inv=%s)", inv));
 
         // For StatelessSessionBeans, ejbCreate/ejbRemove was called without a Tx,
         // so resume client's Tx if needed.
@@ -437,37 +427,34 @@ public class EJBContainerTransactionManager {
         // so resume client's Tx if needed.
         // For EntityBeans, ejbCreate/ejbRemove/ejbFind must be called with a Tx
         // so no special processing needed.
-        if ( container.resumeTransaction(inv) ) {
+        if (container.resumeTransaction(inv)) {
            // check if there was a suspended client Tx
-            if ( inv.clientTx != null ) {
+            if (inv.clientTx != null) {
                 transactionManager.resume(inv.clientTx);
             }
-
-            if ( inv.exception != null
-                     && inv.exception instanceof BaseContainer.PreInvokeException ) {
-                inv.exception = ((BaseContainer.PreInvokeException)exception).exception;
+            if (inv.exception != null && inv.exception instanceof BaseContainer.PreInvokeException) {
+                inv.exception = inv.exception.getCause();
             }
-
             return;
         }
 
         EJBContextImpl context = (EJBContextImpl)inv.context;
 
-        int status = transactionManager.getStatus();
-        int txAttr = inv.invocationInfo.txAttr;
-
-        Throwable newException = exception; // default
+        final int status = transactionManager.getStatus();
+        final int txAttr = inv.invocationInfo.txAttr;
+        final Throwable oriException = inv.exception;
 
         // Note: inv.exception may have been thrown by the container
         // during preInvoke (i.e. bean may never have been invoked).
 
         // Exception and Tx handling rules. See EJB2.0 Sections 17.6, 18.3.
+        final Throwable newException;
         switch (txAttr) {
             case Container.TX_BEAN_MANAGED:
                 // EJB2.0 section 18.3.1, Table 16
                 // Note: only SessionBeans can be TX_BEAN_MANAGED
-                newException = checkExceptionBeanMgTx(context, exception, status);
-                if ( inv.clientTx != null ) {
+                newException = checkExceptionBeanMgTx(context, oriException, status);
+                if (inv.clientTx != null) {
                     // there was a client Tx which was suspended
                     transactionManager.resume(inv.clientTx);
                 }
@@ -478,12 +465,14 @@ public class EJBContainerTransactionManager {
                 // NotSupported and Never are handled in the same way
                 // EJB2.0 sections 17.6.2.1, 17.6.2.6.
                 // EJB executed in no Tx
-                if ( exception != null ) {
-                    newException = checkExceptionNoTx(context, exception);
+                if (oriException == null) {
+                    newException = null;
+                } else {
+                    newException = checkExceptionNoTx(context, oriException);
                 }
                 container.postInvokeNoTx(inv);
 
-                if ( inv.clientTx != null ) {
+                if (inv.clientTx != null) {
                     // there was a client Tx which was suspended
                     transactionManager.resume(inv.clientTx);
                 }
@@ -493,20 +482,24 @@ public class EJBContainerTransactionManager {
             case Container.TX_MANDATORY:
                 // EJB2.0 section 18.3.1, Table 15
                 // EJB executed in client's Tx
-                if ( exception != null ) {
-                    newException = checkExceptionClientTx(context, exception);
+                if (oriException == null) {
+                    newException = null;
+                } else {
+                    newException = checkExceptionClientTx(context, oriException);
                 }
                 break;
 
             case Container.TX_REQUIRED:
                 // EJB2.0 section 18.3.1, Table 15
-                if ( inv.clientTx == null ) {
+                if (inv.clientTx == null) {
                     // EJB executed in new Tx started in preInvokeTx
-                    newException = completeNewTx(context, exception, status);
+                    newException = completeNewTx(context, oriException, status);
                 } else {
                     // EJB executed in client's tx
-                    if ( exception != null ) {
-                        newException = checkExceptionClientTx(context, exception);
+                    if (oriException == null) {
+                        newException = null;
+                    } else {
+                        newException = checkExceptionClientTx(context, oriException);
                     }
                 }
                 break;
@@ -514,9 +507,9 @@ public class EJBContainerTransactionManager {
             case Container.TX_REQUIRES_NEW:
                 // EJB2.0 section 18.3.1, Table 15
                 // EJB executed in new Tx started in preInvokeTx
-                newException = completeNewTx(context, exception, status);
+                newException = completeNewTx(context, oriException, status);
 
-                if ( inv.clientTx != null ) {
+                if (inv.clientTx != null) {
                     // there was a client Tx which was suspended
                     transactionManager.resume(inv.clientTx);
                 }
@@ -524,21 +517,26 @@ public class EJBContainerTransactionManager {
 
             case Container.TX_SUPPORTS:
                 // EJB2.0 section 18.3.1, Table 15
-                if ( status != Status.STATUS_NO_TRANSACTION ) {
+                if (status != Status.STATUS_NO_TRANSACTION) {
                     // EJB executed in client's tx
-                    if ( exception != null ) {
-                        newException = checkExceptionClientTx(context, exception);
+                    if (oriException == null) {
+                        newException = null;
+                    } else {
+                        newException = checkExceptionClientTx(context, oriException);
                     }
                 } else {
                     // EJB executed in no Tx
-                    if ( exception != null ) {
-                        newException = checkExceptionNoTx(context, exception);
+                    if (oriException == null) {
+                        newException = null;
+                    } else {
+                        newException = checkExceptionNoTx(context, oriException);
                     }
                     container.postInvokeNoTx(inv);
                 }
                 break;
 
             default:
+                newException = oriException;
         }
 
         inv.exception = newException;
@@ -551,240 +549,225 @@ public class EJBContainerTransactionManager {
         // Only session beans with bean-managed transactions
         // or message-driven beans with bean-managed transactions
         // can programmatically demarcate transactions.
-        if ( (container.isSession || container.isMessageDriven) && container.isBeanManagedTran ) {
+        if ((container.isSession || container.isMessageDriven) && container.isBeanManagedTran) {
             try {
-                UserTransaction utx = (UserTransaction)
-                        container.namingManager.getInitialContext().lookup(USER_TX);
-                return utx;
-            } catch ( Exception ex ) {
-                _logger.log(Level.FINE, "ejb.user_transaction_exception", ex);
-                throw new EJBException(_logger.getResourceBundle().
-                        getString("ejb.user_transaction_exception"), ex);
+                return (UserTransaction) container.namingManager.getInitialContext().lookup(USER_TX);
+            } catch (Exception ex) {
+                final String message = LOG.getResourceBundle().getString("ejb.user_transaction_exception");
+                throw new EJBException(message, ex);
             }
         }
-        else {
-            throw new IllegalStateException(localStrings.getLocalString(
-                "ejb.ut_only_for_bmt",
-                "Only session beans with bean-managed transactions can obtain UserTransaction"));
-        }
+        final LocalStringManagerImpl localStrings = new LocalStringManagerImpl(EJBContainerTransactionManager.class);
+        throw new IllegalStateException( //
+            localStrings.getLocalString( //
+                "ejb.ut_only_for_bmt", "Only session beans with bean-managed transactions can obtain UserTransaction"));
     }
 
-    private EJBException destroyBeanAndRollback(EJBContextImpl context, String type) throws Exception {
-        try {
-            container.forceDestroyBean(context);
-        } finally {
-            rollback();
-        }
-
-        EJBException ex = null;
-        if (type != null) {
-            ex = new EJBException(type + " method returned without completing transaction");
-            _logger.log(Level.FINE, "ejb.incomplete_sessionbean_txn_exception");
-            _logger.log(Level.FINE,"",ex);
-        }
-        return ex;
-    }
-
-    private Throwable checkExceptionBeanMgTx(EJBContextImpl context,
-            Throwable exception, int status) throws Exception {
-        Throwable newException = exception;
+    private Throwable checkExceptionBeanMgTx(EJBContextImpl context, Throwable exception, int status) throws Exception {
+        LOG.finest(() -> String.format("checkExceptionBeanMgTx(context=%s, exception=%s, status=%s)", //
+            context, exception, status));
         // EJB2.0 section 18.3.1, Table 16
-        if ( exception != null && exception instanceof BaseContainer.PreInvokeException ) {
+        if (exception != null && exception instanceof BaseContainer.PreInvokeException) {
             // A PreInvokeException was thrown, so bean was not invoked
-            newException= ((BaseContainer.PreInvokeException)exception).exception;
-
-        } else if ( status == Status.STATUS_NO_TRANSACTION ) {
+            return exception.getCause();
+        } else if (status == Status.STATUS_NO_TRANSACTION) {
             // EJB was invoked, EJB's Tx is complete.
-            if ( exception != null ) {
-                newException = checkExceptionNoTx(context, exception);
+            if (exception == null) {
+                return exception;
             }
+            return checkExceptionNoTx(context, exception);
         } else {
             // EJB was invoked, EJB's Tx is incomplete.
             // See EJB2.0 Section 17.6.1
-            if ( container.isStatefulSession ) {
-                if ( !container.isSystemUncheckedException(exception) ) {
-                    if( isAppExceptionRequiringRollback(exception) ) {
-                        rollback();
-                    } else {
-                        transactionManager.suspend();
-                    }
-                } else {
+            if (container.isStatefulSession) {
+                if (container.isSystemUncheckedException(exception)) {
                     // system/unchecked exception was thrown by EJB
                     destroyBeanAndRollback(context, null);
-                    newException = processSystemException(exception);
+                    return processSystemException(exception);
                 }
-            } else if( container.isStatelessSession  ) { // stateless SessionBean
-                newException = destroyBeanAndRollback(context, "Stateless SessionBean");
-
-            } else if( container.isSingleton ) {
-                newException = destroyBeanAndRollback(context, "Singleton SessionBean");
-
-            } else { // MessageDrivenBean
-                newException = destroyBeanAndRollback(context, "MessageDrivenBean");
+                if (isAppExceptionRequiringRollback(exception)) {
+                    rollback();
+                } else {
+                    transactionManager.suspend();
+                }
+                return exception;
+            } else if (container.isStatelessSession) { // stateless SessionBean
+                return destroyBeanAndRollback(context, "Stateless SessionBean");
+            } else if (container.isSingleton) {
+                return destroyBeanAndRollback(context, "Singleton SessionBean");
+            } else {
+                return destroyBeanAndRollback(context, "MessageDrivenBean");
             }
         }
-        return newException;
     }
 
-    private Throwable checkExceptionNoTx(EJBContextImpl context, Throwable exception)
-            throws Exception {
-        if ( exception instanceof BaseContainer.PreInvokeException ) {
+    private Throwable checkExceptionNoTx(EJBContextImpl context, Throwable exception) throws EJBException {
+        LOG.finest(() -> String.format("checkExceptionNoTx(context=%s, exception=%s)", context, exception));
+        if (exception instanceof BaseContainer.PreInvokeException) {
             // A PreInvokeException was thrown, so bean was not invoked
-            return ((BaseContainer.PreInvokeException)exception).exception;
+            return exception.getCause();
         }
 
         // If PreInvokeException was not thrown, EJB was invoked with no Tx
-        Throwable newException = exception;
-        if ( container.isSystemUncheckedException(exception) ) {
+        if (container.isSystemUncheckedException(exception)) {
             // Table 15, EJB2.0
-            newException = processSystemException(exception);
+            final Throwable newException = processSystemException(exception);
             container.forceDestroyBean(context);
+            return newException;
         }
-        return newException;
+        return exception;
     }
 
-    // Can be called by the container - do not make it private
-    Throwable checkExceptionClientTx(EJBContextImpl context, Throwable exception)
-             throws Exception {
-        if ( exception instanceof BaseContainer.PreInvokeException ) {
+    // Can be called by the BaseContainer - do not make it private
+    Throwable checkExceptionClientTx(EJBContextImpl context, Throwable exception) throws SystemException {
+        LOG.finest(() -> String.format("checkExceptionClientTx(context=%s, exception=%s)", context, exception));
+        if (exception instanceof BaseContainer.PreInvokeException) {
             // A PreInvokeException was thrown, so bean was not invoked
-            return ((BaseContainer.PreInvokeException)exception).exception;
+            return exception.getCause();
         }
 
         // If PreInvokeException wasn't thrown, EJB was invoked with client's Tx
-        Throwable newException = exception;
-        if ( container.isSystemUncheckedException(exception) ) {
+        if (container.isSystemUncheckedException(exception)) {
             // Table 15, EJB2.0
             try {
                 container.forceDestroyBean(context);
             } finally {
                 transactionManager.setRollbackOnly();
             }
-            if ( exception instanceof Exception ) {
-                newException = new TransactionRolledbackLocalException(
-                	"Exception thrown from bean", (Exception)exception);
-            } else {
-                newException = new TransactionRolledbackLocalException(
-                	"Exception thrown from bean: "+exception.toString());
-                newException.initCause(exception);
-            }
-        } else if( isAppExceptionRequiringRollback(exception ) ) {
+            final TransactionRolledbackLocalException newException = new TransactionRolledbackLocalException(
+                "Exception thrown from bean: " + exception);
+            newException.initCause(exception);
+            return newException;
+        }
+        if (isAppExceptionRequiringRollback(exception)) {
             transactionManager.setRollbackOnly();
         }
-
-        return newException;
+        return exception;
      }
 
     // this is the counterpart of startNewTx
-    private Throwable completeNewTx(EJBContextImpl context, Throwable exception,
-            int status) throws Exception {
-        Throwable newException = exception;
-        if ( exception instanceof BaseContainer.PreInvokeException )
-            newException = ((BaseContainer.PreInvokeException)exception).exception;
+    private Throwable completeNewTx(EJBContextImpl context, Throwable exception, int status) throws Exception {
+        LOG.finest(
+            () -> String.format("completeNewTx(context=%s, exception=%s, status=%s)", context, exception, status));
+        final Throwable newException;
+        if (exception instanceof BaseContainer.PreInvokeException) {
+            newException = exception.getCause();
+        } else {
+            newException = exception;
+        }
 
-        if ( status == Status.STATUS_NO_TRANSACTION ) {
+        if (status == Status.STATUS_NO_TRANSACTION) {
             // no tx was started, probably an exception was thrown
             // before tm.begin() was called
             return newException;
         }
 
-        if ( container.isStatefulSession && (context instanceof SessionContextImpl)) {
+        if (container.isStatefulSession && (context instanceof SessionContextImpl)) {
             ((SessionContextImpl) context).setTxCompleting(true);
         }
 
         // A new tx was started, so we must commit/rollback
-        if ( newException != null && container.isSystemUncheckedException(newException) ) {
+        if (container.isSystemUncheckedException(newException)) {
             // EJB2.0 section 18.3.1, Table 15
             // Rollback the Tx we started
             destroyBeanAndRollback(context, null);
-            newException = processSystemException(newException);
+            return processSystemException(newException);
         }
-        else {
-            try {
-                if (status == Status.STATUS_MARKED_ROLLBACK) {
-                    // EJB2.0 section 18.3.1, Table 15, and 18.3.6:
-                    // rollback tx, no exception
+        try {
+            if (status == Status.STATUS_MARKED_ROLLBACK) {
+                // EJB2.0 section 18.3.1, Table 15, and 18.3.6:
+                // rollback tx, no exception
+                rollback();
+            } else {
+                if (newException != null && isAppExceptionRequiringRollback(newException)) {
                     rollback();
                 } else {
-                    if (newException != null && isAppExceptionRequiringRollback(newException)) {
-                        rollback();
-                    } else {
-                        // Note: if exception is an application exception
-                        // we do a commit as in EJB2.0 Section 18.3.1,
-                        // Table 15. Commit the Tx we started
-                        transactionManager.commit();
-                    }
+                    // Note: if exception is an application exception
+                    // we do a commit as in EJB2.0 Section 18.3.1,
+                    // Table 15. Commit the Tx we started
+                    transactionManager.commit();
                 }
-            } catch (RollbackException ex) {
-                _logger.log(Level.FINE, "ejb.transaction_abort_exception", ex);
-                // EJB2.0 section 18.3.6
-                newException = new EJBException("Transaction aborted", ex);
-            } catch ( Exception ex ) {
-                _logger.log(Level.FINE, "ejb.cmt_exception", ex);
-                // Commit or rollback failed.
-                // EJB2.0 section 18.3.6
-                newException = new EJBException("Unable to complete" + " container-managed transaction.", ex);
             }
+            return newException;
+        } catch (RollbackException ex) {
+            LOG.log(Level.FINE, "ejb.transaction_abort_exception", ex);
+            // EJB2.0 section 18.3.6
+            final EJBException result = new EJBException("Transaction aborted", ex);
+            result.addSuppressed(newException);
+            return result;
+        } catch (Exception ex) {
+            LOG.log(Level.FINE, "ejb.cmt_exception", ex);
+            // Commit or rollback failed.
+            // EJB2.0 section 18.3.6
+            final EJBException result = new EJBException("Unable to complete container-managed transaction.", ex);
+            result.addSuppressed(newException);
+            return result;
         }
-        return newException;
+    }
+
+    /**
+     * @return null if the type was null, {@link EJBException} otherwise.
+     */
+    private EJBException destroyBeanAndRollback(EJBContextImpl context, String type) throws SystemException {
+        LOG.finest(() -> String.format("destroyBeanAndRollback(context=%s, type=%s)", context, type));
+        try {
+            container.forceDestroyBean(context);
+        } finally {
+            rollback();
+        }
+        if (type == null) {
+            return null;
+        }
+        LOG.log(Level.FINE, "ejb.incomplete_sessionbean_txn_exception");
+        return new EJBException(type + " method returned without completing transaction");
     }
 
     private void rollback() throws SystemException {
         if (transactionManager.isTimedOut()) {
-            _logger.log(Level.WARNING, "ejb.tx_timeout",
+            LOG.log(Level.WARNING, "ejb.tx_timeout",
                 new Object[] {transactionManager.getTransaction(), ejbDescriptor.getName()});
         }
         transactionManager.rollback();
     }
 
     private Throwable processSystemException(Throwable sysEx) {
-        Throwable newException;
-        if ( sysEx instanceof EJBException)
+        if (sysEx instanceof EJBException) {
             return sysEx;
-
-        // EJB2.0 section 18.3.4
-        if ( sysEx instanceof NoSuchEntityException ) { // for EntityBeans only
-            newException = new NoSuchObjectLocalException
-                ("NoSuchEntityException thrown by EJB method.");
-            newException.initCause(sysEx);
-        } else {
-            newException = new EJBException();
-            newException.initCause(sysEx);
         }
-
-        return newException;
+        // EJB2.0 section 18.3.4
+        if (sysEx instanceof NoSuchEntityException) { // for EntityBeans only
+            return new NoSuchObjectLocalException("NoSuchEntityException thrown by EJB method.").initCause(sysEx);
+        }
+        return new EJBException(sysEx.getMessage()).initCause(sysEx);
     }
 
 
     /**
-     * Returns true if this exception is an Application Exception and
+     * @return true if this exception is an Application Exception and
      * it requires rollback of the transaction in which it was thrown.
      */
     private boolean isAppExceptionRequiringRollback(Throwable exception) {
-        boolean appExceptionRequiringRollback = false;
-
-        if ( exception != null ) {
-
-            Class clazz = exception.getClass();
-            String exceptionClassName = clazz.getName();
-            Map<String, EjbApplicationExceptionInfo> appExceptions =
-                    ejbDescriptor.getEjbBundleDescriptor().getApplicationExceptions();
-            while (clazz != null) {
-                String eClassName = clazz.getName();
-                if (appExceptions.containsKey(eClassName)) {
-                    if( exceptionClassName.equals(eClassName) ||
-                            appExceptions.get(eClassName).getInherited() == true) {
-                        // Exact exception is specified as an ApplicationException
-                        // or superclass exception is inherited
-                        appExceptionRequiringRollback = appExceptions.get(eClassName).getRollback();
-                    }
-                    break;
-                }
-                clazz = clazz.getSuperclass();
-            }
+        if (exception == null) {
+            return false;
         }
+        final String exceptionClassName = exception.getClass().getName();
+        final Map<String, EjbApplicationExceptionInfo> appExceptions = //
+            ejbDescriptor.getEjbBundleDescriptor().getApplicationExceptions();
 
-        return appExceptionRequiringRollback;
+        Class<?> exceptionClass = exception.getClass();
+        while (exceptionClass != null) {
+            final String eClassName = exceptionClass.getName();
+            if (appExceptions.containsKey(eClassName)) {
+                final EjbApplicationExceptionInfo exceptionInfo = appExceptions.get(eClassName);
+                if (exceptionClassName.equals(eClassName) || exceptionInfo.getInherited()) {
+                    // Exact exception is specified as an ApplicationException
+                    // or superclass exception is inherited
+                    return exceptionInfo.getRollback();
+                }
+                break;
+            }
+            exceptionClass = exceptionClass.getSuperclass();
+        }
+        return false;
     }
-
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBLocalHomeInvocationHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBLocalHomeInvocationHandler.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.ejb.containers;
 
@@ -50,83 +51,79 @@ import com.sun.enterprise.deployment.EjbSessionDescriptor;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.Utility;
 
-import javax.ejb.EJBException;
-import javax.ejb.EJBLocalHome;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.logging.Logger;
 
-/** 
+import javax.ejb.EJBException;
+import javax.ejb.EJBLocalHome;
+
+/**
  * Handler for EJBLocalHome invocations through EJBLocalHome proxy.
  *
  * @author Kenneth Saks
- */    
+ */
+public class EJBLocalHomeInvocationHandler extends EJBLocalHomeImpl implements InvocationHandler {
 
-public class EJBLocalHomeInvocationHandler 
-    extends EJBLocalHomeImpl implements InvocationHandler {
+    private static final Logger LOG = Logger.getLogger(EJBLocalHomeInvocationHandler.class.getName());
 
-    private static final Logger logger = EjbContainerUtilImpl.getLogger();
-
-    private static LocalStringManagerImpl localStrings =
-        new LocalStringManagerImpl(EJBLocalHomeInvocationHandler.class);
-
-    private boolean isStatelessSession_;
+    private final boolean isStatelessSession;
 
     // Our associated proxy object.  Used when a caller needs EJBLocalObject
     // but only has InvocationHandler.
-    private EJBLocalHome proxy_;
+    private EJBLocalHome proxy;
 
-    private Class localHomeIntfClass_;
+    private final Class localHomeIntfClass;
 
     // Cache reference to invocation info.  There is one of these per
     // container.  It's populated during container initialization and
     // passed in when the InvocationHandler is created.  This avoids the
     // overhead of building the method info each time a LocalHome proxy
-    // is created.  
-    private MethodMap invocationInfoMap_;
+    // is created.
+    private MethodMap invocationInfoMap;
 
-    protected EJBLocalHomeInvocationHandler(EjbDescriptor ejbDescriptor,
-                                  Class localHomeIntf)
-        throws Exception {
 
-        if( ejbDescriptor instanceof EjbSessionDescriptor ) {
-            isStatelessSession_ = 
-                ((EjbSessionDescriptor)ejbDescriptor).isStateless();
+    protected EJBLocalHomeInvocationHandler(EjbDescriptor ejbDescriptor, Class localHomeIntf) throws Exception {
+
+        if (ejbDescriptor instanceof EjbSessionDescriptor) {
+            this.isStatelessSession = ((EjbSessionDescriptor) ejbDescriptor).isStateless();
         } else {
-            isStatelessSession_ = false;
+            this.isStatelessSession = false;
         }
 
-        localHomeIntfClass_ = localHomeIntf;
+        this.localHomeIntfClass = localHomeIntf;
 
-        // NOTE : Container is not set on super-class until after 
+        // NOTE : Container is not set on super-class until after
         // constructor is called.
     }
 
     public void setMethodMap(MethodMap map) {
-        invocationInfoMap_ = map;
+        this.invocationInfoMap = map;
     }
 
     public void setProxy(EJBLocalHome proxy) {
-        proxy_ = proxy;
+        this.proxy = proxy;
     }
 
+    @Override
     protected EJBLocalHome getEJBLocalHome() {
-        return proxy_;
+        return proxy;
     }
 
     /**
      * Called by EJBLocalHome proxy.
      */
-    public Object invoke(Object proxy, Method method, Object[] args) 
-        throws Throwable {
-
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        LOG.finest(() -> String.format("invoke(proxy=%s, method=%s, args=%s)", proxy, method, Arrays.toString(args)));
         ClassLoader originalClassLoader = null;
 
-        // NOTE : be careful with "args" parameter.  It is null
-        //        if method signature has 0 arguments.
+        // NOTE : be careful with "args" parameter. It is null
+        // if method signature has 0 arguments.
         try {
-        ((BaseContainer) getContainer()).onEnteringContainer();
+            getContainer().onEnteringContainer();
 
             // In some cases(e.g. CDI + OSGi combination) ClassLoader
             // is accessed from the current Thread. In those cases we need to set
@@ -134,136 +131,123 @@ public class EJBLocalHomeInvocationHandler
             // proceeding. Otherwise, the context classloader could still
             // reflect the caller's class loader.
 
-            if( Thread.currentThread().getContextClassLoader() !=
-                getContainer().getClassLoader() ) {
-                originalClassLoader = Utility.setContextClassLoader
-                    (getContainer().getClassLoader());
+            if (Thread.currentThread().getContextClassLoader() != getContainer().getClassLoader()) {
+                originalClassLoader = Utility.setContextClassLoader(getContainer().getClassLoader());
             }
 
-        Class methodClass = method.getDeclaringClass();
+            final Class methodClass = method.getDeclaringClass();
 
-        if( methodClass == java.lang.Object.class )  {
-            return InvocationHandlerUtil.invokeJavaObjectMethod
-                (this, method, args);    
-        } else if( methodClass == IndirectlySerializable.class ) {
-            return this.getSerializableObjectFactory();
-        } else if( handleSpecialEJBLocalHomeMethod(method, methodClass) ) {
-            return invokeSpecialEJBLocalHomeMethod(method, methodClass, args);
-        }
-
-        // Use optimized version of get that takes param count as an argument.
-        InvocationInfo invInfo = (InvocationInfo)
-            invocationInfoMap_.get(method, ((args != null) ? args.length : 0) );
-            
-        if( invInfo == null ) {
-            throw new IllegalStateException("Unknown method :" + method);
-        } 
-
-        if( (methodClass == javax.ejb.EJBLocalHome.class) ||
-            invInfo.ejbIntfOverride ) {
-            // There is only one method on javax.ejb.EJBLocalHome
-            super.remove(args[0]);
-            return null;
-
-        } else if(methodClass == GenericEJBLocalHome.class) {
-
-            // This is a creation request through the EJB 3.0
-            // client view, so just create a local business object and 
-            // return it.
-            EJBLocalObjectImpl localImpl = 
-                createEJBLocalBusinessObjectImpl((String) args[0]);
-            return localImpl.getClientObject((String) args[0]);
-            
-        } 
-
-        // Process finder, create method, or home method.
-        EJBLocalObjectImpl localObjectImpl = null;
-        Object returnValue = null;
-
-        if( invInfo.startsWithCreate ) {
-            localObjectImpl = createEJBLocalObjectImpl();
-            if (localObjectImpl != null) {
-                returnValue = localObjectImpl.getClientObject();
+            if (methodClass == java.lang.Object.class) {
+                return InvocationHandlerUtil.invokeJavaObjectMethod(this, method, args);
+            } else if (methodClass == IndirectlySerializable.class) {
+                return this.getSerializableObjectFactory();
+            } else if (handleSpecialEJBLocalHomeMethod(method, methodClass)) {
+                return invokeSpecialEJBLocalHomeMethod(method, methodClass, args);
             }
-        }
- 
-        if( !isStatelessSession_ ) {
 
-            if( invInfo.targetMethod1 == null ) {
+            // Use optimized version of get that takes param count as an argument.
+            final InvocationInfo invInfo = (InvocationInfo) invocationInfoMap.get(method,
+                (args == null ? 0 : args.length));
 
-                Object [] params = new Object[] 
-                    { invInfo.ejbName, "LocalHome", 
-                      invInfo.method.toString() };
-                String errorMsg = localStrings.getLocalString
-                    ("ejb.bean_class_method_not_found", "", params);
+            if (invInfo == null) {
+                throw new IllegalStateException("Unknown method: " + method);
+            }
+
+            if ((methodClass == javax.ejb.EJBLocalHome.class) || invInfo.ejbIntfOverride) {
+                // There is exactly one argument on javax.ejb.EJBLocalHome: primaryKey
+                super.remove(args[0]);
+                return null;
+
+            } else if (methodClass == GenericEJBLocalHome.class) {
+
+                // This is a creation request through the EJB 3.0
+                // client view, so just create a local business object and
+                // return it.
+                final EJBLocalObjectImpl localImpl = createEJBLocalBusinessObjectImpl((String) args[0]);
+                return localImpl.getClientObject((String) args[0]);
+
+            }
+
+            // Process finder, create method, or home method.
+            EJBLocalObjectImpl localObjectImpl = null;
+            if (invInfo.startsWithCreate) {
+                localObjectImpl = createEJBLocalObjectImpl();
+                if (localObjectImpl != null) {
+                    if (isStatelessSession) {
+                        return localObjectImpl.getClientObject();
+                    }
+                }
+            }
+
+            if (isStatelessSession) {
+                return null;
+            }
+
+            if (invInfo.targetMethod1 == null) {
+                final LocalStringManagerImpl msgs = new LocalStringManagerImpl(EJBLocalHomeInvocationHandler.class);
+                final Object[] params = new Object[] {invInfo.ejbName, "LocalHome", invInfo.method.toString()};
+                final String errorMsg = msgs.getLocalString("ejb.bean_class_method_not_found", "", params);
                 throw new EJBException(errorMsg);
             }
 
-            EjbInvocation inv = ((BaseContainer) getContainer()).createEjbInvocation();
+            final EjbInvocation inv = getContainer().createEjbInvocation();
 
             inv.isLocal = true;
-            inv.isHome  = true;
-            inv.method  = method;
+            inv.isHome = true;
+            inv.method = method;
 
-            inv.clientInterface = localHomeIntfClass_;
+            inv.clientInterface = localHomeIntfClass;
 
-            // Set cached invocation params.  This will save additional lookups
+            // Set cached invocation params. This will save additional lookups
             // in BaseContainer.
             inv.transactionAttribute = invInfo.txAttr;
             inv.invocationInfo = invInfo;
 
-            if( localObjectImpl != null && invInfo.startsWithCreate ) {
-                inv.ejbObject = (EJBLocalRemoteObject) localObjectImpl;
+            if (localObjectImpl != null && invInfo.startsWithCreate) {
+                inv.ejbObject = localObjectImpl;
             }
 
-            try {
-
-                container.preInvoke(inv);
-
-                if( invInfo.startsWithCreate ) {
-
-                    Object ejbCreateReturnValue = invokeTargetBeanMethod(container,
-                        invInfo.targetMethod1, inv, inv.ejb, args);
-                    postCreate(container, inv, invInfo, ejbCreateReturnValue, args);
-                    if( inv.ejbObject != null ) {
-                        returnValue = ((EJBLocalObjectImpl)inv.ejbObject)
-                            .getClientObject();
-                    } 
-                } else if (invInfo.startsWithFindByPrimaryKey) {
-		    returnValue = container.invokeFindByPrimaryKey(
-			invInfo.targetMethod1, inv, args);
-                } else if ( invInfo.startsWithFind ) {
-
-                    Object pKeys = invokeTargetBeanMethod(container, invInfo.targetMethod1,
-                                      inv, inv.ejb, args);
-                    returnValue = container.postFind(inv, pKeys, null);
-                } else {
-
-                    returnValue = invokeTargetBeanMethod(container, invInfo.targetMethod1,
-                                      inv, inv.ejb, args);
-
-                }
-            } catch(InvocationTargetException ite) {
-                inv.exception = ite.getCause();           
-            } catch(Throwable c) {
-                inv.exception = c;
-            } finally {
-                container.postInvoke(inv);
-            }
-
+            final Object returnValue = invokeBean(args, invInfo, inv);
             if (inv.exception != null) {
-                InvocationHandlerUtil.throwLocalException
-                    (inv.exception, method.getExceptionTypes());
+                InvocationHandlerUtil.throwLocalException(inv.exception, method.getExceptionTypes());
             }
-        }
-
-        return returnValue;
+            return returnValue;
         } finally {
-            if( originalClassLoader != null ) {
+            if (originalClassLoader != null) {
                 Utility.setContextClassLoader(originalClassLoader);
             }
 
-            ((BaseContainer) getContainer()).onLeavingContainer();
+            getContainer().onLeavingContainer();
+        }
+    }
+
+    private Object invokeBean(Object[] args, final InvocationInfo invInfo, final EjbInvocation inv) {
+        try {
+            container.preInvoke(inv);
+            if (invInfo.startsWithCreate) {
+                final Object ejbCreateReturnValue = invokeTargetBeanMethod(container, invInfo.targetMethod1, inv,
+                    inv.ejb, args);
+                postCreate(container, inv, invInfo, ejbCreateReturnValue, args);
+                if (inv.ejbObject == null) {
+                    return null;
+                }
+                return ((EJBLocalObjectImpl) inv.ejbObject).getClientObject();
+            } else if (invInfo.startsWithFindByPrimaryKey) {
+                return container.invokeFindByPrimaryKey(invInfo.targetMethod1, inv, args);
+            } else if (invInfo.startsWithFind) {
+                final Object pKeys = invokeTargetBeanMethod(container, invInfo.targetMethod1, inv, inv.ejb, args);
+                return container.postFind(inv, pKeys, null);
+            } else {
+                return invokeTargetBeanMethod(container, invInfo.targetMethod1, inv, inv.ejb, args);
+            }
+        } catch (final InvocationTargetException ite) {
+            inv.exception = ite.getCause();
+            return null;
+        } catch (final Throwable c) {
+            inv.exception = c;
+            return null;
+        } finally {
+            container.postInvoke(inv);
         }
     }
 
@@ -285,7 +269,7 @@ public class EJBLocalHomeInvocationHandler
     }
 
     // allow subclasses to execute a protected method in BaseContainer
-    protected Object invokeTargetBeanMethod(BaseContainer container, 
+    protected Object invokeTargetBeanMethod(BaseContainer container,
             Method beanClassMethod, EjbInvocation inv, Object target, Object[] params)
             throws Throwable {
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/SessionContextImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/SessionContextImpl.java
@@ -37,76 +37,77 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 package com.sun.ejb.containers;
 
 import com.sun.ejb.EjbInvocation;
+import com.sun.ejb.containers.StatefulSessionContainer.EEMRefInfo;
 import com.sun.ejb.spi.container.StatefulEJBContext;
 import com.sun.enterprise.container.common.impl.PhysicalEntityManagerWrapper;
 import com.sun.enterprise.deployment.EjbSessionDescriptor;
-import org.glassfish.api.invocation.ComponentInvocation;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.ejb.SessionContext;
 import javax.ejb.TimerService;
 import javax.persistence.EntityManagerFactory;
-import java.util.*;
 
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import static com.sun.ejb.containers.StatefulSessionContainer.EEMRefInfo;
+import org.glassfish.api.invocation.ComponentInvocation;
 
 /**
  * Implementation of EJBContext for SessionBeans
  *
  * @author Mahesh Kannan
  */
+public final class SessionContextImpl extends AbstractSessionContextImpl implements StatefulEJBContext {
 
-public final class SessionContextImpl
-    extends AbstractSessionContextImpl
-    implements StatefulEJBContext
-{
+    private static final long serialVersionUID = -559621200233337728L;
 
     private boolean completedTxStatus;
-    private boolean afterCompletionDelayed=false;
-    private boolean committing=false;
-    private boolean inAfterCompletion=false;
+    private boolean afterCompletionDelayed = false;
+    private boolean committing = false;
+    private boolean inAfterCompletion = false;
     private boolean isStateless = false;
-    private boolean isStateful  = false;
+    private boolean isStateful = false;
 
-    private boolean existsInSessionStore = false; 
+    private boolean existsInSessionStore = false;
     private transient int refCount = 0;
 
     private boolean txCheckpointDelayed;
-    private long    lastPersistedAt;
+    private long lastPersistedAt;
 
     private long version;
-    
+
     // Do not call Session Synchronization callbacks when in transactional
     // lifecycle callbacks
     private boolean inLifeCycleCallback = false;
 
-    // Map of entity managers with extended persistence context 
+    // Map of entity managers with extended persistence context
     // for this stateful session bean.
     private transient Map<EntityManagerFactory, PhysicalEntityManagerWrapper> extendedEntityManagerMap;
 
     private transient Set<EntityManagerFactory> emfsRegisteredWithTx;
 
-    //Used during activation to populate entries in the above maps
-    //Also, EEMRefInfo implements IndirectlySerializable
-    private Collection<EEMRefInfo> eemRefInfos = new HashSet<EEMRefInfo>();
+    // Used during activation to populate entries in the above maps
+    // Also, EEMRefInfo implements IndirectlySerializable
+    private Collection<EEMRefInfo> eemRefInfos = new HashSet<>();
 
     // Used to provide serialized access to an SFSB instance.
     private transient ReentrantReadWriteLock statefulSerializedAccessLock;
-    
+
     SessionContextImpl(Object ejb, BaseContainer container) {
         super(ejb, container);
-        EjbSessionDescriptor sessionDesc =
-            (EjbSessionDescriptor) getContainer().getEjbDescriptor();
+        EjbSessionDescriptor sessionDesc = (EjbSessionDescriptor) getContainer().getEjbDescriptor();
         isStateless = sessionDesc.isStateless();
-        isStateful  = sessionDesc.isStateful();
-        if( isStateful ) {
-            initializeStatefulWriteLock();   
+        isStateful = sessionDesc.isStateful();
+        if (isStateful) {
+            initializeStatefulWriteLock();
         }
     }
 
@@ -117,7 +118,6 @@ public final class SessionContextImpl
         return extendedEntityManagerMap;
     }
 
-
     Collection<EEMRefInfo> getAllEEMRefInfos() {
         return eemRefInfos;
     }
@@ -125,15 +125,13 @@ public final class SessionContextImpl
     void setEEMRefInfos(Collection<EEMRefInfo> val) {
         if (val != null) {
             eemRefInfos = val;
-	}
+        }
     }
 
-    public void addExtendedEntityManagerMapping(EntityManagerFactory emf,
-		    EEMRefInfo refInfo) {
-        getExtendedEntityManagerMap().put(emf, new PhysicalEntityManagerWrapper(refInfo.getEntityManager(),
-                refInfo.getSynchronizationType()) );
+    public void addExtendedEntityManagerMapping(EntityManagerFactory emf, EEMRefInfo refInfo) {
+        getExtendedEntityManagerMap().put(emf,
+            new PhysicalEntityManagerWrapper(refInfo.getEntityManager(), refInfo.getSynchronizationType()));
     }
-
 
     public PhysicalEntityManagerWrapper getExtendedEntityManager(EntityManagerFactory emf) {
         return getExtendedEntityManagerMap().get(emf);
@@ -144,15 +142,14 @@ public final class SessionContextImpl
     }
 
     private Set<EntityManagerFactory> getEmfsRegisteredWithTx() {
-        if( emfsRegisteredWithTx == null ) {
-            emfsRegisteredWithTx = new HashSet<EntityManagerFactory>();
+        if (emfsRegisteredWithTx == null) {
+            emfsRegisteredWithTx = new HashSet<>();
         }
         return emfsRegisteredWithTx;
     }
 
-    public void setEmfRegisteredWithTx(EntityManagerFactory emf, boolean flag)
-    {
-        if( flag ) {
+    public void setEmfRegisteredWithTx(EntityManagerFactory emf, boolean flag) {
+        if (flag) {
             getEmfsRegisteredWithTx().add(emf);
         } else {
             getEmfsRegisteredWithTx().remove(emf);
@@ -162,7 +159,6 @@ public final class SessionContextImpl
     public boolean isEmfRegisteredWithTx(EntityManagerFactory emf) {
         return getEmfsRegisteredWithTx().contains(emf);
     }
-
 
     public void initializeStatefulWriteLock() {
         statefulSerializedAccessLock = new ReentrantReadWriteLock(true);
@@ -178,14 +174,13 @@ public final class SessionContextImpl
 
     @Override
     public TimerService getTimerService() throws IllegalStateException {
-        if( isStateful ) {
-            throw new IllegalStateException
-                ("EJBTimer Service is not accessible to Stateful Session ejbs");
+        if (isStateful) {
+            throw new IllegalStateException("EJBTimer Service is not accessible to Stateful Session ejbs");
         }
 
         // Instance key is first set between after setSessionContext and
         // before ejbCreate
-        if ( instanceKey == null ) {
+        if (getInstanceKey() == null) {
             throw new IllegalStateException("Operation not allowed");
         }
 
@@ -193,129 +188,120 @@ public final class SessionContextImpl
     }
 
     @Override
-    protected void checkAccessToCallerSecurity()
-        throws IllegalStateException
-    {
-        
-        if( isStateless ) {
+    protected void checkAccessToCallerSecurity() throws IllegalStateException {
+
+        if (isStateless) {
             // This covers constructor, setSessionContext, ejbCreate,
             // and ejbRemove. NOTE : For stateless session beans,
             // instances don't move past CREATED until after ejbCreate.
-            if( (state == BeanState.CREATED) || inEjbRemove ) {
+            if (state == BeanState.CREATED || inEjbRemove) {
                 throw new IllegalStateException("Operation not allowed");
             }
         } else {
             // This covers constructor and setSessionContext.
             // For stateful session beans, instances move past
             // CREATED after setSessionContext.
-            if( state == BeanState.CREATED ) {
+            if (state == BeanState.CREATED) {
                 throw new IllegalStateException("Operation not allowed");
             }
         }
-        
+
     }
-    
+
     @Override
-    public void checkTimerServiceMethodAccess()
-        throws IllegalStateException
-    {
+    public void checkTimerServiceMethodAccess() throws IllegalStateException {
         // checks that only apply to stateful session beans
         ComponentInvocation compInv = getCurrentComponentInvocation();
         if (isStateful) {
-            if (
-            inStatefulSessionEjbCreate(compInv) ||
-            inActivatePassivate(compInv) ||
-            inAfterCompletion ) {
-                throw new IllegalStateException
-                ("EJB Timer methods for stateful session beans cannot be " +
-                " called in this context");
+            if (inStatefulSessionEjbCreate(compInv) || inActivatePassivate(compInv) || inAfterCompletion) {
+                throw new IllegalStateException(
+                    "EJB Timer methods for stateful session beans cannot be " + " called in this context");
             }
         }
-        
+
         // checks that apply to both stateful AND stateless
-        if ( (state == BeanState.CREATED) || inEjbRemove ) {
-            throw new IllegalStateException
-            ("EJB Timer method calls cannot be called in this context");
+        if (state == BeanState.CREATED || inEjbRemove) {
+            throw new IllegalStateException("EJB Timer method calls cannot be called in this context");
         }
     }
-    
+
     boolean getCompletedTxStatus() {
         return completedTxStatus;
     }
-    
+
     void setCompletedTxStatus(boolean s) {
         this.completedTxStatus = s;
     }
-    
+
     boolean isAfterCompletionDelayed() {
         return afterCompletionDelayed;
     }
-    
+
     void setAfterCompletionDelayed(boolean s) {
         this.afterCompletionDelayed = s;
     }
-    
+
     boolean isTxCompleting() {
         return committing;
     }
-    
+
     void setTxCompleting(boolean s) {
         this.committing = s;
     }
-    
+
     void setInAfterCompletion(boolean flag) {
         inAfterCompletion = flag;
     }
-    
+
     void setInLifeCycleCallback(boolean s) {
         inLifeCycleCallback = s;
     }
-    
+
     boolean getInLifeCycleCallback() {
         return inLifeCycleCallback;
     }
-    
+
     // Used to check if stateful session bean is in ejbCreate.
     // Since bean goes to READY state before ejbCreate is called by
     // EJBHomeImpl and EJBLocalHomeImpl, we can't rely on getState()
     // being CREATED for operations matrix checks.
     private boolean inStatefulSessionEjbCreate(ComponentInvocation inv) {
-        boolean inEjbCreate = false;
-        if ( inv instanceof EjbInvocation ) {
-            Class clientIntf = ((EjbInvocation)inv).clientInterface;
-            // If call came through a home/local-home, this can only be a
-            // create call.
-            inEjbCreate = ((EjbInvocation)inv).isHome &&
-                (javax.ejb.EJBHome.class.isAssignableFrom(clientIntf) ||
-                 javax.ejb.EJBLocalHome.class.isAssignableFrom(clientIntf));
+        if (inv instanceof EjbInvocation) {
+            final EjbInvocation ejbInv = (EjbInvocation) inv;
+            // If call came through a home/local-home, this can only be create call.
+            return ejbInv.isHome
+                && ejbInv.isClientInterfaceAssignableToOneOf(javax.ejb.EJBHome.class, javax.ejb.EJBLocalHome.class);
         }
-        return inEjbCreate;
+        return false;
     }
-    
+
     void setTxCheckpointDelayed(boolean val) {
-	this.txCheckpointDelayed = val;
+        this.txCheckpointDelayed = val;
     }
 
     boolean isTxCheckpointDelayed() {
-	return this.txCheckpointDelayed;
+        return this.txCheckpointDelayed;
     }
 
     long getLastPersistedAt() {
-	return lastPersistedAt;
+        return lastPersistedAt;
     }
 
     void setLastPersistedAt(long val) {
-	this.lastPersistedAt = val;
+        this.lastPersistedAt = val;
     }
 
+    @Override
     public long getVersion() {
         return version;
     }
-    
+
+    @Override
     public long incrementAndGetVersion() {
         return ++version;
     }
 
+    @Override
     public void setVersion(long newVersion) {
         this.version = newVersion;
     }
@@ -324,40 +310,44 @@ public final class SessionContextImpl
     /************ Implementation of StatefulEJBContext ***********************/
     /*************************************************************************/
 
+    @Override
     public long getLastAccessTime() {
         return getLastTimeUsed();
     }
 
+    @Override
     public boolean canBePassivated() {
-        return (state == EJBContextImpl.BeanState.READY);
-    }
-    
-    public boolean hasExtendedPC() {
-        return (this.getExtendedEntityManagerMap().size() != 0);
+        return state == EJBContextImpl.BeanState.READY;
     }
 
+    public boolean hasExtendedPC() {
+        return !this.getExtendedEntityManagerMap().isEmpty();
+    }
+
+    @Override
     public SessionContext getSessionContext() {
         return this;
     }
 
+    @Override
     public boolean existsInStore() {
         return existsInSessionStore ;
     }
 
+    @Override
     public void setExistsInStore(boolean val) {
         this.existsInSessionStore = val;
     }
 
-    public final void incrementRefCount() {
+    public void incrementRefCount() {
         refCount++;
     }
 
-    public final void decrementRefCount() {
+    public void decrementRefCount() {
         refCount--;
     }
 
-    public final int getRefCount() {
+    public int getRefCount() {
         return refCount;
     }
-    
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/WebServiceInvocationHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/WebServiceInvocationHandler.java
@@ -139,7 +139,7 @@ public final class WebServiceInvocationHandler extends EJBLocalRemoteObject
             inv.invocationInfo = (InvocationInfo) invocationInfoMap_.get(inv.method);
 
             if (inv.invocationInfo == null) {
-                throw new EJBException("Web service Invocation Info lookup failed for " + "method " + inv.method);
+                throw new EJBException("Web service Invocation Info lookup failed for method " + inv.method);
             }
 
             inv.transactionAttribute = inv.invocationInfo.txAttr;

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/WebServiceInvocationHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/WebServiceInvocationHandler.java
@@ -37,60 +37,50 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 package com.sun.ejb.containers;
 
-import java.rmi.UnmarshalException;
-import javax.ejb.EJBException;
-import javax.ejb.AccessLocalException;
+import com.sun.ejb.ComponentContext;
+import com.sun.ejb.EjbInvocation;
+import com.sun.ejb.InvocationInfo;
+import com.sun.enterprise.deployment.WebServiceEndpoint;
+import com.sun.enterprise.util.LocalStringManagerImpl;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Proxy;
 import java.lang.reflect.Method;
-
+import java.rmi.UnmarshalException;
 import java.util.Map;
-import java.util.logging.Logger;
 
-import com.sun.ejb.EjbInvocation;
-import com.sun.ejb.ComponentContext;
-import com.sun.ejb.InvocationInfo;
+import javax.ejb.AccessLocalException;
+import javax.ejb.EJBException;
+
 import org.glassfish.api.invocation.InvocationManager;
-import org.glassfish.ejb.api.EjbEndpointFacade;
-import com.sun.ejb.Container;
-import com.sun.enterprise.deployment.EjbDescriptor;
-import com.sun.enterprise.deployment.WebServiceEndpoint;
-import com.sun.enterprise.util.LocalStringManagerImpl;
-import com.sun.logging.LogDomains;
 
-/** 
+/**
  * This is a proxy invocation handler for web service ejb invocations.
  * A single instance of this invocation handler is used for all
  * web service invocations to a particular ejb endpoint, so it must support
  * concurrent use.
  *
  * @author Kenneth Saks
- */    
-
-public final class WebServiceInvocationHandler extends EJBLocalRemoteObject 
+ */
+public final class WebServiceInvocationHandler extends EJBLocalRemoteObject
     implements InvocationHandler {
 
-    private WebServiceEndpoint endpoint_;
-    private Class ejbClass_;
-    private Class serviceEndpointIntfClass_;
-    private InvocationManager invManager_;
-    private boolean hasHandlers_;
-    private Map invocationInfoMap_;
+    private final WebServiceEndpoint endpoint_;
+    private final Class ejbClass_;
+    private final Class serviceEndpointIntfClass_;
+    private final InvocationManager invManager_;
+    private final boolean hasHandlers_;
+    private final Map invocationInfoMap_;
 
     private static final LocalStringManagerImpl localStrings =
         new LocalStringManagerImpl(WebServiceInvocationHandler.class);
 
 
-    public WebServiceInvocationHandler(Class ejbClass, 
-                                       WebServiceEndpoint endpoint,
-                                       Class serviceEndpointIntfClass,
-                                       EjbContainerUtil contUtil,
-                                       Map invocationInfoMap) {
+    public WebServiceInvocationHandler(Class ejbClass, WebServiceEndpoint endpoint, Class serviceEndpointIntfClass,
+        EjbContainerUtil contUtil, Map invocationInfoMap) {
         ejbClass_ = ejbClass;
         serviceEndpointIntfClass_ = serviceEndpointIntfClass;
         endpoint_ = endpoint;
@@ -99,27 +89,44 @@ public final class WebServiceInvocationHandler extends EJBLocalRemoteObject
         invocationInfoMap_ = invocationInfoMap;
     }
 
-    public Object invoke(Object proxy, Method method, Object[] args) 
-        throws Throwable {
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         try {
-        container.onEnteringContainer();
-        // NOTE : be careful with "args" parameter.  It is null
-        //        if method signature has 0 arguments.
+            container.onEnteringContainer();
+            // NOTE : be careful with "args" parameter. It is null
+            // if method signature has 0 arguments.
+            final Class<?> methodClass = method.getDeclaringClass();
+            if (methodClass == java.lang.Object.class) {
+                return InvocationHandlerUtil.invokeJavaObjectMethod(this, method, args);
+            }
 
-        Class methodClass = method.getDeclaringClass();
-        if( methodClass == java.lang.Object.class )  {
-            return InvocationHandlerUtil.
-                invokeJavaObjectMethod(this, method, args);    
+            // Invocation was created earlier in the web service dispatching
+            final EjbInvocation inv = (EjbInvocation) invManager_.getCurrentInvocation();
+            final Object returnValue = invoke(method, args, inv);
+            if (inv.exception != null) {
+                if (inv.exception instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException) inv.exception;
+                } else if (inv.exception instanceof Exception) {
+                    throw inv.exception;
+                } else {
+                    final EJBException ejbEx = new EJBException(inv.exception.getMessage());
+                    ejbEx.initCause(inv.exception);
+                    throw ejbEx;
+                }
+            }
+            return returnValue;
+        } finally {
+            container.onLeavingContainer();
         }
+    }
 
-        Object returnValue = null;
-        // Invocation was created earlier in the web service dispatching
-        EjbInvocation inv = (EjbInvocation) invManager_.getCurrentInvocation();
 
+    private Object invoke(Method method, Object[] args, EjbInvocation inv) throws Exception {
         try {
             inv.ejbObject = this;
-            
-            // things can become hairy here. This handler may have been created 
+
+            // things can become hairy here. This handler may have been created
             // with a dummy SEI to satisfy the EJB container. In such cases, we must
             // find the right method object on the SIB.
             if (endpoint_.getServiceEndpointInterface().equals(ejbClass_.getName())) {
@@ -129,56 +136,50 @@ public final class WebServiceInvocationHandler extends EJBLocalRemoteObject
             inv.method = method;
             inv.clientInterface = serviceEndpointIntfClass_;
 
-            inv.invocationInfo = (InvocationInfo)
-                invocationInfoMap_.get(inv.method);
+            inv.invocationInfo = (InvocationInfo) invocationInfoMap_.get(inv.method);
 
-            if( inv.invocationInfo == null ) {
-                throw new EJBException
-                    ("Web service Invocation Info lookup failed for " +
-                     "method " + inv.method);
+            if (inv.invocationInfo == null) {
+                throw new EJBException("Web service Invocation Info lookup failed for " + "method " + inv.method);
             }
 
             inv.transactionAttribute = inv.invocationInfo.txAttr;
 
-	        // special handling of jaxrpc endpoints (identfied by mapping file)
-            if(endpoint_.getWebService().hasMappingFile()) {
-		
-		        if( hasHandlers_ ) {
-		            // Handler performed method authorization already
-		        } else {
+            // special handling of jaxrpc endpoints (identfied by mapping file)
+            if (endpoint_.getWebService().hasMappingFile()) {
 
-		            boolean authorized = container.authorize(inv);
-		            if( !authorized ) {
-			            throw new AccessLocalException
-			                ("Client not authorized to access " + inv.method);
-		            }
-		        }
-	        } else if ( hasHandlers_ ) {
+                if (hasHandlers_) {
+                    // Handler performed method authorization already
+                } else {
 
-		        // jaxws enpoint
-		        // authorization was done in security pipe
-                // Now that application handlers have run, do 
-                // another method lookup and compare the results 
-                // with the original one. This ensures that the 
+                    final boolean authorized = container.authorize(inv);
+                    if (!authorized) {
+                        throw new AccessLocalException("Client not authorized to access " + inv.method);
+                    }
+                }
+            } else if (hasHandlers_) {
+
+                // jaxws enpoint
+                // authorization was done in security pipe
+                // Now that application handlers have run, do
+                // another method lookup and compare the results
+                // with the original one. This ensures that the
                 // application handlers have not changed
                 // which method is invoked.
 
-                Method methodBefore = inv.getWebServiceMethod();
-                
+                final Method methodBefore = inv.getWebServiceMethod();
+
                 if (methodBefore != null && !methodBefore.equals(inv.method)) {
-                    inv.exception = new UnmarshalException
-			    (localStrings.getLocalString
-			    ("enterprise.webservice.postHandlerMethodMismatch",
-			    "Original Method {0} does not match post-handler method {1}",
-			    new Object[] { methodBefore, inv.method }));
-		        throw inv.exception;
-		        }
+                    inv.exception = new UnmarshalException(
+                        localStrings.getLocalString("enterprise.webservice.postHandlerMethodMismatch",
+                            "Original Method {0} does not match post-handler method {1}",
+                            new Object[] {methodBefore, inv.method}));
+                    throw inv.exception;
+                }
             }
 
-
-            ComponentContext ctx = container.getContext(inv);
-            inv.context  = ctx;
-            inv.ejb      = ctx.getEJB();
+            final ComponentContext ctx = container.getContext(inv);
+            inv.context = ctx;
+            inv.ejb = ctx.getEJB();
             inv.instance = inv.ejb;
 
             container.preInvokeTx(inv);
@@ -186,39 +187,25 @@ public final class WebServiceInvocationHandler extends EJBLocalRemoteObject
             // Enterprise Bean class doesn't necessarily implement
             // web service endpoint interface, so we can't directly
             // dispatch through the given method object.
-            Method beanClassMethod = ejbClass_.getMethod
-                (method.getName(), method.getParameterTypes());
+            final Method beanClassMethod = ejbClass_.getMethod(method.getName(), method.getParameterTypes());
             inv.beanMethod = beanClassMethod;
             inv.methodParams = args;
-            returnValue = container.intercept(inv);
-        } catch(NoSuchMethodException nsme) {
+            return container.intercept(inv);
+        } catch (NoSuchMethodException nsme) {
             inv.exception = nsme;
-        } catch(InvocationTargetException ite) {
+            return null;
+        } catch (InvocationTargetException ite) {
             inv.exception = ite.getCause();
-        } catch(Throwable c) {
+            return null;
+        } catch (Throwable c) {
             inv.exception = c;
+            return null;
         } finally {
-            
-            if( inv.ejb != null ) {
+            if (inv.ejb != null) {
                 // Do post invoke tx processing so that a commit failure
                 // will be visible to web service client.
                 container.postInvokeTx(inv);
             }
-        }
-        if (inv.exception != null) {
-            if(inv.exception instanceof java.lang.RuntimeException) {
-                throw (java.lang.RuntimeException)inv.exception; 
-            } else if (inv.exception instanceof Exception) {
-                throw inv.exception;
-            } else {
-                EJBException ejbEx = new EJBException();
-                ejbEx.initCause(inv.exception);
-                throw ejbEx;
-            }
-        }
-        return returnValue;
-        } finally {
-            container.onLeavingContainer();
         }
     }
 }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/embedded/EJBContainerImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/embedded/EJBContainerImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 package org.glassfish.ejb.embedded;
 
 import java.io.File;
@@ -72,16 +72,15 @@ import org.glassfish.hk2.api.ServiceLocator;
 public class EJBContainerImpl extends EJBContainer {
 
     // Use Bundle from another package
-    private static final Logger _logger =
-            LogDomains.getLogger(EjbContainerUtilImpl.class, LogDomains.EJB_LOGGER);
+    private static final Logger _logger = LogDomains.getLogger(EjbContainerUtilImpl.class, LogDomains.EJB_LOGGER);
 
     private final GlassFish server;
-    
+
     private final Deployer deployer;
 
     private String deployedAppName;
 
-    private ServiceLocator habitat;
+    private final ServiceLocator habitat;
 
     private volatile int state = STARTING;
     private Cleanup cleanup = null;
@@ -93,8 +92,8 @@ public class EJBContainerImpl extends EJBContainer {
     private final static int CLOSED = 3;
 
     /**
-     * Construct new EJBContainerImpl instance 
-     */                                               
+     * Construct new EJBContainerImpl instance
+     */
     EJBContainerImpl(GlassFish server) throws GlassFishException {
         this.server = server;
         this.server.start();
@@ -124,7 +123,7 @@ public class EJBContainerImpl extends EJBContainer {
 
             // Check if appName was set by application creation code
             appName = res_app.getAppName();
-            
+
             String[] params;
             if (appName != null) {
                 params = new String[] {"--name", appName};
@@ -156,7 +155,8 @@ public class EJBContainerImpl extends EJBContainer {
      *
      * @return naming context
      */
-    public Context getContext() { 
+    @Override
+    public Context getContext() {
         if (_logger.isLoggable(Level.FINE)) {
             _logger.fine("IN getContext()");
         }
@@ -171,6 +171,7 @@ public class EJBContainerImpl extends EJBContainer {
     /**
      * Shutdown an embeddable EJBContainer instance.
      */
+    @Override
     public void close() {
         if (cleanup != null) {
             cleanup.disable();
@@ -209,21 +210,10 @@ public class EJBContainerImpl extends EJBContainer {
 
     private void cleanupTransactions() {
         try {
-            /*
-            Providers<TransactionManager> txProviders = habitat.forContract(TransactionManager.class);
-            if (txProviders != null) {
-                Provider<TransactionManager> provider = txProviders.getProvider();
-                if (provider != null && provider.isActive()) {
-                    TransactionManager txMgr = provider.get();
-                    txMgr.rollback();
-                }
-            }
-            */
-            ServiceHandle<TransactionManager> inhabitant =
-                    habitat.getServiceHandle(TransactionManager.class);
+            final ServiceHandle<TransactionManager> inhabitant = habitat.getServiceHandle(TransactionManager.class);
             if (inhabitant != null && inhabitant.isActive()) {
-                TransactionManager txmgr = inhabitant.getService();
-                if ( txmgr.getTransaction() != null ) {
+                final TransactionManager txmgr = inhabitant.getService();
+                if (txmgr.getTransaction() != null) {
                     txmgr.rollback();
                 }
             }
@@ -235,18 +225,7 @@ public class EJBContainerImpl extends EJBContainer {
 
     private void cleanupConnectorRuntime() {
         try {
-            /*
-            Providers<ConnectorRuntime> txProviders = habitat.forContract(ConnectorRuntime.class);
-            if (txProviders != null) {
-                Provider<ConnectorRuntime> provider = txProviders.getProvider();
-                if (provider != null && provider.isActive()) {
-                    ConnectorRuntime connectorRuntime = provider.get();
-                    connectorRuntime.cleanUpResourcesAndShutdownAllActiveRAs();
-                }
-            }
-            */
-            ServiceHandle<ConnectorRuntime> inhabitant =
-                    habitat.getServiceHandle(ConnectorRuntime.class);
+            ServiceHandle<ConnectorRuntime> inhabitant = habitat.getServiceHandle(ConnectorRuntime.class);
             if (inhabitant != null && inhabitant.isActive()) {
                 ConnectorRuntime connectorRuntime = inhabitant.getService();
                 connectorRuntime.cleanUpResourcesAndShutdownAllActiveRAs();
@@ -307,6 +286,7 @@ public class EJBContainerImpl extends EJBContainer {
             );
         }
 
+        @Override
         public void run() {
             if (container.isOpen()) {
                 container.forceClose();

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -1063,7 +1063,6 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     protected void doConcreteContainerShutdown(boolean appBeingUndeployed) {
         _logger.log(Level.FINE, "containers.mdb.shutdown_cleanup_start",
                 appEJBName_);
-        monitorOn = false;
         cleanupResources();
         _logger.log(Level.FINE, "containers.mdb.shutdown_cleanup_end",
                 appEJBName_);

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -128,7 +128,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     // issue 4629. 0 means a bean can remain idle indefinitely.
     private static final int MIN_IDLE_TIMEOUT = 0;
 
-    private String appEJBName_;
+    private final String appEJBName_;
     private MessageBeanClient messageBeanClient_;
 
     private AbstractPool messageBeanPool_;
@@ -140,7 +140,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     private Class<?> messageBeanSubClass_;
 
         // TODO : remove
-    private int statMessageCount = 0;
+    private final int statMessageCount = 0;
 
     private TransactedPoolManager poolMgr;
     private final Class<?> messageListenerType_;
@@ -175,8 +175,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
             // access to the message bean class.
             Method[] msgListenerMethods = msgBeanDesc.getMessageListenerInterfaceMethods(loader);
 
-            for (int i = 0; i < msgListenerMethods.length; i++) {
-                Method next = msgListenerMethods[i];
+            for (Method next : msgListenerMethods) {
                 addInvocationInfo(next, MethodDescriptor.EJB_BEAN, null);
             }
 
@@ -273,7 +272,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     }
 
     @Override
-    protected final boolean isCreateHomeFinder(Method method) {
+    protected boolean isCreateHomeFinder(Method method) {
         return false;
     }
 
@@ -398,6 +397,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
         return sbuf.toString();
     }
 
+    @Override
     public boolean userTransactionMethodsAllowed(ComponentInvocation inv) {
         boolean utMethodsAllowed = false;
         if (isBeanManagedTran) {
@@ -414,14 +414,17 @@ public final class MessageBeanContainer extends BaseContainer implements Message
         throw new Exception("Can't set EJB Home on Message-driven bean");
     }
 
+    @Override
     public EJBObjectImpl getEJBObjectImpl(byte[] instanceKey) {
         throw new EJBException("No EJBObject for message-driven beans");
     }
 
+    @Override
     public EJBObjectImpl createEJBObjectImpl() throws CreateException {
         throw new EJBException("No EJBObject for message-driven beans");
     }
 
+    @Override
     protected void removeBean(EJBLocalRemoteObject ejbo, Method removeMethod,
             boolean local) throws RemoveException, EJBException {
         throw new EJBException("not used in message-driven beans");
@@ -492,11 +495,13 @@ public final class MessageBeanContainer extends BaseContainer implements Message
      * 18.3.1 says that discarding an EJB means that no methods other than
      * finalize() should be invoked on it.
      */
+    @Override
     protected void forceDestroyBean(EJBContextImpl sc) {
         MessageBeanContextImpl mbc = (MessageBeanContextImpl)sc;
 
-        if (mbc.isInState(BeanState.DESTROYED))
+        if (mbc.isInState(BeanState.DESTROYED)) {
             return;
+        }
 
         // mark context as destroyed
         mbc.setState(BeanState.DESTROYED);
@@ -505,6 +510,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     }
 
     // This particular preInvoke signature not used
+    @Override
     public void preInvoke(EjbInvocation inv) {
         throw new EJBException("preInvoke(Invocation) not supported");
     }
@@ -748,7 +754,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     }
 
     @Override
-    protected EJBContextImpl _constructEJBContextImpl(Object instance) {
+    protected MessageBeanContextImpl _constructEJBContextImpl(Object instance) {
         return new MessageBeanContextImpl(instance, this);
     }
 
@@ -866,7 +872,11 @@ public final class MessageBeanContainer extends BaseContainer implements Message
         return false;
     }
 
+    /**
+     * @deprecated not called and not used in Payara 5
+     */
     // default
+    @Deprecated
     public void activateEJB(Object ctx, Object instanceKey) {
     }
 
@@ -954,7 +964,9 @@ public final class MessageBeanContainer extends BaseContainer implements Message
                         // wait in loop to guard against spurious wake-up
                         do {
                             long timeTillTimeout = maxWaitTime - System.currentTimeMillis();
-                            if (timeTillTimeout <= 0) break;
+                            if (timeTillTimeout <= 0) {
+                                break;
+                            }
                             task.wait(timeTillTimeout);
                         } while (!task.isDone());
                     }
@@ -1355,6 +1367,6 @@ public final class MessageBeanContainer extends BaseContainer implements Message
         return statMessageCount;
     }
 
-    public enum MessageDeliveryType { Message, Timer };
+    public enum MessageDeliveryType { Message, Timer }
 
 }

--- a/appserver/ejb/ejb-internal-api/src/main/java/org/glassfish/ejb/api/EJBInvocation.java
+++ b/appserver/ejb/ejb-internal-api/src/main/java/org/glassfish/ejb/api/EJBInvocation.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 package org.glassfish.ejb.api;
 
 
@@ -47,83 +47,99 @@ import javax.xml.rpc.handler.MessageContext;
 
 /**
  * This interface provides access to the exported portions of the
- * ejb invocation object.  
+ * ejb invocation object.
  * @author Kenneth Saks
  */
-
-
 public interface EJBInvocation {
 
-    public EJBContext getEJBContext();
-    
+    /**
+     * @return runtime {@link EJBContext} of this invocation
+     */
+    EJBContext getEJBContext();
+
     /**
      * This is for EJB JAXWS only.
      * @return the JAXWS message
      */
-    public Object getMessage();
-    
+    Object getMessage();
+
     /**
      * This is for EJB JAXWS only.
      * @param message  an unconsumed message
      */
-    public <T> void setMessage(T message);
-    
+    <T> void setMessage(T message);
+
     /**
-     * 
+     *
      * @return true if it is a webservice invocation
      */
-    public boolean isAWebService();
-    
+    boolean isAWebService();
+
     /**
      * @return the Java Method object for this Invocation
      */
-    public Method getMethod();
-    
+    Method getMethod();
+
     /**
-     * 
+     *
      * @return the Method parameters for this Invocation
      */
-    public Object[] getMethodParams();
-    
+    Object[] getMethodParams();
+
     /**
      * Used by JACC implementation to get an enterprise bean
      * instance for the EnterpriseBean policy handler.  The jacc
      * implementation should use this method rather than directly
      * accessing the ejb field.
+     *
+     * @return EnterpriseBean instance or null if not applicable for this invocation.
      */
-    public Object getJaccEjb();
-    
+    Object getJaccEjb();
+
     /**
      * Use the underlying container to authorize this invocation
+     *
+     * @param method method to be invoked
      * @return true if the invocation was authorized by the underlying container
-     * @throws java.lang.Exception TODO, change this to throw some subclass
+     * @throws java.lang.Exception
      */
-    public boolean authorizeWebService(Method m) throws Exception;
-    
-/**
-    *
-    * @return true if the SecurityManager reports that the caller is in role
-    */
-   public boolean isCallerInRole(String role);
+    boolean authorizeWebService(Method method) throws Exception;
 
     /**
-     * Used by JAXRPC pre/postHandler classes
+     * @return true if the SecurityManager reports that the caller is in role
+     */
+   boolean isCallerInRole(String role);
+
+    /**
+     * Used by JAX-RPC pre/postHandler classes
+     *
      * @param tie an instance of com.sun.xml.rpc.spi.runtime.Tie
      */
-    public void setWebServiceTie(Object tie);
+    void setWebServiceTie(Object tie);
 
 
     /**
-     * Used for setting JAXRPC message context.
+     * Used for setting JAX-RPC message context.
      */
-    public void setMessageContext(MessageContext msgContext);
+    void setMessageContext(MessageContext context);
 
     /**
      * @return instance of com.sun.xml.rpc.spi.runtime.Tie
      */
-    public Object getWebServiceTie();
+    Object getWebServiceTie();
 
-    public void setWebServiceMethod(Method method);
-    public Method getWebServiceMethod();
-    public void setWebServiceContext(Object webServiceContext);
+    /**
+     * @param method - web service endpoint method
+     */
+    void setWebServiceMethod(Method method);
+
+    /**
+     * @return web service endpoint {@link Method}
+     */
+    Method getWebServiceMethod();
+
+    /**
+     * @param webServiceContext JAX-WS web service context used for the invocation
+     */
+    void setWebServiceContext(Object webServiceContext);
 }

--- a/appserver/persistence/entitybean-container/src/main/java/org/glassfish/persistence/ejb/entitybean/container/EntityContainer.java
+++ b/appserver/persistence/entitybean-container/src/main/java/org/glassfish/persistence/ejb/entitybean/container/EntityContainer.java
@@ -1243,8 +1243,7 @@ public class EntityContainer extends BaseContainer implements CacheListener {
      * Remove a bean. Used by the PersistenceManager.
      * This is needed because the PM's remove must bypass tx/security checks.
      */
-    private void internalRemoveBeanUnchecked(EJBLocalRemoteObject localRemoteObj,
-            boolean local) {
+    private void internalRemoveBeanUnchecked(EJBLocalRemoteObject localRemoteObj, boolean local) {
         EjbInvocation inv = super.createEjbInvocation();
         inv.ejbObject = localRemoteObj;
         inv.isLocal = local;
@@ -1252,11 +1251,10 @@ public class EntityContainer extends BaseContainer implements CacheListener {
         Method method=null;
         try {
             method = EJBLocalObject.class.getMethod("remove", NO_PARAMS);
-        } catch ( NoSuchMethodException e ) {
+        } catch (NoSuchMethodException e) {
             _logger.log(Level.FINE, "Exception in internalRemoveBeanUnchecked()", e);
         }
         inv.method = method;
-
         inv.invocationInfo = invocationInfoMap.get(method);
 
         try {
@@ -1266,17 +1264,15 @@ public class EntityContainer extends BaseContainer implements CacheListener {
             // based on remove's txAttr.
             // Assume there is a tx on the current thread.
             EntityContextImpl context = getEJBWithIncompleteTx(inv);
-            if ( context == null ) {
+            if (context == null) {
                 context = getReadyEJB(inv);
             }
 
-            synchronized ( context ) {
-                if ( context.isInState(BeanState.INVOKING) && !isReentrant ) {
-                    throw new EJBException(
-                        "EJB is already executing another request");
+            synchronized (context) {
+                if (context.isInState(BeanState.INVOKING) && !isReentrant) {
+                    throw new EJBException("EJB is already executing another request");
                 }
-                if (context.isInState(BeanState.POOLED) ||
-                    context.isInState(BeanState.DESTROYED)) {
+                if (context.isInState(BeanState.POOLED) || context.isInState(BeanState.DESTROYED)) {
                     // somehow a concurrent thread must have changed state.
                     // this is an internal error.
                     throw new EJBException("Internal error: unknown EJB state");
@@ -1298,28 +1294,21 @@ public class EntityContainer extends BaseContainer implements CacheListener {
             try {
                 context.setCascadeDeleteBeforeEJBRemove(true);
                 removeBean(inv);
-            } catch ( Exception ex ) {
-                _logger.log(Level.FINE,
-                    "Exception in internalRemoveBeanUnchecked()", ex);
+            } catch (Exception ex) {
+                _logger.log(Level.FINE, "Exception in internalRemoveBeanUnchecked()", ex);
                 // if system exception mark the tx for rollback
                 inv.exception = checkExceptionClientTx(context, ex);
             }
-            if ( inv.exception != null ) {
+            if (inv.exception != null) {
                 throw inv.exception;
             }
-        }
-        catch ( RuntimeException ex ) {
+        } catch (RuntimeException ex) {
             throw ex;
-        }
-        catch ( Exception ex ) {
+        } catch (Exception ex) {
             throw new EJBException(ex);
-        }
-        catch ( Throwable ex ) {
-            EJBException ejbEx = new EJBException();
-            ejbEx.initCause(ex);
-            throw ejbEx;
-        }
-        finally {
+        } catch (Throwable ex) {
+            throw (EJBException) new EJBException().initCause(ex);
+        } finally {
             invocationManager.postInvoke(inv);
             releaseContext(inv);
         }
@@ -1348,15 +1337,14 @@ public class EntityContainer extends BaseContainer implements CacheListener {
         synchronized ( context ) {
             try {
                 Object primaryKey = context.getPrimaryKey();
-                if ( primaryKey != null ) {
-                    if ( context.getTransaction() != null ) {
+                if (primaryKey != null) {
+                    if (context.getTransaction() != null) {
                         Transaction txCurrent = context.getTransaction();
-			ActiveTxCache activeTxCache = (ActiveTxCache)
-			    ejbContainerUtilImpl.getActiveTxCache(txCurrent);
-                        if (activeTxCache !=  null) {
-			    // remove the context from the store
-			    activeTxCache.remove(this, primaryKey);
-			}
+                        ActiveTxCache activeTxCache = (ActiveTxCache) ejbContainerUtilImpl.getActiveTxCache(txCurrent);
+                        if (activeTxCache != null) {
+                            // remove the context from the store
+                            activeTxCache.remove(this, primaryKey);
+                        }
                     }
 
                     // remove the context from readyStore as well

--- a/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
+++ b/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates.]
+// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.transaction;
 
@@ -122,10 +122,10 @@ public class JavaEETransactionManagerSimplified
 
     // Note: this is not inheritable because we dont want transactions
     // to be inherited by child threads.
-    private ThreadLocal<JavaEETransaction> transactions;
+    private final ThreadLocal<JavaEETransaction> transactions;
 
-    private ThreadLocal<int[]> localCallCounter;
-    private ThreadLocal<JavaEETransactionManagerDelegate> delegates;
+    private final ThreadLocal<int[]> localCallCounter;
+    private final ThreadLocal<JavaEETransactionManagerDelegate> delegates;
 
     // If multipleEnlistDelists is set to true, with in the transaction, for the same
     //  - connection multiple enlistments and delistments might happen
@@ -134,13 +134,13 @@ public class JavaEETransactionManagerSimplified
     private boolean multipleEnlistDelists = false;
 
     private int transactionTimeout;
-    private ThreadLocal<Integer> txnTmout = new ThreadLocal<>();
+    private final ThreadLocal<Integer> txnTmout = new ThreadLocal<>();
 
     private int purgeCancelledTtransactions = 0;
 
     // admin and monitoring related parameters
     private  static final Map<Integer, String> statusMap = new HashMap<>();
-    private List<Transaction> activeTransactions = Collections.synchronizedList(new ArrayList<>());
+    private final List<Transaction> activeTransactions = Collections.synchronizedList(new ArrayList<>());
     private boolean monitoringEnabled = false;
     private ScheduledFuture<?> statisticsMonitoringFuture;
 
@@ -192,6 +192,7 @@ public class JavaEETransactionManagerSimplified
         }
     }
 
+    @Override
     public void postConstruct() {
         initDelegates();
         initProperties();
@@ -216,8 +217,9 @@ public class JavaEETransactionManagerSimplified
                 = System.getProperty("ALLOW_MULTIPLE_ENLISTS_DELISTS");
             if ("true".equalsIgnoreCase(mEnlistDelists)) {
                 multipleEnlistDelists = true;
-                if (_logger.isLoggable(Level.FINE))
+                if (_logger.isLoggable(Level.FINE)) {
                     _logger.log(Level.FINE, "TM: multiple enlists, delists are enabled");
+                }
             }
             String maxEntriesValue
                 = System.getProperty("JTA_RESOURCE_TABLE_MAX_ENTRIES");
@@ -271,8 +273,9 @@ public class JavaEETransactionManagerSimplified
         }
 
         // ENF OF BUG 4665539
-                if (_logger.isLoggable(Level.FINE))
-                _logger.log(Level.FINE, "TM: Tx Timeout = " + transactionTimeout);
+                if (_logger.isLoggable(Level.FINE)) {
+                    _logger.log(Level.FINE, "TM: Tx Timeout = " + transactionTimeout);
+                }
 
         // START IASRI 4705808 TTT004 -- monitor resource table stats
         try {
@@ -295,6 +298,7 @@ public class JavaEETransactionManagerSimplified
     /**
      * Clears the transaction associated with the caller thread
      */
+    @Override
     public void clearThreadTx() {
         setCurrentTransaction(null);
         delegates.set(null);
@@ -302,12 +306,14 @@ public class JavaEETransactionManagerSimplified
 
     /** {@inheritDoc}
     */
+    @Override
     public String getTxLogLocation() {
         return getDelegate().getTxLogLocation();
     }
 
     /** {@inheritDoc}
     */
+    @Override
     public void registerRecoveryResourceHandler(XAResource xaResource) {
         getDelegate().registerRecoveryResourceHandler(xaResource);
     }
@@ -323,10 +329,12 @@ public class JavaEETransactionManagerSimplified
      * that the client had an active
      * tx but the client container did not support tx interop.
      */
+    @Override
     public boolean isNullTransaction() {
         return getDelegate().isNullTransaction();
     }
 
+    @Override
     public void shutdown() {
         if (statisticsMonitoringFuture != null) {
             statisticsMonitoringFuture.cancel(false);
@@ -337,14 +345,17 @@ public class JavaEETransactionManagerSimplified
         scheduledTransactionManagerExecutor.shutdown();
     }
 
+    @Override
     public void initRecovery(boolean force) {
         getDelegate().initRecovery(force);
     }
 
+    @Override
     public void recover(XAResource[] resourceList) {
         getDelegate().recover(resourceList);
     }
 
+    @Override
     public boolean enlistResource(Transaction tran, TransactionalResource h)
             throws RollbackException, IllegalStateException, SystemException {
        if(_logger.isLoggable(Level.FINE)) {
@@ -353,8 +364,9 @@ public class JavaEETransactionManagerSimplified
                    /** +" h.alloc=" +h.getResourceAllocator() **/ +" tran=" + tran);
        }
 
-        if ( !h.isTransactional() )
+        if ( !h.isTransactional() ) {
             return true;
+        }
 
         //If LazyEnlistment is suspended, do not enlist resource.
         if(h.isEnlistmentSuspended()){
@@ -416,9 +428,10 @@ public class JavaEETransactionManagerSimplified
            }
            return enlistXAResource(tx, h);
        } else { // non-XA resource
-            if (tx.isImportedTransaction())
+            if (tx.isImportedTransaction()) {
                 throw new IllegalStateException(
                         sm.getString("enterprise_distributedtx.nonxa_usein_jts"));
+            }
             if (tx.getNonXAResource() == null) {
                 tx.setNonXAResource(h);
             }
@@ -451,6 +464,7 @@ public class JavaEETransactionManagerSimplified
         }
     }
 
+    @Override
     public void unregisterComponentResource(TransactionalResource h) {
         if(_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "\n\nIn JavaEETransactionManagerSimplified.unregisterComponentResource, h="
@@ -458,7 +472,9 @@ public class JavaEETransactionManagerSimplified
         }
 
         Object instance = h.getComponentInstance();
-        if (instance == null) return;
+        if (instance == null) {
+            return;
+        }
         h.setComponentInstance(null);
         ComponentInvocation inv = invMgr.getCurrentInvocation();
         List l = getExistingResourceList(instance, inv);
@@ -491,9 +507,11 @@ public class JavaEETransactionManagerSimplified
      * @param inv Calling component's invocation information
      * @return List of resources
      */
+    @Override
     public List getResourceList(Object instance, ComponentInvocation inv) {
-        if (inv == null)
+        if (inv == null) {
             return new ArrayList(0);
+        }
         List l = null;
 
 /** XXX EJB CONTAINER ONLY XXX -- NEED TO CHECK THE NEW CODE BELOW **
@@ -523,8 +541,9 @@ public class JavaEETransactionManagerSimplified
         }
         else {
             Object key = getResourceTableKey(instance, inv);
-            if (key == null)
+            if (key == null) {
                 return new ArrayList(0);
+            }
             l = (List) resourceTable.get(key);
             if (l == null) {
                 l = new ArrayList(); //FIXME: use an optimum size?
@@ -534,16 +553,19 @@ public class JavaEETransactionManagerSimplified
         return l;
     }
 
+    @Override
     public void enlistComponentResources() throws RemoteException {
-        if (_logger.isLoggable(Level.FINE))
+        if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "TM: enlistComponentResources");
+        }
 
         ComponentInvocation inv = invMgr.getCurrentInvocation();
-        if (inv == null)
+        if (inv == null) {
             return;
+        }
         try {
             Transaction tran = getTransaction();
-            inv.setTransaction((JavaEETransaction)tran);
+            inv.setTransaction(tran);
             enlistComponentResources(inv);
         } catch (InvocationException ex) {
             _logger.log(Level.SEVERE, "enterprise_distributedtx.excep_in_enlist" ,ex);
@@ -554,6 +576,7 @@ public class JavaEETransactionManagerSimplified
         }
     }
 
+    @Override
     public boolean delistResource(Transaction tran, TransactionalResource h, int flag)
             throws IllegalStateException, SystemException {
         if(_logger.isLoggable(Level.FINE)) {
@@ -561,10 +584,13 @@ public class JavaEETransactionManagerSimplified
                    + h + " h.xares=" + h.getXAResource() + " tran=" + tran);
         }
 
-        if (!h.isTransactional()) return true;
+        if (!h.isTransactional()) {
+            return true;
+        }
 
-        if ( !(tran instanceof JavaEETransaction) )
+        if ( !(tran instanceof JavaEETransaction) ) {
             return delistJTSResource(tran, h, flag);
+        }
 
         JavaEETransactionImpl tx = (JavaEETransactionImpl)tran;
         if ( tx.isLocalTx() ) {
@@ -575,15 +601,17 @@ public class JavaEETransactionManagerSimplified
                 throw new RuntimeException(sm.getString("enterprise_distributedtx.xaresource_end_excep", ex),ex);
             }
             return true;
-        }
-        else
+        } else {
             return delistJTSResource(tran, h, flag);
+        }
     }
 
+    @Override
     public void delistComponentResources(boolean suspend)
             throws RemoteException {
-        if (_logger.isLoggable(Level.FINE))
+        if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "TM: delistComponentResources");
+        }
         ComponentInvocation inv = invMgr.getCurrentInvocation();
         // BEGIN IASRI# 4646060
         if (inv == null) {
@@ -602,19 +630,21 @@ public class JavaEETransactionManagerSimplified
     }
 
 
+    @Override
     public void registerComponentResource(TransactionalResource h) {
         ComponentInvocation inv = invMgr.getCurrentInvocation();
         if (inv != null) {
             Object instance = inv.getInstance();
-            if (instance == null) return;
-            h.setComponentInstance(instance);
-            List l = getResourceList(instance, inv);
-            if(_logger.isLoggable(Level.FINE)) {
-                _logger.log(Level.FINE, "\n\nIn JavaEETransactionManagerSimplified.registerComponentResource, h="
-                       + h + " h.xares=" + h.getXAResource());
+            if (instance == null) {
+                return;
             }
-
-            l.add(h);
+            h.setComponentInstance(instance);
+            List resourceList = getResourceList(instance, inv);
+            if(_logger.isLoggable(Level.FINE)) {
+                _logger.log(Level.FINE, "\n\nIn JavaEETransactionManagerSimplified.registerComponentResource, h=" + h
+                    + " h.xares=" + h.getXAResource());
+            }
+            resourceList.add(h);
         }
     }
 
@@ -640,21 +670,12 @@ public class JavaEETransactionManagerSimplified
         return tx;
     }
 
+    @Override
     public List getExistingResourceList(Object instance, ComponentInvocation inv) {
-       if (inv == null)
-           return null;
+       if (inv == null) {
+        return null;
+    }
         List l = null;
-
-/** XXX EJB CONTAINER ONLY XXX -- NEED TO CHECK THE NEW CODE BELOW **
-        if (inv.getInvocationType() ==
-                ComponentInvocation.ComponentInvocationType.EJB_INVOCATION) {
-            ComponentContext ctx = inv.context;
-            if (ctx != null)
-                l = ctx.getResourceList();
-            return l;
-        }
-** XXX EJB CONTAINER ONLY XXX **/
-
         ResourceHandler rh = inv.getResourceHandler();
         if(_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "\n\nIn JavaEETransactionManagerSimplified.getExistingResourceList, "
@@ -667,12 +688,14 @@ public class JavaEETransactionManagerSimplified
         }
         else {
             Object key = getResourceTableKey(instance, inv);
-            if (key != null)
+            if (key != null) {
                 l =  (List) resourceTable.get(key);
+            }
         }
         return l;
     }
 
+    @Override
     public void preInvoke(ComponentInvocation prev)
             throws InvocationException {
         if ( prev != null
@@ -685,11 +708,14 @@ public class JavaEETransactionManagerSimplified
 
     }
 
+    @Override
     public void postInvoke(ComponentInvocation curr, ComponentInvocation prev)
             throws InvocationException {
 
         if ( curr != null && curr.getTransaction() != null )
+         {
             delistComponentResources(curr, false);  // delist with TMSUCCESS
+        }
         if ( prev != null
                 && prev.getTransaction() != null
                 && !prev.isTransactionCompleting()) {
@@ -700,10 +726,12 @@ public class JavaEETransactionManagerSimplified
 
     }
 
+    @Override
     public void componentDestroyed(Object instance) {
         componentDestroyed(instance, null);
     }
 
+    @Override
     public void componentDestroyed(Object instance, ComponentInvocation inv) {
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "TM: componentDestroyed" + instance);
@@ -714,25 +742,30 @@ public class JavaEETransactionManagerSimplified
         List l = (List)resourceTable.remove(getResourceTableKey(instance, inv));
         processResourceList(l);
 
-        if (_logger.isLoggable(Level.FINE))
+        if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "TM: resourceTable after: " + resourceTable.getEntryCount());
+        }
     }
 
+    @Override
     public void componentDestroyed(ResourceHandler rh) {
-        if (_logger.isLoggable(Level.FINE))
+        if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, " componentDestroyed: " + rh);
+        }
 
         if (rh != null) {
             processResourceList(rh.getResourceList());
         }
     }
 
+    @Override
     public boolean isTimedOut() {
         JavaEETransaction tx = transactions.get();
-        if ( tx != null)
+        if ( tx != null) {
             return tx.isTimedOut();
-        else
+        } else {
             return false;
+        }
     }
 
     /**
@@ -740,6 +773,7 @@ public class JavaEETransactionManagerSimplified
      * the server is replying to the client (local + remote client).
      * Check if there is an active transaction and remove it from TLS.
      */
+    @Override
     public void checkTransactionImport() {
         // First check if this is a local call
         int[] count = localCallCounter.get();
@@ -758,6 +792,7 @@ public class JavaEETransactionManagerSimplified
      * Check if there is an active, exportable transaction.
      * @exception RuntimeException if the transaction is not exportable
      */
+    @Override
     public void checkTransactionExport(boolean isLocal) {
 
         if ( isLocal ) {
@@ -773,16 +808,19 @@ public class JavaEETransactionManagerSimplified
         }
 
         JavaEETransaction tx = transactions.get();
-        if ( tx == null )
+        if ( tx == null ) {
             return;
+        }
 
-        if ( !tx.isLocalTx() ) // a JTS tx, can be exported
+        if ( !tx.isLocalTx() ) {
             return;
+        }
 
         // Check if a local tx with non-XA resource is being exported.
         // XXX what if this is a call on a non-transactional remote object ?
-        if ( tx.getNonXAResource() != null )
+        if ( tx.getNonXAResource() != null ) {
             throw new RuntimeException(sm.getString("enterprise_distributedtx.cannot_export_transaction_having_nonxa"));
+        }
 
         // If we came here, it means we have a local tx with no registered
         // resources, so start a JTS tx which can be exported.
@@ -800,6 +838,7 @@ public class JavaEETransactionManagerSimplified
      * @return a <code>XATerminator</code> instance.
      * @throws UnsupportedOperationException
      */
+    @Override
     public XATerminator getXATerminator() {
         return getDelegate().getXATerminator();
     }
@@ -811,6 +850,7 @@ public class JavaEETransactionManagerSimplified
      *
      * @param xid the Xid object representing a transaction.
      */
+    @Override
     public void release(Xid xid) throws WorkException {
         getDelegate().release(xid);
     }
@@ -822,6 +862,7 @@ public class JavaEETransactionManagerSimplified
      *
      * @param xid the Xid object representing a transaction.
      */
+    @Override
     public void recreate(Xid xid, long timeout) throws WorkException {
         getDelegate().recreate(xid, timeout);
     }
@@ -830,10 +871,12 @@ public class JavaEETransactionManagerSimplified
 /** Implementations of JTA TransactionManager APIs **************************/
 /****************************************************************************/
 
+    @Override
     public void registerSynchronization(Synchronization sync)
             throws IllegalStateException, SystemException {
-        if (_logger.isLoggable(Level.FINE))
+        if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "TM: registerSynchronization");
+        }
 
         try {
             Transaction tran = getTransaction();
@@ -846,28 +889,32 @@ public class JavaEETransactionManagerSimplified
         }
     }
 
-   // Implementation of begin() is moved to begin(int timeout)
-   public void begin() throws NotSupportedException, SystemException {
-       begin(getEffectiveTimeout());
-   }
+    // Implementation of begin() is moved to begin(int timeout)
+    @Override
+    public void begin() throws NotSupportedException, SystemException {
+        begin(getEffectiveTimeout());
+    }
 
-   /**
-    * This method is introduced as part of implementing the local transaction timeout
-    * capability. Implementation of begin() moved here. Previpusly there is no timeout
-    * infrastructure for local txns, so when ever a timeout required for local txn, it
-    * uses the globaltxn timeout infrastructure by doing an XA simulation.
-    **/
-   public void begin(int timeout) throws NotSupportedException, SystemException {
-       // Check if tx already exists
-       if ( transactions.get() != null )
-           throw new NotSupportedException(sm.getString("enterprise_distributedtx.notsupported_nested_transaction"));
+    /**
+     * This method is introduced as part of implementing the local transaction timeout
+     * capability. Implementation of begin() moved here. Previpusly there is no timeout
+     * infrastructure for local txns, so when ever a timeout required for local txn, it
+     * uses the globaltxn timeout infrastructure by doing an XA simulation.
+     **/
+    @Override
+    public void begin(int timeout) throws NotSupportedException, SystemException {
+        // Check if tx already exists
+        if (transactions.get() != null) {
+            throw new NotSupportedException(sm.getString("enterprise_distributedtx.notsupported_nested_transaction"));
+        }
 
        setDelegate();
 
        // Check if JTS tx exists, without starting JTS tx.
        // This is needed in case the JTS tx was imported from a client.
-       if ( getStatus() != Status.STATUS_NO_TRANSACTION )
-           throw new NotSupportedException(sm.getString("enterprise_distributedtx.notsupported_nested_transaction"));
+        if (getStatus() != Status.STATUS_NO_TRANSACTION) {
+            throw new NotSupportedException(sm.getString("enterprise_distributedtx.notsupported_nested_transaction"));
+        }
 
         // START IASRI 4662745
         if(monitoringEnabled){
@@ -889,6 +936,7 @@ public class JavaEETransactionManagerSimplified
         // START IASRI 4662745
     }
 
+    @Override
     public void commit() throws RollbackException,
             HeuristicMixedException, HeuristicRollbackException, SecurityException,
             IllegalStateException, SystemException {
@@ -928,6 +976,7 @@ public class JavaEETransactionManagerSimplified
         // END IASRI 4662745
     }
 
+    @Override
     public void rollback() throws IllegalStateException, SecurityException,
                 SystemException {
         boolean acquiredlock=false;
@@ -965,10 +1014,12 @@ public class JavaEETransactionManagerSimplified
     }
 
 
+    @Override
     public int getStatus() throws SystemException {
         return getDelegate().getStatus();
     }
 
+    @Override
     public Transaction getTransaction() throws SystemException {
         return getDelegate().getTransaction();
 
@@ -1001,6 +1052,7 @@ public class JavaEETransactionManagerSimplified
 ** XXX CHECK WHAT'S NEEDED FOR XA DELEGATE XXX **/
     }
 
+    @Override
     public void setRollbackOnly()
         throws IllegalStateException, SystemException {
 
@@ -1018,10 +1070,12 @@ public class JavaEETransactionManagerSimplified
                 tx.setRollbackOnly();
             }
         }
-        else
+        else {
             getDelegate().setRollbackOnlyDistributedTransaction(); // probably a JTS imported tx
+        }
     }
 
+    @Override
     public Transaction suspend() throws SystemException {
         return getDelegate().suspend(transactions.get());
 
@@ -1039,14 +1093,16 @@ public class JavaEETransactionManagerSimplified
 ** XXX TO BE MOVED TO DELEGATES XXX **/
     }
 
+    @Override
     public void resume(Transaction tobj)
             throws InvalidTransactionException, IllegalStateException,
             SystemException {
 
         JavaEETransaction tx = transactions.get();
-        if ( tx != null )
+        if ( tx != null ) {
             throw new IllegalStateException(
                     sm.getString("enterprise_distributedtx.transaction_exist_on_currentThread"));
+        }
 
         if ( tobj != null ) {
             int status = tobj.getStatus();
@@ -1064,8 +1120,9 @@ public class JavaEETransactionManagerSimplified
 
         if ( tobj instanceof JavaEETransactionImpl ) {
             JavaEETransactionImpl javaEETx = (JavaEETransactionImpl)tobj;
-            if ( !javaEETx.isLocalTx() )
+            if ( !javaEETx.isLocalTx() ) {
                 getDelegate().resume(javaEETx.getJTSTx());
+            }
 
             setCurrentTransaction(javaEETx);
         }
@@ -1085,6 +1142,7 @@ public class JavaEETransactionManagerSimplified
      *    encounters an unexpected error condition
      *
      */
+    @Override
     public void setTransactionTimeout(int seconds) throws SystemException {
         if (seconds < 0) {
             throw new SystemException(sm.getString("enterprise_distributedtx.invalid_timeout"));
@@ -1098,6 +1156,7 @@ public class JavaEETransactionManagerSimplified
      * Modify the value to be used to purge transaction tasks after the
      * specified number of cancelled tasks.
      */
+    @Override
     public void setPurgeCancelledTtransactionsAfter(int num) {
         purgeCancelledTtransactions = num;
     }
@@ -1106,27 +1165,33 @@ public class JavaEETransactionManagerSimplified
      * Returns the value to be used to purge transaction tasks after the
      * specified number of cancelled tasks.
      */
+    @Override
     public int getPurgeCancelledTtransactionsAfter() {
         return purgeCancelledTtransactions;
     }
 
+    @Override
     public JavaEETransaction getCurrentTransaction() {
         return transactions.get();
     }
 
+    @Override
     public void setCurrentTransaction(JavaEETransaction t) {
         transactions.set(t);
     }
 
+    @Override
     public XAResourceWrapper getXAResourceWrapper(String clName) {
         return getDelegate().getXAResourceWrapper(clName);
     }
 
+    @Override
     public void handlePropertyUpdate(String name, Object value) {
         delegate.handlePropertyUpdate(name, value);
         // XXX Check if the current delegate needs to be called as well.
     }
 
+    @Override
     public boolean recoverIncompleteTx(boolean delegated, String logPath,
             XAResource[] xaresArray) throws Exception {
         return delegate.recoverIncompleteTx(delegated, logPath, xaresArray);
@@ -1138,6 +1203,7 @@ public class JavaEETransactionManagerSimplified
    /*
     * Called by Admin Framework to freeze the transactions.
     */
+    @Override
     public synchronized void freeze(){
         getDelegate().acquireWriteLock();
         monitor.freezeEvent(true);
@@ -1146,6 +1212,7 @@ public class JavaEETransactionManagerSimplified
      * Called by Admin Framework to freeze the transactions.
      * These undoes the work done by the freeze.
      */
+    @Override
     public synchronized void unfreeze(){
         getDelegate().releaseWriteLock();
         monitor.freezeEvent(false);
@@ -1153,10 +1220,12 @@ public class JavaEETransactionManagerSimplified
 
     /** XXX ???
      */
+    @Override
     public boolean isFrozen() {
         return getDelegate().isWriteLocked();
     }
 
+    @Override
     public void cleanTxnTimeout() {
         txnTmout.set(null);
     }
@@ -1171,6 +1240,7 @@ public class JavaEETransactionManagerSimplified
         }
     }
 
+    @Override
     public void setDefaultTransactionTimeout(int seconds) {
         transactionTimeout = seconds < 0 ? 0 : seconds;
     }
@@ -1181,6 +1251,7 @@ public class JavaEETransactionManagerSimplified
     *  @return ArrayList of TransactionAdminBean
     *  @see TransactionAdminBean
     */
+    @Override
     public ArrayList getActiveTransactions() {
         ArrayList<TransactionAdminBean> tranBeans = new ArrayList<>();
         txnTable = new ConcurrentHashMap<>();
@@ -1192,8 +1263,9 @@ public class JavaEETransactionManagerSimplified
                     // Shouldn't happen
                     _logger.warning("enterprise_distributedtx.txbean_null" + tran);
                 } else {
-                    if (_logger.isLoggable(Level.FINE))
+                    if (_logger.isLoggable(Level.FINE)) {
                         _logger.log(Level.FINE, "TM: Adding txnId " + tBean.getId() + " to txnTable");
+                    }
 
                     txnTable.put(tBean.getId(), tran);
                     tranBeans.add(tBean);
@@ -1229,24 +1301,29 @@ public class JavaEETransactionManagerSimplified
     /*
      *  Called by Admin Framework when transaction monitoring is enabled
      */
+    @Override
     public void forceRollback(String txnId) throws IllegalStateException, SystemException{
          // XXX - WORK AROUND MONITORING BUG
          if (txnTable == null || txnTable.size() == 0)
-             getActiveTransactions();
+         {
+            getActiveTransactions();
          // XXX - WORK AROUND MONITORING BUG
+        }
 
          if (txnTable == null || txnTable.get(txnId) == null) {
             String result = sm.getString("transaction.monitor.rollback_invalid_id");
             throw new  IllegalStateException(result);
         } else {
-            if (_logger.isLoggable(Level.FINE))
+            if (_logger.isLoggable(Level.FINE)) {
                 _logger.log(Level.FINE, "TM: Marking txnId " + txnId + " for rollback");
+            }
 
-             ((Transaction) txnTable.get(txnId)).setRollbackOnly();
+             txnTable.get(txnId).setRollbackOnly();
          }
 
     }
 
+    @Override
     public void setMonitoringEnabled(boolean enabled){
         monitoringEnabled = enabled;
         //reset the variables
@@ -1292,6 +1369,7 @@ public class JavaEETransactionManagerSimplified
 
     // Mods: Adding TimerTask class for statistic dumps
     class StatisticMonitorTask implements Runnable {
+        @Override
         public void run() {
             if (resourceTable != null) {
                 Map stats = resourceTable.getStats();
@@ -1310,7 +1388,7 @@ public class JavaEETransactionManagerSimplified
 /************************* Helper Methods ***********************************/
 /****************************************************************************/
     public static String getStatusAsString(int status) {
-        return (String)statusMap.get(status);
+        return statusMap.get(status);
     }
 
     private void delistComponentResources(ComponentInvocation inv,
@@ -1321,8 +1399,9 @@ public class JavaEETransactionManagerSimplified
             Transaction tran = (Transaction) inv.getTransaction();
             if (isTransactionActive(tran)) {
                 List l = getExistingResourceList(inv.getInstance(), inv);
-                if (l == null || l.size() == 0)
+                if (l == null || l.isEmpty()) {
                     return;
+                }
 
                 int flag = (suspend)? XAResource.TMSUSPEND : XAResource.TMSUCCESS;
                 Iterator it = l.iterator();
@@ -1334,11 +1413,14 @@ public class JavaEETransactionManagerSimplified
                         }
                     } catch (IllegalStateException ex) {
                         if (_logger.isLoggable(Level.FINE))
+                         {
                             _logger.log(Level.FINE, "TM: Exception in delistResource", ex);
                         // ignore error due to tx time out
+                        }
                     }catch(Exception ex){
-                        if (_logger.isLoggable(Level.FINE))
+                        if (_logger.isLoggable(Level.FINE)) {
                             _logger.log(Level.FINE, "TM: Exception in delistResource", ex);
+                        }
                         it.remove();
                         handleResourceError(h, ex, tran);
                     }
@@ -1365,10 +1447,11 @@ public class JavaEETransactionManagerSimplified
 
             XAResource res = h.getXAResource();
             boolean result = tran.enlistResource(res);
-            if (!h.isEnlisted())
+            if (!h.isEnlisted()) {
                 if(_logger.isLoggable(Level.FINE)) {
                     _logger.log(Level.FINE, "\n\nIn JavaEETransactionManagerSimplified.enlistXAResource - enlist");
                 }
+            }
 
                 h.enlistedInTransaction(tran);
             return result;
@@ -1384,7 +1467,9 @@ public class JavaEETransactionManagerSimplified
             Transaction tran = (Transaction) inv.getTransaction();
             if (isTransactionActive(tran)) {
                 List l = getExistingResourceList(inv.getInstance(), inv);
-                if (l == null || l.size() == 0) return;
+                if (l == null || l.size() == 0) {
+                    return;
+                }
                 Iterator it = l.iterator();
                 // END IASRI 4705808 TTT002
                 while(it.hasNext()) {
@@ -1392,8 +1477,9 @@ public class JavaEETransactionManagerSimplified
                     try{
                         enlistResource(tran,h);
                     }catch(Exception ex){
-                        if (_logger.isLoggable(Level.FINE))
+                        if (_logger.isLoggable(Level.FINE)) {
                             _logger.log(Level.WARNING, "enterprise_distributedtx.pooling_excep", ex);
+                        }
 
                         it.remove();
                         handleResourceError(h,ex,tran);
@@ -1417,8 +1503,9 @@ public class JavaEETransactionManagerSimplified
                 try {
                     h.closeUserConnection();
                 } catch (Exception ex) {
-                    if (_logger.isLoggable(Level.FINE))
+                    if (_logger.isLoggable(Level.FINE)) {
                         _logger.log(Level.WARNING, "enterprise_distributedtx.pooling_excep", ex);
+                    }
                 }
             }
             l.clear();
@@ -1542,26 +1629,31 @@ public class JavaEETransactionManagerSimplified
     }
 
     public boolean isDelegate(JavaEETransactionManagerDelegate d) {
-        if (delegate == null)
+        if (delegate == null) {
             return false;
+        }
 
         return (d.getClass().getName().equals(delegate.getClass().getName()));
     }
 
     private void initDelegates() {
         if (habitat == null)
+         {
             return; // the delegate will be set explicitly
+        }
 
         for (JavaEETransactionManagerDelegate d :
                 habitat.<JavaEETransactionManagerDelegate>getAllServices(JavaEETransactionManagerDelegate.class)) {
             setDelegate(d);
         }
 
-        if (delegate != null && _logger.isLoggable(Level.FINE))
-        	_logger.log(Level.INFO, "enterprise_used_delegate_name", delegate.getClass().getName());
+        if (delegate != null && _logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.INFO, "enterprise_used_delegate_name", delegate.getClass().getName());
+        }
 
     }
 
+    @Override
     public synchronized void setDelegate(JavaEETransactionManagerDelegate d) {
         // XXX Check if it's valid to set or if we need to remember all that asked.
 
@@ -1575,9 +1667,10 @@ public class JavaEETransactionManagerSimplified
             // XXX Hk2 work around XXX
             delegate.setTransactionManager(this);
 
-            if (_logger.isLoggable(Level.FINE))
-                    _logger.log(Level.FINE, "Replaced delegate with "
-                            + d.getClass().getName());
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.log(Level.FINE, "Replaced delegate with "
+                        + d.getClass().getName());
+            }
         }
     }
 
@@ -1609,8 +1702,9 @@ public class JavaEETransactionManagerSimplified
 
     public void setTransactionCompeting(boolean b) {
         ComponentInvocation curr = invMgr.getCurrentInvocation();
-        if (curr != null)
+        if (curr != null) {
             curr.setTransactionCompeting(b);
+        }
     }
 
     public JavaEETransaction createImportedTransaction(TransactionInternal jtsTx)
@@ -1668,8 +1762,8 @@ public class JavaEETransactionManagerSimplified
 /** Implementation of javax.transaction.Synchronization *********************/
 /****************************************************************************/
     private static class JTSSynchronization implements Synchronization {
-        private TransactionInternal jtsTx;
-        private JavaEETransactionManagerSimplified javaEETM;
+        private final TransactionInternal jtsTx;
+        private final JavaEETransactionManagerSimplified javaEETM;
 
         JTSSynchronization(TransactionInternal jtsTx,
                 JavaEETransactionManagerSimplified javaEETM){
@@ -1677,8 +1771,10 @@ public class JavaEETransactionManagerSimplified
             this.javaEETM = javaEETM;
         }
 
+        @Override
         public void beforeCompletion() {}
 
+        @Override
         public void afterCompletion(int status) {
             javaEETM.remove(jtsTx);
         }

--- a/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
+++ b/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
@@ -761,11 +761,7 @@ public class JavaEETransactionManagerSimplified
     @Override
     public boolean isTimedOut() {
         JavaEETransaction tx = transactions.get();
-        if ( tx != null) {
-            return tx.isTimedOut();
-        } else {
-            return false;
-        }
+        return tx == null ? false : tx.isTimedOut();
     }
 
     /**
@@ -795,7 +791,7 @@ public class JavaEETransactionManagerSimplified
     @Override
     public void checkTransactionExport(boolean isLocal) {
 
-        if ( isLocal ) {
+        if (isLocal) {
             // Put a counter in TLS indicating this is a local call.
             // Use int[1] as a mutable java.lang.Integer!
             int[] count = localCallCounter.get();
@@ -808,17 +804,13 @@ public class JavaEETransactionManagerSimplified
         }
 
         JavaEETransaction tx = transactions.get();
-        if ( tx == null ) {
-            return;
-        }
-
-        if ( !tx.isLocalTx() ) {
+        if (tx == null || !tx.isLocalTx()) {
             return;
         }
 
         // Check if a local tx with non-XA resource is being exported.
         // XXX what if this is a call on a non-transactional remote object ?
-        if ( tx.getNonXAResource() != null ) {
+        if (tx.getNonXAResource() != null) {
             throw new RuntimeException(sm.getString("enterprise_distributedtx.cannot_export_transaction_having_nonxa"));
         }
 

--- a/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/TransactionManagerHelper.java
+++ b/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/TransactionManagerHelper.java
@@ -37,29 +37,36 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.transaction;
 
-import javax.transaction.*;
+import com.sun.enterprise.transaction.api.JavaEETransactionManager;
+import com.sun.enterprise.transaction.api.TransactionImport;
+
+import javax.inject.Inject;
 import javax.resource.spi.XATerminator;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-import javax.inject.Inject;
-import org.jvnet.hk2.annotations.Service;
-import org.jvnet.hk2.annotations.ContractsProvided;
-import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.api.invocation.ComponentInvocation;
-
-import com.sun.enterprise.transaction.api.JavaEETransactionManager;
-import com.sun.enterprise.transaction.api.TransactionImport;
+import org.glassfish.api.invocation.InvocationManager;
+import org.jvnet.hk2.annotations.ContractsProvided;
+import org.jvnet.hk2.annotations.Service;
 
 /**
 * This class is wrapper for the actual transaction manager implementation.
 * JNDI lookup name "java:appserver/TransactionManager"
 * see the com/sun/enterprise/naming/java/javaURLContext.java
 **/
-
 @Service
 @ContractsProvided({TransactionManagerHelper.class, TransactionManager.class}) // Needed because we can't change spec provided class
 public class TransactionManagerHelper implements TransactionManager, TransactionImport {
@@ -70,26 +77,31 @@ public class TransactionManagerHelper implements TransactionManager, Transaction
     @Inject
     private transient InvocationManager invocationManager;
 
+    @Override
     public void begin() throws NotSupportedException, SystemException {
         transactionManager.begin();
     }
 
-    
+
+    @Override
     public void commit() throws RollbackException,
             HeuristicMixedException, HeuristicRollbackException, SecurityException,
             IllegalStateException, SystemException {
         transactionManager.commit();
     }
 
+    @Override
     public int getStatus() throws SystemException {
         return transactionManager.getStatus();
     }
 
+    @Override
     public Transaction getTransaction() throws SystemException {
         return transactionManager.getTransaction();
     }
 
-    
+
+    @Override
     public void resume(Transaction tobj)
             throws InvalidTransactionException, IllegalStateException,
             SystemException {
@@ -97,28 +109,33 @@ public class TransactionManagerHelper implements TransactionManager, Transaction
         preInvokeTx(false);
     }
 
-    
+
+    @Override
     public void rollback() throws IllegalStateException, SecurityException,
                             SystemException {
         transactionManager.rollback();
     }
 
+    @Override
     public void setRollbackOnly() throws IllegalStateException, SystemException {
         transactionManager.setRollbackOnly();
     }
 
+    @Override
     public void setTransactionTimeout(int seconds) throws SystemException {
         transactionManager.setTransactionTimeout(seconds);
     }
 
+    @Override
     public Transaction suspend() throws SystemException {
         postInvokeTx(true, false);
         return transactionManager.suspend();
     }
 
+    @Override
     public void recreate(Xid xid, long timeout) {
         final JavaEETransactionManager tm = transactionManager;
-        
+
         try {
             tm.recreate(xid, timeout);
         } catch (javax.resource.spi.work.WorkException ex) {
@@ -127,47 +144,49 @@ public class TransactionManagerHelper implements TransactionManager, Transaction
         preInvokeTx(true);
     }
 
+    @Override
     public void release(Xid xid) {
         final JavaEETransactionManager tm = transactionManager;
-     
+
         postInvokeTx(false, true);
         try {
-            tm.release(xid);    
+            tm.release(xid);
         } catch (javax.resource.spi.work.WorkException ex) {
             throw new IllegalStateException(ex);
-        }  finally { 
+        }  finally {
             if (tm instanceof JavaEETransactionManagerSimplified) {
                 ((JavaEETransactionManagerSimplified) tm).clearThreadTx();
             }
-        } 
+        }
     }
-    
+
+    @Override
     public XATerminator getXATerminator() {
         return transactionManager.getXATerminator();
     }
 
 
 
-    
+
     /**
      * PreInvoke Transaction configuration for Servlet Container.
      * BaseContainer.preInvokeTx() handles all this for CMT EJB.
      *
      * Compensate that JavaEEInstanceListener.handleBeforeEvent(
      * BEFORE_SERVICE_EVENT)
-     * gets called before WSIT WSTX Service pipe associates a JTA txn with 
+     * gets called before WSIT WSTX Service pipe associates a JTA txn with
      * incoming thread.
      *
-     * Precondition: assumes JTA transaction already associated with current 
+     * Precondition: assumes JTA transaction already associated with current
      * thread.
      */
     public void preInvokeTx(boolean checkServletInvocation) {
         final ComponentInvocation inv = invocationManager.getCurrentInvocation();
         if (inv != null && (!checkServletInvocation ||
-            inv.getInvocationType() == 
+            inv.getInvocationType() ==
                      ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION)){
-            try { 
-                // Required side effect: note that 
+            try {
+                // Required side effect: note that
                 // enlistComponentResources calls
                 // ComponentInvocation.setTransaction(currentJTATxn).
                 // If this is not correctly set, managed XAResource connections
@@ -177,38 +196,38 @@ public class TransactionManagerHelper implements TransactionManager, Transaction
                 throw new IllegalStateException(re);
             }
         }
-    }    
-    
+    }
+
     /**
      * PostInvoke Transaction configuration for Servlet Container.
      * BaseContainer.preInvokeTx() handles all this for CMT EJB.
      *
-     * Precondition: assumed called prior to current transcation being 
+     * Precondition: assumed called prior to current transcation being
      * suspended or released.
-     * 
-     * @param suspend indicate whether the delisting is due to suspension or 
+     *
+     * @param suspend indicate whether the delisting is due to suspension or
      * transaction completion(commmit/rollback)
      */
     public void postInvokeTx(boolean suspend, boolean checkServletInvocation) {
         final ComponentInvocation inv = invocationManager.getCurrentInvocation();
-        if (inv != null && (!checkServletInvocation || inv.getInvocationType() == 
+        if (inv != null && (!checkServletInvocation || inv.getInvocationType() ==
             ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION)) {
             try {
                 transactionManager.delistComponentResources(suspend);
             } catch (java.rmi.RemoteException re) {
                 throw new IllegalStateException(re);
-            } finally {   
+            } finally {
                 inv.setTransaction(null);
             }
         }
     }
-    
-     /**
+
+    /**
      * Return duration before current transaction would timeout.
      *
      * @return Returns the duration in seconds before current transaction would
      *         timeout.
-     *         Returns zero if transaction has no timeout set and returns 
+     *         Returns zero if transaction has no timeout set and returns
      *         negative value if transaction already timed out.
      *
      * @exception IllegalStateException Thrown if the current thread is
@@ -217,9 +236,10 @@ public class TransactionManagerHelper implements TransactionManager, Transaction
      * @exception SystemException Thrown if the transaction manager
      *    encounters an unexpected error condition.
      */
+    @Override
     public int getTransactionRemainingTimeout() throws SystemException {
         int timeout = 0;
-        Transaction txn = getTransaction(); 
+        Transaction txn = getTransaction();
         if (txn == null) {
             throw new IllegalStateException("no current transaction");
         } else if (txn instanceof JavaEETransactionImpl) {
@@ -228,8 +248,11 @@ public class TransactionManagerHelper implements TransactionManager, Transaction
         return timeout;
     }
 
-    /** {@inheritDoc}
-    */
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void registerRecoveryResourceHandler(XAResource xaResource) {
         transactionManager.registerRecoveryResourceHandler(xaResource);
     }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2014-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2014-2019] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.cdi.transaction;
 
@@ -177,9 +177,10 @@ public class TransactionalInterceptorBase implements Serializable {
         if (transactionManager == null) {
             try {
                 synchronized (TransactionalInterceptorBase.class) {
-                    if (transactionManager == null)
+                    if (transactionManager == null) {
                         transactionManager = (TransactionManager)
                             new InitialContext().lookup("java:appserver/TransactionManager");
+                    }
                 }
             } catch (NamingException e) {
                 _logger.log(SEVERE, CDI_JTA_NAME_EXCEPTION, e);
@@ -195,7 +196,8 @@ public class TransactionalInterceptorBase implements Serializable {
     }
 
     boolean isLifeCycleMethod(InvocationContext ctx) {
-        return ctx.getMethod().getAnnotation(PostConstruct.class) != null || ctx.getMethod().getAnnotation(PreDestroy.class) != null;
+        return ctx.getMethod().getAnnotation(PostConstruct.class) != null
+            || ctx.getMethod().getAnnotation(PreDestroy.class) != null;
     }
 
     public Object proceed(InvocationContext ctx) throws Exception {


### PR DESCRIPTION
- sorted imports, removed unused
- code formatting
  - preferred shorter block first
  - preferred positive if without negation
  - preferred fast return
  - collisions of these rules resolved appropriately
  - removed 10 years old TODOs
- using generics where it is clear
- trivial optimizations
  - declaring variables
  - preferred final instead of changing the default value
- removed redundant keywords (public method in interface, ie)
- removed redundant class typing
- using addSuppressed/cause rather than masking exceptions
- improved logging
  - log entry to important method at least as finest
  - removed some duplicit logs

# Description
This is an enhancement for better readibility and also to provide better informations in logs.
EJB timeout warnings are now printed immediately when the transaction is set to the rollback only state, and later are printed another informations about the rollback - why it is done. These messages are not duplicated, but together lead the developer to some idead what happened and why.

# Important Info

### Dependant PRs <!-- delete as applicable -->


### Blockers <!-- delete as applicable -->

This PR continues the work started in #4323 in much larger scale

# Testing

### New tests

Experimental test will be pushed in #4263 

### Testing Performed

### Test suites executed

- Quicklook - OK
- Payara Samples - not executed
- Java EE7 Samples - OK
- Java EE8 Samples - OK
- Payara Private Tests - not executed
- Payara Microprofile TCKs Runner - not executed
- Jakarta TCKs - ejb32 - fails one test at this moment, but it is not related.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Manual tests: Kubuntu 19.10, OpenJDK11
TestContainers: Debian 11, OpenJDK11
TCK: JDK8

# Notes for Reviewers

The code needs much more love :-)