### PR TITLE
CUSTCOM-11 Update Jersey Version to 2.29.1.payara-p2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <servlet-api.version>4.0.2</servlet-api.version>
         <grizzly.version>2.4.3.payara-p10</grizzly.version>
         <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
-        <jersey.version>2.29.1.payara-p1</jersey.version>
+        <jersey.version>2.29.1.payara-p2</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
         <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>6.0.16.Final</hibernate.validator-cdi.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
Based on https://github.com/payara/Payara_PatchedProjects/pull/289.

When an endpoint with method POST/PUT is defined, and it is called with no payload, it results in an Exception.

~~~
javax.ws.rs.ProcessingException: Error deserializing object from entity stream.
        at org.glassfish.jersey.jsonb.internal.JsonBindingProvider.readFrom(JsonBindingProvider.java:77)
~~~~
However, according to the JAX-RS specification, an 'empty' object should be created:

----
4.2.4 Standard Entity providers

        When reading zero-length message entities all pre-packaged MessageBodyReader implementations, except the JAXB one and those for the (boxed) primitive types above, MUST create a corresponding Java object that represents zero-length data.
----

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Testing

### New tests
<!-- Link to the test suite PR or provide info -->
https://github.com/payara/patched-src-javaee7-samples/pull/50

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples