### PR TITLE
CUSTCOM-153 maven plugin completion xml validation

### DIFF
--- a/appserver/admin/gf_template/pom.xml
+++ b/appserver/admin/gf_template/pom.xml
@@ -130,6 +130,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/admin/gf_template/pom.xml
+++ b/appserver/admin/gf_template/pom.xml
@@ -43,7 +43,7 @@
 <!-- Portions Copyright [2019] [Payara Foundation and/or its affiliates] -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
@@ -88,7 +88,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
@@ -103,12 +103,12 @@
                             <inputFiles>
                                 <inputFile>${project.build.directory}/dependency/config/logging.properties</inputFile>
                                 <inputFile>../../logging/logging.properties</inputFile>
-                            </inputFiles>  
+                            </inputFiles>
                         </configuration>
                     </execution>
-                </executions>						 
+                </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -126,12 +126,11 @@
                             <attach>false</attach>
                             <appendAssemblyId>false</appendAssemblyId>
                             <useProjectArtifact>false</useProjectArtifact>
-                        </configuration>                        
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
 
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
+
    Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
-  
+
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
    and Distribution License("CDDL") (collectively, the "License").  You
@@ -12,20 +12,20 @@
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
    language governing permissions and limitations under the License.
-  
+
    When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-  
+
    GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
    file that accompanied this code.
-  
+
    Modifications:
    If applicable, add the following below the License Header, with the fields
    enclosed by brackets [] replaced by your own identifying information:
    "Portions Copyright [year] [name of copyright owner]"
-  
+
    Contributor(s):
    If you wish your version of this file to be governed by only the CDDL or
    only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -41,7 +41,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
@@ -86,7 +86,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
@@ -101,12 +101,12 @@
                             <inputFiles>
                                 <inputFile>${project.build.directory}/dependency/config/logging.properties</inputFile>
                                 <inputFile>../../logging/logging.properties</inputFile>
-                            </inputFiles>  
+                            </inputFiles>
                         </configuration>
                     </execution>
-                </executions>						 
+                </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -124,12 +124,11 @@
                             <attach>false</attach>
                             <appendAssemblyId>false</appendAssemblyId>
                             <useProjectArtifact>false</useProjectArtifact>
-                        </configuration>                        
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
 
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>

--- a/appserver/admin/gf_template_web/pom.xml
+++ b/appserver/admin/gf_template_web/pom.xml
@@ -128,6 +128,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -42,7 +42,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
@@ -101,12 +101,12 @@
                             <inputFiles>
                                 <inputFile>${project.build.directory}/dependency/config/logging.properties</inputFile>
                                 <inputFile>../../logging/logging.properties</inputFile>
-                            </inputFiles>  
+                            </inputFiles>
                         </configuration>
                     </execution>
-                </executions>						 
+                </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -124,12 +124,11 @@
                             <attach>false</attach>
                             <appendAssemblyId>false</appendAssemblyId>
                             <useProjectArtifact>false</useProjectArtifact>
-                        </configuration>                        
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
 
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>

--- a/appserver/admin/production_domain_template/pom.xml
+++ b/appserver/admin/production_domain_template/pom.xml
@@ -128,6 +128,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/admin/production_domain_template_web/pom.xml
+++ b/appserver/admin/production_domain_template_web/pom.xml
@@ -130,31 +130,15 @@
                 </executions>
             </plugin>
 
+            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>validate</goal>
-                        </goals>
-                        <phase>validate</phase>
+                        <id>validate-xml-files</id>
                     </execution>
                 </executions>
-                <configuration>
-                   <validationSets>
-                       <validationSet>
-                           <dir>src/main/resources/config</dir>
-                           <includes>
-                               <include>default-web.xml</include>
-                               <include>domain.xml</include>
-                               <include>glassfish-acc.xml</include>
-                               <include>wss-server-config-1.0.xml</include>
-                               <include>wss-server-config-2.0.xml</include>
-                           </includes>
-                       </validationSet>
-                   </validationSets>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/appserver/admin/production_domain_template_web/pom.xml
+++ b/appserver/admin/production_domain_template_web/pom.xml
@@ -2,9 +2,9 @@
 
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
+
    Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
-  
+
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
    and Distribution License("CDDL") (collectively, the "License").  You
@@ -13,20 +13,20 @@
    https://github.com/payara/Payara/blob/master/LICENSE.txt
    See the License for the specific
    language governing permissions and limitations under the License.
-  
+
    When distributing the software, include this License Header Notice in each
    file and include the License file at glassfish/legal/LICENSE.txt.
