### PR TITLE
[FISH-1017] Payara can close JarFile instances used by current URLClassLoaders

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/JarFileUtils.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/JarFileUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2015-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -41,8 +41,11 @@ package com.sun.enterprise.admin.util;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ConcurrentModificationException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -80,21 +83,30 @@ public class JarFileUtils {
                 }
             }
             if (files != null && !files.isEmpty()) {
-                Set<JarFile> jarFiles = new HashSet<>();
+                Map<String, JarFile> jarFiles = new HashMap<>();
                 if(jarFileFactoryInstance != null) {
                     synchronized (jarFileFactoryInstance) {
-                        jarFiles.addAll(files.values());
+                        jarFiles.putAll(files);
                     }
                 } else {
-                    jarFiles.addAll(files.values());
+                    jarFiles.putAll(files);
                 }
-                for (JarFile file : jarFiles) {
-                    if (file != null) {
-                        file.close();
+                // Close "file:" JAR files so they can be overwritten on Windows
+                // Leave others open, but remove them from the cache so they
+                // Can be closed when garbage collected.  This prevents
+                // closing JarFile instances opened by URLClassLoader
+                // NOTE: This still may close JarFile instances not opened by the calling process.
+                Method closeMethod = clazz.getMethod("close", JarFile.class);
+                closeMethod.setAccessible(true);
+                for (Map.Entry<String, JarFile> file : jarFiles.entrySet()) {
+                    if (file.getKey().startsWith("file:")) {
+                        file.getValue().close();
+                    } else {
+                        closeMethod.invoke(jarFileFactoryInstance, file.getValue());
                     }
                 }
             }
-        } catch (ClassNotFoundException | IllegalAccessException | SecurityException | IllegalArgumentException | IOException | ConcurrentModificationException ex) {
+        } catch (ClassNotFoundException | IllegalAccessException | SecurityException | IllegalArgumentException | IOException | ConcurrentModificationException | InvocationTargetException | NoSuchMethodException ex) {
             LOG.log(Level.SEVERE, null, ex);
         }
     }


### PR DESCRIPTION
# Description
Changes the closeCachedJarFiles behavior to only close JarFile instances associated with a "file:" URL.  All others are removed from the cache so they can be closed when no longer in use.  The assumption is that others might be owned by a URLClassLoader, but "file:" is most likely owned by the process requesting the close.  This should allow redeployment of the vast majority of applications on Windows without having to worry about file locks, while letting applications which need unusual Jar file URLs to work.

fixes: https://github.com/payara/Payara/issues/4414

# Testing

### New tests
None provided

### Testing Performed
Tested that it fixes the issue using the application which showed it.

### Test suites executed
None

### Testing Environment
OS: RedHat Linux 7
JDK: OpenJDK 8.0.201
Maven: 3.6.2

# Documentation
N/A

# Notes for Reviewers
N/A