### PR TITLE
CLOUD-13 Prevent Hazelcast from being started twice on Payara Micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
@@ -74,7 +74,7 @@ Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
         <config name="server-config">
             <payara-executor-service-configuration/>
             <cdi-service enable-concurrent-deployment="true" pre-loader-thread-pool-size="2"></cdi-service>
-            <hazelcast-config-specific-configuration enabled="true"></hazelcast-config-specific-configuration>
+            <hazelcast-config-specific-configuration enabled="false"></hazelcast-config-specific-configuration>
             <health-check-service-configuration enabled="false">
                 <log-notifier enabled="true"/>
                 <eventbus-notifier enabled="false"/>


### PR DESCRIPTION
# Description
This is a bug fix

As PayaraMicroImpl#L1060 will start Hazelcast whatever, having it
enabled in the domain.xml means that Hazelcast will be started earlier
then restarted when the bootstrap says to enable Hazelcast.

# Testing
### Testing Performed
Start Payara Micro, check the Hazelcast has only been started once.

### Test Suites Run
 - JavaEE7-Samples
 - JavaEE8-Samples

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.2