### PR TITLE
PAYARA-4261 Warning when changing request tracing store properties via asadmin

### DIFF
--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/LocalStrings.properties
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/LocalStrings.properties
@@ -50,6 +50,7 @@ requesttracing.configure.thresholdunit.success=Request Tracing Service Threshold
 requesttracing.configure.sampleratefirst.success=Request Tracing Service Sample Rate First Enabled Value is set to {0}.
 
 requesttracing.configure.store.size.success=Request Tracing Store Size is set to {0}.
+requesttracing.configure.store.size.warning=Please note that from 5.194 onwards the store size refers to the size of a single store shared by all cluster members. Any configuration change regarding the store should be applied to all configurations equally to prevent unbalanced sharing. All affected configurations will be extracted and moved to a central configuration in a future release.
 requesttracing.configure.store.timeout.success=Request Tracing Store Timeout is set to {0}.
 requesttracing.configure.reservoirsampling.enabled.success=Request Tracing Service Reservoir Sampling Enabled Value is set to {0}.
 
@@ -59,3 +60,4 @@ requesttracing.configure.historictrace.timeout.success=Request Tracing Historic 
 
 requesttracing.notifier.configure.status.error=Notifier with name {0} could not be found.
 requesttracing.configure.notifier.added.configured=Request Tracing Notifier with name {0} is registered and set enabled to {1}.
+

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/SetRequestTracingConfiguration.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/SetRequestTracingConfiguration.java
@@ -45,6 +45,7 @@ import fish.payara.nucleus.notification.TimeUtil;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
 import fish.payara.nucleus.requesttracing.configuration.RequestTracingServiceConfiguration;
 import org.glassfish.api.ActionReport;
