### PR TITLE
Monitoring Console Colour Configuration and Colour Schemes

### DIFF
--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -214,11 +214,11 @@ Describes the model expected by the `Settings` component.
 
 ```
 SETTINGS    = [GROUP]
-GROUP       = { id, caption, entries }
+GROUP       = { id, caption, entries, collapsed }
 id 		    = string
 caption     = string
 entries     = [ENTRY]
-ENTRY       = { label, type, input, value, unit, min, max, options, onChange, description, defaultValue } 
+ENTRY       = { label, type, input, value, unit, min, max, options, onChange, description, defaultValue, collapsed } 
 label       = string
 type        = undefined | 'header' | 'checkbox' | 'range' | 'dropdown' | 'value' | 'text' | 'color'
 unit        = string
@@ -230,14 +230,16 @@ options     = { *:string }
 input       = fn () => string | fn () => jquery | string | jquery | [ENTRY]
 onChange    = fn (widget, newValue) => () | fn (newValue) => ()
 description = string
+collapsed   = boolean
 ```
 * When `caption` is provided this adds a _header_ entry identical to adding a _header_ entry explicitly as first element of the `entries` array.
 * The `options` object is used as map where the attribute names are the values of the options and the attribute values are the _string_ labels displayed for that option.
 * `description` is optional for any type of `ENTRY`
+* set `collapsed` to initially collapse the setting group
 
 Mandatory members of `ENTRY` depend on `type` member. Variants are:
 ```
-'header'   : { label }
+'header'   : { label, collapsed }
 'checkbox' : { label, value, onChange }
 'range'    : { label, value, min, max, onChange }
 'dropdown' : { label, value, options, onChange }

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -78,7 +78,7 @@ options    = {
 	noTimeLabels:boolean,
 }
 decorations= { waterline, thresholds }
-waterline  = number
+waterline  = { value:number color:string }
 thresholds = { reference, alarming, critical }
 reference  = 'off' | 'now' | 'min' | 'max' | 'avg'
 alarming   = THRESHOLD
@@ -217,11 +217,12 @@ GROUP       = { id, caption, entries }
 id 		    = string
 caption     = string
 entries     = [ENTRY]
-ENTRY       = { label, type, input, value, unit, min, max, options, onChange, description } 
+ENTRY       = { label, type, input, value, unit, min, max, options, onChange, description, defaultValue } 
 label       = string
-type        = undefined | 'header' | 'checkbox' | 'range' | 'dropdown' | 'value' | 'text'
+type        = undefined | 'header' | 'checkbox' | 'range' | 'dropdown' | 'value' | 'text' | 'color'
 unit        = string
 value       = number | string
+defaultValue= number | string
 min         = number
 max         = number
 options     = { *:string }
@@ -241,6 +242,7 @@ Mandatory members of `ENTRY` depend on `type` member. Variants are:
 'dropdown' : { label, value, options, onChange }
 'value'    : { label, value, unit, onChange }
 'text'     : { label, value, onChange }
+'color'    : { label, value, defaultValue, onChange }
 ```
 * `onChange` may be ommitted for _text_ inputs which makes the field _readonly_.
 * Settings of type `'value'` are inputs for a number that depends on the `unit` 

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -52,12 +52,13 @@ interval        = number
 ### Widget Model
 
 ```
-WIDGET     = { series, type, unit, scaleFactor, target, grid, axis, options, decorations, status, displayName }
+WIDGET     = { series, type, unit, scaleFactor, target, grid, axis, options, decorations, status, displayName, coloring }
 series     = string
 target     = string
 displayName= string
 type       = 'line' | 'bar'
 unit       = 'count' | 'ms' | 'ns' | 'bytes' | 'percent'
+coloring   = 'instance' | 'series' | 'index'
 scaleFactor= number
 grid       = { item, column, span }
 item       = number

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -34,7 +34,7 @@ id              = string
 numberOfColumns = number
 rotate          = boolean
 widgets         = [WIDGET] | { *: WIDGET }
-settings        = { display, home, refresh, rotation }
+settings        = { display, home, refresh, rotation, colors }
 display         = boolean
 home            = string
 refresh         = { paused, interval }
@@ -42,12 +42,18 @@ rotation        = { enabled, interval }
 paused          = boolean
 enabled         = boolean
 interval        = number
+colors          = { palette, opacity, defaults }
+palette         = [COLOR]
+opacity         = number
+defaults        = { *:COLOR }
+COLOR           = string
 ```
 * `id` is derived from `name` and used as attribute name in `pages` object
 * `widgets` can be ommitted for an empty page
 * `numberOfColumns` can be ommitted
 * `widgets` is allowed to be an array - if so it is made into an object using each widget's `series` for the attribute name
 * `home` is the `PAGE.id` of the currently shown page
+* names for `defaults` colors used so far are: `'alarming'`, `'critical'` and `'waterline'`
 
 ### Widget Model
 

--- a/appserver/monitoring-console/webapp/pom.xml
+++ b/appserver/monitoring-console/webapp/pom.xml
@@ -121,6 +121,7 @@
                             <source>src/main/webapp/js/mc-main.js</source>
                             <source>src/main/webapp/js/mc-model.js</source>
                             <source>src/main/webapp/js/mc-view-units.js</source>
+                            <source>src/main/webapp/js/mc-view-colors.js</source>
                             <source>src/main/webapp/js/mc-view-components.js</source>
                             <source>src/main/webapp/js/mc-common-chart.js</source>
                             <source>src/main/webapp/js/mc-line-chart.js</source>

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -56,6 +56,18 @@ select {
   border-radius: 2px;
   margin-bottom: 2px;
 }
