### PR TITLE
APPSERV-47 Adds Custom Watches to Monitoring Console

### DIFF
--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/admin/SetMonitoringConsoleConfigurationCommand.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/admin/SetMonitoringConsoleConfigurationCommand.java
@@ -140,7 +140,7 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
                     if (enabled != null) {
                         configProxy.setEnabled(enabled.toString());
                     }
-                    if (isDefined(disableWatch)) {
+                    if (isDefined(disableWatch) ) {
                         List<String> disabledWatchNames = configProxy.getDisabledWatchNames();
                         if (!disabledWatchNames.contains(disableWatch)) {
                            disabledWatchNames.add(disableWatch);
@@ -172,6 +172,7 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
                                 customWatchValues.remove(index);
                             }
                         }
+                        configProxy.getDisabledWatchNames().remove(removeWatch);
                     }
                     return null;
                 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/admin/SetMonitoringConsoleConfigurationCommand.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/admin/SetMonitoringConsoleConfigurationCommand.java
@@ -96,19 +96,19 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
     private Boolean enabled;
 
     @Param(optional = true, alias = "disable-watch")
-    private String disableWatch;
+    private String _disableWatch;
 
     @Param(optional = true, alias = "enable-watch")
-    private String enableWatch;
+    private String _enableWatch;
 
     @Param(optional = true, alias = "add-watch-name")
-    private String addWatchName;
+    private String _addWatchName;
 
     @Param(optional = true, alias = "add-watch-json")
-    private String addWatchJson;
+    private String _addWatchJson;
 
     @Param(optional = true, alias = "remove-watch")
-    private String removeWatch;
+    private String _removeWatch;
 
     @Inject
     protected CommandRunner commandRunner;
@@ -140,31 +140,31 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
                     if (enabled != null) {
                         configProxy.setEnabled(enabled.toString());
                     }
