### PR TITLE
CUSTCOM-81 Display port number on start-domain with --debug=true option

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -364,30 +364,35 @@ public abstract class GFLauncher {
     private void parseDebug() {
         // look for an option of this form:
         // -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009
+        // or
+        // -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9009
         // and extract the suspend and port values
         for (String opt : debugOptions) {
-            if (!opt.startsWith("-Xrunjdwp:"))
-                continue;
-            String[] attrs = opt.substring(10).split(",");
-            for (String attr : attrs) {
-                if (attr.startsWith("address=")) {
-                    try {
-                        debugPort = Integer.parseInt(attr.substring(8));
-                    }
-                    catch (NumberFormatException ex) {
-                        debugPort = -1;
-                    }
-                }
-                if (attr.startsWith("suspend=")) {
-                    try {
-                        debugSuspend = attr.substring(8).equalsIgnoreCase("y");
-                    }
-                    catch (Exception ex) {
-                        debugSuspend = false;
-                    }
-                }
+            if (opt.startsWith("-Xrunjdwp:") || opt.startsWith("-agentlib:jdwp")) {
+              debugPort = extractDebugPort(opt);
+              debugSuspend = extractDebugSuspend(opt);
             }
         }
+    }
+
+    static int extractDebugPort(String option) {
+        Pattern portRegex = Pattern.compile(".*address=(?<port>\\d*).*");
+        Matcher m = portRegex.matcher(option);
+        if (!m.matches()) {
+            return -1;
+        }
+        try {
+            String addressGroup = m.group("port");
+            return Integer.parseInt(addressGroup);
+        } catch (NumberFormatException nfex) {
+            return -1;
+        }
+    }
+
+    static boolean extractDebugSuspend(String option) {
+        Pattern suspendRegex = Pattern.compile(".*suspend=[yY](?:,.*|$)");
+        Matcher m = suspendRegex.matcher(option);
+        return m.matches();
     }
 
     private void setLogFilename(MiniXmlParser parser) {

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -368,11 +368,15 @@ public abstract class GFLauncher {
         // -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9009
         // and extract the suspend and port values
         for (String opt : debugOptions) {
-            if (opt.startsWith("-Xrunjdwp:") || opt.startsWith("-agentlib:jdwp")) {
+            if (isJdwpOption(opt)) {
               debugPort = extractDebugPort(opt);
               debugSuspend = extractDebugSuspend(opt);
             }
         }
+    }
+
+    static boolean isJdwpOption(String option) {
+        return option.startsWith("-Xrunjdwp:") || option.startsWith("-agentlib:jdwp");
     }
 
     static int extractDebugPort(String option) {

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2008-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008-2019 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractPortTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractPortTest.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.enterprise.admin.launcher;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GFLauncherExtractPortTest {
+    @Test
+    public void shouldExtractPortNumberFromDebugOption() {
+      int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9876");
+
+      assertEquals(9876, port);
+    }
+
+    @Test
+    public void shouldNotFindPortNumberInOption() {
+      int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
+
+      assertEquals(-1, port);
+    }
+}

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractSuspendTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractSuspendTest.java
@@ -1,0 +1,68 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.enterprise.admin.launcher;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GFLauncherExtractSuspendTest {
+    @Test
+    public void shouldExtractSuspendDebugNOption() {
+      boolean suspend = GFLauncher.extractDebugSuspend("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9876");
+
+      assertFalse(suspend);
+    }
+
+    @Test
+    public void shouldExtractSuspendDebugYOption() {
+      boolean suspend = GFLauncher.extractDebugSuspend("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9876");
+
+      assertTrue(suspend);
+    }
+
+    @Test
+    public void shouldDefaultToFalseIfNoSuspendOption() {
+      boolean suspend = GFLauncher.extractDebugSuspend("-agentlib:jdwp=transport=dt_socket,server=y,address=9876");
+
+      assertFalse(suspend);
+    }
+}

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherJdwpCheckerTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherJdwpCheckerTest.java
@@ -1,0 +1,74 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.enterprise.admin.launcher;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GFLauncherJdwpCheckerTest {
+
+    // Pre-1.5 java option:
+    // https://download.oracle.com/otn_hosted_doc/jdeveloper/904preview/jdk14doc/docs/tooldocs/solaris/jdb.html
+    // still supported in OpenJDK 11
+    @Test
+    public void shouldRecognizeXOption() {
+        boolean isJdwp = GFLauncher.isJdwpOption("-Xrunjdwp:transport=dt_socket,server=y,suspend=n");
+
+        assertTrue(isJdwp);
+    }
+
+    // Since 1.5 java option:
+    // https://docs.oracle.com/javase/1.5.0/docs/tooldocs/solaris/java.html
+    @Test
+    public void shouldRecognizeAgentlibOption() {
+        boolean isJdwp = GFLauncher.isJdwpOption("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
+
+        assertTrue(isJdwp);
+    }
+
+    @Test
+    public void shouldRecognizeAsNonJdwpOption() {
+        boolean isJdwp = GFLauncher.isJdwpOption("-agentlib:hprof=transport=dt_socket,server=y,suspend=n");
+
+        assertFalse(isJdwp);
+    }
+}


### PR DESCRIPTION
This is a bug fix. (#4386)

Current `GFLauncher` recognizes only old-style JDWP option (`-Xrunjdwp`), but by default from template new one (`-agentlib:jdwp`) is used. With the effect of port not parsed from option (defaulted to -1), https://github.com/payara/Payara/blob/c2905122f21f49ed1455612bdc3aded5b1d1f2ce/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java#L268 is not fulfilled, and expected message is not logged.

### Testing Performed
After full build following performed:
```shell
unzip  appserver/distributions/payara/target/payara.zip
./payara5/glassfish/bin/asadmin start-domain --debug=true
```
which resulted in
```
Waiting for domain1 to start ............
Successfully started the domain : domain1
domain  Location: /tmp/payara5/glassfish/domains/domain1
Log File: /tmp/payara5/glassfish/domains/domain1/logs/server.log
Admin Port: 4848
Debugging is enabled.  The debugging port is: 9009
Command start-domain executed successfully.
```

### Testing Environment
- Linux
- OpenJDK Runtime Environment (build 1.8.0_232-b09)
- Maven 3.6.3

