### PR TITLE
fixes issue #4169 - Display node uptime in a human readable format

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstanceGeneral.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstanceGeneral.jsf
@@ -167,7 +167,11 @@
             <sun:staticText id="statusReason" text="#{pageSession.statusReason}" />
         </sun:property>
         <sun:property id="uptimeProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.cluster.Uptime}:" >
-            <sun:staticText id="uptime" text="#{pageSession.statusUptime} (ms)" />
+            <!beforeCreate
+                convertMillisToReadable(milliseconds="#{pageSession.statusUptime}"
+                                        readableString=>$attribute{formattedUpTime});
+                />
+            <sun:staticText id="uptime" text="#{formattedUpTime}" />
         </sun:property>
         <sun:property id="deploymentGroupProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.cluster.DeploymentGroup}:" >
             <sun:staticText id="deploymentGRoup" text="#{pageSession.statusDG}" />

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/CommonHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/CommonHandlers.java
@@ -270,7 +270,7 @@ public class CommonHandlers {
 
         String readableString = "";
 
-        long msecLeftover = milliseconds;
+        long msecLeftover = milliseconds != null ? milliseconds : 0L;
 
         long numWeeks = msecLeftover / MSEC_PER_WEEK;
         msecLeftover -= numWeeks * MSEC_PER_WEEK;


### PR DESCRIPTION
# Description

Converted the node uptime display format from milliseconds to a human readable format.
There was already a handler for this purpose that could be used. Since a node can also be stopped and then has no uptime, the handler needed a null check.

fixes #4169 

# Testing

### Testing Performed
Created a new instance and opened its standaloneInstanceGeneral.jsf page.
Checked the result when the instance is running & stopped.

### Testing Environment
Zulu JDK 1.8_232
Windows 10
Maven 3.6.1
