### PR TITLE
APPSERV-43 Removes micro- and nanoseconds from stuck threads configuration

### DIFF
--- a/appserver/admingui/healthcheck-service-console-plugin/src/main/resources/healthcheck/checkers/stuckThreadsConfiguration.jsf
+++ b/appserver/admingui/healthcheck-service-console-plugin/src/main/resources/healthcheck/checkers/stuckThreadsConfiguration.jsf
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ Copyright (c) 2017-2020 Payara Foundation and/or its affiliates. All rights reserved.
 
  The contents of this file are subject to the terms of either the GNU
  General Public License Version 2 only ("GPL") or the Common Development
@@ -126,7 +126,7 @@
                       label="$resource{i18nhx.healthcheck.checker.configuration.stuckThreads.thresholdUnitLabel}"  
                       helpText="$resource{i18nhx.healthcheck.checker.configuration.stuckThreads.thresholdUnitLabelHelpText}">
             <sun:dropDown id="unitDropdown" selected="#{pageSession.valueMap['thresholdUnit']}" 
-                          labels={"NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"} />
+                          labels={"MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"} />
         </sun:property>
     </sun:propertySheetSection>
 </sun:propertySheet>

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/SetHealthCheckServiceConfiguration.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/SetHealthCheckServiceConfiguration.java
@@ -171,7 +171,7 @@ public class SetHealthCheckServiceConfiguration implements AdminCommand {
     private String stuckThreadsThreshold;
 
     @Param(name = "stuck-threads-threshold-unit", optional = true,
-            acceptableValues = "DAYS,HOURS,MICROSECONDS,MILLISECONDS,MINUTES,NANOSECONDS,SECONDS")
+            acceptableValues = "DAYS,HOURS,MILLISECONDS,MINUTES,SECONDS")
     private String stuckThreadsThresholdUnit;
 
     // threshold properties params:

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -138,7 +138,7 @@ public class StuckThreadsHealthCheck extends
             .red(getThresholdInMillis(), -30000L, false, null, null, false);
     }
 
-    public String composeStateText(ThreadInfo info) {
+    private static String composeStateText(ThreadInfo info) {
         if (info.getLockInfo() == null) {
             return "Running";
         }
@@ -166,8 +166,8 @@ public class StuckThreadsHealthCheck extends
         }
     }
 
-    public long getThresholdInMillis() {
-        return TimeUnit.MILLISECONDS.convert(options.getTimeStuck(), options.getUnitStuck());
+    private long getThresholdInMillis() {
+        return Math.max(1, TimeUnit.MILLISECONDS.convert(options.getTimeStuck(), options.getUnitStuck()));
     }
 
 

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/admin/StuckThreadsConfigurer.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/admin/StuckThreadsConfigurer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -124,7 +124,7 @@ public class StuckThreadsConfigurer implements AdminCommand {
     @Min(value = 1, message = "Threshold length must be 1 or more")
     private String threshold;
     
-    @Param(name = "thresholdUnit", optional = true, acceptableValues = "DAYS,HOURS,MICROSECONDS,MILLISECONDS,MINUTES,NANOSECONDS,SECONDS")
+    @Param(name = "thresholdUnit", optional = true, acceptableValues = "DAYS,HOURS,MILLISECONDS,MINUTES,SECONDS")
     private String thresholdUnit;
 
     @Param(name = "checkerName", optional = true)


### PR DESCRIPTION
### Background
Configuring a stuck thread threshold in microsecond or nanosecond range would mean that in order to detect such a "stuck" thread the check detecting it must run faster than the threshold and must run in an interval not much longer than the threshold. Both neither make sense nor are they doable with reasonable effort and resources. Even is such a configuration could be implemented it would not be of much use as threads running for that short of a duration **or longer** are the absolute norm so this would basically trigger all the time. 

TLDR; stuck threads thresholds only make sense in a range that is subjectively "slow" to both humans and machines. 

### Summary
The change is tackled by assuming that:

* in the future configuration will not allow to set a threshold in nano or microseconds
* we still expect existing configuration to have thresholds defined in terms of micro- or nanoseconds
* if existing configuration threshold is converted to less than 1 ms the threshold is effectively 1 ms
* if existing configuration threshold is converted to less than 1 in UI the UI shows it as 1 ms instead

**Fun fact:** out documentation https://docs.payara.fish/documentation/payara-server/health-check-service/asadmin-commands.html for the `set-healthcheck-service-configuration` asadmin command already says:
```js
--stuck-threads-threshold-unit=DAYS|HOURS|MINUTES|SECONDS|MILLISECONDS
```
while the old command `healthcheck-stuckthreads-configure` is documented as 
```js
thresholdUnit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS
```
:thinking:

### Testing
#### Testing Future GUI
1 . Open configuration page for Stuck Threads
2. check available time units for the threshold. Microseconds and Nanoseconds should no longer be possible to chose or save.

#### Testing Future Allowed Values
1. Start the server
2. run following as admin commands: 
```
healthcheck-stuckthreads-configure --enabled=false --thresholdunit=MICROSECONDS
set-healthcheck-service-configuration --enabled=false --service=stuck-thread --stuck-threads-threshold-unit=MICROSECONDS
```
Both commands should be rejected because of the unit. Also try with NANOSECONDS.

#### Testing Existing Value Compatibility
1. Before starting the server edit `./glassfish/domains/domain1/config/domain.xml` , search for `stuck-threads-checker` and change its `threshold-time-unit` attribute to `NANOSECONDS`. Assuming a `threshold` attribute in normal number range this is below 1ms. 
2. Start the server and open configuration page for Stuck Threads
3. check the threshold shows as 1 millisecond

#### Testing Effective Value
1. (as above edit `domain.xml` or still have it set to some nanoseconds)
2. deploy monitoring console
3. enable Stuck Threads health check configuration (_Enabled_ checkbox) - enabling the service in _General_ tab is not needed!
3. open http://localhost:8080/monitoring-console-webapp/api/watches/data/ which shows data collected by monitoring. It should contain an entry `Stuck Threads` as below

```json
{
"name": "Stuck Threads",
"red": {
  "level": "red",
  "start": {
    "forMillis": -30000,
    "onAverage": false,
    "operator": ">",
    "threshold": 1
  }
},
...
```
The `threshold` is given as `1` (ms) not zero. The same method used to read the threshold value for the inspected watch is also used to collect data and run the check in the service.