### PR TITLE
PAYARA-4161 Fixed full logging - increased buffer capacity

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -150,7 +150,7 @@ public class GFFileHandler extends StreamHandler implements
     /** Initially the LogRotation will be off until the domain.xml value is read. */
     private int limitForFileRotation = 0;
 
-    private BlockingQueue<LogRecord> pendingRecords = new ArrayBlockingQueue<>(5000);
+    private BlockingQueue<LogRecord> pendingRecords = new ArrayBlockingQueue<>(10000);
 
     /**Rotation can be done in 3 ways: <ol>
      * <li> Based on the Size: Rotate when some Threshold number of bytes are


### PR DESCRIPTION
Note: To be refactored to be much more effective under PAYARA-4276, this is a minimal fix

The buffer accepts all messages even before the logging handlers are configured, but - if the capacity is reached, the threads are blocked until some thread would start process records from buffer - this will never be done, so this is a bit risky - this issue does not fix it, only increases the capacity.

Under PAYARA-4276 I will refactor and optimize the logging, I already gained 10-50% throughput in yet uncommited changes (depends on system configuration and state).

# Testing

### New tests

See VerboseLoggingITest in https://github.com/payara/Payara/pull/4263

### Testing Environment
Kubuntu 19.10, OpenJDK11
