### PR TITLE
  FISH-761 Deployment of unpacked WAB fails when using Felix fileinstall

### DIFF
--- a/nucleus/deployment/common/src/main/java/org/glassfish/loader/util/ASClassLoaderUtil.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/loader/util/ASClassLoaderUtil.java
@@ -263,6 +263,12 @@ public class ASClassLoaderUtil {
                                             "Error truncating URI with prefix of \"reference:\"",
                                             use);
                                 }
+                            } else if (uri.toString().startsWith("jardir:")) {
+                                // OSGi fileinstall created modules can have a "jardir:" schema for directory
+                                // structures, but their is no FileSystemProvider for this type.
+                                // Since the path is the file system path, just substitute the "file:" schema
+                                tmpString.append("file:").append(uri.toString().substring("jardir:".length()));
+                                tmpString.append(File.pathSeparator);
                             } else {
                                 tmpString.append(Paths.get(uri).toString());
                                 tmpString.append(File.pathSeparator);

--- a/nucleus/deployment/common/src/main/java/org/glassfish/loader/util/ASClassLoaderUtil.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/loader/util/ASClassLoaderUtil.java
@@ -265,7 +265,7 @@ public class ASClassLoaderUtil {
                                 }
                             } else if (uri.toString().startsWith("jardir:")) {
                                 // OSGi fileinstall created modules can have a "jardir:" schema for directory
-                                // structures, but their is no FileSystemProvider for this type.
+                                // structures, but there is no FileSystemProvider for this type.
                                 // Since the path is the file system path, just substitute the "file:" schema
                                 tmpString.append("file:").append(uri.toString().substring("jardir:".length()));
                                 tmpString.append(File.pathSeparator);


### PR DESCRIPTION
# Description
Add explicit support for the "jardir" schema used by fileinstall for unpacked directories by translating it to to the "file" schema.  This allows unpacked WAB (and probably EJB bundles) installed via Felix FileInstall to be deployed successfully (barring other bugs)

Fixes: https://github.com/payara/Payara/issues/4415

This works because the path portion of the jardir: URL is the directory path.  The "jardir:" provides some additional features that don't appear to be needed during Java EE module deployment and it isn't supported for the NIO FileSystem API, which Payara uses during deployment.

# Testing

### New tests
None added

### Testing Performed
Tested this with the application under which we discovered this bug

### Test suites executed
None

### Testing Environment
OS: RedHat Linux 7
JDK: OpenJDK 8.0.201
Maven: 3.6.2

# Documentation
N/A

# Notes for Reviewers
N/A