### PR TITLE
Merge executions of the same plugin

### DIFF
--- a/appserver/packager/monitoring-console/pom.xml
+++ b/appserver/packager/monitoring-console/pom.xml
@@ -69,21 +69,6 @@
                     <execution>
                         <id>process-step2</id>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>process-step3</id>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
                     <execution>
                         <id>unpack</id>
                         <phase>generate-sources</phase>
@@ -101,6 +86,15 @@
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-step3</id>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
# Description
This isn't a bug fix / feature. <!-- delete/modify as applicable-->

<!-- Provide some context here -->
Currently maven build starts with
```
[WARNING] Some problems were encountered while building the effective model for fish.payara.server.internal.packager:monitoring-console:distribution-fragment:5.194-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-dependency-plugin @ line 83, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```
<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Important Info

# Testing

### New tests
None

### Testing Performed
1. Full build `mvn clean install` on travis.
2. Reviewed order of goals executed for `fish.payara.server.internal.packager:monitoring-console` module before and after the change and it is the same, i.e. (with some INFOs removed for brevity):
```
[INFO] ------< fish.payara.server.internal.packager:monitoring-console >-------
[INFO] Building Payara Monitoring Console Package 5.194-SNAPSHOT      [612/632]
[INFO] -----------------------[ distribution-fragment ]------------------------
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ monitoring-console ---
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) @ monitoring-console ---
[INFO] --- glassfishbuild-maven-plugin:3.2.20.payara-p2:echo (echo) @ monitoring-console ---
[INFO] --- maven-resources-plugin:3.1.0:copy-resources (copy-resources) @ monitoring-console ---
[INFO] --- maven-dependency-plugin:3.1.1:unpack (unpack) @ monitoring-console ---
[INFO] --- build-helper-maven-plugin:3.0.0:add-resource (add-resource) @ monitoring-console ---
[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ monitoring-console ---
[INFO] --- maven-antrun-plugin:1.8:run (process-step4) @ monitoring-console ---
[INFO] --- maven-dependency-plugin:3.1.1:copy-dependencies (process-step1) @ monitoring-console ---
[INFO] --- maven-dependency-plugin:3.1.1:unpack-dependencies (process-step2) @ monitoring-console ---
[INFO] --- maven-assembly-plugin:3.1.0:single (process-step3) @ monitoring-console ---
[INFO] --- maven-antrun-plugin:1.8:run (foo) @ monitoring-console ---
[INFO] --- glassfishbuild-maven-plugin:3.2.20.payara-p2:zip (default-zip) @ monitoring-console ---
[INFO] --- maven-install-plugin:3.0.0-M1:install (default-install) @ monitoring-console ---
```

### Test suites executed
All included in `mvn clean install`

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
OpenJDK Runtime Environment (build 1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10)
Maven 3.6.1
Ubuntu 16.04.6 LTS/xenial

# Notes for Reviewers
Executions from 2<sup>nd</sup> `maven-dependency-plugin` were moved to the 1<sup>st</sup> plugin declaration.
