### PR TITLE
CLOUD-12 Removed cruft from Payara Micro

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -105,6 +105,13 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>appserver-core</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>glassfish-cmp</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -105,6 +105,13 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>appserver-core</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>glassfish-hk2</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -87,11 +87,7 @@ Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
             <http-service access-logging-enabled="false">
                 <access-log format="%client.name% %auth-user-name% %datetime% %request% %status% %response.length%" rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd"></access-log>
                 <virtual-server id="server" access-logging-enabled="false" access-log="" network-listeners="http-listener, https-listener"></virtual-server>
-            </http-service>
-            <iiop-service>
-                <orb use-thread-pool-ids="thread-pool-1"></orb>
-                <iiop-listener id="orb-listener-1" enabled="false" address="0.0.0.0"></iiop-listener>
-            </iiop-service>    
+            </http-service>  
             <admin-service system-jmx-connector-name="system" type="das-and-server">
                 <jmx-connector port="8686" address="0.0.0.0" security-enabled="false" auth-realm-name="admin-realm" name="system" enabled="false"></jmx-connector>
                 <das-config></das-config>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -161,7 +161,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
-            <artifactId>glassfish-common-web</artifactId>
+            <artifactId>appserver-core</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>

--- a/appserver/featuresets/minnow/pom.xml
+++ b/appserver/featuresets/minnow/pom.xml
@@ -120,6 +120,12 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>appserver-core</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>glassfish-common-web</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/appserver/packager/appserver-core/pom.xml
+++ b/appserver/packager/appserver-core/pom.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 2 only ("GPL") or the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://github.com/payara/Payara/blob/master/LICENSE.txt
+ See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at glassfish/legal/LICENSE.txt.
+
+ GPL Classpath Exception:
+ The Payara Foundation designates this particular file as subject to the "Classpath"
+ exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ file that accompanied this code.
+
+ Modifications:
+ If applicable, add the following below the License Header, with the fields
+ enclosed by brackets [] replaced by your own identifying information:
+ "Portions Copyright [year] [name of copyright owner]"
+
+ Contributor(s):
+ If you wish your version of this file to be governed by only the CDDL or
+ only the GPL Version 2, indicate your decision by adding "[Contributor]
+ elects to include this software in this distribution under the [CDDL or GPL
+ Version 2] license."  If you don't indicate a single choice of license, a
+ recipient has the option to distribute your version of this file under
+ either the CDDL, the GPL Version 2 or to extend the choice of license to
+ its licensees as provided above.  However, if you add GPL Version 2 code
+ and therefore, elected the GPL Version 2 license, then the option applies
+ only if the new code is made subject to such option by the copyright
+ holder.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.server.internal.packager</groupId>
+        <artifactId>packages</artifactId>
+        <version>5.201-SNAPSHOT</version>
+    </parent>
+    <artifactId>appserver-core</artifactId>
+    <name>Payara Appserver Core Modules</name>
+    <packaging>distribution-fragment</packaging>
+    <description>This pom describes how to assemble the appserver core package</description>
+
+    <properties>
+        <temp.dir>${project.build.directory}/dependency</temp.dir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-step1</id>
+                    </execution>
+                    <execution>
+                        <id>process-step2</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-step3</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+       <profile>
+          <id>ips</id>
+          <activation>
+             <activeByDefault>false</activeByDefault>  
+          </activation>
+          <build>
+             <plugins>
+                <plugin>
+                   <groupId>org.apache.maven.plugins</groupId>
+                   <artifactId>maven-antrun-plugin</artifactId>
+                   <executions>
+                      <execution>
+                         <id>process-step4</id>
+                      </execution>
+                   </executions>
+                </plugin>
+                <plugin>
+                   <groupId>org.glassfish.build</groupId>
+                   <artifactId>glassfishbuild-maven-plugin</artifactId>
+                   <executions>
+                      <execution>
+                         <id>process-step5</id>
+                         <goals>
+                            <goal>exec</goal>
+                         </goals>                            
+                      </execution>
+                   </executions>
+                </plugin>
+                <plugin>
+                   <artifactId>maven-resources-plugin</artifactId>
+                   <executions>
+                      <execution>
+                         <id>copy-resources</id>
+                      </execution>
+                   </executions>
+                </plugin>
+             </plugins>
+          </build>
+       </profile>
+    </profiles>
+    
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.server.internal.security</groupId>
+            <artifactId>security-ee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>amx-javaee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>annotation-framework</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>container-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.deployment</groupId>
+            <artifactId>deployment-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.deployment</groupId>
+            <artifactId>deployment-javaee-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.deployment</groupId>
+            <artifactId>dol</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>appserver-cli</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${jna.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>admin-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.ejb</groupId>
+            <artifactId>ejb-internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.connectors</groupId>
+            <artifactId>connectors-internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.ha</groupId>
+            <artifactId>ha-api</artifactId>
+        </dependency>    
+        <dependency>
+            <groupId>fish.payara.server.internal.ha</groupId>
+            <artifactId>ha-file-store</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- TODO: move to glassfish-nucleus after nucleus distro build moves
+        to its own workspace -->
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>appserver-base</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>        
+        <dependency>
+            <groupId>fish.payara.server.internal.extras</groupId>
+            <artifactId>javaee-frag</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.extras</groupId>
+            <artifactId>appserv-rt-frag</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>backup</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.security</groupId>
+            <artifactId>jacc.provider.inmemory</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.security</groupId>
+            <artifactId>jacc.provider.file</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.security</groupId>
+            <artifactId>jaspic.provider.framework</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>libpam4j-repackaged</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
+            <artifactId>nucleus-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.resources</groupId>
+            <artifactId>resources-connector</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.management.j2ee</groupId>
+            <artifactId>jakarta.management.j2ee-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.jacc</groupId>
+            <artifactId>jakarta.security.jacc-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.transaction</groupId>
+            <artifactId>transaction-internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>jakarta.persistence</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.metro</groupId>
+            <artifactId>webservices-extra-jdk-packages</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.metro</groupId>
+            <artifactId>webservices-api-osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/packager/appserver-core/pom.xml
+++ b/appserver/packager/appserver-core/pom.xml
@@ -149,11 +149,6 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.deployment</groupId>
-            <artifactId>deployment-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -164,17 +159,17 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>
-            <artifactId>appserver-cli</artifactId>
+            <artifactId>admin-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
+            <groupId>fish.payara.server.internal.orb</groupId>
+            <artifactId>orb-connector</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.admin</groupId>
-            <artifactId>admin-core</artifactId>
+            <groupId>fish.payara.server.internal.orb</groupId>
+            <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -215,11 +210,6 @@
             <artifactId>appserv-rt-frag</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.admin</groupId>
-            <artifactId>backup</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>

--- a/appserver/packager/appserver-core/src/main/assembly/appserver-core.xml
+++ b/appserver/packager/appserver-core/src/main/assembly/appserver-core.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 2 only ("GPL") or the Common Development
+ and Distribution License("CDDL") (collectively, the "License").  You
+ may not use this file except in compliance with the License.  You can
+ obtain a copy of the License at
+ https://github.com/payara/Payara/blob/master/LICENSE.txt
+ See the License for the specific
+ language governing permissions and limitations under the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License.
+
+ When distributing the software, include this License Header Notice in each
+ file and include the License file at glassfish/legal/LICENSE.txt.
+
+ GPL Classpath Exception:
+ The Payara Foundation designates this particular file as subject to the "Classpath"
+ exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ file that accompanied this code.
+
+ Modifications:
+ If applicable, add the following below the License Header, with the fields
+ enclosed by brackets [] replaced by your own identifying information:
+ "Portions Copyright [year] [name of copyright owner]"
+
+ Contributor(s):
+ If you wish your version of this file to be governed by only the CDDL or
+ only the GPL Version 2, indicate your decision by adding "[Contributor]
+ elects to include this software in this distribution under the [CDDL or GPL
+ Version 2] license."  If you don't indicate a single choice of license, a
+ recipient has the option to distribute your version of this file under
+ either the CDDL, the GPL Version 2 or to extend the choice of license to
+ its licensees as provided above.  However, if you add GPL Version 2 code
+ and therefore, elected the GPL Version 2 license, then the option applies
+ only if the new code is made subject to such option by the copyright
+ holder.
+ -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
+          http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+    <id>stage-package</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${temp.dir}/glassfish</directory>
+            <outputDirectory>${install.dir.name}/glassfish</outputDirectory>
+            <excludes>
+                <exclude>modules/cli-optional*.jar</exclude>
+                <exclude>modules/appserver-cli*.jar</exclude>
+                <exclude>modules/jna*.jar</exclude>
+                <exclude>modules/jline-terminal-jna*.jar</exclude>
+                <exclude>bin/*</exclude>
+                <exclude>pkg_proto.py</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}/glassfish</directory>
+            <outputDirectory>${install.dir.name}/glassfish</outputDirectory>
+            <fileMode>755</fileMode>
+            <includes>
+                <include>bin/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}/glassfish/modules</directory>
+            <outputDirectory>${install.dir.name}/glassfish/lib/asadmin</outputDirectory>
+            <includes>
+                <include>cli-optional*.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}/glassfish/modules</directory>
+            <outputDirectory>${install.dir.name}/glassfish/lib/client</outputDirectory>
+            <includes>
+                <include>appserver-cli*.jar</include>
+                <include>jna*.jar</include>
+                <include>jline-terminal-jna*.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}/${install.dir.name}</directory>
+            <outputDirectory>${install.dir.name}</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}</directory>
+            <excludes>
+                <exclude>${install.dir.name}/**</exclude>
+                <exclude>glassfish/**</exclude>
+                <exclude>nucleus/**</exclude>
+                <exclude>pkg_proto.py</exclude>
+            </excludes>
+            <outputDirectory>${install.dir.name}/glassfish</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}</directory>
+            <fileMode>755</fileMode>
+            <includes>
+                <include>bin/**</include>
+            </includes>
+            <outputDirectory>${install.dir.name}</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/appserver/packager/appserver-core/src/main/resources/bin/asadmin
+++ b/appserver/packager/appserver-core/src/main/resources/bin/asadmin
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+# or packager/legal/LICENSE.txt.  See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at packager/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# Oracle designates this particular file as subject to the "Classpath"
+# exception as provided by Oracle in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+
+# Always use JDK 1.6 or higher
+AS_INSTALL=`dirname "$0"`/../glassfish
+AS_INSTALL_LIB="$AS_INSTALL/lib"
+. "${AS_INSTALL}/config/asenv.conf"
+JAVA=java
+#Depends upon Java from ../config/asenv.conf
+if [ ${AS_JAVA} ]; then
+    JAVA=${AS_JAVA}/bin/java
+fi
+
+exec "$JAVA" -XX:+IgnoreUnrecognizedVMOptions -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" "$@"
+

--- a/appserver/packager/appserver-core/src/main/resources/bin/asadmin.bat
+++ b/appserver/packager/appserver-core/src/main/resources/bin/asadmin.bat
@@ -1,0 +1,57 @@
+@echo off
+REM
+REM  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+REM 
+REM  Copyright (c) 1997-2013 Oracle and/or its affiliates. All rights reserved.
+REM 
+REM  The contents of this file are subject to the terms of either the GNU
+REM  General Public License Version 2 only ("GPL") or the Common Development
+REM  and Distribution License("CDDL") (collectively, the "License").  You
+REM  may not use this file except in compliance with the License.  You can
+REM  obtain a copy of the License at
+REM  https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+REM  or packager/legal/LICENSE.txt.  See the License for the specific
+REM  language governing permissions and limitations under the License.
+REM 
+REM  When distributing the software, include this License Header Notice in each
+REM  file and include the License file at packager/legal/LICENSE.txt.
+REM 
+REM  GPL Classpath Exception:
+REM  Oracle designates this particular file as subject to the "Classpath"
+REM  exception as provided by Oracle in the GPL Version 2 section of the License
+REM  file that accompanied this code.
+REM 
+REM  Modifications:
+REM  If applicable, add the following below the License Header, with the fields
+REM  enclosed by brackets [] replaced by your own identifying information:
+REM  "Portions Copyright [year] [name of copyright owner]"
+REM 
+REM  Contributor(s):
+REM  If you wish your version of this file to be governed by only the CDDL or
+REM  only the GPL Version 2, indicate your decision by adding "[Contributor]
+REM  elects to include this software in this distribution under the [CDDL or GPL
+REM  Version 2] license."  If you don't indicate a single choice of license, a
+REM  recipient has the option to distribute your version of this file under
+REM  either the CDDL, the GPL Version 2 or to extend the choice of license to
+REM  its licensees as provided above.  However, if you add GPL Version 2 code
+REM  and therefore, elected the GPL Version 2 license, then the option applies
+REM  only if the new code is made subject to such option by the copyright
+REM  holder.
+REM
+
+REM Always use JDK 1.6 or higher
+REM Depends on Java from ..\glassfish\config\asenv.bat
+VERIFY OTHER 2>nul
+setlocal ENABLEEXTENSIONS
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
+:ok
+call "%~dp0..\glassfish\config\asenv.bat"
+if "%AS_JAVA%x" == "x" goto UsePath
+set JAVA="%AS_JAVA%\bin\java"
+goto run
+:UsePath
+set JAVA=java
+:run
+%JAVA% -jar "%~dp0..\glassfish\lib\client\appserver-cli.jar" %*

--- a/appserver/packager/appserver-core/src/main/resources/bin/letsencrypt.py
+++ b/appserver/packager/appserver-core/src/main/resources/bin/letsencrypt.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from os import path
+import os
+import sys
+from subprocess import PIPE,call, check_call, CalledProcessError,Popen
+import argparse
+import shutil
+import re
+
+ASADMIN_PATH="./asadmin"
+WEB_ROOT_PATH=Path("/tmp/payara_le_war")
+LE_LIVE_PATH=Path("/etc/letsencrypt/live/")
+APP_NAME="le"
+FNULL = open(os.devnull, 'w')
+OKGREEN = '\033[92m'
+WARNING = '\033[93m'
+FAIL = '\033[91m'
+ENDC = '\033[0m'
+
+def kill_process():
+	pass
+
+def make_output_dir(dir_path) -> Path:
+	dir_path.mkdir(exist_ok=True, parents=True)
+
+def create_le_war():
+	make_output_dir(WEB_ROOT_PATH / "WEB-INF")
+
+def restart_listener(listener_name):
+	check_call([ASADMIN_PATH, "set", "server.network-config.network-listeners.network-listener.%s.enabled=false" % listener_name])
+	check_call([ASADMIN_PATH, "set", "server.network-config.network-listeners.network-listener.%s.enabled=true" % listener_name])
+
+def upload_keypair(key_path, cert_path, alias, gf_domain_name, gf_domain_dir=None):
+	print("Uploading keypair using asadmin: ", end='')
+	try:
+		if gf_domain_dir is None:
+			check_call([ASADMIN_PATH, "add-pkcs8", "--domain_name", gf_domain_name, "--destalias", alias, "--priv-key-path", key_path, "--cert-chain-path", cert_path], stdout=FNULL, stderr=FNULL)
+		else:
+			check_call([ASADMIN_PATH, "add-pkcs8", "--domain_name", gf_domain_name, "--domaindir", gf_domain_dir, "--destalias", alias, "--priv-key-path", key_path, "--cert-chain-path", cert_path], stdout=FNULL, stderr=FNULL)
+	except CalledProcessError: 
+		print('[' + FAIL + "FAIL" + ENDC + ']' + "\n", sys.exc_info()[1])
+		return 1
+
+	print('[' + OKGREEN + " OK " + ENDC + ']')
+	return 0
+
+def configure_listener_alias(listener_name, alias):
+	check_call([ASADMIN_PATH, "set", "configs.config.server-config.network-config.protocols.protocol.%s.ssl.cert-nickname=%s" % (listener_name, alias)])
+
+def deploy_war():
+	print("Attempting to deploy an EMPTY WAR to the ROOT context: ", end='')
+	try:
+		check_call([ASADMIN_PATH, "deploy", "--name", APP_NAME, "--force", "--contextroot", "/",  WEB_ROOT_PATH], stdout=FNULL, stderr=FNULL)
+		print('[' + OKGREEN + " OK " + ENDC + ']')
+	except CalledProcessError: 
+		print('[' + FAIL + "FAIL" + ENDC + ']' + " Is the server up and running?\n", sys.exc_info()[1])
+		shutil.rmtree(WEB_ROOT_PATH)
+		return 1
+
+	return 0
+
+def undeploy_war():
+	print("Undeploying WAR, doing cleanup: ", end='')
+	try:
+		check_call([ASADMIN_PATH, "undeploy", APP_NAME], stdout=FNULL, stderr=FNULL)
+		print('[' + OKGREEN + " OK " + ENDC + ']')
+		shutil.rmtree(WEB_ROOT_PATH)
+	except CalledProcessError: 
+		print('[' + FAIL + "FAIL" + ENDC + ']' + " Is the server up and running?\n", sys.exc_info()[1])
+		shutil.rmtree(WEB_ROOT_PATH)
+		return 1
+
+	return 0
+
+def invoke_certbot(domain_names):
+	certbot_call_args = ["certbot", "certonly", "--webroot", "-w", WEB_ROOT_PATH]
+	for d in domain_names:
+		certbot_call_args += ["-d", d]
+	
+	try:
+		check_call(certbot_call_args)
+		print('Calling certbot: [' + OKGREEN + " OK " + ENDC + ']')
+	except CalledProcessError: 
+		print(sys.exc_info()[1], '\nCalling certbot: [' + FAIL + "FAIL" + ENDC +  ']')
+		return 1
+
+	return 0
+
+def check_http_port():
+	proc = Popen([ASADMIN_PATH, "get", "server.network-config.network-listeners.network-listener.*.port"], stdout=PIPE)
+	ports = proc.stdout.read()
+	if not '.port=80\n'.encode() in ports:
+		print(WARNING + "WARNING: " + ENDC + "None of the listeners of Payara are running on the standard HTTP port (80).\nUnless there is a port mapping, "
+			"a reverse-proxy exposing port 80 or other solution making the deployed web-app visible through port 80, the following invocation of certbot will "
+			"likely fail (due to a failing 'HTTP Challenge' of the ACME protocol; see Chapter 8.3 on https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html). "
+			"Proceeding nevertheless.")
+
+
+if __name__=="__main__":
+	parser = argparse.ArgumentParser(description="Payara Let's Encrypt integration script. This script deploys an empty WAR, calls (and requires) certbot "
+		"to retrieve your certificate and uploads the certificate to the default keystore of the Payara domain. In addition, this script configures the listener "
+		"with the given alias and restarts it (the listener only, not the whole domain), so that the new certificate is effective. Afterwards the WAR is undeployed. "
+		"CertBot requires root, and as a consequence, so does this script. NOTE: In order for the web-challenge to be successful, the deployed application must be "
+		"visible through the standard HTTP port (80) of the provided certification domain name (see parameter --cert-domain below).")
+	parser.add_argument('-c','--cert-domain', action="append", help="The FQDN of the domain(s) the certificate will be bound too. You may use this arg multiple times.", required=True)
+	parser.add_argument('-n','--name', help="The name of the payara-domain where the certificate will be uploaded.", required=False, default='production')
+	parser.add_argument('-d','--domain-dir', '--domaindir', help="The directory where payara domains are defined. Necessary to provide only when the domains are in non-standard locations.", required=False)
+	parser.add_argument('-l','--listener', help="HTTP Listener's name. By default http-listener-2", required=False, default="http-listener-2")
+	parser.add_argument('-a','--alias', help="The alias that is used to import the keypar and the listener will be configured to use this alias. "
+		"The default is constructed like: 'le_{listener}'", required=False)
+	
+	args = parser.parse_args()
+	alias = "le_" + args.cert_domain[0] if args.alias is None else args.alias
+	create_le_war()
+	if deploy_war() != 0:
+		exit(1)
+
+	check_http_port()
+	code = invoke_certbot(args.cert_domain)
+	undeploy_war()
+
+	if code != 0:
+		exit(code)
+
+	key_path = LE_LIVE_PATH / args.cert_domain[0] / "privkey.pem"
+	cert_path = LE_LIVE_PATH / args.cert_domain[0] / "fullchain.pem"
+	code = upload_keypair(key_path, cert_path, alias, args.name, args.domain_dir)
+	if code == 0:
+		code = configure_listener_alias(alias)
+		if code == 0:
+			restart_listener(args.listener)
+	
+	exit(code)
+	

--- a/appserver/packager/appserver-core/src/main/resources/glassfish/bin/asadmin
+++ b/appserver/packager/appserver-core/src/main/resources/glassfish/bin/asadmin
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 1997-2013 Oracle and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+# or packager/legal/LICENSE.txt.  See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at packager/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# Oracle designates this particular file as subject to the "Classpath"
+# exception as provided by Oracle in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+
+# Always use JDK 1.6 or higher
+AS_INSTALL=`dirname "$0"`/..
+case "`uname`" in
+  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
+esac
+AS_INSTALL_LIB="$AS_INSTALL/lib"
+. "${AS_INSTALL}/config/asenv.conf"
+JAVA=java
+#Depends upon Java from ../config/asenv.conf
+if [ ${AS_JAVA} ]; then
+    JAVA=${AS_JAVA}/bin/java
+fi
+exec "$JAVA" -XX:+IgnoreUnrecognizedVMOptions -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" "$@"

--- a/appserver/packager/appserver-core/src/main/resources/glassfish/bin/asadmin.bat
+++ b/appserver/packager/appserver-core/src/main/resources/glassfish/bin/asadmin.bat
@@ -1,0 +1,57 @@
+@echo off
+REM
+REM  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+REM 
+REM  Copyright (c) 1997-2013 Oracle and/or its affiliates. All rights reserved.
+REM 
+REM  The contents of this file are subject to the terms of either the GNU
+REM  General Public License Version 2 only ("GPL") or the Common Development
+REM  and Distribution License("CDDL") (collectively, the "License").  You
+REM  may not use this file except in compliance with the License.  You can
+REM  obtain a copy of the License at
+REM  https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+REM  or packager/legal/LICENSE.txt.  See the License for the specific
+REM  language governing permissions and limitations under the License.
+REM 
+REM  When distributing the software, include this License Header Notice in each
+REM  file and include the License file at packager/legal/LICENSE.txt.
+REM 
+REM  GPL Classpath Exception:
+REM  Oracle designates this particular file as subject to the "Classpath"
+REM  exception as provided by Oracle in the GPL Version 2 section of the License
+REM  file that accompanied this code.
+REM 
+REM  Modifications:
+REM  If applicable, add the following below the License Header, with the fields
+REM  enclosed by brackets [] replaced by your own identifying information:
+REM  "Portions Copyright [year] [name of copyright owner]"
+REM 
+REM  Contributor(s):
+REM  If you wish your version of this file to be governed by only the CDDL or
+REM  only the GPL Version 2, indicate your decision by adding "[Contributor]
+REM  elects to include this software in this distribution under the [CDDL or GPL
+REM  Version 2] license."  If you don't indicate a single choice of license, a
+REM  recipient has the option to distribute your version of this file under
+REM  either the CDDL, the GPL Version 2 or to extend the choice of license to
+REM  its licensees as provided above.  However, if you add GPL Version 2 code
+REM  and therefore, elected the GPL Version 2 license, then the option applies
+REM  only if the new code is made subject to such option by the copyright
+REM  holder.
+REM
+
+REM Always use JDK 1.6 or higher
+REM Depends on Java from ..\config\asenv.bat
+VERIFY OTHER 2>nul
+setlocal ENABLEEXTENSIONS
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
+:ok
+call "%~dp0..\config\asenv.bat" 
+if "%AS_JAVA%x" == "x" goto UsePath
+set JAVA="%AS_JAVA%\bin\java"
+goto run
+:UsePath
+set JAVA=java
+:run
+%JAVA% -jar "%~dp0..\lib\client\appserver-cli.jar" %*

--- a/appserver/packager/appserver-core/src/main/resources/pkg_proto.py
+++ b/appserver/packager/appserver-core/src/main/resources/pkg_proto.py
@@ -3,7 +3,7 @@
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2009-2011 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Payara Foundation and/or affiliates
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
@@ -39,51 +39,25 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2019] [Payara Foundation and/or its affiliates]
 
 import imp
 
 conf = imp.load_source("pkg_conf", "../pkg_conf.py")
 
 pkg = {
-    "name"          : "glassfish-web-profile",
+    "name"          : "appserver-core",
     "version"       : conf.glassfish_version,
     "attributes"    : {
-                        "pkg.summary" : "GlassFish Web Profile",
-                        "pkg.description" : "GlassFish Web Profile Metapackage.  "+conf.glassfish_description_long,
+                        "pkg.summary" : "Payara Appserver Common Modules",
+                        "pkg.description" : "Payara Appserver Common Modules. "+conf.glassfish_description_long,
                         "info.classification" : conf.glassfish_info_classification,
                       },
     "depends"       : { 
-	                "pkg:/javadb-common" : {"type" : "require" },
-			"pkg:/javadb-core" : {"type" : "require" },
-			"pkg:/javadb-client" : {"type" : "require" },
-			"pkg:/pkg-java" : {"type" : "require" },
-			"pkg:/felix" : {"type" : "require" },
-                        "pkg:/appserver-core" : {"type" : "require" },
-			"pkg:/glassfish-hk2" : {"type" : "require" },
-		 	"pkg:/glassfish-grizzly" : {"type" : "require" },
-			"pkg:/glassfish-nucleus" : {"type" : "require" },
-			"pkg:/glassfish-grizzly-full" : {"type" : "require" },
-			"pkg:/glassfish-common" : {"type" : "require" },
-			"pkg:/shoal" : {"type" : "require" },
-			"pkg:/glassfish-cluster" : {"type" : "require" },
-			"pkg:/glassfish-ha" : {"type" : "require" },
-			"pkg:/jersey@1.8" : {"type" : "require" },
-			"pkg:/glassfish-management" : {"type" : "require" },
-                        "pkg:/glassfish-common-web" : {"type" : "require" },
-			"pkg:/glassfish-jca" : {"type" : "require" },
-			"pkg:/glassfish-jpa" : {"type" : "require" },
-			"pkg:/glassfish-jta" : {"type" : "require" },
-			"pkg:/glassfish-corba-base" : {"type" : "require" },
-			"pkg:/glassfish-jts" : {"type" : "require" },
-			"pkg:/glassfish-ejb-lite" : {"type" : "require" },
-			"pkg:/glassfish-jsf" : {"type" : "require" },
-			"pkg:/glassfish-web" : {"type" : "require" },
-                        "pkg:/glassfish-osgi-http" : {"type" : "require" },
-			"pkg:/glassfish-jcdi" : {"type" : "require" },
-			"pkg:/glassfish-jdbc" : {"type" : "require" },
-			"pkg:/glassfish-gui" : {"type" : "require" },
-			"pkg:/glassfish-web-incorporation" : {"type" : "require" },
+                        "pkg:/glassfish-common" : {"type" : "require" },
+                      },
+    "dirtrees"      : [ "glassfish", "bin" ],
+    "files"         : { 
+                        "README.txt" : {},
                       },
     "licenses"      : {
                         "../../../../CDDL+GPL.txt" : {"license" : "CDDL and GPL v2 with classpath exception"},

--- a/appserver/packager/glassfish-common-web/pom.xml
+++ b/appserver/packager/glassfish-common-web/pom.xml
@@ -128,43 +128,8 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.internal.security</groupId>
-            <artifactId>security-ee</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.sun.pkg</groupId>
             <artifactId>pkg-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
-            <artifactId>amx-javaee</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
-            <artifactId>annotation-framework</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
-            <artifactId>container-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
-            <artifactId>deployment-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
-            <artifactId>deployment-javaee-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
-            <artifactId>dol</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>
@@ -172,34 +137,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.admin</groupId>
-            <artifactId>appserver-cli</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jna</artifactId>
             <version>${jline-terminal-jna}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.admin</groupId>
-            <artifactId>admin-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.ejb</groupId>
-            <artifactId>ejb-internal-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.connectors</groupId>
-            <artifactId>connectors-internal-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.orb</groupId>
@@ -220,16 +160,6 @@
             <artifactId>ha-file-store</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- TODO: move to glassfish-nucleus after nucleus distro build moves
-        to its own workspace -->
-        <dependency>
-            <groupId>fish.payara.server.internal.packager</groupId>
-            <artifactId>appserver-base</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-        </dependency>
-        <!-- TODO: move to glassfish-cluster after nucleus distro build moves
-        to its own workspace or create dedicated cluster package-->
         <dependency>
             <groupId>fish.payara.server.internal.load-balancer</groupId>
             <artifactId>load-balancer-admin</artifactId>
@@ -240,18 +170,6 @@
             <groupId>org.glassfish.external</groupId>
             <artifactId>schema2beans-repackaged</artifactId>
         </dependency>          
-        <dependency>
-            <groupId>fish.payara.server.internal.extras</groupId>
-            <artifactId>javaee-frag</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.extras</groupId>
-            <artifactId>appserv-rt-frag</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-        </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.extras</groupId>
             <artifactId>glassfish-embedded-shell-frag</artifactId>
@@ -265,129 +183,9 @@
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.admin</groupId>
-            <artifactId>backup</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.server.internal.load-balancer</groupId>
             <artifactId>gf-load-balancer-connector</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.security</groupId>
-            <artifactId>jacc.provider.inmemory</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.security</groupId>
-            <artifactId>jacc.provider.file</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.security</groupId>
-            <artifactId>jaspic.provider.framework</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.packager</groupId>
-            <artifactId>libpam4j-repackaged</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
-            <artifactId>nucleus-resources</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.resources</groupId>
-            <artifactId>resources-connector</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.resource</groupId>
-            <artifactId>jakarta.resource-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.management.j2ee</groupId>
-            <artifactId>jakarta.management.j2ee-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.security.auth.message</groupId>
-            <artifactId>jakarta.security.auth.message-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.security.jacc</groupId>
-            <artifactId>jakarta.security.jacc-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.transaction</groupId>
-            <artifactId>transaction-internal-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>jakarta.persistence</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.ejb</groupId>
-            <artifactId>jakarta.ejb-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.interceptor</groupId>
-            <artifactId>jakarta.interceptor-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-osgi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-extra-jdk-packages</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.istack</groupId>
-            <artifactId>istack-commons-runtime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-api-osgi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/packager/glassfish-common-web/pom.xml
+++ b/appserver/packager/glassfish-common-web/pom.xml
@@ -132,24 +132,29 @@
             <artifactId>pkg-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>fish.payara.server.internal.deployment</groupId>
+            <artifactId>deployment-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>cli-optional</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>appserver-cli</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${jna.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jna</artifactId>
             <version>${jline-terminal-jna}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.orb</groupId>
-            <artifactId>orb-connector</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.orb</groupId>
-            <artifactId>orb-enabler</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.ha</groupId>
@@ -158,6 +163,11 @@
         <dependency>
             <groupId>fish.payara.server.internal.ha</groupId>
             <artifactId>ha-file-store</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>backup</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/appserver/packager/pom.xml
+++ b/appserver/packager/pom.xml
@@ -78,6 +78,7 @@
         <module>external</module> 
         <module>legal</module>
         <module>appserver-base</module>
+        <module>appserver-core</module>
         <module>felix</module>
         <module>glassfish-hk2</module>
         <module>glassfish-grizzly</module>


### PR DESCRIPTION
Jars no longer included: glassfish-embedded-shell,
glassfish-embedded-static-shell, jline-terminal-jna, jna, deployment-client, appserver-cli,domain backup and schema2beans.

# Testing

### Testing Performed
Manual restart of server and micro.
Also comparison of jars included in 5.194 and in this PR.

### Test Suites Run
- Java EE 8 Samples
- Microprofile Metrics
- Microprofile Health
