### PR TITLE
CUSTCOM-135: Move config initialization before Startup run level

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/StartupRunLevel.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/StartupRunLevel.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2020] [Payara Foundation and/or its affiliates]
 package org.glassfish.api;
 
 import static java.lang.annotation.ElementType.TYPE;
@@ -60,4 +61,10 @@ import org.glassfish.hk2.runlevel.RunLevel;
 @RunLevel(10)
 public @interface StartupRunLevel {
     public static final int VAL = 10;
+
+    /**
+     * Services in this runlevel might be needed by other services, but there's no explicit HK2 dependency.
+     * Therefore these services just need to start sooner.
+     */
+    int IMPLICITLY_RELIED_ON = VAL - 1;
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
@@ -110,7 +110,7 @@ import fish.payara.nucleus.microprofile.config.source.SystemPropertyConfigSource
  */
 @Service(name = "microprofile-config-provider")
 @ContractsProvided({ConfigProviderResolver.class, ConfigProviderResolverImpl.class})
-@RunLevel(StartupRunLevel.VAL)
+@RunLevel(StartupRunLevel.IMPLICITLY_RELIED_ON)
 public class ConfigProviderResolverImpl extends ConfigProviderResolver {
 
     private static final Logger LOG = Logger.getLogger(ConfigProviderResolverImpl.class.getName());


### PR DESCRIPTION
Many services have implicit dependency on Microprofile config. We therefore need
to assure that it is already available as services enter startup run level.

Expansion of domain.xml attributes should also refer to our implementation rather
than to MP Config API, as that might lock up in certain scenarios, like single-threaded
startup.


# Description
This is a bug fix. <!-- delete/modify as applicable-->

During development of other feature, it became apparent that during load of applications on Payara Micro the startup is single threaded. Therefore no amount of wait would resolve implicit dependency to Microprofile config provider, it simply needs to be started earlier.

Another potential danger point was evalutation of `${MPCONFIG=key}`  while our provider didn't yet start.

# Important Info

# Testing

### Testing Performed

Prepared Payara Micro with an deployed application, then restarted it. Before, in 100% of attempts it resulted in 

```
[WARNING] [] [fish.payara.nucleus.microprofile.config.spi.ConfigProviderResolverImpl] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1581503313800] [levelValue: 900] [[  
  Timeout out waiting for Microprofile Config startup
java.lang.IllegalStateException: Payara Microprofile Config needs running server environment to work. Either it's not running, or you're experiencing a race condition
```

The condition is not happening anymore.

### Test suites executed
- MP Config TCK payara-micro-managed

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
OpenJ9 1.8.0_232 on Windows 10, Maven 3.6.3

