### PR TITLE
CUSTCOM-70 Additional Fix to JAXRS Client With Embedded Dependency

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JerseyOpenTracingAutoDiscoverable.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/JerseyOpenTracingAutoDiscoverable.java
@@ -39,13 +39,12 @@
  */
 package fish.payara.microprofile.opentracing.jaxrs;
 
-import fish.payara.requesttracing.jaxrs.client.PayaraTracingServices;
-
 import javax.ws.rs.core.FeatureContext;
 
-import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable;
+
+import fish.payara.requesttracing.jaxrs.client.PayaraTracingServices;
 
 /**
  * AutoDiscoverable that registers the {@link OpenTracingApplicationEventListener}.
@@ -58,8 +57,8 @@ public class JerseyOpenTracingAutoDiscoverable implements ForcedAutoDiscoverable
     @Override
     public void configure(FeatureContext context) {
         // Only register for application deployments (not the admin console)
-        final ServiceLocator serviceLocator = new PayaraTracingServices().getBasicServiceLocator();
-        if (serviceLocator.getService(Deployment.class).getCurrentDeploymentContext() == null) {
+        final Deployment deployment = new PayaraTracingServices().getDeployment();
+        if (deployment == null || deployment.getCurrentDeploymentContext() == null) {
             return;
         }
 

--- a/appserver/tests/payara-samples/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
+++ b/appserver/tests/payara-samples/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
@@ -40,10 +40,15 @@
 
 package fish.payara.samples.classpath.embeddedvsjersey;
 
-import org.junit.Test;
+import java.io.IOException;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+
+import org.glassfish.grizzly.PortRange;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.NetworkListener;
+import org.junit.Test;
 
 /**
  * Tests if it is possible to use jersey client with embedded payara on the classpath.
@@ -52,8 +57,18 @@ import javax.ws.rs.client.ClientBuilder;
 public class JerseyClasspathTest {
 
     @Test
-    public void jerseyShouldInitialize() {
-        Client client = ClientBuilder.newClient();
-        client.target("https://google.com").request().get();
+    public void jerseyShouldInitialize() throws IOException {
+        HttpServer server = HttpServer.createSimpleServer();
+        NetworkListener listener = new NetworkListener("my-listener", "127.0.0.1", new PortRange(1025, 65535), true);
+        server.addListener(listener);
+
+        try {
+            server.start();
+    
+            Client client = ClientBuilder.newClient();
+            client.target("http://127.0.0.1:" + listener.getPort()).request().get();
+        } finally {
+            server.shutdownNow();
+        }
     }
 }

--- a/appserver/tests/payara-samples/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
+++ b/appserver/tests/payara-samples/classpath/embedded-vs-jersey/src/test/java/fish/payara/samples/classpath/embeddedvsjersey/JerseyClasspathTest.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development
@@ -54,6 +54,6 @@ public class JerseyClasspathTest {
     @Test
     public void jerseyShouldInitialize() {
         Client client = ClientBuilder.newClient();
-        client.target("http://localhost:8080").request().buildGet();
+        client.target("https://google.com").request().get();
     }
 }


### PR DESCRIPTION


<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix.

When Payara Embedded is used as a library rather than starting the embedded server, an exception will be thrown when using the JAX-RS client caused by the request tracing service not having initialised.

The previous CUSTCOM-70 fix allowed a JAX-RS client request to be built, but executing the request would still throw the same exception. This change allows the request to be executed as well.

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->

# Important Info

This PR is an extension to https://github.com/payara/Payara/pull/4443, which didn't address the initial problem. The test has been amended to match.

# Testing

### New tests
<!-- Link to the test suite PR or provide info -->
Payara Sample test amendment.