### PR TITLE
PAYARA-4277 : Uniform jvm-option in server-config and default-config

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -199,7 +199,7 @@
 	<property value="SHA-256" name="default-digest-algorithm" />
       </security-service>
       <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
-        <jvm-options>-client</jvm-options>
+        <jvm-options>-server</jvm-options>
         <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
         <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <!-- Hazelcast internal package access requirement to get the best performance results. -->
@@ -422,7 +422,7 @@
       <microprofile-metrics-configuration></microprofile-metrics-configuration>
          <diagnostic-service />
          <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
-             <jvm-options>-client</jvm-options>
+             <jvm-options>-server</jvm-options>
              <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
              <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <!-- Hazelcast internal package access requirement to get the best performance results. -->

--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -422,7 +422,6 @@
       <microprofile-metrics-configuration></microprofile-metrics-configuration>
          <diagnostic-service />
          <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
-             <jvm-options>-server</jvm-options>
              <jvm-options>-client</jvm-options>
              <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
              <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>


### PR DESCRIPTION
#4277 Description
This is a bug fix.

<!-- Provide some context here -->
Both -client and -server are defined in default-config of domain.1 domain.xml.  This PR removes the -server option line so that options are the same in server-config and default-config.

