### PR TITLE
APPSERV-30 Exception when Adding an Instance to a Deployment Group with an Application Deployed

### DIFF
--- a/nucleus/cluster/admin/src/main/java/fish/payara/admin/cluster/AddInstanceToDeploymentGroupCommand.java
+++ b/nucleus/cluster/admin/src/main/java/fish/payara/admin/cluster/AddInstanceToDeploymentGroupCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -183,10 +183,9 @@ public class AddInstanceToDeploymentGroupCommand implements AdminCommand {
                 List<VirtualServer> hosts = httpService.getVirtualServer();
                 if (hosts != null) {
                     for (VirtualServer host : hosts) {
-                        if (("__asadmin").equals(host.getId())) {
-                            continue;
+                        if (!("__asadmin").equals(host.getId())) {
+                            virtualServers.add(host.getId());
                         }
-                        virtualServers.add(host.getId());
                     }
                 }
             }


### PR DESCRIPTION
# Description
When you create and add a new instance to a deployment group with an application deployed to it, an error is thrown and the application is not deployed

# Important Info
**Steps to reproduce:**
- Start a clean domain
- Create a deployment group with no instances
- Deploy an application to the deployment group
- Create a new instance and add it to the deployment group
- Start the instance and look at the logs

### Testing Performed
Followed the above reproducer to make sure the fix worked as intended.

### Test suites executed
Build Test

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4
