### PR TITLE
PAYARA-2598 / CUSTCOM-71 Fix for multiple Realm Identity Stores registration

### DIFF
--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/cdi/RealmExtension.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/cdi/RealmExtension.java
@@ -164,7 +164,7 @@ public class RealmExtension implements Extension {
                     .scope(ApplicationScoped.class)
                     .beanClass(IdentityStore.class)
                     .types(Object.class, IdentityStore.class)
-                    .addToId(RealmIdentityStore.class)
+                    .addToId(RealmIdentityStore.class + "-" + definition.value())
                     .create(e -> {
                         RealmIdentityStore mechanism = CDI.current().select(RealmIdentityStore.class).get();
                         mechanism.setConfiguration(definition);
@@ -186,7 +186,7 @@ public class RealmExtension implements Extension {
                         .scope(ApplicationScoped.class)
                         .beanClass(IdentityStore.class)
                         .types(Object.class, IdentityStore.class)
-                        .addToId(RealmIdentityStore.class)
+                        .addToId(RealmIdentityStore.class + "-" + definition.value())
                         .create(e -> {
                             RealmIdentityStore mechanism = CDI.current().select(RealmIdentityStore.class).get();
                             mechanism.setConfiguration(definition);

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -71,6 +71,7 @@
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-api</artifactId>
+                <version>${jakartaee.api.version}</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -296,6 +297,7 @@
                     <dependency>
                         <groupId>jakarta.annotation</groupId>
                         <artifactId>jakarta.annotation-api</artifactId>
+                        <version>${jakarta.annotation-api.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
@@ -61,7 +61,6 @@ made subject to such option by the copyright holder. -->
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <scope>test</scope>
-            <version>2.29.payara-p2</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/main/java/fish/payara/samples/realm/identity/store/MultipleRealmIdentityStoreAppConfig.java
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/main/java/fish/payara/samples/realm/identity/store/MultipleRealmIdentityStoreAppConfig.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.realm.identity.store;
+
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.USER;
+import fish.payara.security.annotations.RealmIdentityStoreDefinition;
+import javax.annotation.security.DeclareRoles;
+import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+@DeclareRoles({ADMIN, USER})
+@ApplicationPath("resources")
+@BasicAuthenticationMechanismDefinition
+@RealmIdentityStoreDefinition("file")
+@RealmIdentityStoreDefinition("new-file-realm")
+public class MultipleRealmIdentityStoreAppConfig extends Application {
+}

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/MultipleRealmIdentityStoreDefinitionTest.java
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/MultipleRealmIdentityStoreDefinitionTest.java
@@ -1,0 +1,127 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.realm.identity.store;
+
+import fish.payara.samples.ServerOperations;
+import fish.payara.samples.realm.identity.store.common.AuthoritiesConstants;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_PASSWORD;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_USER;
+import fish.payara.samples.realm.identity.store.common.Person;
+import fish.payara.samples.realm.identity.store.common.PersonController;
+import fish.payara.samples.realm.identity.store.common.PersonControllerClient;
+import static fish.payara.samples.realm.identity.store.common.PersonControllerClientHelper.getBasicPersonControllerClient;
+import java.net.URL;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.valid4j.matchers.http.HttpResponseMatchers.hasStatus;
+
+/**
+ * @author Gaurav Gupta
+ */
+@RunWith(Arquillian.class)
+public class MultipleRealmIdentityStoreDefinitionTest {
+
+    @ArquillianResource
+    private URL deploymentUrl;
+
+    private static final String NEW_USER = "RealmTestUser2";
+
+    private static final Person NEW_INSTANCE = new Person(NEW_USER, "Realm2", "Test");
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        ServerOperations.setupContainerFileIdentityStore("new-file-realm");
+        ServerOperations.restartContainer();
+        return create(WebArchive.class)
+                .addClasses(
+                        MultipleRealmIdentityStoreAppConfig.class,
+                        Person.class,
+                        PersonController.class,
+                        AuthoritiesConstants.class
+                )
+                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
+    }
+
+    @Before
+    public void addTestUser() {
+        ServerOperations.addUserToContainerIdentityStore("file", DEFAULT_USER, ADMIN);
+        ServerOperations.addUserToContainerIdentityStore("new-file-realm", NEW_USER, ADMIN);
+    }
+
+    @Test
+    public void testWithCorrectCredentials() throws Exception {
+        PersonControllerClient client = getBasicPersonControllerClient(deploymentUrl, DEFAULT_USER, DEFAULT_PASSWORD);
+        Response response = client.createPerson(Person.DEFAULT_INSTANCE);
+        assertThat(response, hasStatus(CREATED));
+
+        client = getBasicPersonControllerClient(deploymentUrl, NEW_USER, DEFAULT_PASSWORD);
+        response = client.createPerson(NEW_INSTANCE);
+        assertThat(response, hasStatus(CREATED));
+    }
+
+    @Test
+    public void testWithIncorrectCredentials() throws Exception {
+        PersonControllerClient client = getBasicPersonControllerClient(deploymentUrl, DEFAULT_USER, "invalid_passwd");
+        try {
+            client.createPerson(Person.DEFAULT_INSTANCE);
+            fail("/api/person could be accessed without proper security credentials");
+        } catch (WebApplicationException wae) {
+            assertNotNull(wae);
+            assertThat(wae.getResponse(), hasStatus(UNAUTHORIZED));
+        }
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/resources/addUsersPayara.txt
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/resources/addUsersPayara.txt
@@ -1,1 +1,2 @@
-create-file-user --groups ROLE_ADMIN --passwordfile ${user.dir}/src/test/resources/password.txt test
+create-file-user --groups ROLE_ADMIN --passwordfile ${user.dir}/src/test/resources/password.txt RealmTestUser
+create-file-user --groups ROLE_ADMIN --passwordfile ${user.dir}/src/test/resources/password.txt --authrealmname new-file-realm RealmTestUser2

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
@@ -487,6 +487,34 @@ public class ServerOperations {
         // WildFly ./bin/add-user.sh -a -u u1 -p p1 -g g1
     }
 
+    public static void setupContainerFileIdentityStore(String fileRealmName) {
+
+        String javaEEServer = System.getProperty("javaEEServer");
+
+        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
+
+            System.out.println("Setting up container File identity store for " + javaEEServer);
+
+            List<String> cmd = new ArrayList<>();
+
+            cmd.add("create-auth-realm");
+            cmd.add("--classname");
+            cmd.add("com.sun.enterprise.security.auth.realm.file.FileRealm");
+            cmd.add("--property");
+            cmd.add("jaas-context=fileRealm:file=" + fileRealmName);
+            cmd.add(fileRealmName);
+
+            CliCommands.payaraGlassFish(cmd);
+        } else {
+            if (javaEEServer == null) {
+                System.out.println("javaEEServer not specified");
+            } else {
+                System.out.println(javaEEServer + " not supported");
+            }
+        }
+
+    }
+
     public static X509Certificate createSelfSignedCertificate(KeyPair keys) {
         try {
             Provider provider = new BouncyCastleProvider();


### PR DESCRIPTION
# Description
This is a bug fix for registration of multiple realm Identity Stores.

# Testing

### New tests
`appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/MultipleRealmIdentityStoreDefinitionTest.java`

### Test suites executed
- Payara Samples