+input[type=color] {
+  border-radius: 2px;
+  padding: 0;
+  margin: 0 3px;
+  display: inline-block;
+  vertical-align: bottom;
+  width: 50px;
+}
+input[type=button] {
+  border-radius: 2px;
+  border: 2px outset #ccc;
+}
 input[type=text], input[type=number] {
 	border: 1px solid #ccc;
   padding: 3px 5px;

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -59,7 +59,7 @@ select {
 input[type=color] {
   border-radius: 2px;
   padding: 0;
-  margin: 0 2px 3px 2px;
+  margin: 1px;
   display: inline-block;
   vertical-align: middle;
   width: 30px;
@@ -67,7 +67,7 @@ input[type=color] {
 input[type=button] {
   border-radius: 2px;
   border: 2px outset #ccc;
-  margin: 0 1px;
+  margin: 1px;
   vertical-align: middle;
   display: inline-block;
 }

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -59,14 +59,17 @@ select {
 input[type=color] {
   border-radius: 2px;
   padding: 0;
-  margin: 0 3px;
+  margin: 0 2px 3px 2px;
   display: inline-block;
-  vertical-align: bottom;
-  width: 50px;
+  vertical-align: middle;
+  width: 30px;
 }
 input[type=button] {
   border-radius: 2px;
   border: 2px outset #ccc;
+  margin: 0 1px;
+  vertical-align: middle;
+  display: inline-block;
 }
 input[type=text], input[type=number] {
 	border: 1px solid #ccc;

--- a/appserver/monitoring-console/webapp/src/main/webapp/index.html
+++ b/appserver/monitoring-console/webapp/src/main/webapp/index.html
@@ -47,8 +47,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=x"></script>
-    <link href="css/monitoring-console.css?x=x" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=y"></script>
+    <link href="css/monitoring-console.css?x=y" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/index.html
+++ b/appserver/monitoring-console/webapp/src/main/webapp/index.html
@@ -47,8 +47,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=s"></script>
-    <link href="css/monitoring-console.css?x=s" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=x"></script>
+    <link href="css/monitoring-console.css?x=x" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-bar-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-bar-chart.js
@@ -46,7 +46,6 @@
 MonitoringConsole.Chart.Bar = (function() {
 
   const Units = MonitoringConsole.View.Units;
-  const Common = MonitoringConsole.Chart.Common;
 
    function createData(widget, response) {
       let series = [];

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-common-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-common-chart.js
@@ -42,27 +42,6 @@
 
 MonitoringConsole.Chart.Common = (function() {
 
-   const DEFAULT_BG_COLORS = [
-      'rgba(240, 152, 27, 0.2)',
-      'rgba(0, 140, 196, 0.2)',
-      'rgba(153, 102, 255, 0.2)',
-      'rgba(255, 99, 132, 0.2)',
-      'rgba(54, 162, 235, 0.2)',
-      'rgba(255, 206, 86, 0.2)',
-      'rgba(75, 192, 192, 0.2)',
-      'rgba(255, 159, 64, 0.2)'
-   ];
-   const DEFAULT_LINE_COLORS = [
-      'rgba(240, 152, 27, 1)',
-      'rgba(0, 140, 196, 1)',
-      'rgba(153, 102, 255, 1)',
-      'rgba(255, 99, 132, 1)',
-      'rgba(54, 162, 235, 1)',
-      'rgba(255, 206, 86, 1)',
-      'rgba(75, 192, 192, 1)',
-      'rgba(255, 159, 64, 1)'
-   ];
-
    function createCustomTooltipFunction(createHtmlTooltip) {
       return function(tooltipModel) {
         let tooltip = $('#chartjs-tooltip');
@@ -121,10 +100,6 @@ MonitoringConsole.Chart.Common = (function() {
        */
       createCustomTooltipFunction: (createHtmlTooltip) => createCustomTooltipFunction(createHtmlTooltip),
       formatDate: (date) => formatDate(date),
-      backgroundColor: (n) => DEFAULT_BG_COLORS[n],
-      backgroundColors: () => DEFAULT_BG_COLORS,
-      lineColor: (n) => DEFAULT_LINE_COLORS[n],
-      lineColors: () => DEFAULT_LINE_COLORS,
    };
 
 })();

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
@@ -181,14 +181,18 @@ MonitoringConsole.Chart.Line = (function() {
 		if (points.length > 0 && widget.options.drawMaxLine) {
 			datasets.push(createMaximumLineDataset(seriesData, points, lineColor));
 		}
-    if (widget.decorations.waterline) {
-      datasets.push(createHorizontalLineDataset(' waterline ', points, widget.decorations.waterline, 'Aqua', [2,2]));
+    let decorations = widget.decorations;
+    if (decorations.waterline && decorations.waterline.value) {
+      let color = decorations.waterline.color || 'Aqua';
+      datasets.push(createHorizontalLineDataset(' waterline ', points, decorations.waterline.value, color, [2,2]));
     }
-    if (widget.decorations.thresholds.alarming.display) {
-      datasets.push(createHorizontalLineDataset(' alarming ', points, widget.decorations.thresholds.alarming.value, 'gold', [2,2]));
+    if (decorations.thresholds.alarming.display) {
+      let color = decorations.thresholds.alarming.color || 'gold';
+      datasets.push(createHorizontalLineDataset(' alarming ', points, decorations.thresholds.alarming.value, color, [2,2]));
     }
-    if (widget.decorations.thresholds.critical.display) {
-      datasets.push(createHorizontalLineDataset(' critical ', points, widget.decorations.thresholds.critical.value, 'crimson', [2,2]));      
+    if (decorations.thresholds.critical.display) {
+      let color = decorations.thresholds.critical.color || 'crimson';
+      datasets.push(createHorizontalLineDataset(' critical ', points, decorations.thresholds.critical.value, color, [2,2]));      
     }
 	  return datasets;
   }

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
@@ -46,7 +46,6 @@
 MonitoringConsole.Chart.Line = (function() {
 	
   const Units = MonitoringConsole.View.Units;
-  const Common = MonitoringConsole.Chart.Common;
 
   /**
    * This is like a constant but it needs to yield new objects for each chart.

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
@@ -46,6 +46,8 @@
 MonitoringConsole.Chart.Line = (function() {
 	
   const Units = MonitoringConsole.View.Units;
+  const Colors = MonitoringConsole.View.Colors;
+  const ColorModel = MonitoringConsole.Model.Colors;
 
   /**
    * This is like a constant but it needs to yield new objects for each chart.
@@ -182,15 +184,15 @@ MonitoringConsole.Chart.Line = (function() {
 		}
     let decorations = widget.decorations;
     if (decorations.waterline && decorations.waterline.value) {
-      let color = decorations.waterline.color || 'Aqua';
+      let color = decorations.waterline.color || ColorModel.default('waterline');
       datasets.push(createHorizontalLineDataset(' waterline ', points, decorations.waterline.value, color, [2,2]));
     }
     if (decorations.thresholds.alarming.display) {
-      let color = decorations.thresholds.alarming.color || 'gold';
+      let color = decorations.thresholds.alarming.color || ColorModel.default('alarming');
       datasets.push(createHorizontalLineDataset(' alarming ', points, decorations.thresholds.alarming.value, color, [2,2]));
     }
     if (decorations.thresholds.critical.display) {
-      let color = decorations.thresholds.critical.color || 'crimson';
+      let color = decorations.thresholds.critical.color || ColorModel.default('critical');
       datasets.push(createHorizontalLineDataset(' critical ', points, decorations.thresholds.critical.value, color, [2,2]));      
     }
 	  return datasets;

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -55,6 +55,8 @@ MonitoringConsole.Model = (function() {
 	const TEXT_WEB_HIGH = "Requires *WEB monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'Web Container'* to *'HIGH'*.";
 	const TEXT_REQUEST_TRACING = "If you did enable request tracing at _Configurations_ => _Request Tracing_ not seeing any data means no requests passed the tracing threshold which is a good thing.";
 
+	const DEFAULT_COLOR_SCHEME = [ '#F0981B', '#008CC4', '#87BC25', '#8B79BC', '#FF70DA' ];
+
 	const UI_PRESETS = {
 			pages: {
 				core: {
@@ -251,6 +253,9 @@ MonitoringConsole.Model = (function() {
 			let isPagesOnly = !userInterface.pages || !userInterface.settings;
 			if (!isPagesOnly)
 				settings = userInterface.settings;
+			if (settings.colors === undefined) {
+				settings.colors = {	scheme: DEFAULT_COLOR_SCHEME };
+			}
 			let importedPages = !userInterface.pages ? userInterface : userInterface.pages;
 			// override or add the entry in pages from userInterface
 			if (Array.isArray(importedPages)) {
@@ -393,6 +398,13 @@ MonitoringConsole.Model = (function() {
       	}
 		
 		return {
+			scheme: function(colors) {
+				if (colors === undefined)
+					return settings.colors.scheme || [];
+				settings.colors.scheme = colors || [];
+				doStore();
+			},
+
 			currentPage: function() {
 				return pages[settings.home];
 			},
@@ -1020,6 +1032,10 @@ MonitoringConsole.Model = (function() {
 				UI.Refresh.interval(duration);
 				Interval.resume(UI.Refresh.interval());				
 			},
+		},
+
+		Colors: {
+			scheme: UI.scheme,
 		},
 		
 		Settings: {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -200,6 +200,10 @@ MonitoringConsole.Model = (function() {
 				widget.grid = {};
 			if (typeof widget.decorations !== 'object')
 				widget.decorations = {};
+			if (typeof widget.decorations.waterline !== 'object') {
+				let value = typeof widget.decorations.waterline === 'number' ? widget.decorations.waterline : undefined;
+				widget.decorations.waterline = { value: value };
+			}
 			if (typeof widget.decorations.thresholds !== 'object')
 				widget.decorations.thresholds = {};
 			if (typeof widget.decorations.thresholds.alarming !== 'object')

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -55,9 +55,6 @@ MonitoringConsole.Model = (function() {
 	const TEXT_WEB_HIGH = "Requires *WEB monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'Web Container'* to *'HIGH'*.";
 	const TEXT_REQUEST_TRACING = "If you did enable request tracing at _Configurations_ => _Request Tracing_ not seeing any data means no requests passed the tracing threshold which is a good thing.";
 
-	const DEFAULT_COLOR_PALETTE = [ '#F0981B', '#008CC4', '#87BC25', '#8B79BC', '#FF70DA' ];
-	const DEFAULT_COLOR_OPACITY = 20;
-
 	const UI_PRESETS = {
 			pages: {
 				core: {
@@ -233,10 +230,6 @@ MonitoringConsole.Model = (function() {
 				settings = {};
 			if (settings.colors === undefined)
 				settings.colors = {};
-			if (settings.colors.palette === undefined)
-				settings.colors.palette = DEFAULT_COLOR_PALETTE; 
-			if (settings.colors.opacity === undefined)
-				settings.colors.opacity = DEFAULT_COLOR_OPACITY;
 			if (settings.colors.defaults === undefined)
 				settings.colors.defaults = {};
 			return settings;
@@ -414,15 +407,15 @@ MonitoringConsole.Model = (function() {
 		return {
 			colorPalette: function(colors) {
 				if (colors === undefined)
-					return settings.colors.palette || DEFAULT_COLOR_PALETTE;
-				settings.colors.palette = colors || DEFAULT_COLOR_PALETTE;
+					return settings.colors.palette;
+				settings.colors.palette = colors;
 				doStore();
 			},
 
 			colorOpacity: function(opacity) {
 				if (opacity === undefined)
-					return settings.colors.opacity || DEFAULT_COLOR_OPACITY;
-				settings.colors.opacity = opacity || DEFAULT_COLOR_OPACITY;
+					return settings.colors.opacity;
+				settings.colors.opacity = opacity;
 				doStore();
 			},
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -972,7 +972,8 @@ MonitoringConsole.Model = (function() {
 		if (UI.Refresh.interval() === undefined) {
 			UI.Refresh.interval(DEFAULT_INTERVAL);
 		}
-		Interval.resume(UI.Refresh.interval());
+		if (!UI.Refresh.isPaused())
+			Interval.resume(UI.Refresh.interval());
 		Rotation.init(() => onPageUpdate(doSwitchPage()));
 		if (UI.Rotation.isEnabled()) {
 			Rotation.resume(UI.Rotation.interval());	

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -161,7 +161,7 @@ MonitoringConsole.Model = (function() {
 		/**
 		 * General settings for the user interface
 		 */
-		var settings = {};
+		var settings = sanityCheckSettings({});
 		
 		/**
 		 * Makes sure the page data structure has all required attributes.

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -98,7 +98,9 @@ MonitoringConsole.Model = (function() {
 							grid: { item: 0, column: 0, span: 1 }, 
 							axis: { min: 0, max: 5000 },
 							options: { drawMinLine: true },
-							status: { missing: { hint: TEXT_REQUEST_TRACING }}}
+							status: { missing: { hint: TEXT_REQUEST_TRACING }},
+							coloring: 'series',
+						}
 					]
 				},
 				http: {
@@ -254,7 +256,7 @@ MonitoringConsole.Model = (function() {
 			if (!isPagesOnly)
 				settings = userInterface.settings;
 			if (settings.colors === undefined) {
-				settings.colors = {	scheme: DEFAULT_COLOR_SCHEME };
+				settings.colors = {	scheme: DEFAULT_COLOR_SCHEME, opacity: 20 };
 			}
 			let importedPages = !userInterface.pages ? userInterface : userInterface.pages;
 			// override or add the entry in pages from userInterface
@@ -398,10 +400,17 @@ MonitoringConsole.Model = (function() {
       	}
 		
 		return {
-			scheme: function(colors) {
+			colorScheme: function(colors) {
 				if (colors === undefined)
 					return settings.colors.scheme || [];
 				settings.colors.scheme = colors || [];
+				doStore();
+			},
+
+			colorOpacity: function(opacity) {
+				if (opacity === undefined)
+					return settings.colors.opacity || 20;
+				settings.colors.opacity = opacity || 20;
 				doStore();
 			},
 
@@ -1035,7 +1044,8 @@ MonitoringConsole.Model = (function() {
 		},
 
 		Colors: {
-			scheme: UI.scheme,
+			scheme: UI.colorScheme,
+			opacity: UI.colorOpacity,
 		},
 		
 		Settings: {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-trace-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-trace-chart.js
@@ -46,6 +46,7 @@
 MonitoringConsole.Chart.Trace = (function() {
 
    const Components = MonitoringConsole.View.Components;
+   const Colors = MonitoringConsole.View.Colors;
    const Common = MonitoringConsole.Chart.Common;
 
    var model = {};
@@ -66,6 +67,8 @@ MonitoringConsole.Chart.Trace = (function() {
       let colorCounter = 0;
       let colors = [];
       let bgColors = [];
+      let alpha = MonitoringConsole.Model.Colors.opacity() / 100;
+      let scheme = MonitoringConsole.Model.Colors.scheme();
       data.sort(model.sortBy);
       for (let i = 0; i < data.length; i++) {
          let trace = data[i]; 
@@ -77,9 +80,11 @@ MonitoringConsole.Chart.Trace = (function() {
             minToMaxValues.push(span.endTime - span.startTime);
             labels.push(span.operation);
             if (!operations[span.operation]) {
+               let color = Colors.lookup('index', 'line-' + colorCounter, scheme);
+               colorCounter++;
                operations[span.operation] = {
-                  color: Common.lineColor(colorCounter),
-                  bgColor: Common.backgroundColor(colorCounter++),
+                  color: color,
+                  bgColor: Colors.hex2rgba(color, alpha),
                   count: 1,
                   duration: span.endTime - span.startTime,
                };

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-trace-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-trace-chart.js
@@ -68,7 +68,7 @@ MonitoringConsole.Chart.Trace = (function() {
       let colors = [];
       let bgColors = [];
       let alpha = MonitoringConsole.Model.Colors.opacity() / 100;
-      let scheme = MonitoringConsole.Model.Colors.scheme();
+      let palette = MonitoringConsole.Model.Colors.palette();
       data.sort(model.sortBy);
       for (let i = 0; i < data.length; i++) {
          let trace = data[i]; 
@@ -80,7 +80,7 @@ MonitoringConsole.Chart.Trace = (function() {
             minToMaxValues.push(span.endTime - span.startTime);
             labels.push(span.operation);
             if (!operations[span.operation]) {
-               let color = Colors.lookup('index', 'line-' + colorCounter, scheme);
+               let color = Colors.lookup('index', 'line-' + colorCounter, palette);
                colorCounter++;
                operations[span.operation] = {
                   color: color,

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
@@ -1,0 +1,87 @@
+/*
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+*/
+
+/*jshint esversion: 8 */
+
+/**
+ * Utilities to convert color values.
+ **/
+MonitoringConsole.View.Colors = (function() {
+
+   let colorIndexMaps = {};
+
+   function lookup(coloring, key, scheme) {
+      let mapName = coloring || 'instance';
+      let map = colorIndexMaps[mapName];
+      if (map === undefined) {
+         map = {};
+         colorIndexMaps[mapName] = map;
+      }
+      let index = map[key];
+      if (index === undefined) {
+         index = Object.keys(map).length;
+         map[key] = index;
+      }
+      return scheme[index % scheme.length];
+   }
+
+   function random() {
+     const letters = '0123456789ABCDEF';
+     let color = '#';
+     for (let i = 0; i < 6; i++) {
+       color += letters[Math.floor(Math.random() * 16)];
+     }
+     return color;
+   }
+
+   function hex2rgba(hex, alpha = 1) {
+      const [r, g, b] = hex.match(/\w\w/g).map(x => parseInt(x, 16));
+      return `rgba(${r},${g},${b},${alpha})`;
+   }
+
+   /**
+    * Public API of the color utility module.
+    */
+   return {
+      lookup: lookup,
+      random: random,
+      hex2rgba: hex2rgba,
+   };
+})();

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
@@ -181,14 +181,17 @@ MonitoringConsole.View.Colors = (function() {
       }, { _: '(Select to apply)' });
    }
 
-   function applyScheme(name) {
+   function applyScheme(name, override = true) {
       let scheme = SCHEMES[name];
       if (scheme) {
-         Colors.palette(scheme.palette);
-         Colors.opacity(scheme.opacity);
+         if (override || Colors.palette() === undefined)
+            Colors.palette(scheme.palette);
+         if (override || Colors.opacity() === undefined)
+            Colors.opacity(scheme.opacity);
          if (scheme.defaults) {
             for (let [name, color] of Object.entries(scheme.defaults)) {
-               Colors.default(name, color);
+               if (override || Colors.default(name) === undefined)
+                  Colors.default(name, color);
             }
          }            
       }

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
@@ -41,13 +41,73 @@
 /*jshint esversion: 8 */
 
 /**
- * Utilities to convert color values.
+ * Utilities to convert color values and handle color schemes.
+ *
+ * Color schemes are named sets of colors that are applied to the model.
+ * This is build purely on top of the model. 
+ * The model does not remember a scheme, 
+ * schemes are just a utility to reset color configurations to a certain set.
  **/
 MonitoringConsole.View.Colors = (function() {
 
+   const Colors = MonitoringConsole.Model.Colors;
+
+   const SCHEMES = {
+      Payara: {
+         name: 'Payara',
+         palette: [ '#F0981B', '#008CC4', '#8B79BC', '#87BC25', '#FF70DA' ],
+         opacity: 20,
+         defaults:  { waterline: '#00ffff', alarming: '#FFD700', critical: '#dc143c' }
+      },
+
+      a: {
+         name: '80s',
+         opacity: 30,
+         palette: [ '#ff48c4', '#2bd1fc', '#f3ea5f', '#c04df9', '#ff3f3f'],
+         defaults:  { waterline: '#2bd1fc', alarming: '#f3ea5f', critical: '#ff3f3f' }
+      },
+
+      b: {
+         name: '80s Pastel',
+         opacity: 40,
+         palette: [ '#bd6283', '#96c0bc', '#dbd259', '#d49e54', '#b95f51'],
+         defaults:  { waterline: '#96c0bc', alarming: '#dbd259', critical: '#b95f51' }
+      },
+
+      c: {
+         name: '80s Neon',
+         opacity: 15,
+         palette: [ '#cb268b', '#f64e0c', '#eff109', '#6cf700', '#00aff3'],
+         defaults:  { waterline: '#00aff3', alarming: '#eff109', critical: '#f64e0c' }
+      },
+
+      d: {
+         name: 'VaporWave',
+         opacity: 20,
+         palette: [ '#05ffa1', '#b8a9df', '#01cdfe', '#b967ff', '#fffb96'],
+         defaults:  { waterline: '#01cdfe', alarming: '#fffb96', critical: '#FB637A' }
+      },
+
+      e: {
+         name: 'Solarized',
+         opacity: 20,
+         palette: [ '#b58900', '#cb4b16', '#dc322f', '#d32682', '#c671c4', '#268bd2', '#2aa198', '#859900'],
+         defaults:  { waterline: '#268bd2', alarming: '#b58900', critical: '#dc322f' }
+      }
+   };
+
+   /**
+    * Object used as map to remember the colors by coloring stratgey.
+    * Each strategy leads to an object map that remebers the key as fields 
+    * and the index associated with the key as value.
+    * This is a mapping from e.g. the name 'DAS' to index 0. 
+    * The index is then used to pick a color form the palette.
+    * This makes sure that same key, for example the instance name,
+    * always uses the same color accross widgets and pages.
+    */
    let colorIndexMaps = {};
 
-   function lookup(coloring, key, scheme) {
+   function lookup(coloring, key, palette) {
       let mapName = coloring || 'instance';
       let map = colorIndexMaps[mapName];
       if (map === undefined) {
@@ -59,21 +119,79 @@ MonitoringConsole.View.Colors = (function() {
          index = Object.keys(map).length;
          map[key] = index;
       }
-      return scheme[index % scheme.length];
+      return derive(palette, index);
    }
 
-   function random() {
-     const letters = '0123456789ABCDEF';
-     let color = '#';
-     for (let i = 0; i < 6; i++) {
-       color += letters[Math.floor(Math.random() * 16)];
-     }
-     return color;
+   /**
+    * Returns a palette color.
+    * If index is outside of the palette given a color is derived from the palette.
+    * The derived colors are intentionally biased towards light non-grayish colors.
+    */
+   function derive(palette, index = 1) {
+      let color = palette[index % palette.length];
+      if (index < palette.length)
+         return color;
+      let [r, g, b] = hex2rgb(color);
+      let offset = index - palette.length + 1;
+      let shift = (offset * 110) % 255;
+      r = (r + shift) % 255;
+      g = (g + shift) % 255;
+      b = (b + shift) % 255;
+      let variant = offset % 6;
+      if (variant == 0 || variant == 3 || variant == 4)
+         r = Math.round(r / 2);
+      if (variant == 1 || variant == 3 || variant == 5)
+         g = Math.round(g / 2);
+      if (variant == 2 || variant == 4 || variant == 5)
+         b = Math.round(b / 2);
+      if (r + g + b < 380 && r < 120) r = 255 - r;
+      if (r + g + b < 380 && g < 120) g = 255 - g;
+      if (r + g + b < 380 && b < 120) b = 255 - b;
+      return rgb2hex(r, g, b);
+   }
+
+   function random(palette) {
+      if (Array.isArray(palette))
+         return derive([palette[0]], palette.length); 
+      const letters = '0123456789ABCDEF';
+      let color = '#';
+      for (let i = 0; i < 6; i++) {
+         color += letters[Math.floor(Math.random() * 16)];
+      }
+      return color;
+   }
+
+   function hex2rgb(hex) {
+      return hex.match(/\w\w/g).map(x => parseInt(x, 16));
+   }
+
+   function rgb2hex(r, g, b) {
+      return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
    }
 
    function hex2rgba(hex, alpha = 1) {
-      const [r, g, b] = hex.match(/\w\w/g).map(x => parseInt(x, 16));
+      const [r, g, b] = hex2rgb(hex);
       return `rgba(${r},${g},${b},${alpha})`;
+   }
+
+   function schemeOptions() {
+      return Object.keys(SCHEMES).reduce(function(result, key) {
+         result[key] = SCHEMES[key].name;
+         return result;
+      }, { _: '(Select to apply)' });
+   }
+
+   function applyScheme(name) {
+      let scheme = SCHEMES[name];
+      if (scheme) {
+         Colors.palette(scheme.palette);
+         Colors.opacity(scheme.opacity);
+         if (scheme.defaults) {
+            for (let [name, color] of Object.entries(scheme.defaults)) {
+               Colors.default(name, color);
+            }
+         }            
+      }
    }
 
    /**
@@ -83,5 +201,7 @@ MonitoringConsole.View.Colors = (function() {
       lookup: lookup,
       random: random,
       hex2rgba: hex2rgba,
+      schemes: schemeOptions,
+      scheme: applyScheme,
    };
 })();

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -191,6 +191,8 @@ MonitoringConsole.View.Components = (function() {
         let value = model.value;
         if (value === undefined && model.defaultValue !== undefined)
           value = model.defaultValue;
+        if (Array.isArray(value))
+          return createMultiColorInput(model);
         let config = { id: model.id, type: 'color', value: value };
         if (model.description && !model.label)
           config.title = model.description;
@@ -213,6 +215,54 @@ MonitoringConsole.View.Components = (function() {
           onChange(undefined);
           input.val(model.defaultValue);
         }));
+      }
+
+      function createMultiColorInput(model) {
+        let value = model.value;
+        if (value === undefined && model.defaultValue !== undefined)
+          value = model.defaultValue;
+        if (!Array.isArray(value))
+          value = [value];
+        let list = $('<span/>');
+        //TODO model id goes where?
+        let colors = [...value];
+        let onChange = enhancedOnChange(model.onChange);
+        for (let i = 0; i < value.length; i++) {
+          list.append(createMultiColorItemInput(colors, i, onChange));
+        }
+        let add = $('<input/>', {type: 'button', value: '+'});
+        add.click(() => {
+          colors.push(getRandomColor());
+          createMultiColorItemInput(colors, colors.length-1, onChange).insertBefore(add);
+          onChange(colors);
+        });
+        let remove = $('<input/>', {type: 'button', value: '-'});
+        remove.click(() => {
+          if (colors.length > 1) {
+            colors.length -= 1;
+            list.children('input[type=color]').last().remove();
+            onChange(colors);
+          }
+        });
+        list.append(add);
+        list.append(remove);
+        return list;
+      }
+
+      function getRandomColor() {
+        let letters = '0123456789ABCDEF';
+        let color = '#';
+        for (let i = 0; i < 6; i++) {
+          color += letters[Math.floor(Math.random() * 16)];
+        }
+        return color;
+      }
+
+      function createMultiColorItemInput(colors, index, onChange) {
+        return createColorInput({ value: colors[index], onChange: (val) => {
+          colors[index] = val;
+          onChange(colors);
+        }});
       }
 
       function createInput(model) {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -238,7 +238,7 @@ MonitoringConsole.View.Components = (function() {
         }
         let add = $('<input/>', {type: 'button', value: '+'});
         add.click(() => {
-          colors.push(Colors.random());
+          colors.push(Colors.random(colors));
           createMultiColorItemInput(colors, colors.length-1, onChange).insertBefore(add);
           onChange(colors);
         });

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
@@ -280,16 +280,21 @@ MonitoringConsole.View = (function() {
             ]},
         ]});
         settings.push({ id: 'settings-decorations', caption: 'Decorations', entries: [
-            { label: 'Waterline', type: 'value', unit: unit, value: widget.decorations.waterline, onChange: (widget, value) => widget.decorations.waterline = value },
-            { label: 'Threshold Reference', type: 'dropdown', options: { off: 'Off', now: 'Most Recent Value', min: 'Minimum Value', max: 'Maximum Value', avg: 'Average Value'}, value: thresholds.reference, onChange: (widget, selected) => thresholds.reference = selected},
+            { label: 'Waterline', input: [
+                { type: 'value', unit: unit, value: widget.decorations.waterline.value, onChange: (widget, value) => widget.decorations.waterline.value = value },
+                { type: 'color', value: widget.decorations.waterline.color, defaultValue: '#00ffff', onChange: (widget, value) => widget.decorations.waterline.color = value },
+            ]},
             { label: 'Alarming Threshold', input: [
                 { type: 'value', unit: unit, value: thresholds.alarming.value, onChange: (widget, value) => thresholds.alarming.value = value },
+                { type: 'color', value: thresholds.alarming.color, defaultValue: '#FFD700', onChange: (widget, value) => thresholds.alarming.color = value },
                 { label: 'Line', type: 'checkbox', value: thresholds.alarming.display, onChange: (widget, checked) => thresholds.alarming.display = checked },
             ]},
             { label: 'Critical Threshold', input: [
                 { type: 'value', unit: unit, value: thresholds.critical.value, onChange: (widget, value) => thresholds.critical.value = value },
+                { type: 'color', value: thresholds.critical.color, defaultValue: '#dc143c', onChange: (widget, value) => thresholds.critical.color = value },
                 { label: 'Line', type: 'checkbox', value: thresholds.critical.display, onChange: (widget, checked) => thresholds.critical.display = checked },
             ]},                
+            { label: 'Threshold Reference', type: 'dropdown', options: { off: 'Off', now: 'Most Recent Value', min: 'Minimum Value', max: 'Maximum Value', avg: 'Average Value'}, value: thresholds.reference, onChange: (widget, selected) => thresholds.reference = selected},
             //TODO add color for each threshold
         ]});
         settings.push({ id: 'settings-status', caption: 'Status', description: 'Set a text for an assessment status', entries: [

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
@@ -232,6 +232,7 @@ MonitoringConsole.View = (function() {
                 { type: 'value', unit: 'sec', value: MonitoringConsole.Model.Settings.Rotation.interval(), onChange: (val) => MonitoringConsole.Model.Settings.Rotation.interval(val) },
                 { label: 'enabled', type: 'checkbox', value: MonitoringConsole.Model.Settings.Rotation.isEnabled(), onChange: (checked) => MonitoringConsole.Model.Settings.Rotation.enabled(checked) },
             ]},
+            { label: 'Color Scheme', type: 'color', value: MonitoringConsole.Model.Colors.scheme(), onChange: (colors) => MonitoringConsole.Model.Colors.scheme(colors) },
         ]};
     }
 
@@ -278,6 +279,8 @@ MonitoringConsole.View = (function() {
                 { label: 'Min', type: 'value', unit: unit, value: widget.axis.min, onChange: (widget, value) => widget.axis.min = value},
                 { label: 'Max', type: 'value', unit: unit, value: widget.axis.max, onChange: (widget, value) => widget.axis.max = value},
             ]},
+            { label: 'Coloring', type: 'dropdown', options: { instance: 'Instance Name', series: 'Series Name', index: 'Result Set Index' }, value: widget.coloring, onChange: (widget, value) => widget.coloring = value,
+                description: 'What value is used to select the index from the color scheme' },
         ]});
         settings.push({ id: 'settings-decorations', caption: 'Decorations', entries: [
             { label: 'Waterline', input: [

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
@@ -568,6 +568,7 @@ MonitoringConsole.View = (function() {
             // connect the view to the model by passing the 'onDataUpdate' function to the model
             // which will call it when data is received
             onPageChange(MonitoringConsole.Model.init(onDataUpdate, onPageChange));
+            Colors.scheme('Payara', false);
         },
         onPageChange: (layout) => onPageChange(layout),
         onPageUpdate: (layout) => onPageUpdate(layout),

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/monitoring-console.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/monitoring-console.js
@@ -146,9 +146,6 @@ MonitoringConsole.Model = (function() {
 	const TEXT_WEB_HIGH = "Requires *WEB monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'Web Container'* to *'HIGH'*.";
 	const TEXT_REQUEST_TRACING = "If you did enable request tracing at _Configurations_ => _Request Tracing_ not seeing any data means no requests passed the tracing threshold which is a good thing.";
 
-	const DEFAULT_COLOR_PALETTE = [ '#F0981B', '#008CC4', '#87BC25', '#8B79BC', '#FF70DA' ];
-	const DEFAULT_COLOR_OPACITY = 20;
-
 	const UI_PRESETS = {
 			pages: {
 				core: {
@@ -324,10 +321,6 @@ MonitoringConsole.Model = (function() {
 				settings = {};
 			if (settings.colors === undefined)
 				settings.colors = {};
-			if (settings.colors.palette === undefined)
-				settings.colors.palette = DEFAULT_COLOR_PALETTE; 
-			if (settings.colors.opacity === undefined)
-				settings.colors.opacity = DEFAULT_COLOR_OPACITY;
 			if (settings.colors.defaults === undefined)
 				settings.colors.defaults = {};
 			return settings;
@@ -505,15 +498,15 @@ MonitoringConsole.Model = (function() {
 		return {
 			colorPalette: function(colors) {
 				if (colors === undefined)
-					return settings.colors.palette || DEFAULT_COLOR_PALETTE;
-				settings.colors.palette = colors || DEFAULT_COLOR_PALETTE;
+					return settings.colors.palette;
+				settings.colors.palette = colors;
 				doStore();
 			},
 
 			colorOpacity: function(opacity) {
 				if (opacity === undefined)
-					return settings.colors.opacity || DEFAULT_COLOR_OPACITY;
-				settings.colors.opacity = opacity || DEFAULT_COLOR_OPACITY;
+					return settings.colors.opacity;
+				settings.colors.opacity = opacity;
 				doStore();
 			},
 
@@ -1734,14 +1727,17 @@ MonitoringConsole.View.Colors = (function() {
       }, { _: '(Select to apply)' });
    }
 
-   function applyScheme(name) {
+   function applyScheme(name, override = true) {
       let scheme = SCHEMES[name];
       if (scheme) {
-         Colors.palette(scheme.palette);
-         Colors.opacity(scheme.opacity);
+         if (override || Colors.palette() === undefined)
+            Colors.palette(scheme.palette);
+         if (override || Colors.opacity() === undefined)
+            Colors.opacity(scheme.opacity);
          if (scheme.defaults) {
             for (let [name, color] of Object.entries(scheme.defaults)) {
-               Colors.default(name, color);
+               if (override || Colors.default(name) === undefined)
+                  Colors.default(name, color);
             }
          }            
       }
@@ -3605,6 +3601,7 @@ MonitoringConsole.View = (function() {
             // connect the view to the model by passing the 'onDataUpdate' function to the model
             // which will call it when data is received
             onPageChange(MonitoringConsole.Model.init(onDataUpdate, onPageChange));
+            Colors.scheme('Payara', false);
         },
         onPageChange: (layout) => onPageChange(layout),
         onPageUpdate: (layout) => onPageUpdate(layout),

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/monitoring-console.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/monitoring-console.js
@@ -1063,7 +1063,8 @@ MonitoringConsole.Model = (function() {
 		if (UI.Refresh.interval() === undefined) {
 			UI.Refresh.interval(DEFAULT_INTERVAL);
 		}
-		Interval.resume(UI.Refresh.interval());
+		if (!UI.Refresh.isPaused())
+			Interval.resume(UI.Refresh.interval());
 		Rotation.init(() => onPageUpdate(doSwitchPage()));
 		if (UI.Rotation.isEnabled()) {
 			Rotation.resume(UI.Rotation.interval());	

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/monitoring-console.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/monitoring-console.js
@@ -252,7 +252,7 @@ MonitoringConsole.Model = (function() {
 		/**
 		 * General settings for the user interface
 		 */
-		var settings = {};
+		var settings = sanityCheckSettings({});
 		
 		/**
 		 * Makes sure the page data structure has all required attributes.


### PR DESCRIPTION
### Summary
Makes graph colours configurable by

* adding color input type to `Settings` component that can be used for single or multiple values
* adds configuration for waterline, alerting and critical colours per widget
* adds new settings group _Colors_ which allows to modify the list of colours used for data lines in graphs as well as the defaults for waterline, alerting and critical colours. 

PR also makes settings more flexible by allowing to mark a group as `collapsed` which will not show the settings of the section initially. This was added to hide the colour settings so they don't move the widget settings out of normal screen.

Besides making colours configurable for the user this PR also makes sure that all graphs and pages are consistent in their use of colour for a particular source. With the PR colour used is not simply picked by index of the data series but based on the key property of the series. Mostly this is the instance name. This means graphs will show data belonging to the same instance in the same colour. There are exceptions like request tracing where instance name is not the distinguishing property. This is configured now using the new `Coloring` settings of widgets. 

In addition the changes make sure that duplicate colours for lines in a chart are highly unlikely.
Should there be less colours in the colour palette defined by the user new colours are derived based on the colours in the palette. The algorithm has an intentional bias towards bright colours - dark colours and greyish ones are avoided as they are hard to see or distinguish in a graph.

### Note for Reviewers
As "usual" let me point out that the `monitoring-console.js` file is a merge of the other JS files that does not need a review.

### Testing Performed
Manual testing.

Checking compatibility: clear local browser storage for MC, reload page
Checking colour scheme feature: open settings, chose a scheme and check effect of colour change on _Core_ and _Request Tracing_ page including _Request Tracing_ details page.

Checking defaults:
1. change a default colour, e.g. waterline
2. select widget _Heap Usage_ on _Core_ page and check it has the changed default for waterline
3. change the widgets waterline colour and check that changing the default does not change the widgets custom colour
4. reset the widgets waterline colour to default by clicking on the box right to the colour picker.
5. change the default for waterline again and check that the widget also changes its waterline colour

Testing generated colours:
1. open _Color_ settings
2. remove all colours in the palette but one. 
3. look at a chart with multiple lines (e.g. start additional instances)
4. also add colours to the palette will give the sequence of generated colours derived **only** from the first colour

Testing opacity:
1. open _Color_ settings
2. change _Opacity_ to 80
3. check the background colour in graphs now is almost non-transparent