### PR TITLE
CUSTCOM-167 Remove unused loop and unnecessary collection size checks

### DIFF
--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
@@ -970,7 +970,7 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
             }
         } // End -- for each active timer
 
-        if (timerIdsToRemove.size() > 0) {
+        if (!timerIdsToRemove.isEmpty()) {
             removeTimers(timerIdsToRemove);
         }
 

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -971,9 +971,6 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
         } // End -- for each active timer
 
         if (timerIdsToRemove.size() > 0) {
-            for (HZTimer hZTimer : result) {
-
-            }
             removeTimers(timerIdsToRemove);
         }
 

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/src/main/java/fish/payara/ejb/timer/hazelcast/HazelcastTimerStore.java
@@ -970,9 +970,7 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
             }
         } // End -- for each active timer
 
-        if (!timerIdsToRemove.isEmpty()) {
-            removeTimers(timerIdsToRemove);
-        }
+        removeTimers(timerIdsToRemove);
 
         for (Iterator entries = timersToRestore.entrySet().iterator();
                 entries.hasNext();) {
@@ -1142,9 +1140,7 @@ public class HazelcastTimerStore extends NonPersistentEJBTimerService {
             }
         } // End -- for each active timer
 
-        if (timerIdsToRemove.size() > 0) {
-            removeTimers(timerIdsToRemove);
-        }
+        removeTimers(timerIdsToRemove);
 
         for (Iterator entries = timersToRestore.entrySet().iterator();
                 entries.hasNext();) {


### PR DESCRIPTION
# Testing

### Testing Performed
Full build with `mvn clean install`.

### Testing Environment
GNU/Linux, OpenJDK Runtime Environment (build 1.8.0_232-b09), Maven 3.6.3

### Sonar references:
1. [Use isEmpty() to check whether the collection is empty or not.](https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW0h5iNJbW38OQeaTjl3&open=AW0h5iNJbW38OQeaTjl3)
2. [Either remove or fill this block of code.](https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW0h5iNJbW38OQeaTjmE&open=AW0h5iNJbW38OQeaTjmE)
3. [Remove this unused "hZTimer" local variable.](https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW0h5iNJbW38OQeaTjmI&open=AW0h5iNJbW38OQeaTjmI)
4. [Use isEmpty() to check whether the collection is empty or not.](https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW0h5iNJbW38OQeaTjl4&open=AW0h5iNJbW38OQeaTjl4)