### PR TITLE
CI-33 Fix missed Jakarta versioning

### DIFF
--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -102,12 +102,6 @@
 
             <!-- MicroProfile Dependencies -->
             <dependency>
-                <groupId>org.eclipse.microprofile</groupId>
-                <artifactId>microprofile</artifactId>
-                <type>pom</type>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
                 <version>0.30.0</version>
@@ -303,7 +297,7 @@
                     <dependency>
                         <groupId>jakarta.annotation</groupId>
                         <artifactId>jakarta.annotation-api</artifactId>
-                        <version>1.3.2</version>
+                        <version>1.3.3</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -59,6 +59,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <!-- A workaround for case when module redefines its version (rest-monitoring-war) -->
+                <version>${project.parent.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Java EE -->
             <dependency>
                 <groupId>jakarta.platform</groupId>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -71,7 +71,6 @@
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-api</artifactId>
-                <version>8.0.0</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -297,7 +296,6 @@
                     <dependency>
                         <groupId>jakarta.annotation</groupId>
                         <artifactId>jakarta.annotation-api</artifactId>
-                        <version>1.3.3</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-api</artifactId>
-                <version>8.0</version>
+                <version>8.0.0</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
@@ -43,7 +43,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.samples.ejb-http-remoting</groupId>
         <artifactId>ejb-http-remoting</artifactId>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
@@ -43,7 +43,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.samples.ejb-http-remoting</groupId>
         <artifactId>ejb-http-remoting</artifactId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a test-build fix

In a different PR a regex was run to replace javax with the new jakarta coordinates. However some of the versions didnt exist with jakarta. I have corrected these.

# Testing

### New tests
<!-- Link to the test suite PR or provide info -->

### Testing Performed
<!--- Please describe how you tested these changes.  -->

### Test suites executed

- Payara Samples

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.6.0
Java version: 1.8.0_232, vendor: Azul Systems, Inc., 
Default locale: en_GB, platform encoding: UTF-8
OS name: "linux", version: "5.0.0-36-generic", arch: "amd64", family: "unix"