-                    if (isDefined(disableWatch) ) {
+                    if (isDefined(_disableWatch) ) {
                         List<String> disabledWatchNames = configProxy.getDisabledWatchNames();
-                        if (!disabledWatchNames.contains(disableWatch)) {
-                           disabledWatchNames.add(disableWatch);
+                        if (!disabledWatchNames.contains(_disableWatch)) {
+                           disabledWatchNames.add(_disableWatch);
                         }
                     }
-                    if (isDefined(enableWatch)) {
-                        configProxy.getDisabledWatchNames().remove(enableWatch);
+                    if (isDefined(_enableWatch)) {
+                        configProxy.getDisabledWatchNames().remove(_enableWatch);
                     }
-                    if (isDefined(addWatchName) && isDefined(addWatchJson)) {
+                    if (isDefined(_addWatchName) && isDefined(_addWatchJson)) {
                         List<String> customWatchNames = configProxy.getCustomWatchNames();
                         List<String> customWatchValues = configProxy.getCustomWatchValues();
-                        int index = customWatchNames.indexOf(addWatchName);
+                        int index = customWatchNames.indexOf(_addWatchName);
                         if (index >= 0) {
                             customWatchNames.remove(index);
                             if (index < customWatchValues.size()) {
                                 customWatchValues.remove(index);
                             }
                         } 
-                        customWatchNames.add(addWatchName);
-                        customWatchValues.add(addWatchJson);
+                        customWatchNames.add(_addWatchName);
+                        customWatchValues.add(_addWatchJson);
                     }
-                    if (isDefined(removeWatch)) {
+                    if (isDefined(_removeWatch)) {
                         List<String> customWatchNames = configProxy.getCustomWatchNames();
-                        int index = customWatchNames.indexOf(removeWatch);
+                        int index = customWatchNames.indexOf(_removeWatch);
                         if (index >= 0) {
                             customWatchNames.remove(index);
                             List<String> customWatchValues = configProxy.getCustomWatchValues();
@@ -172,7 +172,7 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
                                 customWatchValues.remove(index);
                             }
                         }
-                        configProxy.getDisabledWatchNames().remove(removeWatch);
+                        configProxy.getDisabledWatchNames().remove(_removeWatch);
                     }
                     return null;
                 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Alert.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Alert.java
@@ -84,6 +84,10 @@ public final class Alert implements Iterable<Alert.Frame> {
         public boolean isLessSevereThan(Level other) {
             return ordinal() > other.ordinal();
         }
+
+        public static fish.payara.monitoring.alert.Alert.Level parse(String level) {
+            return valueOf(level.toUpperCase());
+        }
     }
 
     public static final class Frame implements Iterable<SeriesDataset> {

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Alert.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Alert.java
@@ -85,7 +85,7 @@ public final class Alert implements Iterable<Alert.Frame> {
             return ordinal() > other.ordinal();
         }
 
-        public static fish.payara.monitoring.alert.Alert.Level parse(String level) {
+        public static Level parse(String level) {
             return valueOf(level.toUpperCase());
         }
     }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/AlertService.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/AlertService.java
@@ -94,11 +94,24 @@ public interface AlertService {
      */
 
     /**
+     * @param name name of the {@link Watch} to look up
+     * @return the {@link Watch} with the give name or {@code null} if no such watch exist.
+     */
+    Watch watchByName(String name);
+
+    /**
      * Adds a watch to the evaluation loop. To remove the watch just use {@link Watch#stop()}.
      *
      * @param watch new watch to add to evaluation loop
      */
     void addWatch(Watch watch);
+
+    /**
+     * Removes the given watch. Alerts triggered by this watch will end now.
+     * 
+     * @param watch the watch to end, not null
+     */
+    void removeWatch(Watch watch);
 
     /**
      * @return All watches registered for evaluation.
@@ -111,4 +124,5 @@ public interface AlertService {
      *         {@link #watches()}.
      */
     Collection<Watch> wachtesFor(Series series);
+
 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/AlertService.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/AlertService.java
@@ -113,6 +113,8 @@ public interface AlertService {
      */
     void removeWatch(Watch watch);
 
+    boolean toggleWatch(String name, boolean disabled);
+
     /**
      * @return All watches registered for evaluation.
      */

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Circumstance.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Circumstance.java
@@ -39,6 +39,10 @@
  */
 package fish.payara.monitoring.alert;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+
 import fish.payara.monitoring.alert.Alert.Level;
 import fish.payara.monitoring.model.SeriesLookup;
 import fish.payara.monitoring.model.Metric;
@@ -136,5 +140,31 @@ public final class Circumstance {
             str.append(" until ").append(stop.toString());
         }
         return str.toString();
+    }
+
+    public JsonValue toJSON() {
+        if (isUnspecified()) {
+            return JsonValue.NULL;
+        }
+        return Json.createObjectBuilder()
+                .add("level", level.name().toLowerCase())
+                .add("start", start.toJSON())
+                .add("stop", stop.toJSON())
+                .add("suppress", suppress.toJSON())
+                .add("suppressing", suppressing == null ? JsonValue.NULL : suppressing.toJSON())
+                .build();
+    }
+
+    public static Circumstance fromJson(JsonValue value) {
+        if (value == JsonValue.NULL || value == null) {
+            return Circumstance.UNSPECIFIED;
+        }
+        JsonObject obj = value.asJsonObject();
+        return new Circumstance(
+                Level.parse(obj.getString("level")), 
+                Condition.fromJSON(obj.get("start")),
+                Condition.fromJSON(obj.get("stop")),
+                Metric.fromJSON(obj.get("suppressing")),
+                Condition.fromJSON(obj.get("suppress")));
     }
 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Circumstance.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Circumstance.java
@@ -48,6 +48,12 @@ import fish.payara.monitoring.model.SeriesLookup;
 import fish.payara.monitoring.model.Metric;
 import fish.payara.monitoring.model.SeriesDataset;
 
+/**
+ * The {@link Circumstance} in context of {@link Alert}s describes under what {@link Condition}s a certain
+ * {@link Alert.Level} {@link #starts(SeriesDataset, SeriesLookup)} and {@link #stops(SeriesDataset)}.
+ *
+ * @author Jan Bernitt
+ */
 public final class Circumstance {
 
     /**

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Condition.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Condition.java
@@ -258,16 +258,15 @@ public final class Condition {
         StringBuilder str = new StringBuilder();
         boolean any = isForLastPresent() && forLast.intValue() == 0;
         boolean anyN = isForLastPresent() && forLast.intValue() < 0;
-        if (any || anyN) {
-            str.append("any 1 ");
-        }
         str.append("value ").append(comparison.toString()).append(' ').append(threshold);
-        if (isForLastPresent() && !any) {
+        if (isForLastPresent()) {
             if (onAverage) {
                 str.append(" for average of last ");
             } else if (anyN) {
                 str.append(" in last ");
-            }else {
+            } else if (any) {
+                str.append(" in sample");
+            } else {
                 str.append(" for last ");
             }
         }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Condition.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Condition.java
@@ -42,6 +42,7 @@ package fish.payara.monitoring.alert;
 import static java.lang.Math.abs;
 import static java.lang.Math.min;
 
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import fish.payara.monitoring.model.SeriesDataset;
@@ -73,6 +74,15 @@ public final class Condition {
         @Override
         public String toString() {
             return symbol;
+        }
+
+        public static Operator parse(String symbol) {
+            for (Operator op : values()) {
+                if (op.symbol.equals(symbol) ) {
+                    return op;
+                }
+            }
+            throw new NoSuchElementException("Operator with symbol does not exist: " + symbol);
         }
     }
 

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Condition.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Condition.java
@@ -98,7 +98,7 @@ public final class Condition {
     public Condition(Operator comparison, long threshold, Number forLast, boolean onAverage) {
         this.comparison = comparison;
         this.threshold = threshold;
-        this.forLast = forLast;
+        this.forLast = !onAverage && forLast instanceof Integer && forLast.intValue() == 1 ? null : forLast;
         this.onAverage = onAverage && forLast != null && forLast.longValue() > 0L;
     }
 

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Watch.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Watch.java
@@ -173,6 +173,8 @@ public final class Watch implements WatchBuilder, Iterable<Watch.State> {
         for (State s : statesByInstanceSeries.values()) {
             if (s.ongoing != null) {
                 s.ongoing.stop(WHITE, (System.currentTimeMillis() / 1000L) * 1000L);
+                s.ongoing = null;
+                s.level = WHITE;
             }
         }
     }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Watch.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Watch.java
@@ -118,6 +118,7 @@ public final class Watch implements WatchBuilder, Iterable<Watch.State> {
     private final Metric[] captured;
     private final Map<String, State> statesByInstanceSeries = new ConcurrentHashMap<>();
     private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private boolean disabled;
 
     public Watch(String name, Metric watched) {
         this(name, watched, Circumstance.UNSPECIFIED, Circumstance.UNSPECIFIED, Circumstance.UNSPECIFIED);
@@ -153,6 +154,18 @@ public final class Watch implements WatchBuilder, Iterable<Watch.State> {
 
     public boolean isStopped() {
         return stopped.get();
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public void disable() {
+        this.disabled = true;
+    }
+
+    public void enable() {
+        this.disabled = false;
     }
 
     public List<Alert> check(SeriesLookup lookup) {

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Watch.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/alert/Watch.java
@@ -175,7 +175,7 @@ public final class Watch implements WatchBuilder, Iterable<Watch.State> {
     }
 
     public void enable() {
-        disabled.set(true);
+        disabled.set(false);
     }
 
     public boolean isProgrammatic() {

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
@@ -58,15 +58,32 @@ import com.sun.enterprise.config.serverbeans.DomainExtension;
 @Configured
 public interface MonitoringConsoleConfiguration extends DomainExtension {
 
+    /**
+     * Note that this is not reflecting whether or not the monitoring data is collected.
+     * This is controlled by the general monitoring configuration.
+     * 
+     * @return True, if monitoring console web-app is deployed, else false.
+     */
     @Attribute(defaultValue = "false", dataType = Boolean.class)
     String getEnabled();
     void setEnabled(String value) throws PropertyVetoException;
 
     /**
-     * @return A list of names of watches that are disabled
+     * @return Names of the watches that are disabled (this includes collected and custom watches)
      */
     @Element
-    public List<String> getDisabledWatchNames();
+    List<String> getDisabledWatchNames();
 
-    void setDisabledWatchNames(List<String> watchNames) throws PropertyVetoException;
+    /**
+     * @return Names of custom watches (so collected watches are not included)
+     */
+    @Element
+    List<String> getCustomWatchNames();
+
+    /**
+     * @return JSON values of the custom watches (index is same in {@link #getCustomWatchNames()})
+     */
+    @Element
+    List<String> getCustomWatchValues();
+
 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.monitoring.configuration;
+
+import java.beans.PropertyVetoException;
+import java.util.List;
+
+import org.jvnet.hk2.config.Attribute;
+import org.jvnet.hk2.config.Configured;
+import org.jvnet.hk2.config.Element;
+
+import com.sun.enterprise.config.serverbeans.DomainExtension;
+
+/**
+ * Configuration for the monitoring console core.
+ * This is first of all the data and watch collection and evaluation.
+ * 
+ * @author Jan Bernitt
+ * @since 5.204
+ */
+@Configured
+public interface MonitoringConsoleConfiguration extends DomainExtension {
+
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    String getEnabled();
+    void setEnabled(String value) throws PropertyVetoException;
+
+    /**
+     * @return A list of names of watches that are disabled
+     */
+    @Element
+    public List<String> getDisabledWatchNames();
+
+    void setDisabledWatchNames(List<String> watchNames) throws PropertyVetoException;
+}

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
@@ -53,7 +53,7 @@ import com.sun.enterprise.config.serverbeans.DomainExtension;
  * This is first of all the data and watch collection and evaluation.
  * 
  * @author Jan Bernitt
- * @since 5.204
+ * @since 5.201
  */
 @Configured
 public interface MonitoringConsoleConfiguration extends DomainExtension {

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/model/Metric.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/model/Metric.java
@@ -39,6 +39,10 @@
  */
 package fish.payara.monitoring.model;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+
 public final class Metric {
 
     public final Series series;
@@ -78,5 +82,20 @@ public final class Metric {
 
     public static Metric parse(String series, String unit) {
         return new Metric(new Series(series), Unit.fromShortName(unit));
+    }
+
+    public JsonObject toJSON() {
+        return Json.createObjectBuilder()
+                .add("series", series.toString())
+                .add("unit", unit.toString())
+                .build();
+    }
+
+    public static Metric fromJSON(JsonValue value) {
+        if (value == null || value == JsonValue.NULL) {
+            return null;
+        }
+        JsonObject obj = value.asJsonObject();
+        return new Metric(new Series(obj.getString("series")), Unit.fromShortName(obj.getString("unit", "count")));
     }
 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/model/Metric.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/model/Metric.java
@@ -75,4 +75,8 @@ public final class Metric {
     public String toString() {
         return series + " unit:" + unit.toString();
     }
+
+    public static Metric parse(String series, String unit) {
+        return new Metric(new Series(series), Unit.fromShortName(unit));
+    }
 }

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/store/InMemoryAlarmService.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/store/InMemoryAlarmService.java
@@ -199,6 +199,11 @@ class InMemoryAlarmService extends AbstractMonitoringService implements AlertSer
     }
 
     @Override
+    public Watch watchByName(String name) {
+        return watchesByName.get(name);
+    }
+
+    @Override
     public void addWatch(Watch watch) {
         Watch existing = watchesByName.put(watch.name, watch);
         if (existing != null) {
@@ -209,7 +214,8 @@ class InMemoryAlarmService extends AbstractMonitoringService implements AlertSer
         target.computeIfAbsent(series, key -> new ConcurrentHashMap<>()).put(watch.name, watch);
     }
 
-    private void removeWatch(Watch watch) {
+    @Override
+    public void removeWatch(Watch watch) {
         watch.stop();
         if (watchesByName.get(watch.name) == watch) {
             watchesByName.remove(watch.name);
@@ -378,6 +384,9 @@ class InMemoryAlarmService extends AbstractMonitoringService implements AlertSer
     }
 
     private void checkWatch(Watch watch) {
+        if (watch.isDisabled()) {
+            return;
+        }
         for (Alert newlyRaised : watch.check(monitoringData)) {
             Deque<Alert> seriesAlerts = alerts.computeIfAbsent(newlyRaised.getSeries(),
                     key -> new ConcurrentLinkedDeque<>());

--- a/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/alert/ConditionTest.java
+++ b/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/alert/ConditionTest.java
@@ -239,7 +239,7 @@ public class ConditionTest {
         assertSatisfied(anyGt5, 5, 6, 5);
         assertSatisfied(anyGt5, 5, 6, 5, 4);
         assertNotSatisfied(anyGt5, 5, 5, 5, 4);
-        assertEquals("any 1 value > 5", anyGt5.toString());
+        assertEquals("value > 5 in sample", anyGt5.toString());
     }
 
     @Test
@@ -253,7 +253,7 @@ public class ConditionTest {
         assertSatisfied(anyGt5in3x, 5, 6, 5, 4);
         assertNotSatisfied(anyGt5in3x, 6, 5, 5, 4);
         assertNotSatisfied(anyGt5in3x, 5, 5, 5, 4);
-        assertEquals("any 1 value > 5 in last 3x", anyGt5in3x.toString());
+        assertEquals("value > 5 in last 3x", anyGt5in3x.toString());
     }
 
     @Test
@@ -267,7 +267,7 @@ public class ConditionTest {
         assertSatisfied(anyGt5in3sec, 5, 6, 5, 4);
         assertNotSatisfied(anyGt5in3sec, 6, 5, 5, 5, 4);
         assertNotSatisfied(anyGt5in3sec, 5, 5, 5, 4);
-        assertEquals("any 1 value > 5 in last 3000ms", anyGt5in3sec.toString());
+        assertEquals("value > 5 in last 3000ms", anyGt5in3sec.toString());
     }
 
     private static void assertSatisfied(Condition c, long... points) {

--- a/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/alert/WatchSerializationTest.java
+++ b/appserver/monitoring-console/core/src/test/java/fish/payara/monitoring/alert/WatchSerializationTest.java
@@ -1,0 +1,143 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.monitoring.alert;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Test;
+
+import com.sun.xml.internal.xsom.impl.scd.Iterators.Map;
+
+import fish.payara.monitoring.alert.Alert.Level;
+import fish.payara.monitoring.alert.Condition.Operator;
+import fish.payara.monitoring.model.Metric;
+import fish.payara.monitoring.model.Series;
+import fish.payara.monitoring.model.Unit;
+
+/**
+ * Tests the correctness of the {@link Watch#toJSON()} and {@link Watch#fromJSON(String)} methods and those of the
+ * parts.
+ * 
+ * @author Jan Bernitt
+ */
+public class WatchSerializationTest {
+
+    private Watch sample1 = new Watch("name", new Metric(new Series("series"), Unit.COUNT), false,
+            new Circumstance(Level.RED, new Condition(Operator.GT, 200).forLastMillis(3000)),
+            new Circumstance(Level.AMBER, new Condition(Operator.LE, 300).forLastTimes(5)),
+            new Circumstance(Level.GREEN, new Condition(Operator.GE, 0)));
+
+    private Watch sample2 = new Watch("name", new Metric(new Series("series"), Unit.COUNT), false,
+            new Circumstance(Level.RED, new Condition(Operator.GT, 200).forLastMillis(3000), 
+                    new Condition(Operator.LT, 100).forLastMillis(2000).onAverage()),
+            new Circumstance(Level.AMBER, new Condition(Operator.LE, 300).forLastTimes(0), 
+                    new Condition(Operator.EQ, -4).forLastTimes(-5)),
+            new Circumstance(Level.GREEN, new Condition(Operator.GE, 0).forLastTimes(4).onAverage()),
+            new Metric(new Series("capturedSeries"), Unit.MILLIS));
+
+    @Test
+    public void singlePass() {
+        assertEqualWatches(sample1, toAndFromJson(sample1));
+        assertEqualWatches(sample2, toAndFromJson(sample2));
+    }
+
+    @Test
+    public void doublePass() {
+        assertEqualWatches(sample1, toAndFromJson(toAndFromJson(sample1)));
+        assertEqualWatches(sample2, toAndFromJson(toAndFromJson(sample2)));
+    }
+
+    private static void assertEqualWatches(Watch expected, Watch actual) {
+        assertNotSame(expected, actual);
+        assertEquals(expected, actual);
+        assertEqualFields(expected, actual);
+        assertEquals(expected.toJSON().toString(), actual.toJSON().toString());
+        assertEquals(expected.toString(), actual.toString());
+        assertEquals(expected.isDisabled(), actual.isDisabled());
+        assertEquals(expected.isStopped(), actual.isStopped());
+        assertEquals(expected.isProgrammatic(), actual.isProgrammatic());
+    }
+
+    private static Watch toAndFromJson(Watch w) {
+        return Watch.fromJSON(w.toJSON().toString());
+    }
+
+    private static <T> void assertEqualFields(T a, T b) {
+        if (a == null || b == null) {
+            assertEquals(a, b);
+            return;
+        }
+        Class<?> type = a.getClass();
+        for (Field f : type.getDeclaredFields()) {
+            if (!Modifier.isStatic(f.getModifiers())) {
+                try {
+                    f.setAccessible(true);
+                    Class<?> fieldType = f.getType();
+                    Object aVal = f.get(a);
+                    Object bVal = f.get(b);
+                    if (isSimpleType(fieldType) ) {
+                        assertEquals(aVal, bVal);
+                    } else if (fieldType.isArray()) {
+                        assertArrayEquals((Object[]) aVal, (Object[]) bVal);
+                    } else {
+                        assertEqualFields(aVal, bVal);
+                    }
+                } catch (IllegalArgumentException | IllegalAccessException ex) {
+                    throw new AssertionError("Failed to compare field " + f.getName() + " of " + type.getSimpleName(),
+                            ex);
+                }
+            }
+        }
+    }
+
+    private static boolean isSimpleType(Class<?> fieldType) {
+        return fieldType.isPrimitive() 
+                || fieldType.isEnum()
+                || fieldType == String.class 
+                || fieldType == Metric.class 
+                || Number.class.isAssignableFrom(fieldType) 
+                || Map.class.isAssignableFrom(fieldType);
+    }
+}

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -479,6 +479,7 @@ WATCH_BUILDER   = { id, colors, actions }
 WATCH_MANAGER	= { id, items, colors, actions }
 items           = [ WATCH ]
 actions         = { onCreate, onDelete, onDisable, onEnable }
+onEdit          = fn (WATCH) => ()
 onCreate        = fn (WATCH, onSuccess, onFailure) => ()
 onDelete        = fn (name, onSuccess, onFailure) => ()
 onDisable       = fn (name, onSuccess, onFailure) => ()
@@ -491,6 +492,7 @@ green           = string
 * `WATCH` refers to an object as described for update data structures
 * `onDelete` is a function to call to delete the watch by its `name` (a `string`)
 * `onCreate` is a function to create new watches
+* `onEdit` is created by the `WatchManager` for the `WATCH_LIST` to use when an list entry should be edited.
 
 
 ## Data Driven Chart Plugins

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -218,10 +218,11 @@ end                  = number
 
 Watch Data (as received from server):
 ```
-WATCH                = { name, series, unit, red, amber, green }
+WATCH                = { name, series, unit, disabled, red, amber, green, states }
 name                 = string
 series               = string
 unit                 = string
+disabled             = boolean
 red                  = CIRCUMSTANCE
 amber                = CIRCUMSTANCE
 green                = CIRCUMSTANCE
@@ -229,9 +230,12 @@ CIRCUMSTANCE         = { level, start, stop, suppress, surpressingSeries, surpre
 level                = string,
 start                = CONDITION
 stop                 = CONDITION
-suppress              = CONDITION 
+suppress             = CONDITION 
 surpressingSeries    = string
 surpressingUnit      = string
+states               = SERIES_STATES
+SERIES_STATES        = { *:INSTANCE_STATES }
+INSTANCE_STATES      = { *:string }
 ```
 
 
@@ -460,6 +464,31 @@ type             = undefined | 'pre'
 * `type` and `background` can be omitted (assumes `'em'` and no background colour)
 * `color` is the colour of the annotation item border indicator
 * `fields` is a list of attribute keys that works as filter as well as giving the order; can be undefined or empty to use all attributes in their given order.
+
+
+
+### Watch Manager API
+Describes the model expected by the `WatchManager` component which combines the `WatchList` and `WatchBuilder` components.
+The manager shows a configuration with a list of watches which also allows to create new watches.
+
+```
+WATCH_LIST      = { id, items, colors, actions  }
+WATCH_BUILDER   = { id, colors, actions }
+WATCH_MANAGER	= { id, items, colors, actions }
+items           = [ WATCH ]
+actions         = { onCreate, onDelete, onDisable, onEnable }
+onCreate        = fn (WATCH, onSuccess, onFailure) => ()
+onDelete        = fn (name, onSuccess, onFailure) => ()
+onDisable       = fn (name, onSuccess, onFailure) => ()
+onEnable        = fn (name, onSuccess, onFailure) => ()
+colors          = { red, amber, green }
+red             = string
+amber           = string
+green           = string
+```
+* `WATCH` refers to an object as described for update data structures
+* `onDelete` is a function to call to delete the watch by its `name` (a `string`)
+* `onCreate` is a function to create new watches
 
 
 ## Data Driven Chart Plugins

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -506,12 +506,14 @@ decorations onto the chart background.
 
 ```
 BACKGROUND_AREA = [ AREA_ITEM ];
-AREA_ITEM       = { color, min, max, type }
+AREA_ITEM       = { color, min, max, type, style }
 color           = string
 min             = number
 max             = number
 type            = 'lower' | 'upper'
+style           = 'fill' | 'outline' 
 ```
 * default for `type` is `upper`
+* default for `style` is `fill`
 
 

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -366,9 +366,10 @@ Describes the model expected by the `Indicator` component.
 This component gives feedback on the status of each widget.
 
 ```
-INDICATOR = { status, text }
+INDICATOR = { status, text, color }
 status    = Status
 text      = string
+color     = string
 ```
 
 

--- a/appserver/monitoring-console/webapp/JS_DOCS.md
+++ b/appserver/monitoring-console/webapp/JS_DOCS.md
@@ -218,11 +218,13 @@ end                  = number
 
 Watch Data (as received from server):
 ```
-WATCH                = { name, series, unit, disabled, red, amber, green, states }
+WATCH                = { name, series, unit, stopped, disabled, programmatic, red, amber, green, states }
 name                 = string
 series               = string
 unit                 = string
+stopped              = boolean
 disabled             = boolean
+programmatic         = boolean
 red                  = CIRCUMSTANCE
 amber                = CIRCUMSTANCE
 green                = CIRCUMSTANCE
@@ -294,12 +296,12 @@ entries     = [ENTRY]
 ENTRY       = { label, type, input, value, unit, min, max, options, onChange, description, defaultValue, collapsed } 
 label       = string
 type        = undefined | 'header' | 'checkbox' | 'range' | 'dropdown' | 'value' | 'text' | 'color'
-unit        = string
+unit        = string | fn () => string
 value       = number | string
 defaultValue= number | string
 min         = number
 max         = number
-options     = { *:string }
+options     = { *:string } | [ * ]
 input       = fn () => string | fn () => jquery | string | jquery | [ENTRY]
 onChange    = fn (widget, newValue) => () | fn (newValue) => ()
 description = string

--- a/appserver/monitoring-console/webapp/pom.xml
+++ b/appserver/monitoring-console/webapp/pom.xml
@@ -119,6 +119,8 @@
                         <target>${project.build.directory}/${project.artifactId}/js/monitoring-console.js</target>
                         <sources>
                             <source>src/main/webapp/js/mc-main.js</source>
+                            <source>src/main/webapp/js/mc-controller.js</source>
+                            <source>src/main/webapp/js/mc-data.js</source>
                             <source>src/main/webapp/js/mc-model.js</source>
                             <source>src/main/webapp/js/mc-view-units.js</source>
                             <source>src/main/webapp/js/mc-view-colors.js</source>

--- a/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
+++ b/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
@@ -157,20 +157,28 @@ public final class ApiResponses {
 
     public static final class WatchData {
 
-        public final String name;
-        public final String series;
-        public final String unit;
-        public final boolean disabled;
-        public final CircumstanceData red;
-        public final CircumstanceData amber;
-        public final CircumstanceData green;
+        public String name;
+        public String series;
+        public String unit;
+        public boolean stopped;
+        public boolean disabled;
+        public boolean programmatic; 
+        public CircumstanceData red;
+        public CircumstanceData amber;
+        public CircumstanceData green;
         public final Map<String, Map<String, String>> states = new HashMap<>();
+
+        public WatchData() {
+            // from JSON
+        }
 
         public WatchData(Watch watch) {
             this.name = watch.name;
             this.series = watch.watched.series.toString();
             this.unit = watch.watched.unit.toString();
+            this.stopped = watch.isStopped();
             this.disabled = watch.isDisabled();
+            this.programmatic = watch.isProgrammatic();
             this.red = watch.red.isUnspecified() ? null : new CircumstanceData(watch.red);
             this.amber = watch.amber.isUnspecified() ? null : new CircumstanceData(watch.amber);
             this.green = watch.green.isUnspecified() ? null : new CircumstanceData(watch.green);
@@ -183,12 +191,16 @@ public final class ApiResponses {
 
     public static final class CircumstanceData {
 
-        public final String level;
-        public final ConditionData start;
-        public final ConditionData stop;
-        public final ConditionData suppress;
-        public final String surpressingSeries;
-        public final String surpressingUnit;
+        public String level;
+        public ConditionData start;
+        public ConditionData stop;
+        public ConditionData suppress;
+        public String surpressingSeries;
+        public String surpressingUnit;
+
+        public CircumstanceData() {
+            // from JSON
+        }
 
         public CircumstanceData(Circumstance circumstance) {
             this.level = circumstance.level.name().toLowerCase();
@@ -202,11 +214,15 @@ public final class ApiResponses {
 
     public static final class ConditionData {
 
-        public final String operator;
-        public final long threshold;
-        public final Integer forTimes;
-        public final Long forMillis;
-        public final boolean onAverage;
+        public String operator;
+        public long threshold;
+        public Integer forTimes;
+        public Long forMillis;
+        public boolean onAverage;
+
+        public ConditionData() {
+            // from JSON
+        }
 
         public ConditionData(Condition condition) {
             this.operator = condition.comparison.toString();

--- a/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
+++ b/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
@@ -160,6 +160,7 @@ public final class ApiResponses {
         public final String name;
         public final String series;
         public final String unit;
+        public final boolean disabled;
         public final CircumstanceData red;
         public final CircumstanceData amber;
         public final CircumstanceData green;
@@ -169,6 +170,7 @@ public final class ApiResponses {
             this.name = watch.name;
             this.series = watch.watched.series.toString();
             this.unit = watch.watched.unit.toString();
+            this.disabled = watch.isDisabled();
             this.red = watch.red.isUnspecified() ? null : new CircumstanceData(watch.red);
             this.amber = watch.amber.isUnspecified() ? null : new CircumstanceData(watch.amber);
             this.green = watch.green.isUnspecified() ? null : new CircumstanceData(watch.green);

--- a/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
+++ b/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
@@ -154,24 +154,25 @@ public class MonitoringConsoleResource {
         for (SeriesQuery query : request.queries) {
             Series key = seriesOrNull(query.series);
             List<SeriesDataset> queryData = key == null || query.excludes(DataType.POINTS) //
-                    || Series.ANY.equalTo(key) && query.truncates(POINTS)  // if all alerts are requested don't send any particular data
+                    || Series.ANY.equalTo(key) && query.truncates(POINTS) // if all alerts are requested don't send any particular data
                     ? emptyList()
-                            : dataStore.selectSeries(key, query.instances);
-                    List<SeriesAnnotation> queryAnnotations = key == null || query.excludes(DataType.ANNOTATIONS)
-                            ? emptyList()
-                                    : dataStore.selectAnnotations(key, query.instances);
-                            Collection<Watch> queryWatches = key == null || query.excludes(DataType.WATCHES)
-                                    ? emptyList()
-                                            : alertService.wachtesFor(key);
-                                    Collection<Alert> queryAlerts = key == null || query.excludes(DataType.ALERTS)
-                                            ? emptyList()
-                                                    : alertService.alertsFor(key);
-                                            data.add(queryData);
-                                            watches.add(queryWatches);
-                                            annotations.add(queryAnnotations);
-                                            alerts.add(queryAlerts);
+                    : dataStore.selectSeries(key, query.instances);
+            List<SeriesAnnotation> queryAnnotations = key == null || query.excludes(DataType.ANNOTATIONS) 
+                    ? emptyList()
+                    : dataStore.selectAnnotations(key, query.instances);
+            Collection<Watch> queryWatches = key == null || query.excludes(DataType.WATCHES) 
+                    ? emptyList()
+                    : alertService.wachtesFor(key);
+            Collection<Alert> queryAlerts = key == null || query.excludes(DataType.ALERTS) 
+                    ? emptyList()
+                    : alertService.alertsFor(key);
+            data.add(queryData);
+            watches.add(queryWatches);
+            annotations.add(queryAnnotations);
+            alerts.add(queryAlerts);
         }
-        return new SeriesResponse(request.queries, data, annotations, watches, alerts, alertService.getAlertStatistics());
+        return new SeriesResponse(request.queries, data, annotations, watches, alerts,
+                alertService.getAlertStatistics());
     }
 
     @GET

--- a/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
+++ b/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
@@ -235,7 +235,7 @@ public class MonitoringConsoleResource {
         if (watch != null) {
             alertService.removeWatch(watch);
         }
-        return Response.noContent().build();
+        return noContent();
     }
 
     @PUT
@@ -243,18 +243,18 @@ public class MonitoringConsoleResource {
     @Path("/watches/data/")
     public Response createWatch(WatchData data) {
         if (data.name == null || data.name.isEmpty()) {
-            return Response.status(Status.BAD_REQUEST.getStatusCode(), "Name missing").build();
+            return badRequest("Name missing");
         }
         Circumstance red = createCircumstance(data.red);
         Circumstance amber = createCircumstance(data.amber);
         Circumstance green = createCircumstance(data.green);
         if (red.start.isNone() && amber.start.isNone()) {
-            return Response.status(Status.BAD_REQUEST.getStatusCode(), "Red or amber start condition must be given").build();
+            return badRequest("A start condition for red or amber must be given");
         }
         Metric metric = Metric.parse(data.series, data.unit);
         Watch watch = new Watch(data.name, metric, false, red, amber, green);
         getAlertService().addWatch(watch);
-        return Response.noContent().build();
+        return noContent();
     }
 
     @PATCH
@@ -263,14 +263,14 @@ public class MonitoringConsoleResource {
         AlertService alertService = getAlertService();
         Watch watch = alertService.watchByName(name);
         if (watch == null) {
-            return Response.status(Status.NOT_FOUND).build();
+            return notFound();
         }
         if (disable) {
             watch.disable();
         } else {
             watch.enable();
         }
-        return Response.noContent().build();
+        return noContent();
     }
 
     private static Circumstance createCircumstance(CircumstanceData data) {
@@ -301,5 +301,17 @@ public class MonitoringConsoleResource {
             res = res.onAverage();
         }
         return res;
+    }
+
+    private static Response badRequest(String reason) {
+        return Response.status(Status.BAD_REQUEST.getStatusCode(),reason).build();
+    }
+
+    private static Response noContent() {
+        return Response.noContent().build();
+    }
+
+    private static Response notFound() {
+        return Response.status(Status.NOT_FOUND).build();
     }
 }

--- a/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
+++ b/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
@@ -260,17 +260,7 @@ public class MonitoringConsoleResource {
     @PATCH
     @Path("/watches/data/{name}/")
     public Response patchWatch(@PathParam("name") String name, @QueryParam("disable") boolean disable) {
-        AlertService alertService = getAlertService();
-        Watch watch = alertService.watchByName(name);
-        if (watch == null) {
-            return notFound();
-        }
-        if (disable) {
-            watch.disable();
-        } else {
-            watch.enable();
-        }
-        return noContent();
+        return getAlertService().toggleWatch(name, disable) ? noContent() : notFound();
     }
 
     private static Circumstance createCircumstance(CircumstanceData data) {

--- a/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
+++ b/appserver/monitoring-console/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
@@ -242,11 +242,17 @@ public class MonitoringConsoleResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/watches/data/")
     public Response createWatch(WatchData data) {
+        if (data.name == null || data.name.isEmpty()) {
+            return Response.status(Status.BAD_REQUEST.getStatusCode(), "Name missing").build();
+        }
         Circumstance red = createCircumstance(data.red);
         Circumstance amber = createCircumstance(data.amber);
         Circumstance green = createCircumstance(data.green);
+        if (red.start.isNone() && amber.start.isNone()) {
+            return Response.status(Status.BAD_REQUEST.getStatusCode(), "Red or amber start condition must be given").build();
+        }
         Metric metric = Metric.parse(data.series, data.unit);
-        Watch watch = new Watch(data.name, metric, red, amber, green);
+        Watch watch = new Watch(data.name, metric, false, red, amber, green);
         getAlertService().addWatch(watch);
         return Response.noContent().build();
     }

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -48,7 +48,7 @@
   --button-color-rgb-bg:       210, 216, 218; /* #D2D8DA */
 
   /* Variables used in style definitons */
-  --page-bg-color: #003247;
+  --page-bg-color: #002C3E;
 
 }
 
@@ -181,7 +181,7 @@ button:hover {
   box-sizing: border-box;
 }
 #trace-widget {
-  background-color: #002433;
+  background-color: #001A25;
   position: relative;
   padding: 10px;
 }
@@ -250,7 +250,7 @@ h3 strong {
   padding-top: 5px;
 }
 #chart-grid > tr > td {
-    background-color: #002433;
+    background-color: #001A25;
     padding: 8px;
     vertical-align: top;
     position: relative;
@@ -258,22 +258,6 @@ h3 strong {
 }
 #chart-grid > tr > td.chart-selected {
     border: 2px solid #0096D6;
-}
-.stable {
-	background-color: rgba(153, 102, 255, 0.2);
-	border: 1px solid rgba(153, 102, 255, 1);
-	font-size: 50px;
-	font-weight: bold;
-	color: rgba(153, 102, 255, 1);
-    text-align: center;
-    height: 90%;
-}
-.stable span {
-	position: relative;
-	float: left;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
 }
 
 #panel-grid {
@@ -292,7 +276,7 @@ h3 strong {
     right: 10px;
 }
 #Settings table {
-    background-color: #002433;
+    background-color: #001A25;
     padding: 10px;
     margin-top: 5px;
     width: 100%;
@@ -354,7 +338,7 @@ table.tags th {
   width: 25%;
 }
 table.tags th, table.tags td {
-  background-color: #002433;
+  background-color: #001A25;
 }
 
 /* Widget Settings Toolbar */
@@ -384,7 +368,7 @@ table.tags th, table.tags td {
   bottom: 10px;
   left: 15px;
   padding: 0;
-  background-color: rgba(0, 36, 51, .75);  
+  background-color: rgba(0, 26, 37, .75);  
 }
 .Legend li {
   display: inline-block;
@@ -420,7 +404,7 @@ table.tags th, table.tags td {
     color: red;
 }
 .Legend span, .Legend strong {
-  background-color: #002433;
+  background-color: #001A25;
 }
 @keyframes blinker {
   50% {
@@ -430,14 +414,14 @@ table.tags th, table.tags td {
 
 /* Widget Indicator */
 .Indicator {
-  border: 1px solid #ccc;
-  font-weight: bold;
   padding: 5px 10px;
   text-align: center;
   position: absolute;
-  width: 50%;
-  margin: 15% 25%;
-  background-color: rgba(0,36,51,0.5);
+  max-width: 50%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  top: 25%;
+  background-color: #001A25;
 }
 .Indicator.status-missing {
   border-color: #0096D6;
@@ -539,7 +523,7 @@ table.tags th, table.tags td {
   top: 40px;
   left: 15px;
   width: calc(100% - 38px);
-  background-color: rgba(0, 36, 51, .75);
+  background-color: rgba(0, 26, 37, .75);
   max-height: calc(100% - 100px);
   overflow-y: auto;
   overflow-x: hidden;  
@@ -565,11 +549,11 @@ table.tags th, table.tags td {
   display: inline-block;
   margin: 0 0.9em 0 0.4em;
   padding: 1px;
-  background-color: rgba(0,36,51,0.75);
+  background-color: rgba(0, 26, 37,0.75);
 }
 .AlertTable .Item small {
   color: #bbb;
-  background-color: rgba(0,36,51,0.75);
+  background-color: rgba(0, 26, 37,0.75);
 }
 .AlertTable .Item span {
   white-space: nowrap;
@@ -601,7 +585,7 @@ table.tags th, table.tags td {
   top: 40px;
   left: 15px;
   width: calc(100% - 38px);
-  background-color: rgba(0, 36, 51, .75);
+  background-color: rgba(0, 26, 37, .75);
   max-height: calc(100% - 100px);
   overflow-y: auto;
   overflow-x: hidden;
@@ -617,11 +601,11 @@ table.tags th, table.tags td {
   display: inline-block;
   margin: 0 0.9em 0 0.4em;
   padding: 1px;
-  background-color: rgba(0,36,51,0.75);
+  background-color: rgba(0, 26, 37,0.75);
 }
 .AnnotationTable .Annotation small {
   color: #bbb;
-  background-color: rgba(0,36,51,0.75);
+  background-color: rgba(0, 26, 37,0.75);
 }
 .AnnotationTable .Annotation span {
   white-space: nowrap;
@@ -675,12 +659,16 @@ table.AnnotationTable {
 
 /* Watch List Component */
 .WatchItem {
-  background-color: #002433;
+  background-color: #001A25;
   padding: 10px;
   margin: 5px 0;
 }
 .WatchItem.state-disabled h3 {
   color: #888;
+}
+.WatchItem h3 {
+  text-align: left;
+  margin-bottom: 0.25em;
 }
 .WatchItem h3 input[type=checkbox] {
   float: left;

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -218,7 +218,7 @@ button:hover {
   z-index: 101;
   width: calc(100% - 20px);
 }
-.widget-title-bar h3 {
+h3 {
   font-size: 130%;
   font-weight: bold;
   margin: 0;
@@ -229,7 +229,7 @@ button:hover {
   padding: 1px 5px;
   text-align: center;
 }
-.widget-title-bar h3 span {
+h3 span {
   font-size: 80%;
   font-weight: normal;
   font-style: normal;
@@ -237,7 +237,7 @@ button:hover {
   margin-right: 1em;
   float: left;
 }
-.widget-title-bar h3 strong {
+h3 strong {
   font-style: normal;
   margin-left: 0.5em;
   color: white;
@@ -251,12 +251,13 @@ button:hover {
 }
 #chart-grid > tr > td {
     background-color: #002433;
-    padding: 10px;
+    padding: 8px;
     vertical-align: top;
     position: relative;
+    border: 2px solid transparent;
 }
-#chart-grid > tr > td.chart-selected h3 {
-    background-color: #0096D6;
+#chart-grid > tr > td.chart-selected {
+    border: 2px solid #0096D6;
 }
 .stable {
 	background-color: rgba(153, 102, 255, 0.2);
@@ -524,7 +525,7 @@ table.tags th, table.tags td {
 .Menu .Item:hover .Group {
   display: block;
 }
-.widget .Menu .Group {
+.widget .Menu .Group, .WatchList .Menu .Group {
   margin-left: -85px;
 }
 .Menu .clickable {
@@ -681,6 +682,9 @@ table.AnnotationTable {
 .WatchItem.state-disabled h3 {
   color: #888;
 }
+.WatchItem h3 input[type=checkbox] {
+  float: left;
+}
 .WatchCondition {
   padding: 0 0.5em;
   font-family: monospace;
@@ -701,5 +705,18 @@ table.AnnotationTable {
   border-bottom: 1px dotted #ccc;
 }
 .WatchCondition input.input-value {
-  width: 60px;
+  width: 50px;
+}
+.WatchCondition input.input-text {
+  width: 300px;
+  max-width: 300px;
+}
+.WatchBuilder {
+  position: relative;
+  padding-bottom: 2.5em;
+}
+.WatchBuilder button {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
 }

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -317,7 +317,9 @@ button:hover {
 #console.state-show-settings #Settings {
 	display: block;
 }
-#console.state-show-settings #panel-grid, #console.state-show-settings #panel-trace {
+#console.state-show-settings #panel-grid, 
+#console.state-show-settings #panel-trace,
+#console.state-show-settings #WatchManager {
   width: calc(100% - 390px);
 }
 
@@ -641,4 +643,29 @@ table.AnnotationTable {
 }
 .AnnotationTable tr:hover {
   background-color: #0096D6;
+}
+
+
+/* Watch Manager/Settings Component */
+.WatchManager {
+  position: absolute;
+  top: 32px;
+  left: 0;
+  z-index: 110;
+  padding: 10px;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+/* Watch List Component */
+.WatchItem {
+  background-color: #002433;
+  padding: 10px;
+  margin: 5px 0;
+}
+.WatchItem.state-disabled h3 {
+  color: #888;
+}
+.WatchList .WatchItem .WatchCondition {
+  padding: 0.25em 0.5em;
 }

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -652,6 +652,15 @@ table.AnnotationTable {
   background-color: #001A25;
   padding: 10px;
   margin: 5px 0;
+  padding-left: 40px;
+  position: relative;
+}
+.WatchItem .Icon {
+  position: absolute;
+  left: 15px;
+  top: 10px;
+  font-size: 150%;
+  color: #0096D6;
 }
 .WatchItem.state-disabled h3 {
   color: #888;

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -38,7 +38,7 @@
    holder.
 */
 :root {
-  /* Color RGB values to be used in other variable definitions */
+  /* Colour RGB values to be used in other variable definitions */
   --primary-color-rgb-orange:  240, 152,  27; /* #F0981B */
   --primary-color-rgb-blue:      0,  44,  62; /* #002C3E */
   --secondary-color-rgb-blue:    0, 150, 214; /* #0096D6 */
@@ -655,13 +655,6 @@ table.AnnotationTable {
   padding-left: 40px;
   position: relative;
 }
-.WatchItem .Icon {
-  position: absolute;
-  left: 15px;
-  top: 10px;
-  font-size: 150%;
-  color: #0096D6;
-}
 .WatchItem.state-disabled h3 {
   color: #888;
 }
@@ -670,7 +663,8 @@ table.AnnotationTable {
   margin-bottom: 0.25em;
 }
 .WatchItem h3 input[type=checkbox] {
-  float: left;
+  position: absolute;
+  left: 15px;
 }
 .WatchCondition {
   padding: 0 0.5em;
@@ -691,7 +685,7 @@ table.AnnotationTable {
 .WatchCondition input {
   border-bottom: 1px dotted #ccc;
 }
-.WatchCondition input.input-value {
+.WatchCondition input.input-value, .WatchCondition span span span input.input-text {
   width: 50px;
 }
 .WatchCondition input.input-text {

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -37,8 +37,23 @@
    only if the new code is made subject to such option by the copyright
    holder.
 */
+:root {
+  /* Color RGB values to be used in other variable definitions */
+  --primary-color-rgb-orange:  240, 152,  27; /* #F0981B */
+  --primary-color-rgb-blue:      0,  44,  62; /* #002C3E */
+  --secondary-color-rgb-blue:    0, 150, 214; /* #0096D6 */
+  --secondary-color-rgb-dark:   67,  68,  69; /* #434445 */
+  --secondary-color-rgb-light: 218, 224, 226; /* #DAE0E2 */
+  --button-color-rgb-text:      16,  16,  18; /* #101012 */
+  --button-color-rgb-bg:       210, 216, 218; /* #D2D8DA */
+
+  /* Variables used in style definitons */
+  --page-bg-color: #003247;
+
+}
+
 body {
-    background-color: #003247;
+    background-color: var(--page-bg-color);
     font: 13px/1.231 'IBM Plex Sans', helvetica,clean,sans-serif;
     color: white;
     margin: 0;
@@ -46,7 +61,7 @@ body {
 }
 h1 {
 	font-size: 21px;
-    font-weight: bold;
+  font-weight: bold;
 }
 select {
 	width: 100%;
@@ -666,6 +681,25 @@ table.AnnotationTable {
 .WatchItem.state-disabled h3 {
   color: #888;
 }
-.WatchList .WatchItem .WatchCondition {
-  padding: 0.25em 0.5em;
+.WatchCondition {
+  padding: 0 0.5em;
+  font-family: monospace;
+}
+.WatchCondition em {
+  color: #bbb;
+  font-style: normal;
+}
+.WatchCondition select, .WatchCondition input {
+  width: auto;
+  max-width: auto;
+  background-color: transparent;
+  border-color: transparent;
+  color: inherit;
+  font-family: monospace;
+}
+.WatchCondition input {
+  border-bottom: 1px dotted #ccc;
+}
+.WatchCondition input.input-value {
+  width: 60px;
 }

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -720,3 +720,7 @@ table.AnnotationTable {
   right: 10px;
   bottom: 10px;
 }
+.WatchBuilder h3 input {
+  width: 200px;
+  max-width: 200px;
+}

--- a/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
+++ b/appserver/monitoring-console/webapp/src/main/webapp/css/monitoring-console.css
@@ -85,7 +85,7 @@ input[type=color] {
   vertical-align: middle;
   width: 24px;
   height: 24px;
-  border-radius: 12px;
+  border-radius: 24px;
   overflow: hidden;
   border: 1px solid #444;
   margin: 1px 1px 0 0;  
@@ -423,23 +423,13 @@ table.tags th, table.tags td {
   top: 25%;
   background-color: #001A25;
 }
-.Indicator.status-missing {
-  border-color: #0096D6;
-  color: #0096D6;
-}
-.Indicator.status-alarming {
-  border-color: gold; 
-  color: gold;
-}
-.Indicator.status-critical {
-  border-color: crimson; 
-  color: crimson;
-}
 .Indicator b {
   color: white;
   white-space: nowrap;
+  font-weight: normal;
 }
 .Indicator i {
+  color: #DAE0E2;
   white-space: nowrap;
 }
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/index.html
+++ b/appserver/monitoring-console/webapp/src/main/webapp/index.html
@@ -47,8 +47,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=x"></script>
-    <link href="css/monitoring-console.css?x=x" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=y"></script>
+    <link href="css/monitoring-console.css?x=y" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/index.html
+++ b/appserver/monitoring-console/webapp/src/main/webapp/index.html
@@ -47,8 +47,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=k"></script>
-    <link href="css/monitoring-console.css?x=k" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=x"></script>
+    <link href="css/monitoring-console.css?x=x" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/index.html
+++ b/appserver/monitoring-console/webapp/src/main/webapp/index.html
@@ -47,8 +47,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=h"></script>
-    <link href="css/monitoring-console.css?x=h" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=k"></script>
+    <link href="css/monitoring-console.css?x=k" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/index.html
+++ b/appserver/monitoring-console/webapp/src/main/webapp/index.html
@@ -47,8 +47,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=g"></script>
-    <link href="css/monitoring-console.css?x=g" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=h"></script>
+    <link href="css/monitoring-console.css?x=h" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 
@@ -65,6 +65,8 @@
 </div>
 
 <div id="Settings"></div>
+
+<div id="WatchManager"></div>
 
 <div id='panel-trace'>
   <div id='trace-widget'>

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-bar-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-bar-chart.js
@@ -121,12 +121,16 @@ MonitoringConsole.Chart.Bar = (function() {
             scales: {
                xAxes: [{
                   stacked: true,
+                  gridLines: {
+                    color: 'rgba(0, 127, 255,0.3)',
+                    lineWidth: 0.5,
+                  },                  
                   ticks: {
                     callback: function(value, index, values) {
                       let converter = Units.converter(widget.unit);
                       return converter.format(converter.parse(value));
                     },
-                  },                 
+                  },                
                }],
                yAxes: [{
                   maxBarThickness: 15, //px
@@ -136,7 +140,11 @@ MonitoringConsole.Chart.Bar = (function() {
                   stacked: true,
                   ticks: {
                      display: false,
-                  }
+                  },
+                  gridLines: {
+                    color: 'rgba(0, 127, 255,0.7)',
+                    lineWidth: 0.5,
+                  },
                }]
             },
             legend: {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-controller.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-controller.js
@@ -1,0 +1,158 @@
+/*
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+*/
+
+/*jshint esversion: 8 */
+
+/**
+ * API to talk to the server.
+ *
+ * Main purpose is isolate and document the API between client and server.
+ **/
+MonitoringConsole.Controller = (function() {
+
+   function requestWithJsonBody(method, url, queryData, onSuccess, onFailure) {
+      const request = $.ajax({
+         url: url,
+         type: method,
+         data: JSON.stringify(queryData),
+         contentType:"application/json; charset=utf-8",
+         dataType:"json",
+      }).done(onSuccess).fail(onFailure);
+   }
+
+   function requestWithoutBody(method, url, onSuccess, onFailure) {
+      $.ajax({ type: method, url: url }).done(onSuccess).fail(onFailure);
+   }
+
+   /**
+    * @param {array}    queries   - a JS array with query objects as expected by the server API (object corresponds to java class SeriesQuery)
+    * @param {function} onSuccess - a callback function with one argument accepting the response object as send by the server (java class SeriesResponse)
+    * @param {function} onFailure - a callback function with no arguments
+    */
+   function requestListOfSeriesData(queries, onSuccess, onFailure) {
+      requestWithJsonBody('POST', 'api/series/data/', { queries: queries }, onSuccess, onFailure);
+   }
+
+   /**
+    * @param {function} onSuccess - a function with one argument accepting an array of series names
+    */
+   function requestListOfSeriesNames(onSuccess) {
+      $.getJSON("api/series/", onSuccess);
+   }
+
+   /**
+    * @param {string}   series    - name of the metric series
+    * @param {function} onSuccess - a function with one argument accepting an array request traces as returned by the server (each trace object corresponds to java class RequestTraceResponse)
+    */
+   function requestListOfRequestTraces(series, onSuccess) {
+      $.getJSON("api/trace/data/" + series, onSuccess);
+   }
+
+   /**
+    * @param {function} onSuccess - a callback function with no arguments
+    */
+   function requestListOfWatches(onSuccess) {
+      $.getJSON("api/watches/data/", (response) => onSuccess(response.watches));
+   }
+
+   /**
+    * @param {object}   watch     - a JS watch object as expected by the server API (object corresponds to java class WatchData)
+    * @param {function} onSuccess - a callback function with no arguments
+    * @param {function} onFailure - a callback function with no arguments
+    */
+   function requestCreateWatch(watch, onSuccess, onFailure) {
+      requestWithJsonBody('PUT', 'api/watches/data/', watch, onSuccess, onFailure);
+   }
+
+   /**
+    * @param {string}   name      - name of the watch to delete
+    * @param {function} onSuccess - a callback function with no arguments
+    * @param {function} onFailure - a callback function with no arguments
+    */
+   function requestDeleteWatch(name, onSuccess, onFailure) {
+      requestWithoutBody('DELETE', 'api/watches/data/' + name + '/', onSuccess, onFailure);
+   }
+
+   /**
+    * @param {string}   name      - name of the watch to disable
+    * @param {function} onSuccess - a callback function with no arguments
+    * @param {function} onFailure - a callback function with no arguments
+    */
+   function requestDisableWatch(name, onSuccess, onFailure) {
+      requestWithoutBody('PATCH', 'api/watches/data/' + name + '/?disable=true', onSuccess, onFailure);
+   }
+
+   /**
+    * @param {string}   name      - name of the watch to enable
+    * @param {function} onSuccess - a callback function with no arguments
+    * @param {function} onFailure - a callback function with no arguments
+    */
+   function requestEnableWatch(name, onSuccess, onFailure) {
+      requestWithoutBody('PATCH', 'api/watches/data/' + name + '/?disable=false', onSuccess, onFailure);
+   }
+
+   /**
+    * @param {number}   serial    - serial of the alert to ackknowledge
+    * @param {function} onSuccess - a callback function with no arguments
+    * @param {function} onFailure - a callback function with no arguments
+    */
+   function requestAcknowledgeAlert(serial, onSuccess, onFailure) {
+      requestWithoutBody('POST', 'api/alerts/ack/' + serial + '/', onSuccess, onFailure);
+   }
+
+   /**
+    * Public API to talk to the server.
+    * 
+    * Note that none of the functions have a direct return value.
+    * All function "return" data by calling their "onSuccess" callback with the result
+    * or the "onFailure" callback in case the equest failed.
+    */ 
+   return {
+      requestListOfSeriesData: requestListOfSeriesData,
+      requestListOfSeriesNames: requestListOfSeriesNames,
+      requestListOfRequestTraces: requestListOfRequestTraces,
+      requestListOfWatches: requestListOfWatches,
+      requestCreateWatch: requestCreateWatch,
+      requestDeleteWatch: requestDeleteWatch,
+      requestDisableWatch: requestDisableWatch,
+      requestEnableWatch: requestEnableWatch,
+      requestAcknowledgeAlert: requestAcknowledgeAlert,
+   };
+})();

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-data.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-data.js
@@ -1,0 +1,311 @@
+/*
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+  
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/master/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+  
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+  
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+  
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+  
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+*/
+
+/*jshint esversion: 8 */
+
+/**
+ * Conains the "static" data of the monitoring console.
+ * Most of all this are the page presets.
+ */
+MonitoringConsole.Data = (function() {
+
+	/**
+	 * List of known name-spaces and their text description.
+	 */
+    const NAMESPACES = {
+        web: 'Web Statistics',
+        http: 'HTTP Statistics',
+        jvm: 'JVM Statistics',
+        metric: 'MP Metrics',
+        trace: 'Request Tracing',
+        map: 'Cluster Map Storage Statistics',
+        topic: 'Cluster Topic IO Statistics',
+        monitoring: 'Monitoring Console Internals',
+        health: 'Health Checks',
+        sql: 'SQL Tracing',
+        other: 'Other',
+    };
+
+    /**
+     * Description texts used in the preset pages...
+     */
+	const TEXT_HTTP_HIGH = "Requires *HTTP monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'HTTP Service'* to *'HIGH'*.";
+	const TEXT_WEB_HIGH = "Requires *WEB monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'Web Container'* to *'HIGH'*.";
+	const TEXT_REQUEST_TRACING = "If you did enable request tracing at _Configurations_ => _Request Tracing_ not seeing any data means no requests passed the tracing threshold which is a good thing.";
+
+	const TEXT_CPU_USAGE = "Requires *CPU Usage HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _CPU Usage_ tab and check *'enabled'*";
+	const TEXT_HEAP_USAGE = "Requires *Heap Usage HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Heap Usage_ tab and check *'enabled'*";
+	const TEXT_GC_PERCENTAGE = "Requires *Garbage Collector HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Garbage Collector_ tab and check *'enabled'*";
+	const TEXT_MEM_USAGE = "Requires *Machine Memory HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Machine Memory Usage_ tab and check *'enabled'*";
+	const TEXT_POOL_USAGE = "Requires *Connection Pool HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Connection Pool_ tab and check *'enabled'*";
+	const TEXT_LIVELINESS = "Requires *MicroProfile HealthCheck Checker* to be enabled: Goto _Configurations_ => _HealthCheck_ => _MicroProfile HealthCheck Checker_ tab and check *'enabled'*";
+
+	/**
+	 * Page preset information improted on page load.
+	 */
+	const PAGES = {
+		core: {
+			name: 'Core',
+			numberOfColumns: 3,
+			widgets: [
+				{ series: 'ns:jvm HeapUsage', unit: 'percent',  
+					grid: { item: 1, column: 0}, 
+					axis: { min: 0, max: 100 },
+					decorations: {
+						thresholds: { reference: 'now', alarming: { value: 50, display: true }, critical: { value: 80, display: true }}}},
+				{ series: 'ns:jvm CpuUsage', unit: 'percent',
+					grid: { item: 1, column: 1}, 
+					axis: { min: 0, max: 100 },
+					decorations: {
+						thresholds: { reference: 'now', alarming: { value: 50, display: true }, critical: { value: 80, display: true }}}},							
+				{ series: 'ns:jvm ThreadCount', unit: 'count',  
+					grid: { item: 0, column: 1}},
+				{ series: 'ns:http ThreadPoolCurrentThreadUsage', unit: 'percent',
+					grid: { item: 1, column: 2},
+					status: { missing: { hint: TEXT_HTTP_HIGH }},
+					axis: { min: 0, max: 100 },
+					decorations: {
+						thresholds: { reference: 'avg', alarming: { value: 50, display: true }, critical: { value: 80, display: true }}}},														
+				{ series: 'ns:web RequestCount', unit: 'count',
+					grid: { item: 0, column: 2}, 
+					options: { perSec: true },
+					status: { missing: { hint: TEXT_WEB_HIGH }}},
+				{ series: 'ns:web ActiveSessions', unit: 'count',
+					grid: { item: 0, column: 0},
+					status: { missing: { hint: TEXT_WEB_HIGH }}},
+			]
+		},
+		request_tracing: {
+			name: 'Request Tracing',
+			numberOfColumns: 4,
+			widgets: [
+				{ id: '1 ns:trace @:* Duration', series: 'ns:trace @:* Duration', type: 'bar', unit: 'ms',
+					displayName: 'Trace Duration Range',
+					grid: { item: 0, column: 0, colspan: 4, rowspan: 1 },
+					axis: { min: 0, max: 5000 },
+					options: { drawMinLine: true },
+					status: { missing: { hint: TEXT_REQUEST_TRACING }},
+					coloring: 'instance-series',
+					decorations: { alerts: { noAmber: true, noRed: true }}},
+				{ id: '2 ns:trace @:* Duration', series: 'ns:trace @:* Duration', type: 'line', unit: 'ms', 
+					displayName: 'Trace Duration Above Threshold',
+					grid: { item: 1, column: 0, colspan: 2, rowspan: 3 },
+					options: { noFill: true },
+					coloring: 'instance-series'},
+				{ id: '3 ns:trace @:* Duration', series: 'ns:trace @:* Duration', type: 'annotation', unit: 'ms',
+					displayName: 'Trace Data',
+					grid: { item: 1, column: 2, colspan: 2, rowspan: 3 },
+					coloring: 'instance-series'},
+			]
+		},
+		http: {
+			name: 'HTTP',
+			numberOfColumns: 3,
+			widgets: [
+				{ series: 'ns:http ConnectionQueueCountOpenConnections', unit: 'count',
+					grid: { column: 0, item: 0},
+					status: { missing : { hint: TEXT_HTTP_HIGH }}},
+				{ series: 'ns:http ThreadPoolCurrentThreadsBusy', unit: 'count',
+					grid: { column: 0, item: 1},
+					status: { missing : { hint: TEXT_HTTP_HIGH }}},
+				{ series: 'ns:http ServerCount2xx', unit: 'count', 
+					grid: { column: 1, item: 0},
+					options: { perSec: true },
+					status: { missing : { hint: TEXT_HTTP_HIGH }}},
+				{ series: 'ns:http ServerCount3xx', unit: 'count', 
+					grid: { column: 1, item: 1},
+					options: { perSec: true },
+					status: { missing : { hint: TEXT_HTTP_HIGH }}},
+				{ series: 'ns:http ServerCount4xx', unit: 'count', 
+					grid: { column: 2, item: 0},
+					options: { perSec: true },
+					status: { missing : { hint: TEXT_HTTP_HIGH }}},
+				{ series: 'ns:http ServerCount5xx', unit: 'count', 
+					grid: { column: 2, item: 1},
+					options: { perSec: true },
+					status: { missing : { hint: TEXT_HTTP_HIGH }}},
+			]
+		},
+		health_checks: {
+			name: 'Health Checks',
+			numberOfColumns: 4,
+			widgets: [
+				{ series: 'ns:health CpuUsage', unit: 'percent', displayName: 'CPU',
+  					grid: { column: 0, item: 0},
+  					axis: { max: 100 },
+  					status: { missing : { hint: TEXT_CPU_USAGE }}},
+				{ series: 'ns:health HeapUsage', unit: 'percent', displayName: 'Heap',
+  					grid: { column: 1, item: 1},
+  					axis: { max: 100 },
+  					status: { missing : { hint: TEXT_HEAP_USAGE }}},
+				{ series: 'ns:health TotalGcPercentage', unit: 'percent', displayName: 'GC',
+  					grid: { column: 1, item: 0},
+  					axis: { max: 30 },
+  					status: { missing : { hint: TEXT_GC_PERCENTAGE }}},
+				{ series: 'ns:health PhysicalMemoryUsage', unit: 'percent', displayName: 'Memory',
+  					grid: { column: 0, item: 1},
+  					axis: { max: 100 },
+  					status: { missing : { hint: TEXT_MEM_USAGE }}},
+				{ series: 'ns:health @:* PoolUsage', unit: 'percent', coloring: 'series', displayName: 'Connection Pools',
+  					grid: { column: 1, item: 2},
+  					axis: { max: 100 },          					
+  					status: { missing : { hint: TEXT_POOL_USAGE }}},
+				{ series: 'ns:health LivelinessUp', unit: 'percent', displayName: 'MP Health',
+  					grid: { column: 0, item: 2},
+  					axis: { max: 100 },
+  					options: { noCurves: true },
+  					status: { missing : { hint: TEXT_LIVELINESS }}},
+				{ series: 'ns:health ?:* *', unit: 'percent', type: 'alert', displayName: 'Alerts',
+  					grid: { column: 2, item: 0, colspan: 2, rowspan: 3}}, 
+			]
+		},
+		monitoring: {
+			name: 'Monitoring',
+			numberOfColumns: 3,
+			widgets: [
+				{ series: 'ns:monitoring @:* CollectionDuration', unit: 'ms', displayName: 'Sources Time',
+					grid: { column: 0, item: 0, span: 2},
+					axis: { max: 200 },
+					coloring: 'series'},
+				{ series: 'ns:monitoring @:* AlertCount', displayName: 'Alerts',
+					grid: { column: 2, item: 2},
+					coloring: 'series'},
+				{ series: 'ns:monitoring CollectedSourcesCount', displayName: 'Sources',
+					grid: { column: 0, item: 2}},
+				{ series: 'ns:monitoring CollectedSourcesErrorCount', displayName: 'Sources with Errors', 
+					grid: { column: 1, item: 2}},
+				{ series: 'ns:monitoring CollectionDuration', unit: 'ms', displayName: 'Metrics Time',
+					grid: { column: 2, item: 0},
+					axis: { max: 1000},
+					options: { drawMaxLine: true }},
+				{ series: 'ns:monitoring WatchLoopDuration', unit: 'ms', displayName: 'Watches Time', 
+					grid: { column: 2, item: 1},
+					options: { drawMaxLine: true }},
+			],
+		},
+		jvm: {
+			name: 'JVM',
+			numberOfColumns: 3,
+			widgets: [
+				{ series: 'ns:jvm TotalLoadedClassCount', displayName: 'Loaded Classes', 
+					grid: { column: 2, item: 0}},
+				{ series: 'ns:jvm UnLoadedClassCount', displayName: 'Unloaded Classes',
+					grid: { column: 2, item: 1}},
+				{ series: 'ns:jvm CommittedHeapSize', unit: 'bytes', displayName: 'Heap Size',
+					grid: { column: 1, item: 0}},
+				{ series: 'ns:jvm UsedHeapSize', unit: 'bytes', displayName: 'Used Heap', 
+					grid: { column: 0, item: 0}},
+				{ series: 'ns:jvm ThreadCount', displayName: 'Live Threads', 
+					grid: { column: 1, item: 1}},
+				{ series: 'ns:jvm DaemonThreadCount', displayName: 'Daemon Threads',
+					grid: { column: 0, item: 1}},
+			],
+		},
+		sql: {
+			name: 'SQL',
+			numberOfColumns: 3,
+			widgets: [
+				{ id: '1 ns:sql @:* MaxExecutionTime', 
+					unit: 'ms',
+					type: 'annotation',
+					series: 'ns:sql @:* MaxExecutionTime',
+					displayName: 'Slow SQL Queries',
+					grid: { column: 0, item: 1, colspan: 2, rowspan: 2},
+					mode: 'table',
+					sort: 'value',
+					fields: ['Timestamp', 'SQL', 'Value']},
+				{ id: '2 ns:sql @:* MaxExecutionTime',
+					unit: 'ms',
+					series: 'ns:sql @:* MaxExecutionTime',
+					displayName: 'Worst SQL Execution Time',
+					grid: { column: 2, item: 1 },
+					coloring: 'series' },						
+				{ id: '3 ns:sql @:* MaxExecutionTime',
+					unit: 'ms',
+					type: 'alert',
+					series: 'ns:sql @:* MaxExecutionTime',
+					displayName: 'Slow SQL Alerts',
+					grid: { column: 2, item: 2 },
+					options: { noAnnotations: true }},
+			],
+		},
+		alerts: {
+			name: 'Alerts',
+			numberOfColumns: 1,
+			widgets: [
+				{id: '1 ?:* *', series: '?:* *', type: 'alert', displayName: 'Ongoing Alerts',
+					grid: {column: 0, item: 1},
+					decorations: { alerts: { noStopped: true }},
+					options: { noAnnotations: true}},
+				{id: '2 ?:* *', series: '?:* *', type: 'alert', displayName: 'Past Unacknowledged Alerts',
+					grid: {column: 0, item: 2},
+					decorations: { alerts: { noOngoing: true, noAcknowledged: true}},
+					options: { noAnnotations: true}},
+			],
+		},
+		threads: {
+			name: 'Threads',
+			numberOfColumns: 4,
+			widgets: [
+				{ series: 'ns:health StuckThreadDuration', type: 'annotation', mode: 'table', unit: 'ms',
+					displayName: 'Stuck Thread Incidents',
+					grid: {column: 0, item: 1, colspan: 3, rowspan: 1},
+					fields: ["Thread", "Started", "Value", "Threshold", "Suspended", "Locked", "State"]},
+				{ series: 'ns:health HoggingThreadDuration', type: 'annotation', mode: 'table', unit: 'ms',
+					displayName: 'Hogging Thread Incidents',
+					grid: {column: 0, item: 2, colspan: 3, rowspan: 1},
+					fields: ["Thread", "When", "Value", "Usage%", "Threshold%", "Method", "Exited"]},
+				{ series: 'ns:jvm ThreadCount', displayName: 'Live Threads', 
+					grid: {column: 3, item: 1}},
+				{ series: 'ns:jvm DaemonThreadCount', displayName: 'Daemon Threads', 
+					grid: {column: 3, item: 2}},							
+			],
+		}
+	};
+
+
+	/**
+	 * Public API for data access
+	 */ 
+	return { 
+		PAGES: PAGES,
+		NAMESPACES: NAMESPACES,
+	};
+})();

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
@@ -76,7 +76,7 @@ MonitoringConsole.Chart.Line = (function() {
           display: true,
           type: 'time',
           gridLines: {
-            color: 'rgba(100,100,100,0.3)',
+            color: 'rgba(0, 127, 255,0.5)',
             lineWidth: 0.5,
           },
           time: {
@@ -114,7 +114,7 @@ MonitoringConsole.Chart.Line = (function() {
         yAxes: [{
           display: true,
           gridLines: {
-            color: 'rgba(100,100,100,0.7)',
+            color: 'rgba(0, 127, 255,0.5)',
             lineWidth: 0.5,
           },
           ticks: {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-line-chart.js
@@ -134,6 +134,7 @@ MonitoringConsole.Chart.Line = (function() {
         if (!Array.isArray(areas) || areas.length === 0)
           return;
         let ctx = chart.chart.ctx;
+        ctx.save();
         let xAxis = chart.chart.scales["x-axis-0"];
         function yOffset(y) {
           let yMax = yAxis.ticksAsNumbers[0];
@@ -209,6 +210,7 @@ MonitoringConsole.Chart.Line = (function() {
           if (offsetBar)
             offsetRight += barWidth + 1;
         }
+        ctx.restore();
       }
     };
     return new Chart(widget.target, {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-main.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-main.js
@@ -46,15 +46,28 @@ Chart.defaults.global.tooltips.enabled = false;
 /**
  * The different parts of the Monitoring Console are added as the below properties by the individual files.
  */
-var MonitoringConsole =  {
+const MonitoringConsole =  {
+
+  /**
+   * Static configuration data for page presets.
+   */
+  Data: {},
+
+   /**
+    * Functions of manipulate the model of the MC (often returns a layout that is applied to the View)
+    **/ 
+  Model: {},
+
    /**
     * Functions to update the actual HTML page of the MC
     **/
 	View: {},
+
    /**
-    * Functions of manipulate the model of the MC (often returns a layout that is applied to the View)
+    * API functions to talk to the server.
     **/ 
-	Model: {},
+  Controller: {},
+
    /**
     * Functions specifically to take the data and prepare the display particular chart type using the underlying charting library.
     *

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-main.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-main.js
@@ -40,7 +40,7 @@
 
 /*jshint esversion: 8 */
 
-Chart.defaults.global.defaultFontColor = "#ddd";
+Chart.defaults.global.defaultFontColor = "#007FFF";
 Chart.defaults.global.tooltips.enabled = false;
 
 /**

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -844,13 +844,20 @@ MonitoringConsole.Model = (function() {
 				let instance = seriesData.instance;
 				let series = seriesData.series;
 				let status = 'normal';
-				if (Array.isArray(watches) && watches.length == 1) {
+				if (Array.isArray(watches) && watches.length > 0) {
 					let states = watches
+						.filter(watch => !watch.disabled && !watch.stopped)
 						.map(watch => watch.states[series]).filter(e => e != undefined)
 						.map(states => states[instance]).filter(e => e != undefined);
-					if (states.length == 1) {
-						status = states[0];
-					}					
+					if (states.includes('red')) {
+						status = 'red';
+					} else if (states.includes('amber')) {
+						status = 'amber';
+					} else if (states.includes('green')) {
+						status = 'green';
+					} else if (states.length > 0) {
+						status = 'white';
+					}
 				}
 				let thresholds = widget.decorations.thresholds;
 				if (thresholds.reference && thresholds.reference !== 'off') {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-model.js
@@ -51,238 +51,9 @@ MonitoringConsole.Model = (function() {
 	 */
 	const LOCAL_UI_KEY = 'fish.payara.monitoring-console.defaultConfigs';
 	
-	const TEXT_HTTP_HIGH = "Requires *HTTP monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'HTTP Service'* to *'HIGH'*.";
-	const TEXT_WEB_HIGH = "Requires *WEB monitoring* to be enabled: Goto _Configurations_ => _Monitoring_ and set *'Web Container'* to *'HIGH'*.";
-	const TEXT_REQUEST_TRACING = "If you did enable request tracing at _Configurations_ => _Request Tracing_ not seeing any data means no requests passed the tracing threshold which is a good thing.";
 
-	const TEXT_CPU_USAGE = "Requires *CPU Usage HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _CPU Usage_ tab and check *'enabled'*";
-	const TEXT_HEAP_USAGE = "Requires *Heap Usage HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Heap Usage_ tab and check *'enabled'*";
-	const TEXT_GC_PERCENTAGE = "Requires *Garbage Collector HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Garbage Collector_ tab and check *'enabled'*";
-	const TEXT_MEM_USAGE = "Requires *Machine Memory HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Machine Memory Usage_ tab and check *'enabled'*";
-	const TEXT_POOL_USAGE = "Requires *Connection Pool HealthCheck* to be enabled: Goto _Configurations_ => _HealthCheck_ => _Connection Pool_ tab and check *'enabled'*";
-	const TEXT_LIVELINESS = "Requires *MicroProfile HealthCheck Checker* to be enabled: Goto _Configurations_ => _HealthCheck_ => _MicroProfile HealthCheck Checker_ tab and check *'enabled'*";
-
-	const UI_PRESETS = {
-			pages: {
-				core: {
-					name: 'Core',
-					numberOfColumns: 3,
-					widgets: [
-						{ series: 'ns:jvm HeapUsage', unit: 'percent',  
-							grid: { item: 1, column: 0}, 
-							axis: { min: 0, max: 100 },
-							decorations: {
-								thresholds: { reference: 'now', alarming: { value: 50, display: true }, critical: { value: 80, display: true }}}},
-						{ series: 'ns:jvm CpuUsage', unit: 'percent',
-							grid: { item: 1, column: 1}, 
-							axis: { min: 0, max: 100 },
-							decorations: {
-								thresholds: { reference: 'now', alarming: { value: 50, display: true }, critical: { value: 80, display: true }}}},							
-						{ series: 'ns:jvm ThreadCount', unit: 'count',  
-							grid: { item: 0, column: 1}},
-						{ series: 'ns:http ThreadPoolCurrentThreadUsage', unit: 'percent',
-							grid: { item: 1, column: 2},
-							status: { missing: { hint: TEXT_HTTP_HIGH }},
-							axis: { min: 0, max: 100 },
-							decorations: {
-								thresholds: { reference: 'avg', alarming: { value: 50, display: true }, critical: { value: 80, display: true }}}},														
-						{ series: 'ns:web RequestCount', unit: 'count',
-							grid: { item: 0, column: 2}, 
-							options: { perSec: true },
-							status: { missing: { hint: TEXT_WEB_HIGH }}},
-						{ series: 'ns:web ActiveSessions', unit: 'count',
-							grid: { item: 0, column: 0},
-							status: { missing: { hint: TEXT_WEB_HIGH }}},
-					]
-				},
-				request_tracing: {
-					name: 'Request Tracing',
-					numberOfColumns: 4,
-					widgets: [
-						{ id: '1 ns:trace @:* Duration', series: 'ns:trace @:* Duration', type: 'bar', unit: 'ms',
-							displayName: 'Trace Duration Range',
-							grid: { item: 0, column: 0, colspan: 4, rowspan: 1 },
-							axis: { min: 0, max: 5000 },
-							options: { drawMinLine: true },
-							status: { missing: { hint: TEXT_REQUEST_TRACING }},
-							coloring: 'instance-series',
-							decorations: { alerts: { noAmber: true, noRed: true }}},
-						{ id: '2 ns:trace @:* Duration', series: 'ns:trace @:* Duration', type: 'line', unit: 'ms', 
-							displayName: 'Trace Duration Above Threshold',
-							grid: { item: 1, column: 0, colspan: 2, rowspan: 3 },
-							options: { noFill: true },
-							coloring: 'instance-series'},
-						{ id: '3 ns:trace @:* Duration', series: 'ns:trace @:* Duration', type: 'annotation', unit: 'ms',
-							displayName: 'Trace Data',
-							grid: { item: 1, column: 2, colspan: 2, rowspan: 3 },
-							coloring: 'instance-series'},
-					]
-				},
-				http: {
-					name: 'HTTP',
-					numberOfColumns: 3,
-					widgets: [
-						{ series: 'ns:http ConnectionQueueCountOpenConnections', unit: 'count',
-							grid: { column: 0, item: 0},
-							status: { missing : { hint: TEXT_HTTP_HIGH }}},
-						{ series: 'ns:http ThreadPoolCurrentThreadsBusy', unit: 'count',
-							grid: { column: 0, item: 1},
-							status: { missing : { hint: TEXT_HTTP_HIGH }}},
-						{ series: 'ns:http ServerCount2xx', unit: 'count', 
-							grid: { column: 1, item: 0},
-							options: { perSec: true },
-							status: { missing : { hint: TEXT_HTTP_HIGH }}},
-						{ series: 'ns:http ServerCount3xx', unit: 'count', 
-							grid: { column: 1, item: 1},
-							options: { perSec: true },
-							status: { missing : { hint: TEXT_HTTP_HIGH }}},
-						{ series: 'ns:http ServerCount4xx', unit: 'count', 
-							grid: { column: 2, item: 0},
-							options: { perSec: true },
-							status: { missing : { hint: TEXT_HTTP_HIGH }}},
-						{ series: 'ns:http ServerCount5xx', unit: 'count', 
-							grid: { column: 2, item: 1},
-							options: { perSec: true },
-							status: { missing : { hint: TEXT_HTTP_HIGH }}},
-					]
-				},
-				health_checks: {
-					name: 'Health Checks',
-					numberOfColumns: 4,
-					widgets: [
-						{ series: 'ns:health CpuUsage', unit: 'percent', displayName: 'CPU',
-          					grid: { column: 0, item: 0},
-          					axis: { max: 100 },
-          					status: { missing : { hint: TEXT_CPU_USAGE }}},
-						{ series: 'ns:health HeapUsage', unit: 'percent', displayName: 'Heap',
-          					grid: { column: 1, item: 1},
-          					axis: { max: 100 },
-          					status: { missing : { hint: TEXT_HEAP_USAGE }}},
-						{ series: 'ns:health TotalGcPercentage', unit: 'percent', displayName: 'GC',
-          					grid: { column: 1, item: 0},
-          					axis: { max: 30 },
-          					status: { missing : { hint: TEXT_GC_PERCENTAGE }}},
-						{ series: 'ns:health PhysicalMemoryUsage', unit: 'percent', displayName: 'Memory',
-          					grid: { column: 0, item: 1},
-          					axis: { max: 100 },
-          					status: { missing : { hint: TEXT_MEM_USAGE }}},
-						{ series: 'ns:health @:* PoolUsage', unit: 'percent', coloring: 'series', displayName: 'Connection Pools',
-          					grid: { column: 1, item: 2},
-          					axis: { max: 100 },          					
-          					status: { missing : { hint: TEXT_POOL_USAGE }}},
-						{ series: 'ns:health LivelinessUp', unit: 'percent', displayName: 'MP Health',
-          					grid: { column: 0, item: 2},
-          					axis: { max: 100 },
-          					options: { noCurves: true },
-          					status: { missing : { hint: TEXT_LIVELINESS }}},
-						{ series: 'ns:health ?:* *', unit: 'percent', type: 'alert', displayName: 'Alerts',
-          					grid: { column: 2, item: 0, colspan: 2, rowspan: 3}}, 
-					]
-				},
-				monitoring: {
-					name: 'Monitoring',
-					numberOfColumns: 3,
-					widgets: [
-						{ series: 'ns:monitoring @:* CollectionDuration', unit: 'ms', displayName: 'Sources Time',
-							grid: { column: 0, item: 0, span: 2},
-							axis: { max: 200 },
-							coloring: 'series'},
-						{ series: 'ns:monitoring @:* AlertCount', displayName: 'Alerts',
-							grid: { column: 2, item: 2},
-							coloring: 'series'},
-						{ series: 'ns:monitoring CollectedSourcesCount', displayName: 'Sources',
-							grid: { column: 0, item: 2}},
-						{ series: 'ns:monitoring CollectedSourcesErrorCount', displayName: 'Sources with Errors', 
-							grid: { column: 1, item: 2}},
-						{ series: 'ns:monitoring CollectionDuration', unit: 'ms', displayName: 'Metrics Time',
-							grid: { column: 2, item: 0},
-							axis: { max: 1000},
-							options: { drawMaxLine: true }},
-						{ series: 'ns:monitoring WatchLoopDuration', unit: 'ms', displayName: 'Watches Time', 
-							grid: { column: 2, item: 1},
-							options: { drawMaxLine: true }},
-					],
-				},
-				jvm: {
-					name: 'JVM',
-					numberOfColumns: 3,
-					widgets: [
-						{ series: 'ns:jvm TotalLoadedClassCount', displayName: 'Loaded Classes', 
-							grid: { column: 2, item: 0}},
-						{ series: 'ns:jvm UnLoadedClassCount', displayName: 'Unloaded Classes',
-							grid: { column: 2, item: 1}},
-						{ series: 'ns:jvm CommittedHeapSize', unit: 'bytes', displayName: 'Heap Size',
-							grid: { column: 1, item: 0}},
-						{ series: 'ns:jvm UsedHeapSize', unit: 'bytes', displayName: 'Used Heap', 
-							grid: { column: 0, item: 0}},
-						{ series: 'ns:jvm ThreadCount', displayName: 'Live Threads', 
-							grid: { column: 1, item: 1}},
-						{ series: 'ns:jvm DaemonThreadCount', displayName: 'Daemon Threads',
-							grid: { column: 0, item: 1}},
-					],
-				},
-				sql: {
-					name: 'SQL',
-					numberOfColumns: 3,
-					widgets: [
-						{ id: '1 ns:sql @:* MaxExecutionTime', 
-							unit: 'ms',
-							type: 'annotation',
-							series: 'ns:sql @:* MaxExecutionTime',
-							displayName: 'Slow SQL Queries',
-							grid: { column: 0, item: 1, colspan: 2, rowspan: 2},
-							mode: 'table',
-							sort: 'value',
-							fields: ['Timestamp', 'SQL', 'Value']},
-						{ id: '2 ns:sql @:* MaxExecutionTime',
-							unit: 'ms',
-							series: 'ns:sql @:* MaxExecutionTime',
-							displayName: 'Worst SQL Execution Time',
-							grid: { column: 2, item: 1 },
-							coloring: 'series' },						
-						{ id: '3 ns:sql @:* MaxExecutionTime',
-							unit: 'ms',
-							type: 'alert',
-							series: 'ns:sql @:* MaxExecutionTime',
-							displayName: 'Slow SQL Alerts',
-							grid: { column: 2, item: 2 },
-							options: { noAnnotations: true }},
-					],
-				},
-				alerts: {
-					name: 'Alerts',
-					numberOfColumns: 1,
-					widgets: [
-						{id: '1 ?:* *', series: '?:* *', type: 'alert', displayName: 'Ongoing Alerts',
-							grid: {column: 0, item: 1},
-							decorations: { alerts: { noStopped: true }},
-							options: { noAnnotations: true}},
-						{id: '2 ?:* *', series: '?:* *', type: 'alert', displayName: 'Past Unacknowledged Alerts',
-							grid: {column: 0, item: 2},
-							decorations: { alerts: { noOngoing: true, noAcknowledged: true}},
-							options: { noAnnotations: true}},
-					],
-				},
-				threads: {
-					name: 'Threads',
-					numberOfColumns: 4,
-					widgets: [
-						{ series: 'ns:health StuckThreadDuration', type: 'annotation', mode: 'table', unit: 'ms',
-							displayName: 'Stuck Thread Incidents',
-							grid: {column: 0, item: 1, colspan: 3, rowspan: 1},
-							fields: ["Thread", "Started", "Value", "Threshold", "Suspended", "Locked", "State"]},
-						{ series: 'ns:health HoggingThreadDuration', type: 'annotation', mode: 'table', unit: 'ms',
-							displayName: 'Hogging Thread Incidents',
-							grid: {column: 0, item: 2, colspan: 3, rowspan: 1},
-							fields: ["Thread", "When", "Value", "Usage%", "Threshold%", "Method", "Exited"]},
-						{ series: 'ns:jvm ThreadCount', displayName: 'Live Threads', 
-							grid: {column: 3, item: 1}},
-						{ series: 'ns:jvm DaemonThreadCount', displayName: 'Daemon Threads', 
-							grid: {column: 3, item: 2}},							
-					],
-				}
-			},
-	};
+	const Data = MonitoringConsole.Data;
+	const Controller = MonitoringConsole.Controller;
 
 	//TODO idea: Classification. one can setup a table where a value range is assigned a certain state - this table is used to show that state in the UI, simple but effective
 
@@ -633,7 +404,7 @@ MonitoringConsole.Model = (function() {
 				let ui = localStorage.getItem(LOCAL_UI_KEY);
 				if (ui)
 				doImport(JSON.parse(ui), true);
-				doImport(JSON.parse(JSON.stringify(UI_PRESETS)), false);
+				doImport(JSON.parse(JSON.stringify({ pages: Data.PAGES })), false);
 				return pages[settings.home];
 			},
 			
@@ -673,10 +444,10 @@ MonitoringConsole.Model = (function() {
 			},
 
 			resetPage: function() {
-				let presets = UI_PRESETS;
+				let presets = Data.PAGES;
 				let currentPageId = settings.home;
-				if (presets && presets.pages && presets.pages[currentPageId]) {
-					let preset = presets.pages[currentPageId];
+				if (presets && presets[currentPageId]) {
+					let preset = presets[currentPageId];
 					pages[currentPageId] = sanityCheckPage(JSON.parse(JSON.stringify(preset)));
 					doStore();
 					return true;
@@ -685,8 +456,8 @@ MonitoringConsole.Model = (function() {
 			},
 
 			hasPreset: function() {
-				let presets = UI_PRESETS;
-				return presets && presets.pages && presets.pages[settings.home];
+				let presets = Data.PAGES;
+				return presets && presets[settings.home];
 			},
 			
 			switchPage: function(pageId) {
@@ -1133,7 +904,7 @@ MonitoringConsole.Model = (function() {
 		}
 
 		function createOnError(widgets, onDataUpdate) {
-			return function(jqXHR, textStatus) {
+			return function() {
 				Object.values(widgets).forEach(function(widget) {
 					onDataUpdate({
 						widget: widget,
@@ -1154,8 +925,7 @@ MonitoringConsole.Model = (function() {
 		UI.load();
 		Interval.init(function() {
 			let widgets = UI.currentPage().widgets;
-			let payload = {};
-			payload.queries = Object.values(widgets).map(function(widget) { 
+			const queries = Object.values(widgets).map(function(widget) { 
 				let truncate = [];
 				let exclude = [];
 				let alerts = widget.decorations.alerts;
@@ -1179,22 +949,16 @@ MonitoringConsole.Model = (function() {
 					default:
 						truncate.push('ALERTS');
 				}				
-				return { 
+				return {
 					series: widget.series,
 					truncate: truncate,
 					exclude: exclude,
 					instances: undefined, // all
 				}; 
 			});
-			let request = $.ajax({
-				url: 'api/series/data/',
-				type: 'POST',
-				data: JSON.stringify(payload),
-				contentType:"application/json; charset=utf-8",
-				dataType:"json",
-			});
-			request.done(Update.createOnSuccess(widgets, onDataUpdate));
-			request.fail(Update.createOnError(widgets, onDataUpdate));
+			Controller.requestListOfSeriesData(queries, 
+				Update.createOnSuccess(widgets, onDataUpdate),
+				Update.createOnError(widgets, onDataUpdate));
 		});
 		if (UI.Refresh.interval() === undefined) {
 			UI.Refresh.interval(DEFAULT_INTERVAL);
@@ -1248,7 +1012,7 @@ MonitoringConsole.Model = (function() {
 		/**
 		 * @param {function} consumer - a function with one argument accepting the array of series names
 		 */
-		listSeries: (consumer) => $.getJSON("api/series/", consumer),
+		listSeries: (consumer) => Controller.requestListOfSeriesNames(consumer),
 
 		listPages: UI.listPages,
 		exportPages: UI.exportPages,

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-trace-chart.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-trace-chart.js
@@ -45,6 +45,7 @@
  */ 
 MonitoringConsole.Chart.Trace = (function() {
 
+   const Controller = MonitoringConsole.Controller;
    const Components = MonitoringConsole.View.Components;
    const Colors = MonitoringConsole.View.Colors;
    const Common = MonitoringConsole.Chart.Common;
@@ -228,7 +229,7 @@ MonitoringConsole.Chart.Trace = (function() {
 
 
    function onDataRefresh() {
-      $.getJSON("api/trace/data/"+model.series, onDataUpdate);
+      Controller.requestListOfRequestTraces(model.series, onDataUpdate);
    }
 
    function onOpenPopup(series) {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-colors.js
@@ -61,6 +61,7 @@ MonitoringConsole.View.Colors = (function() {
             '#800000', '#911eb4', '#f032e6', '#fabebe', '#e6beff', '#fffac8' ],
          opacity: 10,
          colors:  { 
+            error: '#e6194B', missing: '#0096D6',
             waterline: '#3cb44b', alarming: '#f58231', critical: '#e6194B',
             white: '#ffffff', green: '#3cb44b', amber: '#f58231', red: '#e6194B',
          }

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -962,11 +962,11 @@ MonitoringConsole.View.Components = (function() {
         kind = 'inSample';
       } else if (editedCondition[editedCondition.forLastType] < 0) {
         kind = 'inLast';
-      } else if (editedCondition.average) {
+      } else if (editedCondition.onAverage) {
         kind = 'forAvgOfLast';
       }
       const kindDropdown = Settings.createInput({ type: 'dropdown', value: kind, options: kindOptions, onChange: (selected) => {
-        editedCondition.average = selected === 'forAvgOfLast';
+        editedCondition.onAverage = selected === 'forAvgOfLast';
         if (selected == 'forLast' || selected == 'forAvgOfLast') {
           editedCondition[editedCondition.forLastType] = Math.abs(editedCondition.forLast);
         } else if (selected == 'inLast') {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -413,14 +413,14 @@ MonitoringConsole.View.Components = (function() {
   /**
    * Component drawn for each widget legend item to indicate data status.
    */
-  let Indicator = (function() {
+  const Indicator = (function() {
 
     function createComponent(model) {
        if (!model.text) {
           return $('<div/>', {'class': 'Indicator', style: 'display: none;'});
        }
        let html = model.text.replace(/\*([^*]+)\*/g, '<b>$1</b>').replace(/_([^_]+)_/g, '<i>$1</i>');
-       return $('<div/>', { 'class': 'Indicator status-' + model.status }).html(html);
+       return $('<div/>', { 'class': 'Indicator status-' + model.status, style: 'color: ' + model.color + ';' }).html(html);
     }
 
     return { createComponent: createComponent };
@@ -429,7 +429,7 @@ MonitoringConsole.View.Components = (function() {
   /**
    * Component for any of the text+icon menus/toolbars.
    */
-  let Menu = (function() {
+  const Menu = (function() {
 
     function createComponent(model) {
       let attrs = { 'class': 'Menu' };
@@ -822,7 +822,7 @@ MonitoringConsole.View.Components = (function() {
         }
       }});
       const menu = [
-        { icon: '&#128295;', label: 'Edit', onClick: () => actions.onEdit(item) }
+        { icon: '&#128295;', label: item.programmatic ? 'Duplicate' : 'Edit', onClick: () => actions.onEdit(item) }
       ];
       if (item.disabled) {
         menu.push({ icon: '&#9745;', label: 'Enable', onClick: () => actions.onEnable(item.name) });        

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -878,7 +878,7 @@ MonitoringConsole.View.Components = (function() {
       }
       const builder = $('<div/>', config);
       const nameInput = Settings.createInput({ type: 'text', value: editedWatch.name, onChange: (name) => editedWatch.name = name });
-      builder.append($('<h3/>').append('Name: ').append(nameInput));
+      builder.append($('<h3/>').append(nameInput));
       const unitDropdowns = [];
       const seriesInputs = [];
       for (let level of ['red', 'amber', 'green']) {

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -870,12 +870,14 @@ MonitoringConsole.View.Components = (function() {
       const config = { 'class': 'WatchBuilder WatchItem' };
       if (model.id)
         config.id = model.id;
-      const editedWatch = watch || { unit: 'count', name: 'New Watch' };
+      let editedWatch = watch || { unit: 'count', name: 'New Watch' };
+      if (editedWatch.programmatic) {
+        editedWatch = JSON.parse(JSON.stringify(watch));
+        editedWatch.name = 'Copy of ' + watch.name;
+        editedWatch.programmatic = false;
+      }
       const builder = $('<div/>', config);
-      let name = editedWatch.name;
-      if (editedWatch.programmatic)
-        name = 'Copy of ' + name;
-      const nameInput = Settings.createInput({ type: 'text', value: name, onChange: (name) => editedWatch.name = name });
+      const nameInput = Settings.createInput({ type: 'text', value: editedWatch.name, onChange: (name) => editedWatch.name = name });
       builder.append($('<h3/>').append('Name: ').append(nameInput));
       const unitDropdowns = [];
       const seriesInputs = [];

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-components.js
@@ -832,10 +832,12 @@ MonitoringConsole.View.Components = (function() {
       if (!item.programmatic) {
         menu.push({ icon: '&times;', label: 'Delete', onClick: () => actions.onDelete(item.name) });
       }
+      const icon = item.stopped ? '&#9209;' : item.disabled ? '&#9208;' : '&#9210;';
       const general = $('<h3/>').append(disableButton).append(item.name).click(() => actions.onEdit(item));
       watch
         .append(Menu.createComponent({ groups: [{ icon: '&#9881;', items: menu }]}))
-        .append(general);
+        .append(general)
+        .append($('<span/>', { 'class': 'Icon' }).html(icon));
       for (let level of ['red', 'amber', 'green'])
         if (item[level])
           watch.append(createCircumstance(level, item[level], item.unit, item.series, colors[level]));

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-units.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-units.js
@@ -115,6 +115,21 @@ MonitoringConsole.View.Units = (function() {
       percent: PERCENT_FACTORS,
    };
 
+   const UNIT_NAMES = {
+      count: 'Count', 
+      ms: 'Milliseconds', 
+      ns: 'Nanoseconds', 
+      bytes: 'Bytes', 
+      percent: 'Percentage'
+   };
+
+   const ALERT_STATUS_NAMES = { 
+      white: 'Normal', 
+      green: 'Healthy', 
+      amber: 'Degraded', 
+      red: 'Unhealthy' 
+   };
+
    function parseNumber(valueAsString, factors) {
       if (!valueAsString || typeof valueAsString === 'string' && valueAsString.trim() === '')
          return undefined;
@@ -251,8 +266,11 @@ MonitoringConsole.View.Units = (function() {
    return {
       Alerts: {
          maxLevel: maxAlertLevel,
+         name: (level) => ALERT_STATUS_NAMES[level == undefined ? 'white' : level],
       },
       
+      names: () => UNIT_NAMES,
+
       formatTime: formatTime,
       formatNumber: formatNumber,
       formatMilliseconds: (valueAsNumber) => formatNumber(valueAsNumber, MS_FACTORS),

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-units.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view-units.js
@@ -256,7 +256,7 @@ MonitoringConsole.View.Units = (function() {
    }
 
    function maxAlertLevel(a, b) {
-      const table = ['white', 'green', 'amber', 'red'];
+      const table = ['white', 'normal', 'green', 'alarming', 'amber', 'critical', 'red'];
       return table[Math.max(0, Math.max(table.indexOf(a), table.indexOf(b)))];
    }
 

--- a/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
+++ b/appserver/monitoring-console/webapp/src/main/webapp/js/mc-view.js
@@ -256,7 +256,10 @@ MonitoringConsole.View = (function() {
             return (value) => { Theme.configure(theme => theme.options[name] = value); };
         }    
         function createColorDefaultSettingMapper(name) {
-            return { label: name[0].toUpperCase() + name.slice(1), type: 'color', value: Theme.color(name), onChange: createChangeColorDefaultFn(name) };
+            let label = Units.Alerts.name(name);
+            if (label === undefined)
+                label = name[0].toUpperCase() + name.slice(1);
+            return { label: label, type: 'color', value: Theme.color(name), onChange: createChangeColorDefaultFn(name) };
         }
         let collapsed = $('#settings-colors').children('tr:visible').length <= 1;
         return { id: 'settings-colors', caption: 'Colors', collapsed: collapsed, entries: [
@@ -706,8 +709,8 @@ MonitoringConsole.View = (function() {
                         $.ajax({
                             type: 'PUT',
                             url: 'api/watches/data/',
-                            contentType: 'application/json',
-                            data: watch
+                            contentType: 'application/json; charset=utf-8',
+                            data: JSON.stringify(watch)
                         }).done(onSuccess).fail(onFailure);
                     },
                     onDelete: (name, onSuccess, onFailure) => {

--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/WriteableView.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/WriteableView.java
@@ -53,6 +53,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * A WriteableView is a view of a ConfigBean object that allow access to the
@@ -62,12 +63,14 @@ import java.util.*;
  */
 public class WriteableView implements InvocationHandler, Transactor, ConfigView {
     private static final TraversableResolver TRAVERSABLE_RESOLVER = new TraversableResolver() {
+        @Override
         public boolean isReachable(Object traversableObject,
                 Path.Node traversableProperty, Class<?> rootBeanType,
                 Path pathToTraversableObject, ElementType elementType) {
                     return true;
         }
 
+        @Override
         public boolean isCascadable(Object traversableObject,
                 Path.Node traversableProperty, Class<?> rootBeanType,
                 Path pathToTraversableObject, ElementType elementType) {
@@ -104,7 +107,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
     private final ConfigBean bean;
     private final ConfigBeanProxy defaultView;
     private final Map<String, PropertyChangeEvent> changedAttributes;
-    private final Map<String, ProtectedList> changedCollections;
+    private final Map<String, ProtectedList<?>> changedCollections;
     Transaction currentTx;
     private boolean isDeleted;
 
@@ -116,10 +119,11 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
     public WriteableView(ConfigBeanProxy readView) {
         this.bean = (ConfigBean) ((ConfigView) Proxy.getInvocationHandler(readView)).getMasterView();
         this.defaultView = bean.createProxy();
-        changedAttributes = new HashMap<String, PropertyChangeEvent>();
-        changedCollections = new HashMap<String, ProtectedList>();
+        changedAttributes = new HashMap<>();
+        changedCollections = new HashMap<>();
     }
 
+    @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 
         if (method.getName().equals("hashCode"))
@@ -145,29 +149,24 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
                 Object changedValue = changedAttributes.get(property.xmlName()).getNewValue();
                 if (changedValue instanceof Dom) {
                     return ((Dom) changedValue).createProxy();
-                } else {
-                    return changedValue;
                 }
-            } else {
-                // pass through.
-                return getter(property, method.getGenericReturnType());
+                return changedValue;
             }
-        } else {
-            setter(property, args[0], method.getGenericParameterTypes()[0]);
-            return null;
+            // pass through.
+            return getter(property, method.getGenericReturnType());
         }
+        setter(property, args[0], method.getGenericParameterTypes()[0]);
+        return null;
     }
 
     public String getPropertyValue(String propertyName) {
-
         ConfigModel.Property prop = this.getProperty(propertyName);
         if (prop!=null) {
             if (changedAttributes.containsKey(prop.xmlName())) {
                 // serve masked changes.
                 return (String) changedAttributes.get(prop.xmlName()).getNewValue();
-            } else {
-                return (String) getter(prop, String.class);
             }
+            return (String) getter(prop, String.class);
         }
         return null;
     }
@@ -178,7 +177,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
             if (!changedCollections.containsKey(property.xmlName())) {
                 // wrap collections so we can record events on that collection mutation.
                 changedCollections.put(property.xmlName(),
-                        new ProtectedList(List.class.cast(value), defaultView, property.xmlName()));
+                        new ProtectedList<>(List.class.cast(value), defaultView, property.xmlName()));
             }
             return changedCollections.get(property.xmlName());
         }
@@ -230,7 +229,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
                 // Resources
                 List<Dom> siblings = parent != null
                         ? parent.domNodeByTypeElements(thisview.getProxyType())
-                        : new ArrayList<Dom>();
+                        : new ArrayList<>();
 
                 // Iterate through each sibling element and see if anyone has
                 // same key. If true throw an exception after unlocking this
@@ -251,13 +250,13 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
         Object oldValue = bean.getter(property, t);
         if (newValue instanceof ConfigBeanProxy) {
             ConfigView bean = (ConfigView)
-                Proxy.getInvocationHandler((ConfigBeanProxy) newValue);
+                Proxy.getInvocationHandler(newValue);
             newValue = bean.getMasterView();
         }
         PropertyChangeEvent evt = new PropertyChangeEvent(
             defaultView,property.xmlName(), oldValue, newValue);
         try {
-            for (ConfigBeanInterceptor interceptor : bean.getOptionalFeatures()) {
+            for (ConfigBeanInterceptor<?> interceptor : bean.getOptionalFeatures()) {
                 interceptor.beforeChange(evt);
             }
         } catch(PropertyVetoException e) {
@@ -265,7 +264,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
         }
 
         changedAttributes.put(property.xmlName(), evt);
-        for (ConfigBeanInterceptor interceptor : bean.getOptionalFeatures()) {
+        for (ConfigBeanInterceptor<?> interceptor : bean.getOptionalFeatures()) {
             interceptor.afterChange(evt, System.currentTimeMillis());
         }
     }
@@ -285,6 +284,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
      * @return true if the enlisting with the passed transaction was accepted,
      *         false otherwise
      */
+    @Override
     public synchronized boolean join(Transaction t) {
         if (currentTx==null) {
             currentTx = t;
@@ -301,10 +301,11 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
      *          one passed during the join(Transaction t) call.
      * @return true if the trsaction commiting would be successful
      */
+    @Override
     public synchronized boolean canCommit(Transaction t) throws TransactionFailure {
         if (!isDeleted) { // HK2-127: validate only if not marked for deletion
 
-            Set constraintViolations =
+            Set<? extends ConstraintViolation<?>> constraintViolations =
                 beanValidator.validate(this.getProxy(this.getProxyType()));
 
             try {
@@ -317,16 +318,16 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
         return currentTx==t;
     }
 
-    private void handleValidationException(Set constraintViolations) throws ConstraintViolationException {
+    private void handleValidationException(Set<? extends ConstraintViolation<?>> constraintViolations) throws ConstraintViolationException {
 
         if (constraintViolations != null && !constraintViolations.isEmpty()) {
-            Iterator<ConstraintViolation<ConfigBeanProxy>> it = constraintViolations.iterator();
+            Iterator<? extends ConstraintViolation<?>> it = constraintViolations.iterator();
 
             StringBuilder sb = new StringBuilder();
             sb.append(MessageFormat.format(i18n.getString("bean.validation.failure"), this.<ConfigBeanProxy>getProxyType().getSimpleName()));
             String violationMsg = i18n.getString("bean.validation.constraintViolation");
             while (it.hasNext()) {
-                ConstraintViolation cv = it.next();
+                ConstraintViolation<?> cv = it.next();
                 sb.append(" ");
                 sb.append(MessageFormat.format(violationMsg, cv.getMessage(), cv.getPropertyPath()));
                 if (it.hasNext()) {
@@ -356,6 +357,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
      * @throws TransactionFailure
      *          if the transaction commit failed
      */
+    @Override
     public synchronized List<PropertyChangeEvent> commit(Transaction t) throws TransactionFailure {
         if (currentTx==t) {
             currentTx=null;
@@ -377,10 +379,10 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
 
 
         try {
-            List<PropertyChangeEvent> appliedChanges = new ArrayList<PropertyChangeEvent>();
+            List<PropertyChangeEvent> appliedChanges = new ArrayList<>();
             for (PropertyChangeEvent event : changedAttributes.values()) {
                 ConfigModel.Property property = bean.model.findIgnoreCase(event.getPropertyName());
-                ConfigBeanInterceptor interceptor  = bean.getOptionalFeature(ConfigBeanInterceptor.class);
+                ConfigBeanInterceptor<?> interceptor  = bean.getOptionalFeature(ConfigBeanInterceptor.class);
                 try {
                     if (interceptor!=null) {
                         interceptor.beforeChange(event);
@@ -394,43 +396,8 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
                 }
                 appliedChanges.add(event);
             }
-            for (ProtectedList entry :  changedCollections.values())  {
-                List<Object> originalList = entry.readOnly;
-                for (PropertyChangeEvent event : entry.changeEvents) {
-                    if (event.getOldValue()==null) {
-                        originalList.add(event.getNewValue());
-                    } else {
-                        final Object toBeRemovedObj = event.getOldValue();
-                        if ( toBeRemovedObj instanceof ConfigBeanProxy ) {
-                            final Dom toBeRemoved = Dom.unwrap((ConfigBeanProxy)toBeRemovedObj);
-                            for (int index=0;index<originalList.size();index++) {
-                                Object element = originalList.get(index);
-                                Dom dom = Dom.unwrap((ConfigBeanProxy) element);
-                                if (dom==toBeRemoved) {
-                                    Object newValue = event.getNewValue();
-                                    if (newValue == null) {
-                                        originalList.remove(index);
-                                    } else {
-                                        originalList.set(index, newValue);
-                                    }
-                                }
-                            }
-                        }
-                        else if ( toBeRemovedObj instanceof String ) {
-                            final String toBeRemoved = (String)toBeRemovedObj;
-                            for (int index=0;index<originalList.size();index++) {
-                                final String item = (String)originalList.get(index);
-                                if (item.equals(toBeRemoved)) {
-                                    originalList.remove(index);
-                                }
-                            }
-                        }
-                        else {
-                              throw new IllegalArgumentException();
-                        }
-                    }
-                    appliedChanges.add(event);
-                }
+            for (ProtectedList<?> entry :  changedCollections.values())  {
+                commitListChanges(entry, appliedChanges);
             }
             changedAttributes.clear();
             changedCollections.clear();
@@ -442,7 +409,46 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
         } finally {
             bean.getLock().unlock();
         }
+    }
 
+    @SuppressWarnings("unchecked")
+    private static <E> void commitListChanges(ProtectedList<E> entry, List<PropertyChangeEvent> appliedChanges) {
+        List<E> originalList = entry.readOnly;
+        for (PropertyChangeEvent event : entry.changeEvents) {
+            if (event.getOldValue()==null) {
+                originalList.add((E) event.getNewValue());
+            } else {
+                final Object toBeRemovedObj = event.getOldValue();
+                if ( toBeRemovedObj instanceof ConfigBeanProxy ) {
+                    final Dom toBeRemoved = Dom.unwrap((ConfigBeanProxy)toBeRemovedObj);
+                    for (int index=0;index<originalList.size();index++) {
+                        Object element = originalList.get(index);
+                        Dom dom = Dom.unwrap((ConfigBeanProxy) element);
+                        if (dom==toBeRemoved) {
+                            Object newValue = event.getNewValue();
+                            if (newValue == null) {
+                                originalList.remove(index);
+                            } else {
+                                originalList.set(index, (E) newValue);
+                            }
+                        }
+                    }
+                }
+                else if ( toBeRemovedObj instanceof String ) {
+                    final String toBeRemoved = (String)toBeRemovedObj;
+                    for (int index=0;index<originalList.size();index++) {
+                        final String item = (String)originalList.get(index);
+                        if (item.equals(toBeRemoved)) {
+                            originalList.remove(index);
+                        }
+                    }
+                }
+                else {
+                    throw new IllegalArgumentException();
+                }
+            }
+            appliedChanges.add(event);
+        }
     }
 
     /**
@@ -450,6 +456,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
      *
      * @param t the aborting transaction
      */
+    @Override
     public synchronized void abort(Transaction t) {
         currentTx=null;
         bean.getLock().unlock();
@@ -472,24 +479,29 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
             throw new TransactionFailure("Not part of a transaction", null);
         }
         ConfigBean newBean = bean.allocate(type);
-        WriteableView writeableView = bean.getHabitat().<ConfigSupport>getService(ConfigSupport.class).getWriteableView(newBean.getProxy(type), newBean);
+        bean.getHabitat().<ConfigSupport>getService(ConfigSupport.class);
+        WriteableView writeableView = ConfigSupport.getWriteableView(newBean.getProxy(type), newBean);
         writeableView.join(currentTx);
 
         return writeableView.getProxy(type);
    }
 
+    @Override
     public ConfigBean getMasterView() {
         return bean;
     }
 
+    @Override
     public void setMasterView(ConfigView view) {
 
     }
 
+    @Override
     public <T extends ConfigBeanProxy> Class<T> getProxyType() {
         return bean.getProxyType();
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public <T extends ConfigBeanProxy> T getProxy(final Class<T> type) {
         final ConfigBean sourceBean = getMasterView();
@@ -497,7 +509,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
             throw new IllegalArgumentException("This config bean interface is " + sourceBean.model.targetTypeName
                     + " not "  + type.getName());
         }
-        Class[] interfacesClasses = { type };
+        Class<?>[] interfacesClasses = { type };
         ClassLoader cl;
         if (System.getSecurityManager()!=null) {
             cl = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
@@ -540,7 +552,7 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
             if (property.isCollection()) {
                 Object nested = writableView.getter(property,
                         parameterizedType);
-                ProtectedList list = (ProtectedList) nested;
+                ProtectedList<?> list = (ProtectedList<?>) nested;
                 if (list.size() > 0) {
                     list.clear();
                     removed = true;
@@ -563,16 +575,16 @@ public class WriteableView implements InvocationHandler, Transactor, ConfigView 
  *
  * @author Jerome Dochez
  */
-private class ProtectedList extends AbstractList {
+private class ProtectedList<E> extends AbstractList<E> {
 
     final ConfigBeanProxy readView;
-    final List<Object> readOnly;
+    final List<E> readOnly;
     final String id;
-    final List<PropertyChangeEvent> changeEvents = new ArrayList<PropertyChangeEvent>();
-    final List proxied;
+    final List<PropertyChangeEvent> changeEvents = new ArrayList<>();
+    final List<E> proxied;
 
-    ProtectedList(List<Object> readOnly, ConfigBeanProxy parent, String id) {
-        proxied = Collections.synchronizedList(new ArrayList<Object>(readOnly));
+    ProtectedList(List<E> readOnly, ConfigBeanProxy parent, String id) {
+        proxied = Collections.synchronizedList(new ArrayList<>(readOnly));
         this.readView = parent;
         this.readOnly = readOnly;
         this.id = id;
@@ -585,6 +597,7 @@ private class ProtectedList extends AbstractList {
      *
      * @return the number of elements in this collection.
      */
+    @Override
     public int size() {
         return proxied.size();
     }
@@ -597,12 +610,28 @@ private class ProtectedList extends AbstractList {
      * @throws IndexOutOfBoundsException if the given index is out of range
      *                                   (<tt>index &lt; 0 || index &gt;= size()</tt>).
      */
-    public Object get(int index) {
+    @Override
+    public E get(int index) {
         return proxied.get(index);
     }
 
     @Override
-    public synchronized boolean add(Object object) {
+    public int indexOf(Object object) {
+        return proxied.indexOf(object);
+    }
+
+    @Override
+    public int lastIndexOf(Object object) {
+        return proxied.lastIndexOf(object);
+    }
+
+    @Override
+    public String toString() {
+        return proxied.toString();
+    }
+
+    @Override
+    public synchronized boolean add(E object) {
         Object param = object;
         Object handler = null;
         try {
@@ -655,7 +684,7 @@ private class ProtectedList extends AbstractList {
         boolean added =  proxied.add(object);
 
         try {
-            for (ConfigBeanInterceptor interceptor : bean.getOptionalFeatures()) {
+            for (ConfigBeanInterceptor<?> interceptor : bean.getOptionalFeatures()) {
                 interceptor.beforeChange(evt);
             }
         } catch(PropertyVetoException e) {
@@ -668,34 +697,31 @@ private class ProtectedList extends AbstractList {
     @Override
     public synchronized void clear() {
         // make a temporary list, iterating while removing doesn't work
-        final List allItems = new ArrayList( proxied );
+        final List<E> allItems = new ArrayList<>( proxied );
         for( final Object item : allItems ) {
             remove( item );
         }
     }
 
     @Override
-    public synchronized boolean retainAll( final Collection keepers ) {
-        final List toRemoveList = new ArrayList();
-        for( final Object iffy : proxied ) {
+    public synchronized boolean retainAll( final Collection<?> keepers ) {
+        final List<E> toRemoveList = new ArrayList<>();
+        for( final E iffy : proxied ) {
             if ( ! keepers.contains(iffy) ) {
                 toRemoveList.add(iffy);
             }
         }
-        final boolean changed = removeAll(toRemoveList);
-
-        return changed;
+        return removeAll(toRemoveList);
     }
 
     @Override
-    public synchronized boolean removeAll( final Collection goners ) {
+    public synchronized boolean removeAll( final Collection<?> goners ) {
         boolean listChanged = false;
         for( final Object goner : goners ) {
             if ( remove(goner) ) {
                 listChanged = true;
             }
         }
-
         return listChanged;
     }
 
@@ -724,7 +750,7 @@ private class ProtectedList extends AbstractList {
         }
 
         try {
-            for (ConfigBeanInterceptor interceptor : bean.getOptionalFeatures()) {
+            for (ConfigBeanInterceptor<?> interceptor : bean.getOptionalFeatures()) {
                 interceptor.beforeChange(evt);
             }
         } catch(PropertyVetoException e) {
@@ -736,11 +762,31 @@ private class ProtectedList extends AbstractList {
         return removed;
     }
 
-    public Object set(int index, Object object) {
-        Object replaced = proxied.set(index, object);
+    @Override
+    public E remove(int index) {
+        if (index >= size())
+                throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size());
+        E removed = proxied.get(index);
+        return remove(removed) ? removed : null;
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super E> filter) {
+        boolean removedAny = false;
+        for (E e : proxied) {
+            if (filter.test(e) && remove(e)) {
+                removedAny = true;
+            }
+        }
+        return removedAny;
+    }
+
+    @Override
+    public E set(int index, E object) {
+        E replaced = proxied.set(index, object);
         PropertyChangeEvent evt = new PropertyChangeEvent(defaultView, id, replaced, object);
         try {
-            for (ConfigBeanInterceptor interceptor : bean.getOptionalFeatures()) {
+            for (ConfigBeanInterceptor<?> interceptor : bean.getOptionalFeatures()) {
                 interceptor.beforeChange(evt);
             }
         } catch(PropertyVetoException e) {
@@ -750,7 +796,7 @@ private class ProtectedList extends AbstractList {
         return replaced;
     }}
 
-    private String toCamelCase(String xmlName) {
+    private static String toCamelCase(String xmlName) {
         StringTokenizer st =  new StringTokenizer(xmlName, "-");
         StringBuilder camelCaseName = null;
         if (st.hasMoreTokens()) {
@@ -774,11 +820,11 @@ private class ProtectedList extends AbstractList {
         // such as AssertBoolean, AssertInteger etc. But since GUI and other
         // config clients such as AMX need dataType key in @Attribute it's been
         // decided to validate using existing annotation information
-        Set<ConstraintViolation<?>> constraintViolations = new HashSet<ConstraintViolation<?>>();
+        Set<ConstraintViolation<?>> constraintViolations = new HashSet<>();
         if (property instanceof ConfigModel.AttributeLeaf) {
             ConfigModel.AttributeLeaf al = (ConfigModel.AttributeLeaf)property;
             if (!al.isReference()) {
-                ConstraintViolation cv = validateDataType(al, value.toString());
+                ConstraintViolation<?> cv = validateDataType(al, value.toString());
                 if (cv!=null) {
                     constraintViolations.add(cv);
                 }
@@ -792,7 +838,7 @@ private class ProtectedList extends AbstractList {
         handleValidationException(constraintViolations);
     }
 
-    private ConstraintViolation validateDataType(final ConfigModel.AttributeLeaf al, final String value)
+    private ConstraintViolation<?> validateDataType(final ConfigModel.AttributeLeaf al, final String value)
     {
         if (value.startsWith("${") && value.endsWith("}"))
           return null;
@@ -849,7 +895,7 @@ private class ProtectedList extends AbstractList {
 
                 @Override
                 public Path getPropertyPath() {
-                    final Set<Path.Node> nodes = new HashSet<Path.Node>();
+                    final Set<Path.Node> nodes = new HashSet<>();
                     nodes.add(new Path.Node() {
                         @Override
                         public String getName() {
@@ -915,19 +961,19 @@ private class ProtectedList extends AbstractList {
         return null;
     }
 
-    private boolean representsBoolean(String value) {
+    private static boolean representsBoolean(String value) {
         boolean isBoolean =
            "true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value);
         return (isBoolean);
     }
 
-    private boolean representsChar(String value) {
+    private static boolean representsChar(String value) {
             if (value.length() == 1)
                 return true;
             return false;
     }
 
-    private boolean representsInteger(String value) {
+    private static boolean representsInteger(String value) {
         try {
             Integer.parseInt(value);
             return true;
@@ -937,7 +983,7 @@ private class ProtectedList extends AbstractList {
     }
 
 
-    private boolean representsLong(String value) {
+    private static boolean representsLong(String value) {
         try {
             Long.parseLong(value);
             return true;


### PR DESCRIPTION
### Summary
Adds custom watches to client. In contrast to watches collected from `MonitoringWatchSource`s a custom watch is a user defined `Watch` instance. The monitoring client is used to compose such a watch. This can be done in the new page _Watches_ that also lists all watches and allows to edit, delete or disable and enable them.

A disabled watch is simply not actively evaluating data, it is ignored but it will show in the graphs as a outline box instead of a filled one. All watches can be disabled and enabled. This is stored in the added configuration so that the disabled state can be recreated on server startup.

Only custom watches can be delete. Collected (or programmatic) watches cannot be deleted as they originate from the server's code.

Custom watches can be edited. Programmatic watches can be duplicated, which changes the name of the duplicate to _Copy of {Name}_. So this becomes another watch but allows to use the programmatic watch as a template.

To recreate the custom watches on server-startup the watches need to be stored in some form.
I decided to write custom to and from JSON methods for the affected classes. This will allow to put in the proper code that can handle changes to the data structure. The strategy here is to be able to handle missing fields (that would be added) and ignore fields (that would be removed).
The conversion is covered with unit tests.

On server side:
* adds monitoring console configuration to store disabled watches as well as custom watch data
* REST and service API to enable/disable watches
* distinction between custom watches and programmatic watches
* watch states are shared when deriving a watch
* REST and service API to create custom watches
* REST and service API to delete custom watches
* `WatchData` REST API class is not writable to receive custom watch data send by client 

On client side:
* adds a _Watches_ configuration page that lists existing watches, allows to edit, delete or disable/enable them.
* extracts model constants to a separate file for better readability and clarity
* extracts a controller file that encapsulation the client-server communication on client side for better readability and clarity
* fixes/updates formatting of watch conditions (e.g. in alert tables) and watch lists
* uses payara design system colors with better contrast
* fixes alignment of indicator (text message above graph)
* uses configured colours for status messages
* now also triggers status messages from alerts (red=critical, amber=alerting)
* adds new colour defaults for _error_ and _missing_ status
* use of `const` instead of `let` (TLDR; `const` should be default, `let` only when variable is actually changed, `var` is basically never needed or better suited in our "non-legacy" codebase)
* watch indicator at right side of the graph now shows the indicator as outline if the watch is disabled
* `Setting` input with `unit` now can use a function to provide a changing unit.


### `WriteableView` and `ProtectedList`
Tried to improve it to make it more usable. Code also could do with some cleanup.
* added generics
* added missing `@Override` annoations
* removed unnecessary `else` nesting
* made static helpers `static`
* added some `List` methods that would otherwise throw a `UnsupportedOperationException` on the basis of existing method (so no actual transaction management was needed)

As mentioned some of the existing methods of the `ProtectedList` still show some odd behaviour.
When using `set(int, E)` the value at the index would be null next time I loaded the list.

### Tests
Unit tests were added to verify the correctness of the to/from JSON conversion of the `Watch` class and all classes involved.

General information can be taken from the documentation https://github.com/payara/Payara-Server-Documentation/pull/705.

The custom watches feature was tested manually following the steps below:

#### General Setup:
1. build, install and start the server
2. use `set-monitoring-console-configuration --enabled=true` to deploy MC
3. open MC at http://localhost:8080/monitoring-console/
4. make sure browser cache for JS/CSS is cleared for MC's domain
5. check that following pages do exist: _Watches_ (if not most likely a browser cache issue - or get in touch)

#### Testing Disabling Existing Watches
1. Open page _Watches_ in MC
2. click checkbox of one of the listed watches to disable it, e.g. _Metric Collection Duration_
3. for _Metric Collection Duration_ watch open page _Monitoring_ and check the watch indicator on right side of the graph is now drawn as outline instead of filled
4. restart the server, e.g. using asadmin commands
5. refresh page _Watches_ in MC and check disabled watch is still disabled
6. enable the watch again
7. for _Metric Collection Duration_ watch open page _Monitoring_ again and check the indicator is now drawn filled

#### Testing Disabling Custom Watches
1. Open page _Watches_ in MC
2. create a new watch named _Heap Check_ by checking _Unhealthy_, filling in: _If_ `ns:jvm HeapUsage` _in_ `Percent` _is_ `>` _(some value clearly below your current heap usage, see _Core_ page)_, and press _Save or Update_
3. goto _Core_ page and check that the graph shows an alert because heap usage is above the watch level
4. go back to _Watches_ page and disable the created watch by clicking the checkbox on the left or using the cogs menu
5. go back to _Core_ and check that alert is gone (and that indicator is now as outline)
6. go to _Alerts_ page and check the alert is shown in _Past Unacknowledged Alerts_
7. go to _Watches_ page again an enable the watch once more, check on _Core_ page that an alert is triggered again

#### Testing Custom Watches
1. create a custom watch as given in steps for _Testing Disabling Custom Watches_
2. restart the server
3. open _Watches_ page and check the custom watch created is still there

#### Testing Listing of collected Watches
1. open _Watches_ page of MC, with default settings two watches should be listed
2. open admin console and browse to _Configurations_ => _server-config_ => HealthCheck_ tab _CPU Usage_ and check _Enabled_
3. go back to _Watches_ page and check a new watch _CPU Usage_ is listed now

#### Testing new admin command parameters are hidden
run:
```
asadmin> set-monitoring-console-configuration --help
NAME
     set-monitoring-console-configuration

SYNOPSIS
     Usage: set-monitoring-console-configuration [--enabled=true|
     false] 

OPTIONS
     --enabled

Command set-monitoring-console-configuration executed successfully.
```