### PR TITLE
PAYARA-4255 Fix servletcontext and mapping errors

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/MappingImpl.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/MappingImpl.java
@@ -88,6 +88,7 @@ public class MappingImpl implements HttpServletMapping, Serializable {
                 break;
             case MappingData.DEFAULT:
                 mappingMatch = MappingMatch.DEFAULT;
+                matchValue = "";
                 break;
             case MappingData.EXACT:
                 mappingMatch = MappingMatch.EXACT;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -1857,6 +1857,12 @@ public class StandardContext
     @Override
     public void setSessionTimeout(int timeout) {
 
+        if (isContextInitializedCalled) {
+            String msg = MessageFormat.format(rb.getString(LogFacade.SERVLET_CONTEXT_ALREADY_INIT_EXCEPTION),
+                    new Object[] {"setSessionTimeout", getName()});
+            throw new IllegalStateException(msg);
+        }
+
         int oldSessionTimeout = this.sessionTimeout;
 
         /*
@@ -3564,7 +3570,7 @@ public class StandardContext
         wrapper.addMapping(pattern);
 
         // Update context mapper
-        mapper.addWrapper(pattern, wrapper, jspWildCard, true);
+        mapper.addWrapper(pattern, wrapper, jspWildCard, name, true);
 
         if (notifyContainerListeners) {
             fireContainerEvent("addServletMapping", pattern);


### PR DESCRIPTION
Cherrypick of a single commit fixing the PAYARA-4056 issue in master (for master under PAYARA-4255)

### Executed tests
 
- Jakarta TCKs

```
real    54m12,844s
user    27m49,124s
sys     2m8,883s
Waiting for the domain to stop ..
Command stop-domain executed successfully.
Not passed: 0/846 /home/dmatej/work/repo/git/jakartaeetck-runner/cts_home/jakartaeetck-report/servlet_api/text/summary.txt
Writing stage file for servlet/api  into stage_servlet_api
```
