### PR TITLE
CUSTCOM-56 Extend domain.xml validation to every domain.xml file

### DIFF
--- a/appserver/admin/gf_template/pom.xml
+++ b/appserver/admin/gf_template/pom.xml
@@ -130,6 +130,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -128,6 +128,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -128,6 +128,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/admin/production_domain_template_web/pom.xml
+++ b/appserver/admin/production_domain_template_web/pom.xml
@@ -130,31 +130,15 @@
                 </executions>
             </plugin>
 
+            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>validate</goal>
-                        </goals>
-                        <phase>validate</phase>
+                        <id>validate-xml-files</id>
                     </execution>
                 </executions>
-                <configuration>
-                   <validationSets>
-                       <validationSet>
-                           <dir>src/main/resources/config</dir>
-                           <includes>
-                               <include>default-web.xml</include>
-                               <include>domain.xml</include>
-                               <include>glassfish-acc.xml</include>
-                               <include>wss-server-config-1.0.xml</include>
-                               <include>wss-server-config-2.0.xml</include>
-                           </includes>
-                       </validationSet>
-                   </validationSets>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -99,6 +99,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -99,6 +99,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/appserver/extras/payara-micro/payara-micro-boot/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/pom.xml
@@ -61,6 +61,29 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <plugins>
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                        <configuration>
+                            <validationSets>
+                                <validationSet>
+                                    <dir>src/main/resources/MICRO-INF/domain</dir>
+                                    <includes>
+                                        <include>default-web.xml</include>
+                                        <include>domain.xml</include>
+                                    </includes>
+                                </validationSet>
+                            </validationSets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,21 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
                     <version>1.0.2</version>
+                    <executions>
+                        <execution>
+                            <id>validate-xml-files</id>
+                            <goals>
+                                <goal>validate</goal>
+                            </goals>
+                            <configuration>
+                                <validationSets>
+                                    <validationSet>
+                                        <dir>src/main/resources/config</dir>
+                                    </validationSet>
+                                </validationSets>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The validation added in https://github.com/payara/Payara/pull/4379 was only performed for the production domain of payara-web. This commit extends the validation to every packaged domain.xml.

## Tests performed

`mvn validate` on each of the changed modules

`mvn validate` fails when the domain.xml isn't well formed