### PR TITLE
PAYARA-4280 Fixed MicroProfile version from 3.0 to 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <jsonp.version>1.1.5</jsonp.version>
         <jbi.version>1.0</jbi.version>
         <jakarta-platform.version>8.0.0</jakarta-platform.version>
-        <microprofile-release.version>3.0</microprofile-release.version>
+        <microprofile-release.version>3.2</microprofile-release.version>
         <microprofile-config.version>1.3</microprofile-config.version>
         <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
         <microprofile-config.version>1.3</microprofile-config.version>


### PR DESCRIPTION
- all dependencies are from 3.2, not 3.0

https://download.eclipse.org/microprofile/microprofile-3.2/microprofile-spec-3.2.html#microprofile3.2
