### PR TITLE
CUSTCOM-144 Avoid NPEx on unboxing null Boolean (javaee/glassfish 22406)

### DIFF
--- a/appserver/web/web-glue/pom.xml
+++ b/appserver/web/web-glue/pom.xml
@@ -260,5 +260,11 @@
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/deploy/FilterDefDecorator.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/deploy/FilterDefDecorator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2020 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -114,7 +114,8 @@ public class FilterDefDecorator extends FilterDef {
     }
 
     public boolean isAsyncSupported() {
-        return decoree.isAsyncSupported();
+        Boolean decoreeAsyncFlag = decoree.isAsyncSupported();
+        return (decoreeAsyncFlag == null ? false : decoreeAsyncFlag);
     }   
 
 }

--- a/appserver/web/web-glue/src/test/java/com/sun/enterprise/web/deploy/FilterDefDecoratorTest.java
+++ b/appserver/web/web-glue/src/test/java/com/sun/enterprise/web/deploy/FilterDefDecoratorTest.java
@@ -1,0 +1,68 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package com.sun.enterprise.web.deploy;
+
+import com.sun.enterprise.deployment.web.ServletFilter;
+import java.util.Vector;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilterDefDecoratorTest {
+  @Mock
+  private ServletFilter filter;
+
+  @Test
+  public void nullAsyncSupportedFlagShallNotCauseException() {
+    when(filter.isAsyncSupported()).thenReturn(null);
+    when(filter.getInitializationParameters()).thenReturn(new Vector());
+
+    FilterDefDecorator fdd = new FilterDefDecorator(filter);
+
+    assertFalse(fdd.isAsyncSupported());
+  }
+}
+


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix, for issue originally reported against javaee/glassfish (22406).

# Testing

### New tests
New UT `FilterDefDecoratorTest.nullAsyncSupportedFlagShallNotCauseException`.

### Testing Performed
A. `mvn clean install` 
1. for first commit to make sure UT fails
2. for second commit to make sure it fixes `FilterDefDecorator` and doesn't break the build in other parts.

B. With distribution built in step A2 - *Steps to reproduce* from [22406](https://github.com/eclipse-ee4j/glassfish/issues/22406#issuecomment-504749628), but with step 7 producing expected welcome page.

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
Only included in full build with command above.

### Testing Environment
A. Ubuntu 16.04.6 LTS, OpenJDK Runtime Environment (build 1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10), maven 3.6.3
B. GNU/Linux, OpenJDK Runtime Environment (build 1.8.0_232-b09), maven 3.6.3
