### PR TITLE
CUSTCOM-150 Leaking Managed Connector Dependency

### DIFF
--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -92,6 +92,7 @@
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-managed</artifactId>
                     <scope>test</scope>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
 
@@ -159,6 +160,7 @@
                     <artifactId>arquillian-payara-micro-managed</artifactId>
                     <version>${arquillian.payara.micro.version}</version>
                     <scope>test</scope>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
 
@@ -220,6 +222,7 @@
                     <artifactId>arquillian-payara-server-remote</artifactId>
                     <version>${arquillian.payara.remote.version}</version>
                     <scope>test</scope>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
See commit message for details.

I've added the optional flag to make none of the connectors include themselves transiently.