### PR TITLE
Remove unused field debug from StartServerHelper

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-//Portions Copyright [2017-2018] Payara Foundation and/or affiliates
+//Portions Copyright [2017-2020] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -147,8 +147,7 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
                     programOpts.isTerse(),
                     getServerDirs(),
                     launcher,
-                    mpv,
-                    debug);
+                    mpv);
 
             if (helper.prepareForLaunch() == false){
                 return ERROR;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] Payara Foundation and/or Affiliates
+// Portions Copyright [2017-2020] Payara Foundation and/or Affiliates
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -88,7 +88,6 @@ public class StartServerHelper {
     private final ServerDirs serverDirs;
     private final String masterPassword;
     private final String serverOrDomainName;
-    private final boolean debug;
     private final int debugPort;
     private final boolean isDebugSuspend;
     // only set when actively trouble-shooting or investigating...
@@ -113,7 +112,6 @@ public class StartServerHelper {
         serverDirs = serverDirs0;
         pidFile = serverDirs.getPidFile();
         masterPassword = masterPassword0;
-        debug = debug0;
         // it will be < 0 if both --debug is false and debug-enabled=false in jvm-config
         debugPort = launcher.getDebugPort();
         isDebugSuspend = launcher.isDebugSuspend();

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -96,7 +96,7 @@ public class StartServerHelper {
 
     public StartServerHelper(Logger logger0, boolean terse0,
             ServerDirs serverDirs0, GFLauncher launcher0,
-            String masterPassword0, boolean debug0) {
+            String masterPassword0) {
         logger = logger0;
         terse = terse0;
         launcher = launcher0;

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2017-2020] Payara Foundation and/or affiliates
 package com.sun.enterprise.admin.cli.cluster;
 
 import static com.sun.enterprise.admin.cli.CLIConstants.RESTART_DEBUG_OFF;
@@ -172,7 +172,7 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
             createLauncher();
 
             startServerHelper = new StartServerHelper(
-                    logger, programOpts.isTerse(), getServerDirs(), launcher, getMasterPassword(), debug);
+                    logger, programOpts.isTerse(), getServerDirs(), launcher, getMasterPassword());
 
             if (!startServerHelper.prepareForLaunch()) {
                 return ERROR;


### PR DESCRIPTION
This is refactoring.

Field
https://github.com/payara/Payara/blob/c2905122f21f49ed1455612bdc3aded5b1d1f2ce/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java#L91
is not used, so I propose to remove it.

It's also [reported by sonar](https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW0h5g1lbW38OQeaThxd&open=AW0h5g1lbW38OQeaThxd) I see.


# Testing

### Testing Performed

`mvn clean install` to make sure whole project is still compilable.

### Testing Environment
Linux
OpenJDK Runtime Environment (build 1.8.0_232-b09)
maven 3.6.3

