### PR TITLE
Thread Naming for easier Thread Dump analysis - CUSTCOM-145

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ResourceAdapterAdminServiceImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ResourceAdapterAdminServiceImpl.java
@@ -78,6 +78,7 @@ public class ResourceAdapterAdminServiceImpl extends ConnectorService {
            public Thread newThread(Runnable r) {
              Thread th = new Thread(r);
              th.setDaemon(true);
+             th.setName("RA Shutdown");
              return th;
            }
     });   

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
@@ -319,6 +319,7 @@ public final class AMXConfigLoader implements TransactionListener {
 
             mLoaderThread = new AMXConfigLoaderThread(mPendingConfigBeans);
             mLoaderThread.setDaemon(true);
+            mLoaderThread.setName("AMX Config Loader");
             mLoaderThread.start();
 
             mPendingConfigBeans.swapTransactionListener(this);

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/NotificationEmitterSupport.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/util/jmx/NotificationEmitterSupport.java
@@ -356,6 +356,7 @@ public final class NotificationEmitterSupport extends NotificationBroadcasterSup
         public SenderThread()
         {
             setDaemon(true);
+            setName("JMX Notification Emitter");
             mQuit = false;
             mPendingNotifications = new LinkedBlockingQueue<QueueItem>();
         }

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingOutputStream.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingOutputStream.java
@@ -134,7 +134,7 @@ public class LoggingOutputStream extends ByteArrayOutputStream {
                 }
             }
         };
-        pump.setName("logging output pump");
+        pump.setName("Logging output pump");
         pump.setDaemon(true);
         pump.start();
     }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiFrameworkLauncher.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiFrameworkLauncher.java
@@ -97,6 +97,7 @@ public class OSGiFrameworkLauncher {
                 }
             };
             thread.setDaemon(true);
+            thread.setName("OSGI Framework Init");
             thread.start();
             thread.join();
         } else {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobCleanUpService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobCleanUpService.java
@@ -100,21 +100,20 @@ public class JobCleanUpService implements PostConstruct,ConfigListener {
     public void postConstruct() {
         logger.log(Level.FINE,KernelLoggerInfo.initializingJobCleanup);
 
-
+        if (Version.getFullVersion().contains("Micro")) {
+            //if Micro we don't have any jobs to cleanup
+            return;
+        }
 
         scheduler = Executors.newScheduledThreadPool(10, new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
                 Thread result = new Thread(r);
                 result.setDaemon(true);
+                result.setName("Job Cleanup Service");
                 return result;
             }
         });
-        
-        if (Version.getFullVersion().contains("Micro")) {
-            //if Micro we don't have any jobs to cleanup
-            return;
-        }
 
         managedJobConfig = domain.getExtensionByType(ManagedJobConfig.class);
         ObservableBean bean = (ObservableBean) ConfigSupport.getImpl(managedJobConfig);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobCleanUpService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobCleanUpService.java
@@ -80,10 +80,10 @@ public class JobCleanUpService implements PostConstruct,ConfigListener {
 
     @Inject
     Domain domain;
-    
+
     @Inject
     private ProcessEnvironment processEnv;
-    
+
     private ManagedJobConfig managedJobConfig;
 
     private final static Logger logger = KernelLoggerInfo.getLogger();
@@ -98,12 +98,12 @@ public class JobCleanUpService implements PostConstruct,ConfigListener {
 
     @Override
     public void postConstruct() {
-        logger.log(Level.FINE,KernelLoggerInfo.initializingJobCleanup);
-
         if (Version.getFullVersion().contains("Micro")) {
             //if Micro we don't have any jobs to cleanup
             return;
         }
+
+        logger.log(Level.FINE,KernelLoggerInfo.initializingJobCleanup);
 
         scheduler = Executors.newScheduledThreadPool(10, new ThreadFactory() {
             @Override

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/GFDomainXml.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/GFDomainXml.java
@@ -71,6 +71,7 @@ public class GFDomainXml extends DomainXml {
                         public Thread newThread(Runnable r) {
                             Thread t = Executors.defaultThreadFactory().newThread(r);
                             t.setDaemon(true);
+                            t.setName("GF Domain XML");
                             t.setContextClassLoader(habitat.<ServerContext>getService(ServerContext.class).getCommonClassLoader());
                             return t;
                         }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ScheduledExecutorServiceFactory.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ScheduledExecutorServiceFactory.java
@@ -64,6 +64,7 @@ public class ScheduledExecutorServiceFactory implements Factory<ScheduledExecuto
             public Thread newThread(Runnable r) {
                     Thread t = Executors.defaultThreadFactory().newThread(r);
                     t.setDaemon(true);
+                    t.setName("Scheduled Executor Service");
                     return t;
                 }
             }


### PR DESCRIPTION
# CUSTCOM-145: Assign meaningful thread names

During Thread dump analysis, it was not always easy to identify what threads are due to their name (Thread-[n] or pool-[x]-thread-[y])

After this update, threads name are mostly set. Some threads are still un named and could be done in

osgi-javaee-base org.glassfish.osgijavaeebase.ExtenderManager.GlassFishServerTracker#addingService
org.glassfish.osgijavaeebase.JavaEEExtender.HybridBundleTrackerCustomizer#addingBundle

and Apache Felix


# Description
This is a improvement

Should be easier to identify threads in Thread Dump.

# Testing

### Testing Performed

Manual testing to identify the list of threads through JConsole.

### Test suites executed
- Quicklook

### Testing Environment

Mac OS
