### PR TITLE
CUSTCOM-174 Avoid NPE by EJBException.addSuppressed() 

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
@@ -671,14 +671,18 @@ public class EJBContainerTransactionManager {
             LOG.log(Level.FINE, "ejb.transaction_abort_exception", ex);
             // EJB2.0 section 18.3.6
             final EJBException result = new EJBException("Transaction aborted", ex);
-            result.addSuppressed(newException);
+            if (newException != null) {
+                result.addSuppressed(newException);
+            }
             return result;
         } catch (Exception ex) {
             LOG.log(Level.FINE, "ejb.cmt_exception", ex);
             // Commit or rollback failed.
             // EJB2.0 section 18.3.6
             final EJBException result = new EJBException("Unable to complete container-managed transaction.", ex);
-            result.addSuppressed(newException);
+            if (newException != null) {
+                result.addSuppressed(newException);
+            }
             return result;
         }
     }


### PR DESCRIPTION
CUSTCOM-174 Avoid NPE by EJBException.addSuppressed() by ContainerTransactionManager.

# Description
This is a bug fix

EJBException.addSuppressed() will throw a NPE when called with a null parameter. The code within 
ContainerTransactionManager doesn't check for this condition and user encountered this problem due to changes done in 5.194 release (https://github.com/payara/Payara/pull/4325)

# Testing

### New tests
No unit test created due to some final methods which cannot be mocked.

### Test suites executed
- Quicklook

### Testing Environment
Oracle 1.8.0_181 on Mac 10.14.6 with Maven 3.5.4
