### PR TITLE
CUSTOM-142 Delete JVM options with min max versions.

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/DeleteJvmOptions.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/DeleteJvmOptions.java
@@ -162,7 +162,8 @@ public final class DeleteJvmOptions implements AdminCommand, AdminCommandSecurit
         SingleConfigCode<JvmOptionBag> scc = (JvmOptionBag bag1) -> {
             List<String> jvmopts = new ArrayList<>(bag1.getJvmRawOptions());
             int orig = jvmopts.size();
-            boolean removed = jvmopts.removeIf(option -> toRemove.contains(new JvmOption(option).option));
+            // using new JvmOption(option).toString() (instead op option directly) to make sure the correct formatting is applied.
+            boolean removed = jvmopts.removeIf(option -> toRemove.contains(new JvmOption(option).toString()));
             bag1.setJvmOptions(jvmopts);
             int now = jvmopts.size();
             if (removed) {


### PR DESCRIPTION
This is a bug fix

When you try to delete a JVM option which has defined a min and/or max version, the option cannot be found (and thus not deleted).

This PR fixes the delete logic of the JVM Options.

# Important Info

No Unit Test created due to proxy requirements of JavaConfig within `org.jvnet.hk2.config.ConfigSupport#apply(org.jvnet.hk2.config.SingleConfigCode<T>, T)` 

# Testing

### Testing Performed

./asadmin start-domain
./asadmin create-jvm-options '[1.8.123|1.8.231]-DtestOption'
./asadmin delete-jvm-options '[1.8.123|1.8.231]-DtestOption'

- Quicklook

### Testing Environment

Maven 3.5.4
JDK 1.8u181