+import org.glassfish.api.ActionReport.ExitCode;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.*;
@@ -166,63 +167,72 @@ public class SetRequestTracingConfiguration implements AdminCommand {
             try {
                 ConfigSupport.apply(new SingleConfigCode<RequestTracingServiceConfiguration>() {
                     @Override
-                    public Object run(final RequestTracingServiceConfiguration requestTracingServiceConfigurationProxy) throws
+                    public Object run(final RequestTracingServiceConfiguration proxy) throws
                             PropertyVetoException, TransactionFailure {
+                        boolean warn = false;
                         if (enabled != null) {
-                            requestTracingServiceConfigurationProxy.enabled(enabled.toString());
+                            proxy.enabled(enabled.toString());
                         }
                         
                         if (sampleRate != null) {
-                            requestTracingServiceConfigurationProxy.setSampleRate(sampleRate);
+                            proxy.setSampleRate(sampleRate);
                         }
                         if (adaptiveSamplingEnabled != null) {
-                            requestTracingServiceConfigurationProxy.setAdaptiveSamplingEnabled(adaptiveSamplingEnabled.toString());
+                            proxy.setAdaptiveSamplingEnabled(adaptiveSamplingEnabled.toString());
                         }
                         if (adaptiveSamplingTargetCount != null) {
-                            requestTracingServiceConfigurationProxy.setAdaptiveSamplingTargetCount(adaptiveSamplingTargetCount);
+                            proxy.setAdaptiveSamplingTargetCount(adaptiveSamplingTargetCount);
                         }
                         if (adaptiveSamplingTimeValue != null) {
-                            requestTracingServiceConfigurationProxy.setAdaptiveSamplingTimeValue(adaptiveSamplingTimeValue.toString());
+                            proxy.setAdaptiveSamplingTimeValue(adaptiveSamplingTimeValue.toString());
                         }
                         if (adaptiveSamplingTimeUnit != null) {
-                            requestTracingServiceConfigurationProxy.setAdaptiveSamplingTimeUnit(adaptiveSamplingTimeUnit);
+                            proxy.setAdaptiveSamplingTimeUnit(adaptiveSamplingTimeUnit);
                         }
                         
                         if (applicationsOnlyEnabled != null) {
-                            requestTracingServiceConfigurationProxy.setApplicationsOnlyEnabled(applicationsOnlyEnabled.toString());
+                            proxy.setApplicationsOnlyEnabled(applicationsOnlyEnabled.toString());
                         }
                         if (thresholdValue != null) {
-                            requestTracingServiceConfigurationProxy.setThresholdValue(thresholdValue);
+                            proxy.setThresholdValue(thresholdValue);
                         }
                         if (thresholdUnit != null) {
-                            requestTracingServiceConfigurationProxy.setThresholdUnit(thresholdUnit);
+                            proxy.setThresholdUnit(thresholdUnit);
                         }
                         if (sampleRateFirstEnabled != null) {
-                            requestTracingServiceConfigurationProxy.setSampleRateFirstEnabled(sampleRateFirstEnabled.toString());
+                            proxy.setSampleRateFirstEnabled(sampleRateFirstEnabled.toString());
                         }
                         
                         if (traceStoreSize != null) {
-                            requestTracingServiceConfigurationProxy.setTraceStoreSize(traceStoreSize.toString());
+                            warn = !traceStoreSize.toString().equals(proxy.getTraceStoreSize());
+                            proxy.setTraceStoreSize(traceStoreSize.toString());
                         }
                         if (traceStoreTimeout != null) {
-                            requestTracingServiceConfigurationProxy.setTraceStoreTimeout(traceStoreTimeout);
+                            warn = !traceStoreTimeout.equals(proxy.getTraceStoreTimeout());
+                            proxy.setTraceStoreTimeout(traceStoreTimeout);
                         }
                         if (reservoirSamplingEnabled != null) {
-                            requestTracingServiceConfigurationProxy.setReservoirSamplingEnabled(reservoirSamplingEnabled.toString());
+                            proxy.setReservoirSamplingEnabled(reservoirSamplingEnabled.toString());
                         }
                         
                         if (historicTraceStoreEnabled != null) {
-                            requestTracingServiceConfigurationProxy.setHistoricTraceStoreEnabled(historicTraceStoreEnabled.toString());
+                            proxy.setHistoricTraceStoreEnabled(historicTraceStoreEnabled.toString());
                         }
                         if (historicTraceStoreSize != null) {
-                            requestTracingServiceConfigurationProxy.setHistoricTraceStoreSize(historicTraceStoreSize.toString());
+                            warn = !historicTraceStoreSize.toString().equals(proxy.getHistoricTraceStoreSize());
+                            proxy.setHistoricTraceStoreSize(historicTraceStoreSize.toString());
                         }
                         if (historicTraceStoreTimeout != null) {
-                            requestTracingServiceConfigurationProxy.setHistoricTraceStoreTimeout(historicTraceStoreTimeout);
+                            warn = !historicTraceStoreTimeout.equals(proxy.getHistoricTraceStoreTimeout());
+                            proxy.setHistoricTraceStoreTimeout(historicTraceStoreTimeout);
                         }
-
-                        actionReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
-                        return requestTracingServiceConfigurationProxy;
+                        actionReport.setActionExitCode(ExitCode.SUCCESS);
+                        if (warn) {
+                            actionReport.setMessage(strings.getLocalString(
+                                    "requesttracing.configure.store.size.warning",
+                                    "Please note that from 5.194 onwards the store size refers to the size of a single store shared by all cluster members. Any configuration change regarding the store should be applied to all configurations equally to prevent unbalanced sharing. All affected configurations will be extracted and moved to a central configuration in a future release."));
+                        }
+                        return proxy;
                     }
                 }, requestTracingServiceConfiguration);
             } catch (TransactionFailure ex) {

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/SetRequestTracingConfiguration.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/admin/SetRequestTracingConfiguration.java
@@ -39,6 +39,7 @@
 package fish.payara.nucleus.requesttracing.admin;
 
 import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import fish.payara.nucleus.notification.TimeUtil;
@@ -84,6 +85,7 @@ import java.util.logging.Logger;
 public class SetRequestTracingConfiguration implements AdminCommand {
 
     final private static LocalStringManagerImpl strings = new LocalStringManagerImpl(SetRequestTracingConfiguration.class);
+    private static final LocalStringsImpl STRINGS = new LocalStringsImpl(SetRequestTracingConfiguration.class);
 
     @Inject
     ServerEnvironment server;
@@ -228,9 +230,7 @@ public class SetRequestTracingConfiguration implements AdminCommand {
                         }
                         actionReport.setActionExitCode(ExitCode.SUCCESS);
                         if (warn) {
-                            actionReport.setMessage(strings.getLocalString(
-                                    "requesttracing.configure.store.size.warning",
-                                    "Please note that from 5.194 onwards the store size refers to the size of a single store shared by all cluster members. Any configuration change regarding the store should be applied to all configurations equally to prevent unbalanced sharing. All affected configurations will be extracted and moved to a central configuration in a future release."));
+                            actionReport.setMessage(STRINGS.get("requesttracing.configure.store.size.warning"));
                         }
                         return proxy;
                     }


### PR DESCRIPTION
### Summary
PR in response to @Pandrex247 comment https://github.com/payara/Payara/pull/4332#issuecomment-555974202 that adds a warning message to the action report in case any of the store properties is changed. 

### Note to the Reviewer
I do not change state status to `WARNING` since that would report the action as failed when it wasn't:

    Command set-requesttracing-configuration failed.

### Testing Performed
Start the server, use asadmin console:

```
asadmin> set-requesttracing-configuration --traceStoreSize=20 --enabled=true
Command set-requesttracing-configuration executed successfully.

asadmin> set-requesttracing-configuration --traceStoreSize=19 --enabled=true
Please note that from 5.194 onwards the store size refers to the size of a single store shared by all cluster members. Any configuration change regarding the store should be applied to all configurations equally to prevent unbalanced sharing. All affected configurations will be extracted and moved to a central configuration in a future release.
Command set-requesttracing-configuration executed successfully.

asadmin> set-requesttracing-configuration --traceStoreSize=19 --enabled=true
Command set-requesttracing-configuration executed successfully.

asadmin> set-requesttracing-configuration --traceStoreSize=20 --enabled=true
Please note that from 5.194 onwards the store size refers to the size of a single store shared by all cluster members. Any configuration change regarding the store should be applied to all configurations equally to prevent unbalanced sharing. All affected configurations will be extracted and moved to a central configuration in a future release.
Command set-requesttracing-configuration executed successfully.
```
As seen below (formatted for better readability) when changing the value the warning is added while when setting it to the old value the warning isn't added.
This should be tested for all 4 properties:
* `traceStoreSize`
* `traceStoreTimeout`
* `historicTraceStoreSize`
* `historicTraceStoreTimeout`