### PR TITLE
APPSERV-40 Fix NPE when starting Payara Micro in JobCleanUpService

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobCleanUpService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobCleanUpService.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2020] Payara Foundation and/or affiliates
 package com.sun.enterprise.v3.admin;
 
 import com.sun.appserv.server.util.Version;
@@ -94,11 +95,12 @@ public class JobCleanUpService implements PostConstruct,ConfigListener {
     private static final LocalStringManagerImpl adminStrings =
             new LocalStringManagerImpl(JobCleanUpService.class);
 
-
+    private boolean micro;
 
     @Override
     public void postConstruct() {
-        if (Version.getFullVersion().contains("Micro")) {
+        micro = Version.getFullVersion().contains("Micro");
+        if (micro) {
             //if Micro we don't have any jobs to cleanup
             return;
         }
@@ -130,6 +132,9 @@ public class JobCleanUpService implements PostConstruct,ConfigListener {
      * This will schedule a cleanup of expired jobs based on configurable values
      */
     private void scheduleCleanUp() {
+        if (micro) {
+            return;
+        }
 
         if (managedJobConfig == null) {
             managedJobConfig = domain.getExtensionByType(ManagedJobConfig.class);


### PR DESCRIPTION
# Description
This is a bug fix

# Testing

### Testing Performed
Start Payara Micro.
Before: NPE
Afterwards: None

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.2