### PR TITLE
APPSERV-27 Allow Temp/Unmanaged Docker Node instance to Join a Deployment Group on Creation

### DIFF
--- a/appserver/extras/docker-images/src/main/resources/payaraserver-node/entrypoint.sh
+++ b/appserver/extras/docker-images/src/main/resources/payaraserver-node/entrypoint.sh
@@ -77,42 +77,79 @@ function createNewInstance {
     checkAndCreateNewNodeIfRequired
 
     echo "Running command create-local-instance:"
-    if [ -z "${PAYARA_INSTANCE_NAME}" ]; then
-        if [ -z "${PAYARA_CONFIG_NAME}" ]; then
-            ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP}"
-            echo "${ASADMIN_COMMAND}"
-            PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
-        else
-            if [ "${PAYARA_CONFIG_NAME}" == "server-config" ] || [ "${PAYARA_CONFIG_NAME}" == "default-config" ]; then
-                echo "You cannot use 'server-config' or 'default-config', ignoring provided config name."
-                ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP}"
-                echo "${ASADMIN_COMMAND}"
-                PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+	if [ -z "${PAYARA_INSTANCE_NAME}" ]; then
+            if [ -z "${PAYARA_CONFIG_NAME}" ]; then
+                if [ -z "${PAYARA_DEPLOYMENT_GROUP}" ]; then
+                    ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP}"
+                    echo "${ASADMIN_COMMAND}"
+                    PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                else
+                    ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} --deploymentgroup ${PAYARA_DEPLOYMENT_GROUP}"
+                    echo "${ASADMIN_COMMAND}"
+                    PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                fi
             else
-                ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --config ${PAYARA_CONFIG_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP}"
-                echo "${ASADMIN_COMMAND}"
-                PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                if [ "${PAYARA_CONFIG_NAME}" == "server-config" ] || [ "${PAYARA_CONFIG_NAME}" == "default-config" ]; then
+                    echo "You cannot use 'server-config' or 'default-config', ignoring provided config name."
+                    if [ -z "${PAYARA_DEPLOYMENT_GROUP}" ]; then
+                        ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP}"
+                        echo "${ASADMIN_COMMAND}"
+                        PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                    else
+                        ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} --deploymentgroup ${PAYARA_DEPLOYMENT_GROUP}"
+                        echo "${ASADMIN_COMMAND}"
+                        PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                    fi
+                else
+                    if [ -z "${PAYARA_DEPLOYMENT_GROUP}" ]; then
+                        ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --config ${PAYARA_CONFIG_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP}"
+                        echo "${ASADMIN_COMMAND}"
+                        PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                    else
+                        ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --config ${PAYARA_CONFIG_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} --deploymentgroup ${PAYARA_DEPLOYMENT_GROUP}"
+                        echo "${ASADMIN_COMMAND}"
+                        PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                    fi
+                fi
             fi
-        fi
-    else
-        if [ -z "${PAYARA_CONFIG_NAME}" ]; then
-            ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME}"
-            echo "${ASADMIN_COMMAND}"
-            PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
         else
-            if [ "${PAYARA_CONFIG_NAME}" == "server-config" ] || [ "${PAYARA_CONFIG_NAME}" == "default-config" ]; then
-                echo "You cannot use 'server-config' or 'default-config', ignoring provided config name."
-                ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME}"
-                echo "${ASADMIN_COMMAND}"
-                PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+            if [ -z "${PAYARA_CONFIG_NAME}" ]; then
+                if [ -z "${PAYARA_DEPLOYMENT_GROUP}" ]; then
+                    ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME}"
+                    echo "${ASADMIN_COMMAND}"
+                    PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                else
+                    ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME} --deploymentgroup ${PAYARA_DEPLOYMENT_GROUP}"
+                    echo "${ASADMIN_COMMAND}"
+                    PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                fi
             else
-                ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --config ${PAYARA_CONFIG_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME}"
-                echo "${ASADMIN_COMMAND}"
-                PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                if [ "${PAYARA_CONFIG_NAME}" == "server-config" ] || [ "${PAYARA_CONFIG_NAME}" == "default-config" ]; then
+                    if [ -z "${PAYARA_DEPLOYMENT_GROUP}" ]; then
+                        echo "You cannot use 'server-config' or 'default-config', ignoring provided config name."
+                        ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME}"
+                        echo "${ASADMIN_COMMAND}"
+                        PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                    else
+                        echo "You cannot use 'server-config' or 'default-config', ignoring provided config name."
+                        ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME} --deploymentgroup ${PAYARA_DEPLOYMENT_GROUP}"
+                        echo "${ASADMIN_COMMAND}"
+                        PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                    fi
+            else
+                if [ -z "${PAYARA_DEPLOYMENT_GROUP}" ]; then
+                    ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --config ${PAYARA_CONFIG_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME}"
+                    echo "${ASADMIN_COMMAND}"
+                    PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                else
+                    ASADMIN_COMMAND="./payara5/bin/asadmin -I false -T -a -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} create-local-instance --node ${PAYARA_NODE_NAME} --config ${PAYARA_CONFIG_NAME} --dockernode true --ip ${DOCKER_CONTAINER_IP} ${PAYARA_INSTANCE_NAME} --deploymentgroup ${PAYARA_DEPLOYMENT_GROUP}"
+                    echo "${ASADMIN_COMMAND}"
+                    PAYARA_INSTANCE_NAME="$(${ASADMIN_COMMAND})"
+                fi
             fi
         fi
     fi
-
+    
     # Register Docker container ID to DAS
     echo "Setting Docker Container ID for instance ${PAYARA_INSTANCE_NAME}: ${DOCKER_CONTAINER_ID}"
     ASADMIN_COMMAND="./payara5/bin/asadmin -I false -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} _set-docker-container-id --instance ${PAYARA_INSTANCE_NAME} --id ${DOCKER_CONTAINER_ID}"


### PR DESCRIPTION
# Description
This is a feature to allow Temp/Unmanaged Docker Node instance to Join a Deployment Group on Creation. When creating temporary docker node instances using either the Docker Rest API or Docker CLI, the only way to have an instance join a deployment group upon creation is for you to use a custom Docker image.

With this PR you can specify a Docker Env variable, `PAYARA_DEPLOYMENT_GROUP` which would then be read and used upon instance creation.

# Testing

### Testing Performed
Created a Docker image using the newly updated `entrypoint.sh`. Using the Docker image created a container with the `PAYARA_DEPLOYMENT_GROUP` Docker Env variable. 

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Documentation
TODO
