### PR TITLE
APPSERV-18 Use application name provided by a user when a deployment descriptor does not define the name

### DIFF
--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericHandler.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericHandler.java
@@ -150,6 +150,9 @@ public abstract class GenericHandler implements ArchiveHandler {
         String appName = null;
         if (nameProvider != null) {
             appName = nameProvider.getNameFor(archive, context);
+            if (originalAppName != null && appName.equals(archive.getName())) {
+                appName = originalAppName;
+            }
             if (appName != null) {
                 return appName;
             }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericHandler.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericHandler.java
@@ -150,14 +150,15 @@ public abstract class GenericHandler implements ArchiveHandler {
         String appName = null;
         if (nameProvider != null) {
             appName = nameProvider.getNameFor(archive, context);
-            if (originalAppName != null && appName.equals(archive.getName())) {
-                appName = originalAppName;
-            }
+
             if (appName != null) {
+                if (originalAppName != null && appName.equals(archive.getName())) {
+                    appName = originalAppName;
+                }
                 return appName;
             }
         }
-        
+
         if (originalAppName != null) {
             return originalAppName;
         }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is an improvement to use application name provided by a user if a deployment descriptor does not define the name. 

# Testing

### Testing Performed
Tested both the `deploy` and `redeploy` command to make sure the improvement works as intended. 

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4>

# Documentation
TODO

# Notes for Reviewers
<!-- Please give notes for any reviewers. The code should explain itself, but where should they start? Do you want feedback on anything specific? -->
<!-- Have you tagged any appropriate reviewers?-->
