### PR TITLE
CUSTCOM-109 Injection of parameters into array will default to 0-length array

### DIFF
--- a/nucleus/hk2/hk2-config/src/test/java/org/jvnet/hk2/config/test/InjectionTest.java
+++ b/nucleus/hk2/hk2-config/src/test/java/org/jvnet/hk2/config/test/InjectionTest.java
@@ -1,0 +1,99 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package org.jvnet.hk2.config.test;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Type;
+import javax.inject.Inject;
+import org.glassfish.hk2.api.MultiException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hk2.config.InjectionManager;
+import org.jvnet.hk2.config.InjectionResolver;
+
+/**
+ * Test for injection into an array defaulting to an empty array
+ * @author jonathan coustick
+ */
+public class InjectionTest {
+    
+    @Test
+    public void injectionManagerTest() {
+        InjectionManager manager = new InjectionManager();
+        Injectee injectee = new Injectee();
+        manager.inject(injectee, new InjectionResolverImpl());
+        Assert.assertNull(injectee.string);
+        Assert.assertArrayEquals(new String[0], injectee.array);
+    }
+    
+    private class Injectee {
+    
+        @Inject
+        String[] array;
+        
+        @Inject
+        String string;
+    
+    }
+    
+    private class InjectionResolverImpl extends InjectionResolver<Inject> {
+        
+        private InjectionResolverImpl() {
+            super(Inject.class);
+        }
+
+        @Override
+        public <V> V getValue(Object component, AnnotatedElement annotated, Type genericType, Class<V> type) throws MultiException {
+            return null;
+        }
+
+        @Override
+        public boolean isOptional(AnnotatedElement annotated, Inject annotation) {
+            return true;
+        }
+        
+        
+        
+    }
+    
+}


### PR DESCRIPTION
# Description
This is a bug fix.

When an asadmin command has a Param that is an array and is optional then it it defaulted to null, which in some cases caused an NPE when Payara tried to iterate over it.

# Testing

### New tests
New `InjectionTest` unit test added.

### Testing Performed
Manual test - `send-asadmin-command` fails  before this PR, and succeeds afterwards.

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 18.04 with Maven 3.6.2
