### PR TITLE
PAYARA-4265: Fix cleanup issues in DirWatcher

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/WatchProcessor.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/WatchProcessor.java
@@ -60,6 +60,7 @@ class WatchProcessor {
     protected boolean registered;
     protected boolean overflowed;
     protected boolean cancelled;
+    private int subscribers = 1;
 
     public WatchProcessor(Path root, WatchService watchService) {
         this.root = root;
@@ -103,5 +104,14 @@ class WatchProcessor {
 
     protected boolean isCancelled() {
         return this.cancelled;
+    }
+
+    public WatchProcessor subscribe() {
+        subscribers++;
+        return this;
+    }
+
+    public boolean unsubscribe() {
+        return --subscribers == 0;
     }
 }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/WatchProcessor.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/WatchProcessor.java
@@ -106,12 +106,16 @@ class WatchProcessor {
         return this.cancelled;
     }
 
-    public WatchProcessor subscribe() {
+    /**
+     * Register additional subscriber to path.
+     * @return
+     */
+    WatchProcessor subscribe() {
         subscribers++;
         return this;
     }
 
-    public boolean unsubscribe() {
+    boolean unsubscribe() {
         return --subscribers == 0;
     }
 }

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/loader/DirWatcherTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/loader/DirWatcherTest.java
@@ -129,6 +129,25 @@ public class DirWatcherTest {
         assertTrue("only first level is considered for items added after registration", () -> hasItem(root, "com/empty/reallyEmpty"));
     }
 
+    @Test
+    public void itemsFoundIfTwoLevelsDoNotExist() throws IOException {
+        Path root = createTempDirectory(Paths.get("target") , "watch").resolve("later/and/more");
+        DirWatcher.register(root);
+        assertFalse("non-existing root item should not be found", () -> hasItem(root, "file1"));
+
+        createDirectories(root);
+        createFile(root.resolve("file1"));
+        createFile(root.resolve("file2"));
+        assertTrue("root item should be found", () -> hasItem(root, "file1"));
+        assertTrue("root item should be found", () -> hasItem(root, "file2"));
+
+        createDirectories(root.resolve("com/empty/"));
+
+        assertTrue("only first level is considered for items added after registration", () -> hasItem(root, "com/"));
+        assertTrue("only first level is considered for items added after registration", () -> hasItem(root, "com/empty"));
+        assertTrue("only first level is considered for items added after registration", () -> hasItem(root, "com/empty/reallyEmpty"));
+    }
+
     static void assertTrue(String message, Supplier<Boolean> test) {
         for(int i=0; i<5; i++) { // watch service takes some time to react, so let's make few attempts before giving up
             Boolean result = test.get();


### PR DESCRIPTION


<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

Log messages `Watch service attempted to get checker for untracked item...` that appeared during deployment in recent build hinted, that the lifecycle around directory watchers (deployment optimizations from #4279) was not correct:

Same path can be registered multiple times. Therefore we cannot remove a watcher while there is still a classloader interested in the directory -- this is what caused the message to be logged.
We now keep track of subscription count and remove only if there are no subscribers left.

On some occasions, multiple levels of parent directories might be non-existing, therefore we need to register parent watchers until we find an existing directory.

# Important Info

### Dependant PRs <!-- delete as applicable -->
#4279 - Original implementation

# Testing

### New tests
<!-- Link to the test suite PR or provide info -->

### Testing Performed
<!--- Please describe how you tested these changes.  -->
Executing the test suite and watching for references to `watch`.

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Java EE7 Samples

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 1.8_222 on Windows 10 with Maven 3.6.2

