### PR TITLE
CUSTCOM-77 Payara-Samples integrated to the Payara build

### DIFF
--- a/appserver/tests/payara-samples/classpath/embedded-vs-jersey/pom.xml
+++ b/appserver/tests/payara-samples/classpath/embedded-vs-jersey/pom.xml
@@ -55,41 +55,9 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>payara4</id>
-            <activation>
-                <property>
-                    <name>payara.version</name>
-                    <value>/4.+/</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>payara-client-ee7</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    
-        <profile>
-            <id>payara5</id>
-            <activation>
-                <property>
-                    <name>payara.version</name>
-                    <value>/5.+/</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>payara-client-ee8</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/appserver/tests/payara-samples/classpath/embedded-vs-jersey/pom.xml
+++ b/appserver/tests/payara-samples/classpath/embedded-vs-jersey/pom.xml
@@ -55,9 +55,5 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/classpath/embedded-vs-jersey/pom.xml
+++ b/appserver/tests/payara-samples/classpath/embedded-vs-jersey/pom.xml
@@ -44,13 +44,30 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>classpath</artifactId>
+        <artifactId>samples-classpath-checked</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
     <artifactId>embedded-vs-jersey</artifactId>
+    <name>Payara Samples - Running Jersey Client with Payara Embedded</name>
+
+    <properties>
+        <payara.embedded.version>${payara.version}</payara.embedded.version>
+    </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-embedded-all</artifactId>
+            <!-- forced override required to test different versions -->
+            <version>[${payara.embedded.version}]</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/appserver/tests/payara-samples/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
+++ b/appserver/tests/payara-samples/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
@@ -45,6 +45,10 @@ import org.junit.Test;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+/**
+ * Tests if it is possible to use jersey client with embedded payara on the classpath.
+ * Response does not matter, it is only required to execute the request.
+ */
 public class JerseyClasspathTest {
 
     @Test

--- a/appserver/tests/payara-samples/classpath/pom.xml
+++ b/appserver/tests/payara-samples/classpath/pom.xml
@@ -11,7 +11,10 @@
     <packaging>pom</packaging>
 
     <name>Classpath tests</name>
-    <description>These test verify that artifacts provide classpath isolated enough not to interfere with client code in unexpected ways.</description>
+    <description>
+      These test verify that artifacts provide classpath isolated enough not to interfere
+      with client code in unexpected ways.
+    </description>
 
     <modules>
         <module>embedded-vs-jersey</module>
@@ -36,6 +39,9 @@
                                     <excludes>
                                         <exclude>*:*</exclude>
                                     </excludes>
+                                    <includes>
+                                        <include>com.sun:tools-jar</include>
+                                    </includes>
                                     <message>This module cannot inherit any dependencies to keep children's classpaths clean</message>
                                 </bannedDependencies>
                             </rules>

--- a/appserver/tests/payara-samples/classpath/pom.xml
+++ b/appserver/tests/payara-samples/classpath/pom.xml
@@ -7,10 +7,9 @@
         <version>5.201-SNAPSHOT</version>
     </parent>
 
-    <artifactId>classpath</artifactId>
+    <artifactId>samples-classpath-checked</artifactId>
     <packaging>pom</packaging>
-
-    <name>Classpath tests</name>
+    <name>Payara Samples - Classpath Tests</name>
     <description>
       These test verify that artifacts provide classpath isolated enough not to interfere
       with client code in unexpected ways.
@@ -25,7 +24,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
@@ -41,6 +39,8 @@
                                     </excludes>
                                     <includes>
                                         <include>com.sun:tools-jar</include>
+                                        <include>junit:junit</include>
+                                        <include>org.hamcrest:hamcrest-core</include>
                                     </includes>
                                     <message>This module cannot inherit any dependencies to keep children's classpaths clean</message>
                                 </bannedDependencies>

--- a/appserver/tests/payara-samples/classpath/pom.xml
+++ b/appserver/tests/payara-samples/classpath/pom.xml
@@ -3,7 +3,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>payara-samples-aggregator</artifactId>
+        <artifactId>payara-samples</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <groupId>fish.payara.samples</groupId>
-    <artifactId>payara-samples-aggregator</artifactId>
+    <artifactId>payara-samples</artifactId>
     <packaging>pom</packaging>
 
     <name>Payara Samples - root</name>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -67,10 +67,6 @@
         </repository>
     </repositories>
 
-    <dependencies>
-        <!-- DO NOT ADD DEPENDENCIES -->
-    </dependencies>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -122,7 +118,7 @@
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
-                <version>0.30.0</version>
+                <version>0.32.0</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -7,10 +7,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>fish.payara.server</groupId>
-        <artifactId>payara-aggregator</artifactId>
+        <groupId>fish.payara.server.internal.tests</groupId>
+        <artifactId>payara-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
     </parent>
 
     <groupId>fish.payara.samples</groupId>
@@ -53,6 +52,21 @@
         <module>classpath</module>
     </modules>
 
+    <repositories>
+        <!-- omnifaces jacc-provider is not in any other repository -->
+        <repository>
+            <id>payara-eclipse</id>
+            <name>Payara Eclipse</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/eclipse</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- DO NOT ADD DEPENDENCIES -->
     </dependencies>
@@ -62,8 +76,7 @@
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-bom</artifactId>
-                <!-- A workaround for case when module redefines its version (rest-monitoring-war) -->
-                <version>${project.parent.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -85,6 +98,11 @@
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-micro</artifactId>
+                <version>${payara.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.server.internal.extras</groupId>
+                <artifactId>payara-micro-boot</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
@@ -110,24 +128,6 @@
 
             <!-- Testing Dependencies -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.valid4j</groupId>
                 <artifactId>http-matchers</artifactId>
                 <version>1.1</version>
@@ -150,37 +150,37 @@
                 <version>1.4.197</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.main.security</groupId>
+                <groupId>fish.payara.server.internal.security</groupId>
                 <artifactId>security</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.main.common</groupId>
+                <groupId>fish.payara.server.internal.common</groupId>
                 <artifactId>internal-api</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.main.deployment</groupId>
+                <groupId>fish.payara.server.internal.deployment</groupId>
                 <artifactId>dol</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.main.common</groupId>
+                <groupId>fish.payara.server.internal.common</groupId>
                 <artifactId>simple-glassfish-api</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
-                <groupId>fish.payara.payara-modules</groupId>
+                <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>notification-core</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
-                <groupId>fish.payara.payara-modules</groupId>
+                <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>healthcheck-core</artifactId>
                 <version>${payara.version}</version>
             </dependency>
             <dependency>
-                <groupId>fish.payara.payara-modules</groupId>
+                <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>healthcheck-stuck</artifactId>
                 <version>${payara.version}</version>
             </dependency>
@@ -268,7 +268,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${java.min.version}</source>
                     <target>${java.min.version}</target>
@@ -285,21 +284,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
-
                 <configuration>
                     <systemPropertyVariables>
                         <isUsingMicroProfile>${micro.isActive}</isUsingMicroProfile>
                     </systemPropertyVariables>
                 </configuration>
-
-                <dependencies>
-                    <dependency>
-                        <groupId>jakarta.annotation</groupId>
-                        <artifactId>jakarta.annotation-api</artifactId>
-                        <version>${jakarta.annotation-api.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -322,7 +311,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <attachClasses>true</attachClasses>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -359,81 +347,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-
-            <url>https://repo.maven.apache.org/maven2</url>
-
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>payara-milestones</id>
-            <name>Payara Milestones</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>payara-eclipse</id>
-            <name>Payara Eclipse</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/eclipse</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>ossrh</id>
-            <name>Sonatype-snapshot</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-staging</id>
-            <name>Java.net Staging Repositories</name>
-            <url>https://maven.java.net/content/repositories/staging</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-    </repositories>
-
     <reporting>
         <plugins>
             <plugin>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -22,29 +22,14 @@
         <java.min.version>1.8</java.min.version>
         <maven.min.version>3.5</maven.min.version>
 
-        <maven.test.skip>false</maven.test.skip>
-        <skipTests>false</skipTests>
-
-        <skipEJB>${skipTests}</skipEJB>
-        <skipCDI>${skipTests}</skipCDI>
-        <skipJSF>${skipTests}</skipJSF>
-        <skipJACC>${skipTests}</skipJACC>
-
-        <!-- Micro implementation versions (these are downloaded and installed
-            in these versions by Maven for the CI profiles) -->
+        <arquillian.payara.micro.version>2.0</arquillian.payara.micro.version>
+        <arquillian.payara.remote.version>2.0</arquillian.payara.remote.version>
         <payara.version>${project.version}</payara.version>
-        <payara.container.version>2.0</payara.container.version>
-        <payara.micro.container.version>2.0</payara.micro.container.version>
-        <payara_domain>domain1</payara_domain>
+        <payara.domain.name>domain1</payara.domain.name>
 
         <micro.isActive>false</micro.isActive>
     </properties>
 
-
-    <!--
-        The vendors for which this project is providing samples for.
-        Each vendor is represented by one module. "test-utils" is a helper module.
-    -->
     <modules>
         <module>test-utils</module>
         <module>samples</module>
@@ -72,262 +57,137 @@
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-bom</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Java EE -->
+
             <dependency>
-                <groupId>jakarta.platform</groupId>
-                <artifactId>jakarta.jakartaee-api</artifactId>
-                <version>${jakartaee.api.version}</version>
-                <scope>provided</scope>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.5.0.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
-            <!-- Payara Dependencies -->
             <dependency>
-                <groupId>fish.payara.api</groupId>
-                <artifactId>payara-api</artifactId>
+                <groupId>org.omnifaces</groupId>
+                <artifactId>jacc-provider</artifactId>
+                <version>0.3</version>
+            </dependency>
+            <!-- JSON Web Token implementation -->
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>7.1</version>
+            </dependency>
+            <!-- Used to automatically configure microprofile rest client in tests -->
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-config</artifactId>
+                <version>1.3.7</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.server.internal.admin</groupId>
+                <artifactId>config-api</artifactId>
                 <version>${payara.version}</version>
-                <scope>provided</scope>
+                <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>fish.payara.extras</groupId>
-                <artifactId>payara-micro</artifactId>
+                <groupId>fish.payara.server.internal.common</groupId>
+                <artifactId>internal-api</artifactId>
                 <version>${payara.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.server.internal.common</groupId>
+                <artifactId>simple-glassfish-api</artifactId>
+                <version>${payara.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.extras</groupId>
                 <artifactId>payara-micro-boot</artifactId>
                 <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee8</artifactId>
-                <version>${payara.container.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee7</artifactId>
-                <version>${payara.container.version}</version>
+                <groupId>fish.payara.server.internal.payara-modules</groupId>
+                <artifactId>hazelcast-bootstrap</artifactId>
+                <version>${payara.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.server.internal.payara-modules</groupId>
+                <artifactId>healthcheck-core</artifactId>
+                <version>${payara.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.server.internal.payara-modules</groupId>
+                <artifactId>healthcheck-stuck</artifactId>
+                <version>${payara.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.server.internal.security</groupId>
+                <artifactId>security</artifactId>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
 
-            <!-- MicroProfile Dependencies -->
             <dependency>
-                <groupId>io.opentracing</groupId>
-                <artifactId>opentracing-api</artifactId>
-                <version>0.32.0</version>
-                <scope>provided</scope>
+                <groupId>net.sourceforge.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>2.35.0</version>
+                <scope>test</scope>
             </dependency>
-
-            <!-- Testing Dependencies -->
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.9.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.omnifaces</groupId>
+                <artifactId>omniutils</artifactId>
+                <version>0.11</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.valid4j</groupId>
                 <artifactId>http-matchers</artifactId>
                 <version>1.1</version>
                 <scope>test</scope>
             </dependency>
-
-            <!-- Arquillian BOM -->
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.4.1.Final</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <!-- Internal Dependencies -->
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>1.4.197</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.security</groupId>
-                <artifactId>security</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.common</groupId>
-                <artifactId>internal-api</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.deployment</groupId>
-                <artifactId>dol</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.common</groupId>
-                <artifactId>simple-glassfish-api</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.payara-modules</groupId>
-                <artifactId>notification-core</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.payara-modules</groupId>
-                <artifactId>healthcheck-core</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.internal.payara-modules</groupId>
-                <artifactId>healthcheck-stuck</artifactId>
-                <version>${payara.version}</version>
-            </dependency>
-
-            <!-- Miscellaneous Utility Dependencies-->
-            <dependency>
-                <groupId>org.omnifaces</groupId>
-                <artifactId>omniutils</artifactId>
-                <version>0.11</version>
-            </dependency>
-            <dependency>
-                <groupId>com.jayway.awaitility</groupId>
-                <artifactId>awaitility</artifactId>
-                <version>1.7.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>net.sourceforge.htmlunit</groupId>
-                <artifactId>htmlunit</artifactId>
-                <version>2.35.0</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>4.5.8</version>
-            </dependency>
-            <dependency>
-                <groupId>xmlunit</groupId>
-                <artifactId>xmlunit</artifactId>
-                <version>1.6</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.skyscreamer</groupId>
-                <artifactId>jsonassert</artifactId>
-                <version>1.5.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>rhino</groupId>
-                <artifactId>js</artifactId>
-                <version>1.7R2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>20180130</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>7.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>1.61</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>1.61</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <build>
-        <finalName>${project.artifactId}</finalName>
-
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>
                 <filtering>true</filtering>
             </testResource>
         </testResources>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.min.version}</source>
-                    <target>${java.min.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.21.0</version>
-                <configuration>
-                    <aggregate>true</aggregate>
-                    <linkXRef>true</linkXRef>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <isUsingMicroProfile>${micro.isActive}</isUsingMicroProfile>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
-                <configuration>
-                    <!-- run all tests in a single thread (less server start/stop,
-                        occupied ports etc.) -->
-                    <forkCount>1</forkCount>
-                    <reuseForks>true</reuseForks>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <configuration>
-                    <attachClasses>true</attachClasses>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
+                <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M1</version>
                 <configuration>
                     <rules>
                         <requireMavenVersion>
-                            <message>At least Maven in version
-                                ${maven.min.version} is
-                                required.</message>
+                            <message>At least Maven in version ${maven.min.version} is required.</message>
                             <version>${maven.min.version}</version>
                         </requireMavenVersion>
                         <requireJavaVersion>
-                            <message>At least a JDK in version
-                                ${java.min.version} is
-                                required.</message>
+                            <message>At least a JDK in version ${java.min.version} is required.</message>
                             <version>${java.min.version}</version>
                         </requireJavaVersion>
                     </rules>
@@ -340,22 +200,55 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-            </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>${java.min.version}</source>
+                        <target>${java.min.version}</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <isUsingMicroProfile>${micro.isActive}</isUsingMicroProfile>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                    <configuration>
+                        <!-- don't run tests in parallel -->
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.2.3</version>
+                    <configuration>
+                        <attachClasses>true</attachClasses>
+                        <failOnMissingWebXml>false</failOnMissingWebXml>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <linkXRef>true</linkXRef>
@@ -363,5 +256,4 @@
             </plugin>
         </plugins>
     </reporting>
-
 </project>

--- a/appserver/tests/payara-samples/samples-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/samples-programmatic/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>payara-micro</artifactId>
         </dependency>
         <dependency>
+            <groupId>fish.payara.server.internal.extras</groupId>
+            <artifactId>payara-micro-boot</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/appserver/tests/payara-samples/samples-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/samples-programmatic/pom.xml
@@ -18,6 +18,7 @@
         <dependency>
             <groupId>fish.payara.extras</groupId>
             <artifactId>payara-micro</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.extras</groupId>

--- a/appserver/tests/payara-samples/samples-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/samples-programmatic/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>payara-samples-aggregator</artifactId>
+        <artifactId>payara-samples</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 

--- a/appserver/tests/payara-samples/samples/asadmin/pom.xml
+++ b/appserver/tests/payara-samples/samples/asadmin/pom.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c) 
-    [2019] Payara Foundation and/or its affiliates. All rights reserved. The 
-    contents of this file are subject to the terms of either the GNU General 
-    Public License Version 2 only ("GPL") or the Common Development and Distribution 
-    License("CDDL") (collectively, the "License"). You may not use this file 
-    except in compliance with the License. You can obtain a copy of the License 
-    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License 
-    for the specific language governing permissions and limitations under the 
-    License. When distributing the software, include this License Header Notice 
-    in each file and include the License file at glassfish/legal/LICENSE.txt. 
-    GPL Classpath Exception: The Payara Foundation designates this particular 
-    file as subject to the "Classpath" exception as provided by the Payara Foundation 
-    in the GPL Version 2 section of the License file that accompanied this code. 
-    Modifications: If applicable, add the following below the License Header, 
-    with the fields enclosed by brackets [] replaced by your own identifying 
-    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s): 
-    If you wish your version of this file to be governed by only the CDDL or 
-    only the GPL Version 2, indicate your decision by adding "[Contributor] elects 
-    to include this software in this distribution under the [CDDL or GPL Version 
-    2] license." If you don't indicate a single choice of license, a recipient 
-    has the option to distribute your version of this file under either the CDDL, 
-    the GPL Version 2 or to extend the choice of license to its licensees as 
-    provided above. However, if you add GPL Version 2 code and therefore, elected 
-    the GPL Version 2 license, then the option applies only if the new code is 
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c)
+    [2019] Payara Foundation and/or its affiliates. All rights reserved. The
+    contents of this file are subject to the terms of either the GNU General
+    Public License Version 2 only ("GPL") or the Common Development and Distribution
+    License("CDDL") (collectively, the "License"). You may not use this file
+    except in compliance with the License. You can obtain a copy of the License
+    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License
+    for the specific language governing permissions and limitations under the
+    License. When distributing the software, include this License Header Notice
+    in each file and include the License file at glassfish/legal/LICENSE.txt.
+    GPL Classpath Exception: The Payara Foundation designates this particular
+    file as subject to the "Classpath" exception as provided by the Payara Foundation
+    in the GPL Version 2 section of the License file that accompanied this code.
+    Modifications: If applicable, add the following below the License Header,
+    with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor] elects
+    to include this software in this distribution under the [CDDL or GPL Version
+    2] license." If you don't indicate a single choice of license, a recipient
+    has the option to distribute your version of this file under either the CDDL,
+    the GPL Version 2 or to extend the choice of license to its licensees as
+    provided above. However, if you add GPL Version 2 code and therefore, elected
+    the GPL Version 2 license, then the option applies only if the new code is
     made subject to such option by the copyright holder. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -41,19 +41,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.main.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>notification-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/samples/asadmin/pom.xml
+++ b/appserver/tests/payara-samples/samples/asadmin/pom.xml
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -41,12 +41,21 @@
 
     <dependencies>
         <dependency>
+          <groupId>fish.payara.server.internal.admin</groupId>
+          <artifactId>config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>internal-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
-            <artifactId>notification-core</artifactId>
+            <artifactId>hazelcast-bootstrap</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
@@ -55,6 +64,11 @@
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/pom.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/pom.xml
@@ -59,4 +59,32 @@
     <build>
         <finalName>clustered_singleton</finalName>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/src/main/java/fish/payara/samples/clustered/singleton/ejb/HelloServlet.java
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/src/main/java/fish/payara/samples/clustered/singleton/ejb/HelloServlet.java
@@ -42,14 +42,14 @@
 
 package fish.payara.samples.clustered.singleton.ejb;
 
+import java.io.IOException;
+
 import javax.ejb.EJB;
-import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 /**
  * @author Rudy De Busscher

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/src/test/java/fish/payara/samples/clustered/singleton/ejb/ClusteredSingletonEjbTest.java
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/src/test/java/fish/payara/samples/clustered/singleton/ejb/ClusteredSingletonEjbTest.java
@@ -1,3 +1,5 @@
+package fish.payara.samples.clustered.singleton.ejb;
+
 /*
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/appserver/tests/payara-samples/samples/clustered-singleton/pom.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/pom.xml
@@ -47,7 +47,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-impl/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-impl/pom.xml
@@ -16,19 +16,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.main.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>org.glassfish.main.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>org.glassfish.main.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-impl/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-impl/pom.xml
@@ -18,14 +18,11 @@
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
-            <artifactId>dol</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-   
+
     <parent>
         <groupId>fish.payara.samples</groupId>
         <artifactId>custom-loginmodule-realm</artifactId>
@@ -15,8 +15,29 @@
         <dependency>
             <groupId>fish.payara.samples</groupId>
             <artifactId>loginmodule-realm-impl</artifactId>
-	        <version>${payara.version}</version>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.security</groupId>
+            <artifactId>security</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/src/test/java/fish/payara/samples/loginmodule/realm/custom/CustomLoginModuleRealmTest.java
@@ -39,12 +39,15 @@
  */
 package fish.payara.samples.loginmodule.realm.custom;
 
-import static fish.payara.samples.ServerOperations.addMavenJarsToContainerLibFolder;
-import static org.junit.Assert.assertTrue;
+import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
+
+import fish.payara.samples.CliCommands;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,15 +62,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-
-import fish.payara.samples.CliCommands;
-import fish.payara.samples.NotMicroCompatible;
-import fish.payara.samples.PayaraArquillianTestRunner;
-import static fish.payara.samples.ServerOperations.*;
+import static fish.payara.samples.ServerOperations.addMavenJarsToContainerLibFolder;
+import static fish.payara.samples.ServerOperations.getPayaraDomainFromServer;
+import static fish.payara.samples.ServerOperations.restartContainer;
+import static org.junit.Assert.assertTrue;
 
 @NotMicroCompatible
 @RunWith(PayaraArquillianTestRunner.class)
@@ -123,9 +121,9 @@ public class CustomLoginModuleRealmTest {
 
     @Test
     @RunAsClient
-    public void testAuthenticationWithCorrectUser() throws FailingHttpStatusCodeException, MalformedURLException, IOException {
+    public void testAuthenticationWithCorrectUser() throws Exception {
 
-        System.out.println("\n\nRequesting: " + (base + "testServlet"));
+        System.out.println("\n\nRequesting: " + base + "testServlet");
 
         DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
         credentialsProvider.addCredentials("realmUser", "realmPassword");

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 

--- a/appserver/tests/payara-samples/samples/dynamic-roles/pom.xml
+++ b/appserver/tests/payara-samples/samples/dynamic-roles/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> 
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-   
+
     <parent>
         <groupId>fish.payara.samples</groupId>
         <artifactId>samples-parent</artifactId>
@@ -13,12 +13,6 @@
     <name>Payara Samples - Payara - Dynamic Roles</name>
 
     <dependencies>
-        <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.valid4j</groupId>
             <artifactId>http-matchers</artifactId>

--- a/appserver/tests/payara-samples/samples/dynamic-roles/pom.xml
+++ b/appserver/tests/payara-samples/samples/dynamic-roles/pom.xml
@@ -4,7 +4,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -14,15 +14,60 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+            <artifactId>jersey-mp-rest-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.valid4j</groupId>
             <artifactId>http-matchers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-config</artifactId>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
             <scope>test</scope>
-            <version>1.3.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/dynamic-roles/src/test/java/fish/payara/samples/dynamic/roles/cdi/DynamicRolesCDITest.java
+++ b/appserver/tests/payara-samples/samples/dynamic-roles/src/test/java/fish/payara/samples/dynamic/roles/cdi/DynamicRolesCDITest.java
@@ -39,38 +39,41 @@
  */
 package fish.payara.samples.dynamic.roles.cdi;
 
+import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.dynamic.roles.PersonControllerClient;
-import static fish.payara.samples.dynamic.roles.PersonControllerClientHelper.getPersonControllerClient;
 import fish.payara.samples.dynamic.roles.common.AuthoritiesConstants;
-import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_PASSWORD;
-import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_USER;
-import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INSTANCE;
-import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INVALID_ACCEESS_TYPE_INSTANCE;
+
 import java.io.File;
 import java.net.URL;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.dynamic.roles.PersonControllerClientHelper.getPersonControllerClient;
+import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_PASSWORD;
+import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_USER;
+import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INSTANCE;
+import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INVALID_ACCEESS_TYPE_INSTANCE;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasStatus;
 
 /**
- *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class DynamicRolesCDITest {
 
     private static final String WEBAPP_SOURCE = "src/main/webapp";

--- a/appserver/tests/payara-samples/samples/dynamic-roles/src/test/java/fish/payara/samples/dynamic/roles/ejb/DynamicRolesEJBTest.java
+++ b/appserver/tests/payara-samples/samples/dynamic-roles/src/test/java/fish/payara/samples/dynamic/roles/ejb/DynamicRolesEJBTest.java
@@ -39,39 +39,42 @@
  */
 package fish.payara.samples.dynamic.roles.ejb;
 
+import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.dynamic.roles.PersonControllerClient;
-import static fish.payara.samples.dynamic.roles.PersonControllerClientHelper.getPersonControllerClient;
 import fish.payara.samples.dynamic.roles.common.AuthoritiesConstants;
-import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_PASSWORD;
-import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_USER;
 import fish.payara.samples.dynamic.roles.common.Person;
-import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INSTANCE;
-import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INVALID_ACCEESS_TYPE_INSTANCE;
+
 import java.io.File;
 import java.net.URL;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.dynamic.roles.PersonControllerClientHelper.getPersonControllerClient;
+import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_PASSWORD;
+import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_USER;
+import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INSTANCE;
+import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INVALID_ACCEESS_TYPE_INSTANCE;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasStatus;
 
 /**
- *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class DynamicRolesEJBTest {
 
     private static final String WEBAPP_SOURCE = "src/main/webapp";

--- a/appserver/tests/payara-samples/samples/dynamic-roles/src/test/java/fish/payara/samples/dynamic/roles/rest/DynamicRolesRESTTest.java
+++ b/appserver/tests/payara-samples/samples/dynamic-roles/src/test/java/fish/payara/samples/dynamic/roles/rest/DynamicRolesRESTTest.java
@@ -39,38 +39,41 @@
  */
 package fish.payara.samples.dynamic.roles.rest;
 
+import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.dynamic.roles.PersonControllerClient;
-import static fish.payara.samples.dynamic.roles.PersonControllerClientHelper.getPersonControllerClient;
 import fish.payara.samples.dynamic.roles.common.AuthoritiesConstants;
-import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_PASSWORD;
-import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_USER;
-import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INSTANCE;
-import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INVALID_ACCEESS_TYPE_INSTANCE;
+
 import java.io.File;
 import java.net.URL;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.dynamic.roles.PersonControllerClientHelper.getPersonControllerClient;
+import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_PASSWORD;
+import static fish.payara.samples.dynamic.roles.common.AuthoritiesConstants.DEFAULT_USER;
+import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INSTANCE;
+import static fish.payara.samples.dynamic.roles.common.Person.DEFAULT_INVALID_ACCEESS_TYPE_INSTANCE;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasStatus;
 
 /**
- *
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class DynamicRolesRESTTest {
 
     private static final String WEBAPP_SOURCE = "src/main/webapp";

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/api/pom.xml
@@ -51,36 +51,22 @@
     </parent>
 
     <artifactId>api</artifactId>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <name>Payara Samples - EJB http remoting - common api</name>
     <dependencies>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
-            <version>1.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>1.1.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/client/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/client/pom.xml
@@ -43,7 +43,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.samples.ejb-http-remoting</groupId>
         <artifactId>ejb-http-remoting</artifactId>
@@ -51,8 +51,10 @@
     </parent>
 
     <artifactId>client</artifactId>
+    <name>Payara Samples - EJB http remoting - client application</name>
 
     <properties>
+        <deployableName>server-app</deployableName>
         <payara.adminPort>4848</payara.adminPort>
         <payara.username>admin</payara.username>
         <payara.password></payara.password>
@@ -65,76 +67,40 @@
 
     <dependencies>
         <dependency>
+            <groupId>fish.payara.samples.ejb-http-remoting</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.extras</groupId>
             <artifactId>ejb-http-client</artifactId>
-	        <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.mq</groupId>
+            <artifactId>imq</artifactId>
+            <version>5.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.9.1</version>
-            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>fish.payara.samples.ejb-http-remoting</groupId>
-            <artifactId>api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.mq</groupId>
-            <artifactId>imq</artifactId><!-- mq-client hasn't been released by EE4J-->
-            <version>5.1</version>
-        </dependency>
-
     </dependencies>
 
-    <!-- This will use cargo for testing to keep all the dependencies away from the test classpath -->
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.21.0</version>
-                <executions>
-                    <execution>
-                        <id>perform-it</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <systemProperties>
-                                <property>
-                                    <name>servlet.port</name>
-                                    <value>${servlet.port}</value>
-                                </property>
-                            </systemProperties>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-it</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-server-app</id>
+                        <id>copy-${deployableName}</id>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -145,7 +111,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>${project.groupId}</groupId>
-                                    <artifactId>server-app</artifactId>
+                                    <artifactId>${deployableName}</artifactId>
                                     <version>${project.version}</version>
                                     <type>war</type>
                                 </artifactItem>
@@ -154,82 +120,58 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
-                <configuration>
-                    <skip>${skipTests}</skip>
-                </configuration>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>deploy</id>
+                        <id>configure-domain-ejb-invoker</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>redeploy</goal>
+                            <goal>exec</goal>
                         </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>set-ejb-invoker-configuration --enabled=true</commandlineArgs>
+                        </configuration>
                     </execution>
                     <execution>
-                        <id>undeploy</id>
+                        <id>deploy-${deployableName}</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>deploy ${project.build.directory}/dependency/${deployableName}.war</commandlineArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>undeploy-${deployableName}</id>
                         <phase>post-integration-test</phase>
                         <goals>
-                            <goal>undeploy</goal>
+                            <goal>exec</goal>
                         </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>undeploy ${deployableName}</commandlineArgs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <systemProperties>
+                        <property>
+                            <name>servlet.port</name>
+                            <value>${servlet.port}</value>
+                        </property>
+                    </systemProperties>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
         </plugins>
-
-
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.cargo</groupId>
-                    <artifactId>cargo-maven2-plugin</artifactId>
-                    <version>1.7.3</version>
-                    <configuration>
-                        <container>
-                            <containerId>glassfish5x</containerId>
-                            <type>remote</type>
-                        </container>
-                        <configuration>
-                            <type>runtime</type>
-                            <properties>
-                                <cargo.remote.username>${payara.username}</cargo.remote.username>
-                                <cargo.remote.password>${payara.password}</cargo.remote.password>
-                                <cargo.glassfish.admin.port>${payara.adminPort}</cargo.glassfish.admin.port>
-                                <cargo.hostname>${payara.hostname}</cargo.hostname>
-                                <cargo.servlet.port>${servlet.port}</cargo.servlet.port>
-                            </properties>
-                        </configuration>
-                        <deployables>
-                            <deployable>
-                                <properties>
-                                    <context>server-app</context>
-                                </properties>
-                                <location>${project.build.directory}/dependency/server-app.war</location>
-                                <type>war</type>
-                            </deployable>
-                        </deployables>
-                    </configuration>
-                    <!-- provides JSR88 client API to deploy on Payara -->
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.glassfish.main.deployment</groupId>
-                            <artifactId>deployment-client</artifactId>
-                            <version>5.0</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
@@ -88,7 +88,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
@@ -102,6 +101,11 @@
                                     <excludes>
                                         <exclude>*:*</exclude>
                                     </excludes>
+                                    <includes>
+                                        <include>com.sun:tools-jar</include>
+                                        <include>junit:junit</include>
+                                        <include>org.hamcrest:hamcrest-core</include>
+                                    </includes>
                                     <message>This module cannot inherit any dependencies to keep children's classpaths clean</message>
                                 </bannedDependencies>
                             </rules>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
@@ -49,12 +49,12 @@
     </modules>
 
     <!--
-        This test needs to have no dependencies other than the ejb-http-remoting 
+        This test needs to have no dependencies other than the ejb-http-remoting
         module. Make sure that no dependencies are added to the parent.
     -->
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>payara-samples-aggregator</artifactId>
+        <artifactId>payara-samples</artifactId>
         <version>5.201-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/server-app/pom.xml
@@ -52,11 +52,7 @@
 
     <artifactId>server-app</artifactId>
     <packaging>war</packaging>
-
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+    <name>Payara Samples - EJB http remoting - server application</name>
 
     <dependencies>
         <dependency>
@@ -64,20 +60,10 @@
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.2</version>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> 
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-   
+
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -14,14 +14,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.valid4j</groupId>
-            <artifactId>http-matchers</artifactId>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>ejb-http-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.extras</groupId>
-            <artifactId>ejb-http-client</artifactId>
-            <version>${payara.version}</version>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/AbstractRemoteBeanSecurityTest.java
+++ b/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/AbstractRemoteBeanSecurityTest.java
@@ -40,6 +40,26 @@
 package fish.payara.samples.ejb.invoker.security;
 
 import fish.payara.ejb.http.client.RemoteEJBContextFactory;
+import fish.payara.ejb.http.protocol.SerializationType;
+import fish.payara.samples.ServerOperations;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
 import static fish.payara.ejb.http.client.RemoteEJBContextFactory.JAXRS_CLIENT_KEY_STORE;
 import static fish.payara.ejb.http.client.RemoteEJBContextFactory.JAXRS_CLIENT_KEY_STORE_PASSOWRD;
 import static fish.payara.ejb.http.client.RemoteEJBContextFactory.JAXRS_CLIENT_PROTOCOL_VERSION;
@@ -48,32 +68,15 @@ import static fish.payara.ejb.http.client.RemoteEJBContextFactory.JAXRS_CLIENT_T
 import static fish.payara.ejb.http.client.RemoteEJBContextFactory.PROVIDER_AUTH_TYPE;
 import static fish.payara.ejb.http.client.RemoteEJBContextFactory.PROVIDER_CREDENTIALS;
 import static fish.payara.ejb.http.client.RemoteEJBContextFactory.PROVIDER_PRINCIPAL;
-import fish.payara.ejb.http.protocol.SerializationType;
-import fish.payara.samples.ServerOperations;
 import static fish.payara.samples.ServerOperations.getClientTrustStoreURL;
 import static fish.payara.samples.ServerOperations.getKeyStore;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Hashtable;
-import javax.naming.Context;
 import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
 import static javax.naming.Context.PROVIDER_URL;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
 import static javax.ws.rs.core.SecurityContext.BASIC_AUTH;
-import static javax.ws.rs.core.SecurityContext.CLIENT_CERT_AUTH;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import static org.jboss.shrinkwrap.api.asset.EmptyAsset.INSTANCE;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import org.junit.Test;
 
 /**
  *

--- a/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/RemoteBeanBasicAuthTest.java
+++ b/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/RemoteBeanBasicAuthTest.java
@@ -40,13 +40,15 @@
 package fish.payara.samples.ejb.invoker.security;
 
 import fish.payara.samples.CliCommands;
-import static fish.payara.samples.ServerOperations.addUsersToContainerIdentityStore;
-import static java.util.Arrays.asList;
-import static javax.ws.rs.core.SecurityContext.BASIC_AUTH;
+
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.ServerOperations.addUsersToContainerIdentityStore;
+import static java.util.Arrays.asList;
+import static javax.ws.rs.core.SecurityContext.BASIC_AUTH;
 
 /**
  * Calls an EJB bean from a remote server via ejb-invoker endpoint secured with
@@ -59,7 +61,7 @@ public class RemoteBeanBasicAuthTest extends AbstractRemoteBeanSecurityTest {
     private static final String USERNAME = "myuser";
     private static final String PASSWORD = "mypassword";
     private static final String ROLE = "invoker";
-    
+
     @BeforeClass
     public static void enableSecurity() {
         // undeploy the ejb-invoker app

--- a/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/RemoteBeanCustomRealmTest.java
+++ b/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/RemoteBeanCustomRealmTest.java
@@ -40,12 +40,14 @@
 package fish.payara.samples.ejb.invoker.security;
 
 import fish.payara.samples.CliCommands;
-import static fish.payara.samples.ServerOperations.addUsersToContainerIdentityStore;
-import static java.util.Arrays.asList;
+
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.ServerOperations.addUsersToContainerIdentityStore;
+import static java.util.Arrays.asList;
 
 /**
  * Calls an EJB bean from a remote server via ejb-invoker endpoint secured with
@@ -67,7 +69,7 @@ public class RemoteBeanCustomRealmTest extends AbstractRemoteBeanSecurityTest {
                 "--classname", "com.sun.enterprise.security.auth.realm.file.FileRealm",
                 "--login-module", "com.sun.enterprise.security.auth.login.FileLoginModule",
                 "--property", "jaas-context=fileRealm:file=" + REALM, REALM));
-        
+
         // undeploy the ejb-invoker app
         CliCommands.payaraGlassFish(asList("set-ejb-invoker-configuration",
                 "--enabled", "false"));
@@ -85,7 +87,7 @@ public class RemoteBeanCustomRealmTest extends AbstractRemoteBeanSecurityTest {
     public static void resetSecurity() {
         // delete the auth realm
         CliCommands.payaraGlassFish(asList("delete-auth-realm", REALM));
-                
+
         // undeploy the ejb-invoker app
         CliCommands.payaraGlassFish(asList("set-ejb-invoker-configuration",
                 "--enabled", "false"));

--- a/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/RemoteBeanCustomRoleTest.java
+++ b/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/src/test/java/fish/payara/samples/ejb/invoker/security/RemoteBeanCustomRoleTest.java
@@ -40,12 +40,14 @@
 package fish.payara.samples.ejb.invoker.security;
 
 import fish.payara.samples.CliCommands;
-import static fish.payara.samples.ServerOperations.addUsersToContainerIdentityStore;
-import static java.util.Arrays.asList;
+
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.ServerOperations.addUsersToContainerIdentityStore;
+import static java.util.Arrays.asList;
 
 /**
  * Calls an EJB bean from a remote server via secured ejb-invoker endpoint

--- a/appserver/tests/payara-samples/samples/formauth/pom.xml
+++ b/appserver/tests/payara-samples/samples/formauth/pom.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c) 
-    [2019] Payara Foundation and/or its affiliates. All rights reserved. The 
-    contents of this file are subject to the terms of either the GNU General 
-    Public License Version 2 only ("GPL") or the Common Development and Distribution 
-    License("CDDL") (collectively, the "License"). You may not use this file 
-    except in compliance with the License. You can obtain a copy of the License 
-    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License 
-    for the specific language governing permissions and limitations under the 
-    License. When distributing the software, include this License Header Notice 
-    in each file and include the License file at glassfish/legal/LICENSE.txt. 
-    GPL Classpath Exception: The Payara Foundation designates this particular 
-    file as subject to the "Classpath" exception as provided by the Payara Foundation 
-    in the GPL Version 2 section of the License file that accompanied this code. 
-    Modifications: If applicable, add the following below the License Header, 
-    with the fields enclosed by brackets [] replaced by your own identifying 
-    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s): 
-    If you wish your version of this file to be governed by only the CDDL or 
-    only the GPL Version 2, indicate your decision by adding "[Contributor] elects 
-    to include this software in this distribution under the [CDDL or GPL Version 
-    2] license." If you don't indicate a single choice of license, a recipient 
-    has the option to distribute your version of this file under either the CDDL, 
-    the GPL Version 2 or to extend the choice of license to its licensees as 
-    provided above. However, if you add GPL Version 2 code and therefore, elected 
-    the GPL Version 2 license, then the option applies only if the new code is 
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c)
+    [2019] Payara Foundation and/or its affiliates. All rights reserved. The
+    contents of this file are subject to the terms of either the GNU General
+    Public License Version 2 only ("GPL") or the Common Development and Distribution
+    License("CDDL") (collectively, the "License"). You may not use this file
+    except in compliance with the License. You can obtain a copy of the License
+    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License
+    for the specific language governing permissions and limitations under the
+    License. When distributing the software, include this License Header Notice
+    in each file and include the License file at glassfish/legal/LICENSE.txt.
+    GPL Classpath Exception: The Payara Foundation designates this particular
+    file as subject to the "Classpath" exception as provided by the Payara Foundation
+    in the GPL Version 2 section of the License file that accompanied this code.
+    Modifications: If applicable, add the following below the License Header,
+    with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor] elects
+    to include this software in this distribution under the [CDDL or GPL Version
+    2] license." If you don't indicate a single choice of license, a recipient
+    has the option to distribute your version of this file under either the CDDL,
+    the GPL Version 2 or to extend the choice of license to its licensees as
+    provided above. However, if you add GPL Version 2 code and therefore, elected
+    the GPL Version 2 license, then the option applies only if the new code is
     made subject to such option by the copyright holder. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -39,4 +39,10 @@
     <name>Payara Samples - Payara - FORM Auth</name>
     <packaging>war</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/formauth/src/test/java/fish/payara/samples/formauth/PermittedFormBasedAuthHttpMethodsTest.java
+++ b/appserver/tests/payara-samples/samples/formauth/src/test/java/fish/payara/samples/formauth/PermittedFormBasedAuthHttpMethodsTest.java
@@ -40,7 +40,8 @@
 package fish.payara.samples.formauth;
 
 
-import static org.junit.Assert.assertEquals;
+import fish.payara.samples.CliCommands;
+import fish.payara.samples.PayaraArquillianTestRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +52,6 @@ import java.net.URL;
 import java.util.Arrays;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -60,12 +60,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import fish.payara.samples.CliCommands;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Verifies that the {@code fish.payara.permittedFormBasedAuthHttpMethods} system property has an effect.
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class PermittedFormBasedAuthHttpMethodsTest {
 
     @ArquillianResource

--- a/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
@@ -19,5 +19,10 @@
             <groupId>org.omnifaces</groupId>
             <artifactId>jacc-provider</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
@@ -18,8 +18,6 @@
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>jacc-provider</artifactId>
-            <version>0.1</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -18,11 +18,56 @@
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>jacc-provider</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.jacc</groupId>
+            <artifactId>jakarta.security.jacc-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>-DpomPath=${basedir}/pom.xml</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/appserver/tests/payara-samples/samples/jacc-per-app/src/test/java/fish/payara/samples/jaccperapp/InstallJaccProviderTest.java
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/src/test/java/fish/payara/samples/jaccperapp/InstallJaccProviderTest.java
@@ -2,10 +2,8 @@
 
 package fish.payara.samples.jaccperapp;
 
-import static javax.ws.rs.client.ClientBuilder.newClient;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.junit.Assert.assertTrue;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
 
 import java.io.IOException;
 import java.net.URI;
@@ -20,9 +18,10 @@ import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import fish.payara.arquillian.ws.rs.WebApplicationException;
-import fish.payara.samples.NotMicroCompatible;
-import fish.payara.samples.PayaraArquillianTestRunner;
+import static javax.ws.rs.client.ClientBuilder.newClient;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This sample tests that we can install a custom JACC provider
@@ -100,25 +99,18 @@ public class InstallJaccProviderTest {
     @RunAsClient
     public void testNotAuthenticated() throws IOException {
 
-        try {
-            String response =
-                    newClient()
-                         .target(
-                             URI.create(new URL(base, "protected/servlet").toExternalForm()))
-                         .request(TEXT_PLAIN)
-                         .get(String.class);
+        String response =
+                newClient()
+                     .target(
+                         URI.create(new URL(base, "protected/servlet").toExternalForm()))
+                     .request(TEXT_PLAIN)
+                     .get(String.class);
 
-            System.out.println("-------------------------------------------------------------------------");
-            System.out.println("Response: \n\n" + response);
-            System.out.println("-------------------------------------------------------------------------");
+        System.out.println("-------------------------------------------------------------------------");
+        System.out.println("Response: \n\n" + response);
+        System.out.println("-------------------------------------------------------------------------");
 
-            assertTrue(
-                !response.contains("web user has role \"a\": true")
-            );
-        } catch (WebApplicationException e) {
-            // Ignore, no access
-        }
-
+        assertTrue(!response.contains("web user has role \"a\": true"));
     }
 
 }

--- a/appserver/tests/payara-samples/samples/jacc-per-app/src/test/java/fish/payara/samples/jaccperapp/InstallJaccProviderTest.java
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/src/test/java/fish/payara/samples/jaccperapp/InstallJaccProviderTest.java
@@ -12,15 +12,17 @@ import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static javax.ws.rs.client.ClientBuilder.newClient;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -38,6 +40,14 @@ public class InstallJaccProviderTest {
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
+        String pomPath = System.getProperty("pomPath");
+        System.out.println(pomPath);
+        assertNotNull("System property pomPath", pomPath);
+        MavenResolvedArtifact jaccLibrary = Maven.resolver()
+             .loadPomFromFile(pomPath)
+             .resolve("org.omnifaces:jacc-provider")
+             .withTransitivity()
+             .asSingleResolvedArtifact();
         WebArchive archive =
             create(WebArchive.class)
                 .addClasses(
@@ -46,12 +56,7 @@ public class InstallJaccProviderTest {
                     ProtectedServlet.class,
                     TestAuthenticationMechanism.class,
                     TestIdentityStore.class
-                ).addAsLibraries(
-                    Maven.resolver()
-                         .loadPomFromFile("pom.xml")
-                         .resolve("org.omnifaces:jacc-provider")
-                         .withTransitivity()
-                         .as(JavaArchive.class))
+                ).addAsLibraries(jaccLibrary.asFile())
                 ;
 
         System.out.println("************************************************************");
@@ -110,7 +115,7 @@ public class InstallJaccProviderTest {
         System.out.println("Response: \n\n" + response);
         System.out.println("-------------------------------------------------------------------------");
 
-        assertTrue(!response.contains("web user has role \"a\": true"));
+        assertFalse(response.contains("web user has role \"a\": true"));
     }
 
 }

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/pom.xml
@@ -6,13 +6,36 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-rolesallowed-servlet</artifactId>
     <packaging>war</packaging>
     <name>Payara Samples - Payara - JAX-RS using RolesAllowed and Servlet Security</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/src/test/java/fish/payara/samples/jaxrs/rolesallowed/servlet/JAXRSRolesAllowedEETest.java
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/src/test/java/fish/payara/samples/jaxrs/rolesallowed/servlet/JAXRSRolesAllowedEETest.java
@@ -2,10 +2,7 @@
 
 package fish.payara.samples.jaxrs.rolesallowed.servlet;
 
-import static javax.ws.rs.client.ClientBuilder.newClient;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.junit.Assert.assertTrue;
+import fish.payara.samples.ServerOperations;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,7 +19,11 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import fish.payara.samples.ServerOperations;
+
+import static javax.ws.rs.client.ClientBuilder.newClient;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This sample tests that we can install a custom JACC provider

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -14,4 +14,26 @@
     <packaging>war</packaging>
     <name>Payara Samples - Payara - JAX-RS using RolesAllowed and EE Security</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed/src/test/java/fish/payara/samples/jaxrs/rolesallowed/ee/JAXRSRolesAllowedEETest.java
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed/src/test/java/fish/payara/samples/jaxrs/rolesallowed/ee/JAXRSRolesAllowedEETest.java
@@ -7,6 +7,8 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertTrue;
 
+import fish.payara.samples.PayaraArquillianTestRunner;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -16,7 +18,6 @@ import javax.ws.rs.WebApplicationException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -28,7 +29,7 @@ import org.junit.runner.RunWith;
  *
  * @author Arjan Tijms
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class JAXRSRolesAllowedEETest {
 
     @ArquillianResource

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
@@ -13,15 +13,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
+            <groupId>org.eclipse.microprofile.opentracing</groupId>
+            <artifactId>microprofile-opentracing-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
@@ -3,7 +3,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -12,6 +12,21 @@
     <name>Payara Samples - JAX-WS - Tracing</name>
 
     <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/endpoint/servlet/ServletEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/endpoint/servlet/ServletEndpointTest.java
@@ -39,9 +39,9 @@
  */
 package fish.payara.samples.jaxws.endpoint.servlet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.runners.MethodSorters.NAME_ASCENDING;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.SincePayara;
+import fish.payara.samples.jaxws.endpoint.JAXWSEndpointTest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -51,7 +51,6 @@ import javax.xml.ws.Service;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -60,10 +59,11 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import fish.payara.samples.SincePayara;
-import fish.payara.samples.jaxws.endpoint.JAXWSEndpointTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 @FixMethodOrder(NAME_ASCENDING)
 @SincePayara("5.193")
 public class ServletEndpointTest extends JAXWSEndpointTest {
@@ -82,7 +82,7 @@ public class ServletEndpointTest extends JAXWSEndpointTest {
         jaxwsEndPointService = Service.create(
             // The WSDL file used to create this service is fetched from the application we deployed
             // above using the createDeployment() method.
-                
+
             new URL(url, "JAXWSEndPointImplementationService?wsdl"),
             new QName("http://servlet.endpoint.jaxws.samples.payara.fish/", "JAXWSEndPointImplementationService"));
     }
@@ -94,7 +94,7 @@ public class ServletEndpointTest extends JAXWSEndpointTest {
                 .getPort(JAXWSEndPointInterface.class)
                 .sayHi("Payara!"));
     }
-    
+
     @Test
     // Runs on Server
     public void test2ServerCheck() throws MalformedURLException {

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/pom.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c) 
-    [2019] Payara Foundation and/or its affiliates. All rights reserved. The 
-    contents of this file are subject to the terms of either the GNU General 
-    Public License Version 2 only ("GPL") or the Common Development and Distribution 
-    License("CDDL") (collectively, the "License"). You may not use this file 
-    except in compliance with the License. You can obtain a copy of the License 
-    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License 
-    for the specific language governing permissions and limitations under the 
-    License. When distributing the software, include this License Header Notice 
-    in each file and include the License file at glassfish/legal/LICENSE.txt. 
-    GPL Classpath Exception: The Payara Foundation designates this particular 
-    file as subject to the "Classpath" exception as provided by the Payara Foundation 
-    in the GPL Version 2 section of the License file that accompanied this code. 
-    Modifications: If applicable, add the following below the License Header, 
-    with the fields enclosed by brackets [] replaced by your own identifying 
-    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s): 
-    If you wish your version of this file to be governed by only the CDDL or 
-    only the GPL Version 2, indicate your decision by adding "[Contributor] elects 
-    to include this software in this distribution under the [CDDL or GPL Version 
-    2] license." If you don't indicate a single choice of license, a recipient 
-    has the option to distribute your version of this file under either the CDDL, 
-    the GPL Version 2 or to extend the choice of license to its licensees as 
-    provided above. However, if you add GPL Version 2 code and therefore, elected 
-    the GPL Version 2 license, then the option applies only if the new code is 
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c)
+    [2019] Payara Foundation and/or its affiliates. All rights reserved. The
+    contents of this file are subject to the terms of either the GNU General
+    Public License Version 2 only ("GPL") or the Common Development and Distribution
+    License("CDDL") (collectively, the "License"). You may not use this file
+    except in compliance with the License. You can obtain a copy of the License
+    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License
+    for the specific language governing permissions and limitations under the
+    License. When distributing the software, include this License Header Notice
+    in each file and include the License file at glassfish/legal/LICENSE.txt.
+    GPL Classpath Exception: The Payara Foundation designates this particular
+    file as subject to the "Classpath" exception as provided by the Payara Foundation
+    in the GPL Version 2 section of the License file that accompanied this code.
+    Modifications: If applicable, add the following below the License Header,
+    with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor] elects
+    to include this software in this distribution under the [CDDL or GPL Version
+    2] license." If you don't indicate a single choice of license, a recipient
+    has the option to distribute your version of this file under either the CDDL,
+    the GPL Version 2 or to extend the choice of license to its licensees as
+    provided above. However, if you add GPL Version 2 code and therefore, elected
+    the GPL Version 2 license, then the option applies only if the new code is
     made subject to such option by the copyright holder. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -39,6 +39,27 @@
     <name>Payara Samples - Payara - Microprofile insecure endpoints</name>
     <packaging>war</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <profiles>
         <profile>
             <id>payara-micro-managed</id>
@@ -48,7 +69,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <environmentVariables>
-                                <EXTRA_MICRO_OPTIONS>--postbootcommandfile ${basedir}\src\test\resources\post-boot-commands.txt --sslPort 8181 --autoBindSsl</EXTRA_MICRO_OPTIONS>
+                                <EXTRA_MICRO_OPTIONS>--postbootcommandfile ${project.build.testOutputDirectory}/post-boot-commands.txt --sslPort 8181 --autoBindSsl</EXTRA_MICRO_OPTIONS>
                             </environmentVariables>
                         </configuration>
                     </plugin>

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/src/test/java/fish/payara/samples/microprofile/endpoint/insecure/MicroprofileInsecureEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/src/test/java/fish/payara/samples/microprofile/endpoint/insecure/MicroprofileInsecureEndpointTest.java
@@ -40,34 +40,38 @@
 package fish.payara.samples.microprofile.endpoint.insecure;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.junit.Assert.assertEquals;
-import java.net.URL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+
 import fish.payara.samples.CliCommands;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.ServerOperations;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import static java.util.Arrays.asList;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static org.hamcrest.Matchers.containsString;
-import org.junit.AfterClass;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import org.junit.BeforeClass;
 
 /**
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class MicroprofileInsecureEndpointTest {
 
     @ArquillianResource

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/pom.xml
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/pom.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c) 
-    [2019] Payara Foundation and/or its affiliates. All rights reserved. The 
-    contents of this file are subject to the terms of either the GNU General 
-    Public License Version 2 only ("GPL") or the Common Development and Distribution 
-    License("CDDL") (collectively, the "License"). You may not use this file 
-    except in compliance with the License. You can obtain a copy of the License 
-    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License 
-    for the specific language governing permissions and limitations under the 
-    License. When distributing the software, include this License Header Notice 
-    in each file and include the License file at glassfish/legal/LICENSE.txt. 
-    GPL Classpath Exception: The Payara Foundation designates this particular 
-    file as subject to the "Classpath" exception as provided by the Payara Foundation 
-    in the GPL Version 2 section of the License file that accompanied this code. 
-    Modifications: If applicable, add the following below the License Header, 
-    with the fields enclosed by brackets [] replaced by your own identifying 
-    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s): 
-    If you wish your version of this file to be governed by only the CDDL or 
-    only the GPL Version 2, indicate your decision by adding "[Contributor] elects 
-    to include this software in this distribution under the [CDDL or GPL Version 
-    2] license." If you don't indicate a single choice of license, a recipient 
-    has the option to distribute your version of this file under either the CDDL, 
-    the GPL Version 2 or to extend the choice of license to its licensees as 
-    provided above. However, if you add GPL Version 2 code and therefore, elected 
-    the GPL Version 2 license, then the option applies only if the new code is 
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c)
+    [2019] Payara Foundation and/or its affiliates. All rights reserved. The
+    contents of this file are subject to the terms of either the GNU General
+    Public License Version 2 only ("GPL") or the Common Development and Distribution
+    License("CDDL") (collectively, the "License"). You may not use this file
+    except in compliance with the License. You can obtain a copy of the License
+    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License
+    for the specific language governing permissions and limitations under the
+    License. When distributing the software, include this License Header Notice
+    in each file and include the License file at glassfish/legal/LICENSE.txt.
+    GPL Classpath Exception: The Payara Foundation designates this particular
+    file as subject to the "Classpath" exception as provided by the Payara Foundation
+    in the GPL Version 2 section of the License file that accompanied this code.
+    Modifications: If applicable, add the following below the License Header,
+    with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor] elects
+    to include this software in this distribution under the [CDDL or GPL Version
+    2] license." If you don't indicate a single choice of license, a recipient
+    has the option to distribute your version of this file under either the CDDL,
+    the GPL Version 2 or to extend the choice of license to its licensees as
+    provided above. However, if you add GPL Version 2 code and therefore, elected
+    the GPL Version 2 license, then the option applies only if the new code is
     made subject to such option by the copyright holder. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -39,6 +39,28 @@
     <name>Payara Samples - Payara - Microprofile Secure endpoints</name>
     <packaging>war</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+       <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <profiles>
         <profile>
             <id>payara-micro-managed</id>
@@ -49,7 +71,7 @@
                         <configuration>
                             <skipTests>${skipClientCertificate}</skipTests>
                             <environmentVariables>
-                                <EXTRA_MICRO_OPTIONS>--postbootcommandfile ${basedir}\src\test\resources\post-boot-commands.txt --sslPort 8181 --autoBindSsl</EXTRA_MICRO_OPTIONS>
+                                <EXTRA_MICRO_OPTIONS>--postbootcommandfile ${project.build.testOutputDirectory}/post-boot-commands.txt --sslPort 8181 --autoBindSsl</EXTRA_MICRO_OPTIONS>
                             </environmentVariables>
                         </configuration>
                     </plugin>

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/src/test/java/fish/payara/samples/microprofile/endpoint/secure/MicroprofileSecureEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/src/test/java/fish/payara/samples/microprofile/endpoint/secure/MicroprofileSecureEndpointTest.java
@@ -39,43 +39,47 @@
  */
 package fish.payara.samples.microprofile.endpoint.secure;
 
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import java.net.URL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+
 import fish.payara.samples.CliCommands;
+import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.ServerOperations;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import static java.util.Arrays.asList;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Gaurav Gupta
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class MicroprofileSecureEndpointTest {
 
     @ArquillianResource
     private URL base;
-    
+
     private static String clientKeyStorePath;
 
     private WebClient webClient;

--- a/appserver/tests/payara-samples/samples/oauth2/pom.xml
+++ b/appserver/tests/payara-samples/samples/oauth2/pom.xml
@@ -39,15 +39,42 @@
  holder.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>oauth2</artifactId>
     <name>Payara Samples - Payara - OAuth2</name>
     <packaging>war</packaging>
-    
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/openid/pom.xml
+++ b/appserver/tests/payara-samples/samples/openid/pom.xml
@@ -39,15 +39,62 @@
  holder.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>openid</artifactId>
     <name>Payara Samples - Payara - OpenId Connect</name>
     <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/server/ApplicationConfig.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/server/ApplicationConfig.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -39,9 +39,11 @@
  */
 package fish.payara.security.oidc.server;
 
-import static java.util.Collections.singleton;
 import java.util.Set;
+
 import javax.ws.rs.core.Application;
+
+import static java.util.Collections.singleton;
 
 /**
  *

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/server/OidcProvider.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/server/OidcProvider.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -41,6 +41,29 @@ package fish.payara.security.oidc.server;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
 import static fish.payara.security.openid.api.OpenIdConstant.ACCESS_TOKEN;
 import static fish.payara.security.openid.api.OpenIdConstant.AUTHORIZATION_CODE;
 import static fish.payara.security.openid.api.OpenIdConstant.CLIENT_ID;
@@ -56,30 +79,10 @@ import static fish.payara.security.openid.api.OpenIdConstant.SCOPE;
 import static fish.payara.security.openid.api.OpenIdConstant.STATE;
 import static fish.payara.security.openid.api.OpenIdConstant.SUBJECT_IDENTIFIER;
 import static fish.payara.security.openid.api.OpenIdConstant.TOKEN_TYPE;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URISyntaxException;
 import static java.util.Arrays.asList;
-import java.util.Date;
-import java.util.UUID;
 import static java.util.logging.Level.SEVERE;
-import java.util.logging.Logger;
 import static java.util.stream.Collectors.joining;
-import javax.json.Json;
-import javax.json.JsonObjectBuilder;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
 
 /**
  *
@@ -88,9 +91,9 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 @Path("/oidc-provider")
 public class OidcProvider {
 
-        private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_TYPE = "Bearer";
-    
+
     private static final String AUTH_CODE_VALUE = "sample_auth_code";
     private static final String ACCESS_TOKEN_VALUE = "sample_access_token";
     public static final String CLIENT_ID_VALUE = "sample_client_id";
@@ -132,7 +135,7 @@ public class OidcProvider {
         returnURL.append("?&" + STATE + "=").append(state);
         returnURL.append("&" + CODE + "=" + AUTH_CODE_VALUE);
 
-        this.nonce = nonce;
+        OidcProvider.nonce = nonce;
         JsonObjectBuilder jsonBuilder = Json.createObjectBuilder();
         if (!CODE.equals(responseType)) {
             jsonBuilder.add(ERROR_PARAM, "invalid_response_type");
@@ -181,7 +184,7 @@ public class OidcProvider {
                     .issueTime(now)
                     .jwtID(UUID.randomUUID().toString())
                     .claim(NONCE, nonce)
-                    
+
                     .build();
             PlainJWT idToken = new PlainJWT(jwtClaims);
             jsonBuilder.add(IDENTITY_TOKEN, idToken.serialize());
@@ -192,13 +195,13 @@ public class OidcProvider {
 
         return builder.entity(jsonBuilder.build()).build();
     }
-    
+
     @Path("/userinfo")
     @Produces(APPLICATION_JSON)
     @GET
     public Response userinfoEndpoint(@HeaderParam(AUTHORIZATION_HEADER) String authorizationHeader) {
         String accessToken = authorizationHeader.substring(BEARER_TYPE.length() + 1);
-        
+
         ResponseBuilder builder;
         JsonObjectBuilder jsonBuilder = Json.createObjectBuilder();
         if (ACCESS_TOKEN_VALUE.equals(accessToken)) {

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
@@ -41,23 +41,27 @@ package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.WebClient;
+
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
-import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_REDIRECT_URI;
+
 import java.io.IOException;
 import java.net.URL;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_REDIRECT_URI;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  *

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
@@ -40,12 +40,15 @@
 package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
+
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
-import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION;
+import fish.payara.samples.ServerOperations;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -55,7 +58,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import fish.payara.samples.ServerOperations;
+
+import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION;
 
 /**
  *

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
@@ -40,11 +40,13 @@
 package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
+
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
-import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE;
+
 import java.io.IOException;
 import java.net.URL;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -54,6 +56,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE;
 
 /**
  *

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -183,7 +183,6 @@
                 <dependency>
                     <groupId>fish.payara.distributions</groupId>
                     <artifactId>payara</artifactId>
-                    <version>${payara.version}</version>
                     <type>zip</type>
                 </dependency>
 
@@ -191,7 +190,6 @@
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-managed</artifactId>
-                    <version>${payara.container.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
         </dependency>
@@ -48,14 +53,6 @@
         <dependency>
             <groupId>fish.payara.api</groupId>
             <artifactId>payara-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
@@ -126,53 +123,24 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.arquillian</groupId>
+            <artifactId>payara-client-ee8</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.omnifaces</groupId>
+                <artifactId>jacc-provider</artifactId>
+                <version>0.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <profiles>
-
-        <!-- Helper profiles to set properties etc -->
-
-        <profile>
-            <id>payara4</id>
-            <activation>
-                <property>
-                    <name>payara.version</name>
-                    <value>/4.+/</value>
-                </property>
-            </activation>
-            <properties>
-                <payara.directory.name>payara41</payara.directory.name>
-                <payara.container.version>1.3</payara.container.version>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>payara-client-ee7</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>payara5</id>
-            <activation>
-                <property>
-                    <name>payara.version</name>
-                    <value>/5.+/</value>
-                </property>
-            </activation>
-            <properties>
-                <payara.directory.name>payara5</payara.directory.name>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>payara-client-ee8</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
         <profile>
             <id>stable</id>
             <build>
@@ -205,6 +173,9 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <payara.directory.name>payara5</payara.directory.name>
+            </properties>
 
             <dependencies>
 
@@ -358,7 +329,6 @@
                 <module>ejb-invoker-secure-endpoint</module>
             </modules>
             <dependencies>
-
                 <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
@@ -377,43 +347,6 @@
                                 <payara_domain>${payara_domain}</payara_domain>
                             </systemPropertyVariables>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>nothing</id>
-        </profile>
-
-        <!-- Activate this profile to download javadoc and sources jars. run: mvn
-        process-resources -Ddownload Notice: This feature has been removed with plugin
-        version 2.5, so keep this plugin configuration in a profile section. -->
-        <profile>
-            <id>javadocs</id>
-            <activation>
-                <property>
-                    <name>javadocs</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sources</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>sources</goal>
-                                    <goal>resolve</goal>
-                                </goals>
-                                <configuration>
-                                    <classifier>javadoc</classifier>
-                                    <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -5,7 +5,7 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>payara-samples-aggregator</artifactId>
+        <artifactId>payara-samples</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -9,10 +9,10 @@
         <version>5.201-SNAPSHOT</version>
     </parent>
 
-    <artifactId>samples-parent</artifactId>
+    <artifactId>payara-samples-profiled-tests</artifactId>
     <packaging>pom</packaging>
 
-    <name>Payara Samples - Payara</name>
+    <name>Payara Samples - Profiled Tests</name>
 
     <modules>
         <module>clustered-singleton</module>
@@ -31,111 +31,13 @@
         <module>realm-identity-stores</module>
     </modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.api</groupId>
-            <artifactId>payara-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>rhino</groupId>
-            <artifactId>js</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.omnifaces</groupId>
-            <artifactId>omniutils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee8</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.omnifaces</groupId>
-                <artifactId>jacc-provider</artifactId>
-                <version>0.3</version>
+                <groupId>fish.payara.samples</groupId>
+                <artifactId>test-utils</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -164,8 +66,7 @@
         <profile>
             <!--
             This profile will install a Payara server and start up the server per sample. Useful for CI servers.
-            The Payara version that's used can be set via the payara.container.version property.
-
+            The Payara version that's used can be set via the payara.version property.
             This is the default profile and does not have to be specified explicitly.
             -->
             <id>payara-server-managed</id>
@@ -232,7 +133,7 @@
                             <systemPropertyVariables>
                                 <glassfishRemote_gfHome>${session.executionRootDirectory}/target/${payara.directory.name}</glassfishRemote_gfHome>
                                 <javaEEServer>payara-remote</javaEEServer>
-                                <payara_domain>${payara_domain}</payara_domain>
+                                <payara.domain.name>${payara.domain.name}</payara.domain.name>
                                 <arquillian.launch>payara</arquillian.launch>
                             </systemPropertyVariables>
                         </configuration>
@@ -244,28 +145,19 @@
 
         <profile>
             <id>payara-micro-managed</id>
-
             <!--
             This profile will install a Payara Micro and start up the server per sample. Useful for CI servers.
             The Payara version that's used can be set via the payara.version property.
             -->
-
             <properties>
-                <skipJMS>true</skipJMS>
-                <skipJAXWS>true</skipJAXWS>
-                <skipClientCertificate>true</skipClientCertificate>
                 <micro.isActive>true</micro.isActive>
             </properties>
 
             <dependencies>
-                <!-- Java EE based client dependencies to contact a server via WebSocket
-                or REST -->
-
-                <!-- The Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-micro-managed</artifactId>
-                    <version>${payara.micro.container.version}</version>
+                    <version>${arquillian.payara.micro.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -312,26 +204,21 @@
 
         <profile>
             <id>payara-server-remote</id>
-
             <!--
             This profile requires you to start up a Payara server outside of the build.
 
             Each sample will then reuse this instance to run the tests.
             Useful for development to avoid the server start up cost per sample.
-
             -->
-
-            <!-- http remoting tests are only available remote, with asadmin set-ejb-invoker-configuration \-\-enabled=true -->
             <modules>
                 <module>ejb-http-remoting</module>
                 <module>ejb-invoker-secure-endpoint</module>
             </modules>
             <dependencies>
-                <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-remote</artifactId>
-                    <version>${payara.container.version}</version>
+                    <version>${arquillian.payara.remote.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -342,7 +229,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <javaEEServer>payara-remote</javaEEServer>
-                                <payara_domain>${payara_domain}</payara_domain>
+                                <payara.domain.name>${payara.domain.name}</payara.domain.name>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c) 
-[2019] Payara Foundation and/or its affiliates. All rights reserved. The 
-contents of this file are subject to the terms of either the GNU General 
-Public License Version 2 only ("GPL") or the Common Development and Distribution 
-License("CDDL") (collectively, the "License"). You may not use this file 
-except in compliance with the License. You can obtain a copy of the License 
-at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License 
-for the specific language governing permissions and limitations under the 
-License. When distributing the software, include this License Header Notice 
-in each file and include the License file at glassfish/legal/LICENSE.txt. 
-GPL Classpath Exception: The Payara Foundation designates this particular 
-file as subject to the "Classpath" exception as provided by the Payara Foundation 
-in the GPL Version 2 section of the License file that accompanied this code. 
-Modifications: If applicable, add the following below the License Header, 
-with the fields enclosed by brackets [] replaced by your own identifying 
-information: "Portions Copyright [year] [name of copyright owner]" Contributor(s): 
-If you wish your version of this file to be governed by only the CDDL or 
-only the GPL Version 2, indicate your decision by adding "[Contributor] elects 
-to include this software in this distribution under the [CDDL or GPL Version 
-2] license." If you don't indicate a single choice of license, a recipient 
-has the option to distribute your version of this file under either the CDDL, 
-the GPL Version 2 or to extend the choice of license to its licensees as 
-provided above. However, if you add GPL Version 2 code and therefore, elected 
-the GPL Version 2 license, then the option applies only if the new code is 
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c)
+[2019] Payara Foundation and/or its affiliates. All rights reserved. The
+contents of this file are subject to the terms of either the GNU General
+Public License Version 2 only ("GPL") or the Common Development and Distribution
+License("CDDL") (collectively, the "License"). You may not use this file
+except in compliance with the License. You can obtain a copy of the License
+at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License
+for the specific language governing permissions and limitations under the
+License. When distributing the software, include this License Header Notice
+in each file and include the License file at glassfish/legal/LICENSE.txt.
+GPL Classpath Exception: The Payara Foundation designates this particular
+file as subject to the "Classpath" exception as provided by the Payara Foundation
+in the GPL Version 2 section of the License file that accompanied this code.
+Modifications: If applicable, add the following below the License Header,
+with the fields enclosed by brackets [] replaced by your own identifying
+information: "Portions Copyright [year] [name of copyright owner]" Contributor(s):
+If you wish your version of this file to be governed by only the CDDL or
+only the GPL Version 2, indicate your decision by adding "[Contributor] elects
+to include this software in this distribution under the [CDDL or GPL Version
+2] license." If you don't indicate a single choice of license, a recipient
+has the option to distribute your version of this file under either the CDDL,
+the GPL Version 2 or to extend the choice of license to its licensees as
+provided above. However, if you add GPL Version 2 code and therefore, elected
+the GPL Version 2 license, then the option applies only if the new code is
 made subject to such option by the copyright holder. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -40,12 +40,6 @@ made subject to such option by the copyright holder. -->
     <packaging>war</packaging>
 
     <dependencies>
-        <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.valid4j</groupId>
             <artifactId>http-matchers</artifactId>

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
@@ -31,7 +31,7 @@ made subject to such option by the copyright holder. -->
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
@@ -41,19 +41,64 @@ made subject to such option by the copyright holder. -->
 
     <dependencies>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+            <artifactId>jersey-mp-rest-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.valid4j</groupId>
             <artifactId>http-matchers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-config</artifactId>
-            <scope>test</scope>
-            <version>1.3.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/main/java/fish/payara/samples/realm/identity/store/DynamicRealmIdentityStoreAppConfig.java
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/main/java/fish/payara/samples/realm/identity/store/DynamicRealmIdentityStoreAppConfig.java
@@ -39,14 +39,16 @@
  */
 package fish.payara.samples.realm.identity.store;
 
-import static fish.payara.samples.realm.identity.store.DynamicRealmIdentityStoreAppConfig.REALM_NAME;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.USER;
 import fish.payara.security.annotations.FileIdentityStoreDefinition;
+
 import javax.annotation.security.DeclareRoles;
 import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+
+import static fish.payara.samples.realm.identity.store.DynamicRealmIdentityStoreAppConfig.REALM_NAME;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.USER;
 
 /**
  *

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/main/java/fish/payara/samples/realm/identity/store/common/PersonController.java
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/main/java/fish/payara/samples/realm/identity/store/common/PersonController.java
@@ -39,9 +39,9 @@
  */
 package fish.payara.samples.realm.identity.store.common;
 
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
 import java.net.URI;
 import java.net.URISyntaxException;
+
 import javax.annotation.security.RolesAllowed;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -50,6 +50,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
 
 /**
  * REST controller for managing Person.

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/DynamicRealmIdentityStoreDefinitionTest.java
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/DynamicRealmIdentityStoreDefinitionTest.java
@@ -40,34 +40,37 @@
 package fish.payara.samples.realm.identity.store;
 
 import fish.payara.samples.ServerOperations;
-import static fish.payara.samples.realm.identity.store.DynamicRealmIdentityStoreAppConfig.REALM_NAME;
 import fish.payara.samples.realm.identity.store.common.AuthoritiesConstants;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_PASSWORD;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_USER;
 import fish.payara.samples.realm.identity.store.common.Person;
 import fish.payara.samples.realm.identity.store.common.PersonController;
 import fish.payara.samples.realm.identity.store.common.PersonControllerClient;
-import static fish.payara.samples.realm.identity.store.common.PersonControllerClientHelper.getBasicPersonControllerClient;
-import java.io.File;
+
 import java.net.URL;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ArchivePaths;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.realm.identity.store.DynamicRealmIdentityStoreAppConfig.REALM_NAME;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_PASSWORD;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_USER;
+import static fish.payara.samples.realm.identity.store.common.PersonControllerClientHelper.getBasicPersonControllerClient;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasStatus;
 
 /**

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/ExistingRealmIdentityStoreDefinitionTest.java
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/src/test/java/fish/payara/samples/realm/identity/store/ExistingRealmIdentityStoreDefinitionTest.java
@@ -41,32 +41,35 @@ package fish.payara.samples.realm.identity.store;
 
 import fish.payara.samples.ServerOperations;
 import fish.payara.samples.realm.identity.store.common.AuthoritiesConstants;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_PASSWORD;
-import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_USER;
 import fish.payara.samples.realm.identity.store.common.Person;
 import fish.payara.samples.realm.identity.store.common.PersonController;
 import fish.payara.samples.realm.identity.store.common.PersonControllerClient;
-import static fish.payara.samples.realm.identity.store.common.PersonControllerClientHelper.getBasicPersonControllerClient;
-import java.io.File;
+
 import java.net.URL;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ArchivePaths;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.ADMIN;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_PASSWORD;
+import static fish.payara.samples.realm.identity.store.common.AuthoritiesConstants.DEFAULT_USER;
+import static fish.payara.samples.realm.identity.store.common.PersonControllerClientHelper.getBasicPersonControllerClient;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasStatus;
 
 /**

--- a/appserver/tests/payara-samples/samples/rolesPermitted/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesPermitted/pom.xml
@@ -1,14 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-   
+
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>samples-parent</artifactId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
 
     <artifactId>rolesPermitted</artifactId>
     <packaging>war</packaging>
     <name>Payara Samples - Payara - Roles Permitted</name>
-    
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/appserver/tests/payara-samples/samples/rolesPermitted/src/test/java/fish/payara/samples/rolespermitted/RolesPermittedTest.java
+++ b/appserver/tests/payara-samples/samples/rolesPermitted/src/test/java/fish/payara/samples/rolespermitted/RolesPermittedTest.java
@@ -43,29 +43,33 @@ import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebResponse;
+
+import fish.payara.samples.PayaraArquillianTestRunner;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.runner.RunWith;
-import org.junit.Before;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.junit.Test;
 
 /**
  *
  * @author Susan Rai
  */
-@RunWith(Arquillian.class)
+@RunWith(PayaraArquillianTestRunner.class)
 public class RolesPermittedTest {
 
     private static final String WEBAPP_SOURCE = "src/main/webapp";

--- a/appserver/tests/payara-samples/test-utils/pom.xml
+++ b/appserver/tests/payara-samples/test-utils/pom.xml
@@ -14,6 +14,26 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <scope>compile</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <scope>compile</scope>
+        </dependency>
+       <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.omnifaces</groupId>
+            <artifactId>omniutils</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>
@@ -27,21 +47,11 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.omnifaces</groupId>
-            <artifactId>omniutils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/payara-samples/test-utils/pom.xml
+++ b/appserver/tests/payara-samples/test-utils/pom.xml
@@ -5,10 +5,10 @@
 
     <parent>
         <groupId>fish.payara.samples</groupId>
-        <artifactId>payara-samples-aggregator</artifactId>
+        <artifactId>payara-samples</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>test-utils</artifactId>
     <name>Payara Samples - test-utils</name>
 
@@ -44,5 +44,5 @@
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestRunnerDelegate.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestRunnerDelegate.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -42,15 +42,13 @@ package fish.payara.samples;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
 /**
  * A class used by all Payara test runners to utilise the custom annotations.
- * 
+ *
  * @author Matt Gill
  */
 public class PayaraTestRunnerDelegate extends BlockJUnit4ClassRunner {

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
@@ -172,10 +172,10 @@ public class ServerOperations {
                 return;
             }
                         
-            String domain = System.getProperty("payara_domain");
+            String domain = System.getProperty("payara.domain.name");
             if (domain == null) {
                 domain = getPayaraDomainFromServer();
-                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara_domain to override.");
+                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
             }
             
             Path libsPath = gfHomePath.resolve("glassfish/lib");
@@ -232,10 +232,10 @@ public class ServerOperations {
                 return;
             }
                         
-            String domain = System.getProperty("payara_domain", "domain1");
+            String domain = System.getProperty("payara.domain.name", "domain1");
             if (domain != null) {
                 domain = getPayaraDomainFromServer();
-                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara_domain to override.");
+                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
             }
             
             Path cacertsPath = gfHomePath.resolve("glassfish/domains/" + domain + "/config/cacerts.jks");
@@ -378,7 +378,7 @@ public class ServerOperations {
             
             String restartDomain = domain;
             if (restartDomain == null) {
-                restartDomain = System.getProperty("payara_domain");
+                restartDomain = System.getProperty("payara.domain.name");
             }
             
             if (restartDomain == null) {
@@ -607,7 +607,7 @@ public class ServerOperations {
 
         // Add the client certificate that we just generated to the trust store of the server.
         // That way the server will trust our certificate.
-        // Set the actual domain used with -Dpayara_domain=[domain name]
+        // Set the actual domain used with -Dpayara.domain.name=[domain name]
         addCertificateToContainerTrustStore(clientCertificate);
 
         return clientKeyStorePath;

--- a/appserver/tests/payara-samples/test-utils/src/main/resources/arquillian.xml
+++ b/appserver/tests/payara-samples/test-utils/src/main/resources/arquillian.xml
@@ -7,7 +7,7 @@
     
      <container qualifier="payara">
         <configuration>
-            <property name="domain">${payara_domain}</property>
+            <property name="domain">${payara.domain.name}</property>
         </configuration>
      </container>
      

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -68,6 +68,12 @@
                 <module>quicklook</module>
             </modules>
         </profile>
+        <profile>
+            <id>payara-samples</id>
+            <modules>
+                <module>payara-samples</module>
+            </modules>
+        </profile>
     </profiles>
 
     <build>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -77,27 +77,18 @@
     </profiles>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
                     <configuration>
                         <skip>true</skip>
                     </configuration>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -56,7 +56,14 @@
 
     <profiles>
         <profile>
+            <!-- deprecated, remove after replacing with quicklook -->
             <id>ci</id>
+            <modules>
+                <module>quicklook</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>quicklook</id>
             <modules>
                 <module>quicklook</module>
             </modules>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -50,7 +50,7 @@
     </parent>
 
     <groupId>fish.payara.server.internal.tests</groupId>
-    <artifactId>tests</artifactId>
+    <artifactId>payara-tests</artifactId>
     <packaging>pom</packaging>
     <name>GlassFish Tests related modules</name>
 

--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -44,24 +44,24 @@
 <!--"Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]" -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.server.internal.tests</groupId>
-        <artifactId>tests</artifactId>
+        <artifactId>payara-tests</artifactId>
         <version>5.201-SNAPSHOT</version>
     </parent>
-    
+
     <groupId>org.glassfish.quicklook</groupId>
     <artifactId>quicklook</artifactId>
     <name>Glassfish Quicklook Bundle</name>
     <description>This pom describes how to run QuickLook tests on the Glassfish Bundle</description>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        
+
         <jruby-all.version>1.5.4</jruby-all.version>
         <jruby-all.classifier>1.3.1</jruby-all.classifier>
         <domain.name>test-domain</domain.name>
@@ -86,12 +86,12 @@
                                 <echo message="${line.separator} ###############################" />
                                 <echo message="plugin classpath:  ${plugin_classpath}"/>
                                 <echo message="${line.separator}" />
-                                
-                                
+
+
                                 <if>
                                     <equals arg1="${test.gd}" arg2="true" />
                                     <then>
-                                        
+
                                         <echo>${line.separator}</echo>
                                         <echo>+--------------------------------------------+</echo>
                                         <echo>|                                            |</echo>
@@ -101,16 +101,16 @@
                                         <echo>${line.separator}</echo>
                                         <echo>glassfish.home: ${glassfish.home} </echo>
                                         <echo>domain.name: ${domain.name} </echo>
-                                        
+
                                         <ant dir="." antfile="build.xml" target="all">
                                             <property name="glassfish.home" value="${glassfish.home}"/>
                                             <property name="domain.name" value="${domain.name}"/>
                                             <property name="jruby-all.version" value="${jruby-all.version}"/>
                                             <property name="jruby-all.classifier" value="${jruby-all.classifier}"/>
-                                        </ant>                                        
+                                        </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${test.wd}" arg2="true" />
                                     <then>
@@ -119,7 +119,7 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${test.em}" arg2="true" />
                                     <then>
@@ -128,7 +128,7 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${test.ri}" arg2="true" />
                                     <then>
@@ -137,7 +137,7 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${test.wd.security}" arg2="true" />
                                     <then>
@@ -146,7 +146,7 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${start.wd.security}" arg2="true" />
                                     <then>
@@ -155,7 +155,7 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${stop.wd.security}" arg2="true" />
                                     <then>
@@ -164,7 +164,7 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${test.gd.security}" arg2="true" />
                                     <then>
@@ -175,14 +175,14 @@
                                         </ant>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <isset property="test.report" />
                                     <then>
                                         <ant dir="." antfile="build.xml" target="report"/>
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <equals arg1="${test.debug}" arg2="true" />
                                     <then>
@@ -198,7 +198,7 @@
                         </goals>
                     </execution>
                 </executions>
-                
+
                 <dependencies>
                     <dependency>
                         <groupId>commons-codec</groupId>
@@ -302,56 +302,56 @@
                 <test.report>test-output</test.report>
             </properties>
         </profile>
-        
+
         <profile>
             <id>test_wd</id>
             <properties>
                 <test.wd>true</test.wd>
             </properties>
         </profile>
-        
+
         <profile>
             <id>test_em</id>
             <properties>
                 <test.em>true</test.em>
             </properties>
         </profile>
-        
+
         <profile>
             <id>test_ri</id>
             <properties>
                 <test.ri>true</test.ri>
             </properties>
         </profile>
-        
+
         <profile>
             <id>test_wd_security</id>
             <properties>
                 <test.wd.security>true</test.wd.security>
             </properties>
         </profile>
-        
+
         <profile>
             <id>start_wd_security</id>
             <properties>
                 <start.wd.security>true</start.wd.security>
             </properties>
         </profile>
-        
+
         <profile>
             <id>stop_wd_security</id>
             <properties>
                 <stop.wd.security>true</stop.wd.security>
             </properties>
         </profile>
-        
+
         <profile>
             <id>test_gd_security</id>
             <properties>
                 <test.gd.security>true</test.gd.security>
             </properties>
         </profile>
-        
+
         <profile>
             <id>dev_debug</id>
             <properties>
@@ -359,6 +359,6 @@
             </properties>
         </profile>
     </profiles>
-    
+
 </project>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -892,16 +892,19 @@ Parent is ${project.parent}</echo>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>6.14.3</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jmockit</groupId>
                 <artifactId>jmockit</artifactId>
                 <version>1.40</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/nucleus/test-utils/utils-ng/pom.xml
+++ b/nucleus/test-utils/utils-ng/pom.xml
@@ -63,8 +63,8 @@
             </roles>
         </developer>
     </developers>
-    
-    <dependencies>    
+
+    <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
@@ -73,6 +73,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>compile</scope>
         </dependency>
-    </dependencies>    
+    </dependencies>
 </project>

--- a/nucleus/test-utils/utils/pom.xml
+++ b/nucleus/test-utils/utils/pom.xml
@@ -64,8 +64,8 @@
             </roles>
         </developer>
     </developers>
-    
-    <dependencies>    
+
+    <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-core</artifactId>
@@ -75,22 +75,14 @@
             <artifactId>hk2-junitrunner</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.stream</groupId>
-            <artifactId>sjsxp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
-        </dependency>      
-        <dependency>
-            <groupId>javax.xml.stream</groupId>
-            <artifactId>stax-api</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <optional>true</optional>
+            <scope>compile</scope>
         </dependency>
-    </dependencies>    
+    </dependencies>
 </project>


### PR DESCRIPTION
# Description

Examples how to run:
```
 # run only samples, payara instance managed by Maven
mvn clean install -Ppayara-samples -pl :payara-samples -amd -fae

# run payara build and samples directly at once
mvn clean install -PQuickBuild,payara-samples -fae 

# run samples and all it's modules
mvn clean install -PQuickBuild,payara-samples -pl :payara-samples -amd -fae 

# with different implementation; some modules will fail because groupIds changed.
mvn clean install -PQuickBuild,payara-samples -pl :payara-samples -amd -Dpayara.version=5.193.1 -fae 

# in payara-samples directory
cd appserver/tests/payara-samples;
mvn clean verify -fae 

# test embedded payara and jersey-client running in the same JVM (currently fails on 5.193.1 and newer)
mvn clean verify -Ppayara-samples -fae -rf :payara-samples -Dpayara.embedded.version=5.193.1

# remote tests, payara managed manually - 6 modules should fail, due to some undeployment bug will fail one more if tried more times on the same domain
mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:payara-samples -Ppayara-server-remote -amd -Dpayara.home=/app/payara5

# micro
mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:payara-samples -amd -Ppayara-micro-managed 

# 
```
# Results

remote: 5/6 failures on master
managed: 2 failures on master, 1 with -Dpayara.version=5.193
micro: 5 failures on master

# Warning

The build uses target in the current directory of the reactor, so changing current directory still affects results, because clean does not delete unpacked payara if used with -rf or -pl skipping project in current directory.
This will be resolved after finishing PAYARA-4176 after which we will probably use different mechanism.

# Remaining failures

mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:embedded-vs-jersey
- fails always, will be fixed under CUSTCOM-70

mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:openid 
- fails on remote due to hostname verification
- passes on managed
- on micro ignored

mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:jaxws-tracing
- fails on all profiles
- on managed+remote - tracing is not enabled
- on micro - wsdl is not on the expected context

mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:formauth
- fails only on micro, HTTP 200 instead of 403

mvn clean verify -Ppayara-samples -fae -pl fish.payara.samples:microprofile-secure-endpoints 
- fails on remote (hostname verification)
- fails on micro (No https URL could be created from http://localhost:8910/dcf53e26-e8a6-47a9-b67f-317ad93139ad/)





