### PR TITLE
CLOUD-41: Payara Micro warmup mode and optimization-friendly classpath

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -78,6 +78,7 @@ public enum RUNTIME_OPTION {
     deployfromgav(true),
     additionalrepository(true),
     outputuberjar(true, new FileValidator(false, false, false)),
+    outputlauncher(false),
     copytouberjar(true, new DirectoryValidator(true,true, false)),
     systemproperties(true, new FileValidator(true, true, false)),
     disablephonehome(false),
@@ -109,7 +110,8 @@ public enum RUNTIME_OPTION {
     hzpublicaddress(true),
     shutdowngrace(true, new IntegerValidator(1, Integer.MAX_VALUE)),
     hzinitialjoinwait(true, new IntegerValidator(0,100000)),
-    contextroot(true);
+    contextroot(true),
+    warmup(false);
 
     private RUNTIME_OPTION(boolean hasValue) {
         this(hasValue, new Validator());

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/LauncherCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/LauncherCreator.java
@@ -1,0 +1,188 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.micro.impl;
+
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+
+class LauncherCreator {
+    public static final String LAUNCHER_JAR = "launch-micro.jar";
+    private static final String MAIN_CLASS = RootDirLauncher.class.getName();
+
+    private final File rootDir;
+    private final URLClassLoader classLoader;
+    private final String bootJarUrl = System.getProperty(RootDirLauncher.BOOT_JAR_URL);
+    private String[] classpath;
+    private Attributes bootManifestAttributes;
+
+    LauncherCreator(File root, URLClassLoader microClassLoader) {
+        this.rootDir = root;
+        this.classLoader = microClassLoader;
+    }
+
+    public void buildLauncher() throws IOException {
+        buildClasspath();
+        buildLauncherJar();
+        buildEnvFile();
+    }
+
+
+    /**
+     * Collect the classpath entries into form suitable for Class-Path manifest atrribute
+     */
+    private void buildClasspath() {
+        URI baseUri = rootDir.toURI();
+        this.classpath = Stream.of(classLoader.getURLs())
+                // filter out directories - it prevents OpenJDK CDS (JDK-8209385)
+                // and root/runtime/ doesn't contain any direct resources anyway
+                .filter(url -> !url.getPath().endsWith("/"))
+                .map(url -> relativize(baseUri, url))
+                .map(URI::toString)
+                .toArray(String[]::new);
+    }
+
+    private static URI relativize(URI baseUri, URL url) {
+        try {
+            return baseUri.relativize(url.toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Cannot turn classpath entry into relative path "+url, e);
+        }
+    }
+
+
+    /**
+     * Create file with parameters to java executable when user cannot use java -jar
+     * @throws IOException
+     */
+    private void buildEnvFile() throws IOException {
+        try (PrintWriter envOut = new PrintWriter(new FileWriter(new File(rootDir, ".env")))) {
+            envOut.print("MICRO_CLASSPATH=");
+            envOut.println(
+                    Stream.concat(Stream.of(LAUNCHER_JAR),Stream.of(classpath))
+                            .map(LauncherCreator::uriToPath)
+                            .collect(joining(File.pathSeparator)));
+            // we escape opens so the file can be sourced into shell env easily.
+            envOut.print("MICRO_OPENS=\"");
+            envOut.print(Stream.concat(buildOpens(), buildExports()).collect(joining(" ")));
+            envOut.println('"');
+            envOut.print("MICRO_MAIN=");
+            envOut.println(MAIN_CLASS);
+        }
+    }
+
+    private static String uriToPath(String entry) {
+        // additional libraries outside runtime are stored as file URIs
+        // --class-path argument needs path
+        return entry.startsWith("file:") ? new File(URI.create(entry)).getAbsolutePath() : entry;
+    }
+
+    private Stream<String> buildOpens() {
+        return Stream.of(bootManifestAttributes.getValue("Add-Opens").split(" "))
+                .map(open -> "--add-opens "+open+"=ALL-UNNAMED");
+    }
+
+    private Stream<String> buildExports() {
+        return Stream.of(bootManifestAttributes.getValue("Add-Exports").split(" "))
+                .map(export -> "--add-exports "+export+"=ALL-UNNAMED");
+    }
+
+    private void buildLauncherJar() throws IOException {
+        if (bootJarUrl == null || !bootJarUrl.startsWith("file:")) {
+            throw new IllegalArgumentException("Output launcher was not launched via Payara Micro Distribution artifact ("+bootJarUrl+" isn't one)");
+        }
+
+        try (JarFile bootJar = new JarFile(new File(URI.create(bootJarUrl)))) {
+            this.bootManifestAttributes = bootJar.getManifest().getMainAttributes();
+            Manifest mf = buildManifest();
+            writeLauncher(bootJar, mf);
+        }
+    }
+
+    private void writeLauncher(JarFile bootJar, Manifest mf) throws IOException {
+        try (JarOutputStream out = new JarOutputStream(new FileOutputStream(new File(rootDir, LAUNCHER_JAR)), mf)) {
+
+            // Boot classes and API are in boot jar and not in runtime directory, we need those
+            // But we don't need MICRO-INF, we are already unpacked
+            bootJar.stream().filter(entry -> entry.getName().startsWith("fish/"))
+                    .forEach(entry -> {
+                        try {
+                            out.putNextEntry(entry);
+                            try (InputStream input = bootJar.getInputStream(entry)) {
+                                byte[] buffer = new byte[4096];
+                                for (int read = 0; (read = input.read(buffer)) > 0; ) {
+                                    out.write(buffer, 0, read);
+                                }
+                            }
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+    }
+
+    private Manifest buildManifest() {
+        Manifest result = new Manifest();
+        Attributes attr = result.getMainAttributes();
+        attr.putAll(bootManifestAttributes);
+        attr.putValue("Class-Path", Stream.of(this.classpath).collect(joining(" ")));
+        attr.putValue("Main-Class", MAIN_CLASS);
+        attr.remove("Start-Class");
+        return result;
+    }
+
+
+}

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
@@ -1,0 +1,105 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.micro.impl;
+
+import fish.payara.micro.PayaraMicro;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RootDirLauncher {
+    static final String BOOT_JAR_URL = "fish.payara.micro.BootJar";
+    static final String ROOT_DIR_PATH = "fish.payara.micro.UnpackDir";
+    private static final Logger LOGGER = Logger.getLogger("PayaraMicro");
+
+    public static void main(String[] args) throws Exception {
+        File bootJar = determineBootJar();
+        String rootDir = bootJar.getParentFile().getAbsolutePath();
+        System.setProperty(BOOT_JAR_URL, bootJar.toURI().toString());
+        System.setProperty(ROOT_DIR_PATH, rootDir);
+        PayaraMicroImpl.main(prepareArgs(args, rootDir));
+    }
+
+    private static String[] prepareArgs(String[] args, String rootDir) {
+        String[] result = args;
+        boolean containedRootDir = false;
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].equalsIgnoreCase("--rootdir")) {
+                LOGGER.warning("Overriding --rootdir with "+rootDir);
+                args[i+1] = rootDir;
+                containedRootDir = true;
+            }
+            if (args[i].equalsIgnoreCase("--addlibs")
+                    || args[i].equalsIgnoreCase("--addjars")
+                    || args[i].equals("--outputlauncher")) {
+                LOGGER.log(Level.SEVERE, "Switch {0} cannot be used with launcher jar", args[i]);
+                System.exit(-1);
+            }
+        }
+        if (!containedRootDir) {
+            result = Arrays.copyOf(args, args.length + 2);
+            result[result.length - 2] = "--rootdir";
+            result[result.length - 1] = rootDir;
+        }
+        return result;
+    }
+
+    private static File determineBootJar() {
+        ProtectionDomain protectionDomain = PayaraMicro.class.getProtectionDomain();
+        CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource != null) {
+            try {
+                URI sourceUri = codeSource.getLocation().toURI();
+                return new File(sourceUri);
+            } catch (RuntimeException | URISyntaxException e) {
+                throw new IllegalStateException("Could not determine location of launcher jar", e);
+            }
+        } else {
+            throw new IllegalStateException("Could not determine location of launcher.jar");
+        }
+    }
+}


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a feature. <!-- delete/modify as applicable-->

`--warmup` initializes payara micro and immediately shuts down. To be used for preconfiguring fixed root directory in a script or for class data sharing warmup.

`--outputlauncher`  writes out `launch-micro.jar` into defined root directory. This launcher can be used to launch micro from that directory, skipping any directory preparation and dynamic classloading of runtime jars. This makes startup faster and runtime classpath is class data sharing-friendly.

# Testing

### New tests
Needs way of test end-to-end behavior on the command line, with precise selection of JDKs. Therefore only manual testing was performed:

### Testing Performed
<!--- Please describe how you tested these changes.  -->

Smoke test
```
java -jar payara-micro.jar --rootdir micro-root --outputlauncher
java -jar micro-root/launch-micro.jar --warmup
 
## with env 
cd micro-root
. .env
java -cp $MICRO_CLASSPATH $MICRO_OPENS $MICRO_MAIN --warmup
```

CDS with OpenJDK (11.0.6 needed, on 11.0.4 one needs to use env as jar classpath is not read)
```
java -jar payara-micro.jar --rootdir micro-root --outputlauncher
cd micro-root
java -XX:DumpLoadedClassList=classes.lst -jar launch-micro.jar --warmup
java -Xshare:dump -XX:SharedClassListFile=classes.lst -XX:SharedArchiveFile=cds.jsa -jar launch-micro.jar
java -Xshare:on -XX:SharedArchiveFile=cds.jsa -jar launch-micro.jar --warmup #test
```

CDS with OpenJ9
```
java -jar payara-micro.jar --rootdir micro-root --outputlauncher
cd micro-root
java -Xshareclasses:name=micro-cds -jar launch-micro.jar --warmup
java -Xshareclasses:name=micro-cds -jar launch-micro.jar --warmup #test
```

Adding libraries to classpath
```
java -jar payara-micro.jar --rootdir micro-root --outputlauncher --addlibs $libPath
java -jar micro-root/launch-micro.jar
# verify that libraries are on the classpath

#also with env
. .env
java -cp $MICRO_CLASSPATH $MICRO_OPENS $MICRO_MAIN
# verify that libraries are on the classpath
```

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu 11.0.6 (11.37) on Windows 10, Maven 3.6.3.
OpenJ9 1.8.0_242 on Windows 10, Maven 3.6.3
OpenJDK 11.0.6 on Ubuntu 19.04

# Documentation
<!-- Link to the documentation PR where applicable -->
Being worked on. Internal feature documentation "Payara Micro CDS-friendly mode" available.

# Notes for Reviewers
<!-- Please give notes for any reviewers. The code should explain itself, but where should they start? Do you want feedback on anything specific? -->
<!-- Have you tagged any appropriate reviewers?-->
