### PR TITLE
CUSTOM-54: NullPointerException when JMX attribute is null

### DIFF
--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -89,8 +89,7 @@
         <!-- JSONP Provider -->
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1</version>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -71,6 +71,28 @@
             <version>7.0</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JSONP Provider -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/src/main/java/fish/payara/monitoring/rest/app/handler/MBeanAttributeReadHandler.java
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/src/main/java/fish/payara/monitoring/rest/app/handler/MBeanAttributeReadHandler.java
@@ -101,6 +101,9 @@ public class MBeanAttributeReadHandler extends ReadHandler {
         try {
             Object attribute = delegate
                     .getMBeanAttribute(mbeanname, attributename);
+            if (attribute == null) {
+                return JsonValue.NULL;
+            }
             TypeProcessor<?> processor = ProcessorFactory.getTypeProcessor(attribute);
             
             return processor.processObject(attribute);

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/src/main/java/fish/payara/monitoring/rest/app/handler/MBeanAttributeReadHandler.java
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/src/main/java/fish/payara/monitoring/rest/app/handler/MBeanAttributeReadHandler.java
@@ -1,7 +1,7 @@
-/**
+/*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2017] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/src/test/java/fish/payara/monitoring/rest/app/handler/MBeanAttributeReadHandlerTest.java
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/src/test/java/fish/payara/monitoring/rest/app/handler/MBeanAttributeReadHandlerTest.java
@@ -1,0 +1,121 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.monitoring.rest.app.handler;
+
+import fish.payara.monitoring.rest.app.MBeanServerDelegate;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+public class MBeanAttributeReadHandlerTest {
+
+    private static final String BEAN_NAME = "someName";
+    private static final String BEAN_ATTRIBUTE = "someAttribute";
+
+    @Mock
+    private MBeanServerDelegate delegateMock;
+
+    @Before
+    public void setup() {
+        delegateMock = Mockito.mock(MBeanServerDelegate.class);
+    }
+
+    @Test
+    public void getValueObject_String() throws Exception {
+        MBeanAttributeReadHandler handler = new MBeanAttributeReadHandler(delegateMock, BEAN_NAME, BEAN_ATTRIBUTE);
+        when(delegateMock.getMBeanAttribute(BEAN_NAME, BEAN_ATTRIBUTE)).thenReturn("Payara");
+
+        JsonValue value = handler.getValueObject();
+        assertThat(value.getValueType()).isEqualTo(JsonValue.ValueType.STRING);
+        assertThat(((JsonString) value).getString()).isEqualTo("Payara");
+    }
+
+    @Test
+    public void getValueObject_Long() throws Exception {
+        MBeanAttributeReadHandler handler = new MBeanAttributeReadHandler(delegateMock, BEAN_NAME, BEAN_ATTRIBUTE);
+        when(delegateMock.getMBeanAttribute(BEAN_NAME, BEAN_ATTRIBUTE)).thenReturn(123L);
+
+        JsonValue value = handler.getValueObject();
+        assertThat(value.getValueType()).isEqualTo(JsonValue.ValueType.NUMBER);
+        assertThat(((JsonNumber) value).longValue()).isEqualTo(123L);
+    }
+
+    @Test
+    public void getValueObject_Boolean() throws Exception {
+        MBeanAttributeReadHandler handler = new MBeanAttributeReadHandler(delegateMock, BEAN_NAME, BEAN_ATTRIBUTE);
+        when(delegateMock.getMBeanAttribute(BEAN_NAME, BEAN_ATTRIBUTE)).thenReturn(Boolean.TRUE);
+
+        JsonValue value = handler.getValueObject();
+        assertThat(value).isEqualTo(JsonValue.TRUE);
+
+    }
+
+    @Test
+    public void getValueObject_Array() throws Exception {
+        MBeanAttributeReadHandler handler = new MBeanAttributeReadHandler(delegateMock, BEAN_NAME, BEAN_ATTRIBUTE);
+        when(delegateMock.getMBeanAttribute(BEAN_NAME, BEAN_ATTRIBUTE)).thenReturn(new Integer[]{1,2,3});
+
+        JsonValue value = handler.getValueObject();
+        assertThat(value.getValueType()).isEqualTo(JsonValue.ValueType.ARRAY);
+        List<JsonNumber> data = ((JsonArray) value).getValuesAs(JsonNumber.class);
+        assertThat(data.stream().map(JsonNumber::intValue)).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void getValueObject_null() throws Exception {
+        MBeanAttributeReadHandler handler = new MBeanAttributeReadHandler(delegateMock, BEAN_NAME, BEAN_ATTRIBUTE);
+        when(delegateMock.getMBeanAttribute(BEAN_NAME, BEAN_ATTRIBUTE)).thenReturn(null);
+
+        JsonValue value = handler.getValueObject();
+        System.out.println(value);
+    }
+}


### PR DESCRIPTION
CUSTOM-54: NullPointerException when JMX attribute is null within the rest-monitoring endpoint

# Description
This is a bug fix

When JMX attributes are null, it results in NPE when accessed from the rest-monitoring endpoint.

The fix  checks if the attribute value is null and return JsonValue.NULL in that case instead of the 'generic' method who tries to convert the instance to a JsonValue.


# Testing

### Testing Performed

Manual testing

- /asadmin start-domain 
- deploy simple jms example (https://github.com/payara/Payara-Examples/tree/master/javaee/simple-jms-example)
- ./asadmin set-monitoring-level --level=HIGH --module=jmsService --target=server-config
- ./asadmin set-amx-enabled --dynamic=true --enabled=true --target=server-config 
- ./asadmin set-monitoring-service-configuration --mbeanEnabled=true --monitoringEnabled=true --dtraceEnabled=false --target=server-config
- ./asadmin set-rest-monitoring-configuration --securityenabled=false --contextroot=/rest-monitoring --enabled=true --applicationname=__restmonitoring --target=server-config 
- http://localhost:4848/rest-monitoring/rest/read/com.sun.messaging.jms.server:type=Destination,subtype=Monitor,desttype=q,name="simpleQ"

### Testing Environment
Oracle 1.8.0_181 on Mac 10.14.6 with Maven 3.5.4

# Documentation
N/A

