### PR TITLE
CUSTCOM-171 Prevent ClassCastException

### DIFF
--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/BlockingQueueHandler.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/BlockingQueueHandler.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2017] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2017, 2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -193,7 +193,7 @@ public class BlockingQueueHandler extends Handler implements BlockingQueue<LogRe
 
     @Override
     public LogRecord[] toArray() {
-        return (LogRecord[]) queue.toArray();
+        return queue.toArray(new LogRecord[0]);
     }
 
     @Override

--- a/nucleus/payara-modules/notification-core/src/test/java/fish/payara/nucleus/notification/BlockingQueueHandlerTest.java
+++ b/nucleus/payara-modules/notification-core/src/test/java/fish/payara/nucleus/notification/BlockingQueueHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.nucleus.notification;
+
+import static java.util.logging.Level.INFO;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class BlockingQueueHandlerTest {
+  @Test
+  public void toArrayShallNotThrowClassCastException() {
+    BlockingQueueHandler bqh = new BlockingQueueHandler();
+
+    bqh.toArray();
+  }
+
+  @Test
+  public void toArrayOnNonEmptyQueueShallNotThrowClassCastException() {
+    BlockingQueueHandler bqh = new BlockingQueueHandler();
+
+    bqh.publish(new LogRecord(INFO, "Info Log Record"));
+    LogRecord [] records = bqh.toArray();
+
+    assertEquals(1, records.length);
+  }
+}
+


### PR DESCRIPTION
# Description
This is a bug fix.

Current https://github.com/payara/Payara/blob/ff7bf071c20e021ef1614e65f765c6ec18bf4468/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/BlockingQueueHandler.java#L194-L197 throws `ClassCastException`. (It is shown in the first commit.)

# Testing

### Testing Performed
```
mvn clean test -pl nucleus/payara-modules/notification-core -Dtest=BlockingQueueHandlerTest
```
and full build (`mvn clean install`)

### Testing Environment
GNU/Linux, OpenJDK Runtime Environment (build 1.8.0_232-b09), maven 3.6.3
