### PR TITLE
CI-108 Fixed error when there is no file to remove (Jenkinsfile)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
         }
         stage('Setup for Quicklook Tests') {
             steps {
-                sh "rm *.zip"
+                sh "rm -f -v *.zip"
                 setupDomain()
             }
         }


### PR DESCRIPTION
Fixed build. rm returns non-zero error code if there is nothing to delete.

Example:

```
dmatej@dmatej-G5-5587:/repo/git/Payara$ rm *.zip && echo "this works"
rm: cannot remove '*.zip': No such file or directory
dmatej@dmatej-G5-5587:/repo/git/Payara$ rm -f *.zip && echo "this works"
this works

```