### PR TITLE
PAYARA-4215: Enable persistent timers in Deployment Group targets

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EjbContainerUtilImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EjbContainerUtilImpl.java
@@ -43,6 +43,7 @@ package com.sun.ejb.containers;
 
 import com.sun.ejb.base.io.EJBObjectInputStreamHandler;
 import com.sun.ejb.base.io.EJBObjectOutputStreamHandler;
+import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.container.common.spi.util.JavaEEIOUtils;
 import com.sun.enterprise.transaction.api.JavaEETransaction;
 import com.sun.enterprise.transaction.api.JavaEETransactionManager;
@@ -54,6 +55,7 @@ import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.admin.monitor.callflow.Agent;
 import com.sun.enterprise.util.Utility;
 import com.sun.logging.LogDomains;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import org.glassfish.ejb.spi.CMPDeployer;
 import com.sun.enterprise.deployment.xml.RuntimeTagNames;
 
@@ -83,6 +85,7 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.Synchronization;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
@@ -494,6 +497,19 @@ public class EjbContainerUtilImpl
                     _logger.log(Level.FINE, "Found {0}", config);
                 }
                 if (config != null) {
+                    ejbt = config.getExtensionByType(EjbContainer.class).getEjbTimerService();
+                }
+            } else if (domain.getDeploymentGroupNamed(target) != null) {
+                DeploymentGroup deploymentGroup = domain.getDeploymentGroupNamed(target);
+                List<Server> instances = deploymentGroup.getInstances();
+                if (instances.isEmpty()) {
+                    _logger.log(Level.WARNING,
+                            "Deployment targets deployment group {0} that has no instances. Cannot instantiate timer service",
+                            target);
+                } else {
+                    Config config = instances.get(0).getConfig();
+                    _logger.log(Level.INFO,
+                            "Timer Service configuration {0} will be used to prepare timers", config.getName());
                     ejbt = config.getExtensionByType(EjbContainer.class).getEjbTimerService();
                 }
             }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
@@ -473,7 +473,7 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
             boolean isDeployment = opsparams.origin.isDeploy() || opsparams.origin.isCreateAppRef();
             boolean isDirectTarget = env.getInstanceName().equals(dcp.target);
             // Create timers on DAS only if this condition is not met
-            if (!isDeployment || isDirectTarget || isDeploymentGroup) {
+            if (!isDeployment || isDirectTarget) {
                 // Create them on deploy for a cluster or create-application-ref (the latter will
                 // check if it's the 1st ref being added or a subsequent one (timers with this unique id are present
                 // or not)
@@ -483,6 +483,10 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
                 }
                 // But is-timed-app needs to be set in AppInfo in any case
                 createTimers = false;
+            }
+            if (isDeploymentGroup) {
+                _logger.log(Level.WARNING, "Deployment targets deployment group {0}, it is assumed that timer "+
+                        "service configuration is consistent accross all members of the group", dcp.target);
             }
 
             String target = dcp.target;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bugfix / feature (bit of both). <!-- delete/modify as applicable-->

Method annotated with `@Schedule` weren't executed when application was deployed to a deployment group. It was quite correct thing to do, because Deployment Groups are loose groupings of instances that do not necessarily share configuration, inclusive Timer Service configuration.

It is task of DAS to register timers defined by annotations and xml descriptor, and in general it couldn't know which timer service defined in domain to use.

However, from now on we will assume, that user is doing the right thing and his instances' timer service configurations are compatible. E. g. point to same external database, or use DataGrid timer service. At this point, `server-config` needs to have same timer service configuration as well (separate issue).
DAS will use one of instance's configuration to create the timers.

When such application is deployed a warning is printed on DAS:

```
[2019-11-20T20:54:53.787+0100] [Payara 5.194] [WARNING] [] [javax.enterprise.system.container.ejb.org.glassfish.ejb.startup] [tid: _ThreadID=57 _ThreadName=admin-thread-pool::admin-listener(1)] [timeMillis: 1574279693787] [levelValue: 900] [[
  Deployment targets deployment group localDG, it is assumed that timer service configuration is consistent accross all members of the group]]

[2019-11-20T20:54:53.836+0100] [Payara 5.194] [INFO] [] [javax.enterprise.system.container.ejb.com.sun.ejb.containers] [tid: _ThreadID=57 _ThreadName=admin-thread-pool::admin-listener(1)] [timeMillis: 1574279693836] [levelValue: 800] [[
  Timer Service configuration local-instance-config will be used to prepare timers]]
```

Persistent timer will now migrate whenever deployment group member disappears (instance shuts down). Therefore, following are limitations to use persistent timers properly and have them correctly migrate:

* Timer service config is the same for all instances of deployment group and DAS (same database or DataGrid)
* DataGrid is enabled and instances see each other
* Deployment Groups do not form complex topologies. Timers migrate to any instance that is part of any deployment group the parting instance was member of. Any target instance should have same set of (persistence-timer enabled) applications.
* No application management is done on instance level - disabling application, or undeploying it from instance may break timer migration.

# Testing

### Testing Performed
Used reproducer from [payara-4125.zip](https://github.com/payara/Payara/files/3871154/payara-4125.zip).
Create deployment group with multiple instances and deploy the application.
After deployment, all instancess will print 3 messages per second:

```
  Non-Persistent annotated timer runs
  Non-Persistent Programmatic timer inst1-177f171c-137e-45a4-b3ac-e82efc5f67db runs
  Persistent Programmatic timer inst1 runs
```
where `inst1` is name of instance. One of the instances will also print
```
  Persistent annotated timer runs
```

Stopping or killing instances cause persistent timers to migrate to different instance.

### Test suites executed


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 1.8_222 on Windows 10 with Maven 3.6.2

# Documentation
<!-- Link to the documentation PR where applicable -->
T.B.D.

