### PR TITLE
APPSERV-35 Add 'Enterprise' to product.name

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
 
 <project name="payara-micro" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -132,7 +132,7 @@
                 <include name="*payara-micro-boot*.jar"/>      
             </fileset>
         </delete>
-	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@PRODUCT@@@" value="Payara Micro"/>
+	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@PRODUCT@@@" value="${product.name}"/>
 	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@BUILD_NUMBER@@@" value="${build.number}"/>
      </target>
      

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -51,6 +51,10 @@
     <artifactId>payara-micro</artifactId>
     <name>Payara Micro Distribution</name>
 
+    <properties>
+        <product.name>Payara Micro</product.name>
+    </properties>
+
     <build>
         <defaultGoal>install</defaultGoal>
         <plugins>
@@ -91,6 +95,7 @@
                                         value="${project.build.directory}/payara-micro.jar" />
                                     <property name="install.dir.name"
                                         value="${install.dir.name}" />
+                                    <property name="product.name" value="${product.name}" />
                                 </ant>
                             </tasks>
                         </configuration>
@@ -496,6 +501,12 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>enterprise</id>
+            <properties>
+                <product.name>Payara Micro Enterprise</product.name>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -684,4 +684,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>enterprise</id>
+            <properties>
+                <product.name>Payara Server Enterprise</product.name>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 


### PR DESCRIPTION
# Description
Changes the product name to _Payara Server Enterprise_ or _Payara Micro Enterprise_ for Payara Server & Micro respectively when building using a new _enterprise_ profile.

### Dependant PRs
None

### Blockers 
Narp

# Testing
Build the server and micro with and without the new _enterprise_ profile.
Without the product name present in glassfish-version.properties should be Payara Server / Payara Micro, and Payara Server Enterprise / Payara Micro Enterprise when the profile is provided.

### New tests
Negative

### Testing Performed
See above.

### Test suites executed
N/A

### Testing Environment
Windows, Java 8

# Documentation
N/A

# Notes for Reviewers
None.
