### PR TITLE
CUSTCOM-109 SendAsadminCommand now does a check for if supplied instances is null

### DIFF
--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/asadmin/SendAsadminCommand.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/asadmin/SendAsadminCommand.java
@@ -1,24 +1,46 @@
-/**
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- * Copyright (c) 2016-2017 Payara Foundation and/or its affiliates. All rights reserved.
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * The contents of this file are subject to the terms of the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
+ *  Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
  */
 package fish.payara.appserver.micro.services.asadmin;
 
 import com.sun.enterprise.config.serverbeans.Domain;
 import fish.payara.appserver.micro.services.PayaraInstanceImpl;
-import fish.payara.appserver.micro.services.command.ClusterCommandResultImpl;
 import fish.payara.micro.ClusterCommandResult;
 import fish.payara.micro.data.InstanceDescriptor;
 import java.util.ArrayList;
@@ -354,7 +376,7 @@ public class SendAsadminCommand implements AdminCommand
                     }
                 }
             }
-        } else if (explicitTargets.length == 0) {
+        } else if (explicitTargets == null || explicitTargets.length == 0) {
             for (InstanceDescriptor instance : instances) {
                 // Only send the command to Micro instances
                 if (instance.isMicroInstance()) {
@@ -373,6 +395,9 @@ public class SendAsadminCommand implements AdminCommand
      */
     private Map<String, InstanceDescriptor> getExplicitTargetInstanceDescriptors(String[] explicitTargets) {
         Map<String, InstanceDescriptor> targetInstanceDescriptors = new HashMap<>();
+        if (explicitTargets == null) {
+            return targetInstanceDescriptors;
+        }
         
         // Get all of the clustered instances
         Set<InstanceDescriptor> instances = payaraMicro.getClusteredPayaras();


### PR DESCRIPTION
# Description
This is a bug fix.

# Important Info
This is an alternative to #4398

As the other commands which accept multiple operands have it as non-optional then I think a better approach is to only check in the command that does it this way, rather than doing a check every single time (which is less efficient).