### PR TITLE
CUSTCOM-13 A REST management DELETE command returns 415 code instead of 404

### DIFF
--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -23,6 +23,7 @@
         <module>jaxrs-rolesallowed</module>
         <module>jaxrs-rolesallowed-servlet</module>
         <module>jaxws-tracing</module>
+        <module>rest-management</module>
         <module>rolesPermitted</module>
         <module>oauth2</module>
         <module>openid</module>

--- a/appserver/tests/payara-samples/samples/rest-management/pom.xml
+++ b/appserver/tests/payara-samples/samples/rest-management/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+    
+    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+    
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+    
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+    
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+    
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+    
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>5.201-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rest-management</artifactId>
+    <name>Payara Samples - Payara - REST Management</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/HttpResponsesTest.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/HttpResponsesTest.java
@@ -1,0 +1,66 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rest.management;
+
+import static org.junit.Assert.assertEquals;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+
+import org.junit.Test;
+
+import fish.payara.samples.NotMicroCompatible;
+
+/**
+ * Test the REST management interface for it's basic HTTP responses
+ */
+@NotMicroCompatible
+public class HttpResponsesTest extends RestManagementTest {
+
+    /**
+     * Tests that when deleting a non-existent resource a 404 is returned instead of
+     * a 415. See CUSTCOM-13 for details.
+     */
+    @Test
+    public void when_DELETE_non_existent_resource_expect_404() {
+        int status = request(HttpMethod.DELETE, "servers/server/server/application-ref/non-existent-application-ref").getStatus();
+        assertEquals("A non-existent resource should return a 404.", 404, status);
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/RestManagementTest.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/RestManagementTest.java
@@ -1,0 +1,120 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rest.management;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.ServerOperations;
+
+@RunWith(PayaraArquillianTestRunner.class)
+public abstract class RestManagementTest {
+
+    private WebTarget target;
+
+    @ArquillianResource
+    private URL baseUrl;
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return PayaraTestShrinkWrap.getWebArchive()
+            .addClass(RestManagementTest.class);
+    }
+
+    @Before
+    public final void setUpFields() throws URISyntaxException {
+        URI adminBaseUrl = ServerOperations.toAdminPort(baseUrl).toURI();
+        assertNotNull("Something went wrong with the test, and an admin port cannot be found.", adminBaseUrl);
+        target = ClientBuilder
+            .newClient()
+            .target(adminBaseUrl.resolve("/management/domain/").toString());
+    }
+
+    /**
+     * Make a synchronous request to the REST management interface.
+     * 
+     * @param method the HTTP method to use for the request
+     * @param path   the path of the request, relative to /management/domain/
+     * @param entity the entity to send in the request
+     * 
+     * @return the response of the request.
+     */
+    protected Response request(HttpMethod method, String path, Entity<?> entity) {
+        return target
+            .path(path)
+            .request()
+            .header("X-Requested-By", "Payara")
+            .build(method.toString(), entity)
+            .invoke();
+    }
+
+
+    /**
+     * Make a synchronous request to the REST management interface. This method
+     * sends nothing in the body. To send data, see
+     * {@link #request(HttpMethod, String, Entity)}.
+     * 
+     * @param method the HTTP method to use for the request
+     * @param path   the path of the request, relative to /management/domain/
+     * 
+     * @return the response of the request.
+     */
+    protected Response request(HttpMethod method, String path) {
+        return request(method, path, null);
+    }
+}

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestShrinkWrap.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestShrinkWrap.java
@@ -26,8 +26,11 @@ public final class PayaraTestShrinkWrap {
     }
 
     private static <T extends Archive<T> & ClassContainer<T>> T getArchive(Class<T> archiveType) {
-        return ShrinkWrap.create(archiveType).addClass(PayaraArquillianTestRunner.class)
-                .addClass(PayaraTestRunnerDelegate.class).addClass(SincePayara.class).addClass(NotMicroCompatible.class)
+        return ShrinkWrap.create(archiveType)
+                .addClass(PayaraArquillianTestRunner.class)
+                .addClass(PayaraTestRunnerDelegate.class)
+                .addClass(SincePayara.class)
+                .addClass(NotMicroCompatible.class)
                 .addClass(PayaraVersion.class);
     }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/readers/FormReader.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/readers/FormReader.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2020] Payara Foundation and/or affiliates
 
 package org.glassfish.admin.rest.readers;
 
@@ -49,6 +49,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.StringTokenizer;
 import javax.ws.rs.Consumes;
@@ -64,22 +65,22 @@ import javax.ws.rs.ext.Provider;
  */
 @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_OCTET_STREAM})
 @Provider
-public class FormReader implements MessageBodyReader<HashMap<String, String>> {
+public class FormReader implements MessageBodyReader<Map<String, String>> {
     
     private static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.toString();
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return type.equals(HashMap.class);
+        return Map.class.isAssignableFrom(type);
     }
 
     @Override
-    public HashMap<String, String> readFrom(Class<HashMap<String, String>> type, Type genericType,
+    public Map<String, String> readFrom(Class<Map<String, String>> type, Type genericType,
             Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> headers, 
             InputStream in) throws IOException {        
         String formData = readAsString(in);
 
-        HashMap<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<String, String>();
         StringTokenizer tokenizer = new StringTokenizer(formData, "&");
         String token;
         while (tokenizer.hasMoreTokens()) {


### PR DESCRIPTION
This is a bug fix. Starting a fresh domain in 5.194 and running the following curl command:

~~~
curl -X DELETE -v -H "Content-Type: application/x-www-form-urlencoded" -H "X-Requested-By:Payara" http://localhost:4848/management/domain/servers/server/server/application-ref/non-existing-app-ref
~~~

will cause a HTTP 415 to return, where it should be a 404. Note that in 5.193 this worked.

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Testing

### New tests

Second commit. I've made the testing module fairly generic, as I see it as something that could be useful in the future.

### Testing Performed
<!--- Please describe how you tested these changes.  -->
The new test against 5.193 and the SNAPSHOT on micro, managed and remote profiles.

### Test suites executed
- Payara Samples (only single test)
- Java EE7 Samples (only JAX-RS tests against remote)
- Java EE8 Samples (only JAX-RS tests against remote)

# Notes for Reviewers
Read the commit messages ;)

I've deliberately ignored the previous fix that regressed. I hope this does the same job but with lower technical debt.