### PR TITLE
CUSTCOM-181 Remove unused method

### DIFF
--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IIOPSSLSocketFactory.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IIOPSSLSocketFactory.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation]
+// Portions Copyright [2016-2020] [Payara Foundation]
 
 package org.glassfish.enterprise.iiop.impl;
 
@@ -789,10 +789,6 @@ public class IIOPSSLSocketFactory implements ORBSocketFactory {
 
         void addProtocol(String protocol) {
             allowedProtocols.add(protocol);
-        }
-
-        String[] getAllowedProtocol() {
-            return (String[]) allowedProtocols.toArray();
         }
 
         String[] getSsl3TlsCiphers() {


### PR DESCRIPTION
This is a [possible] bug fix
```
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Ljava.lang.String;
```

# Testing

### Testing Performed
`mvn clean install`

### Testing Environment
GNU/Linux, OpenJDK Runtime Environment (build 1.8.0_232-b09), Maven 3.6.3