-  
+
    GPL Classpath Exception:
    The Payara Foundation designates this particular file as subject to the "Classpath"
    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
    file that accompanied this code.
-  
+
    Modifications:
    If applicable, add the following below the License Header, with the fields
    enclosed by brackets [] replaced by your own identifying information:
    "Portions Copyright [year] [name of copyright owner]"
-  
+
    Contributor(s):
    If you wish your version of this file to be governed by only the CDDL or
    only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -42,7 +42,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>fish.payara.server.internal.admin</groupId>
         <artifactId>admin</artifactId>
@@ -87,7 +87,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
@@ -102,12 +102,12 @@
                             <inputFiles>
                                 <inputFile>${project.build.directory}/dependency/config/logging.properties</inputFile>
                                 <inputFile>../../logging/logging.properties</inputFile>
-                            </inputFiles>  
+                            </inputFiles>
                         </configuration>
                     </execution>
-                </executions>						 
+                </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -125,12 +125,11 @@
                             <attach>false</attach>
                             <appendAssemblyId>false</appendAssemblyId>
                             <useProjectArtifact>false</useProjectArtifact>
-                        </configuration>                        
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
 
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -99,6 +99,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -99,8 +99,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -99,6 +99,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -99,8 +99,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
@@ -306,7 +304,7 @@
            <type>zip</type>
            <optional>true</optional>
         </dependency>
-       
+
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>notification-email</artifactId>
@@ -386,7 +384,7 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
-	    <dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>

--- a/appserver/extras/payara-micro/payara-micro-boot/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/pom.xml
@@ -61,6 +61,29 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <plugins>
+            <!-- Validate XML resources -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate-xml-files</id>
+                        <configuration>
+                            <validationSets>
+                                <validationSet>
+                                    <dir>src/main/resources/MICRO-INF/domain</dir>
+                                    <includes>
+                                        <include>default-web.xml</include>
+                                        <include>domain.xml</include>
+                                    </includes>
+                                </validationSet>
+                            </validationSets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/appserver/extras/payara-micro/payara-micro-boot/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/pom.xml
@@ -62,7 +62,6 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Validate XML resources -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
@@ -72,10 +71,9 @@
                         <configuration>
                             <validationSets>
                                 <validationSet>
-                                    <dir>src/main/resources/MICRO-INF/domain</dir>
+                                    <dir>${project.build.outputDirectory}/MICRO-INF/domain</dir>
                                     <includes>
-                                        <include>default-web.xml</include>
-                                        <include>domain.xml</include>
+                                        <include>*.xml</include>
                                     </includes>
                                 </validationSet>
                             </validationSets>
@@ -89,7 +87,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
-            <version>${hk2.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,21 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
                     <version>1.0.2</version>
+                    <executions>
+                        <execution>
+                            <id>validate-xml-files</id>
+                            <goals>
+                                <goal>validate</goal>
+                            </goals>
+                            <configuration>
+                                <validationSets>
+                                    <validationSet>
+                                        <dir>src/main/resources/config</dir>
+                                    </validationSet>
+                                </validationSets>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -457,10 +457,19 @@
                             <goals>
                                 <goal>validate</goal>
                             </goals>
+                            <!-- some modules change target structure in package phase -->
+                            <phase>verify</phase>
                             <configuration>
                                 <validationSets>
                                     <validationSet>
-                                        <dir>src/main/resources/config</dir>
+                                        <dir>${project.build.directory}</dir>
+                                        <includes>
+                                            <include>**/*.xml</include>
+                                        </includes>
+                                        <excludes>
+                                            <!-- these files contain templates with placeholders -->
+                                            <exclude>**/glassfish/lib/install/templates/resources/custom/**</exclude>
+                                        </excludes>
                                     </validationSet>
                                 </validationSets>
                             </configuration>


### PR DESCRIPTION
# Description

In #4379 @pzygielo came with the idea to validate broken domain.xml in module we broke in one release.
@MattGill98 extended it in #4396  to validate all source domain.xml files.
I am expanding it here to validate all output xml files in modules where it was already enabled by @MattGill98 . I could be even enabled to all modules, unfortunately xml plugin does not have option to accept non-existing directories as valid set of files.

# Tests performed

Build everything and check if the plugin was called
mvn clean install -PBuildExtras,BuildDockerImages

Break some domain.xml and run 
mvn clean verify -pl :xxx
- were xxx is artifactId where is the domain.xml file used

# Note

There is also a set of templates which are invalid, because they contains a placeholder with `<` characters. They are excluded from tests.
If the maven plugin would be extended, we can move the configuration even higher.