### PR TITLE
CUSTCOM-204 - Fixed comparator of OpenApiWalker's internal Tre…

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.Comparator;
 import java.util.logging.Logger;
 
 import javax.ws.rs.ApplicationPath;
@@ -69,7 +70,6 @@ import javax.ws.rs.OPTIONS;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -117,25 +117,7 @@ public class OpenApiWalker implements ApiWalker {
 
     public OpenApiWalker(OpenAPI api, Set<Class<?>> allowedClasses) {
         this.api = api;
-        this.classes = new TreeSet<>((class1, class2) -> {
-            if (class1.equals(class2)) {
-                return 0;
-            }
-            // Subclasses first
-            if (class1.isAssignableFrom(class2)) {
-                return -1;
-            }
-            // Non contextual objects at the start
-            if (!class1.isAnnotationPresent(ApplicationPath.class) && !class1.isAnnotationPresent(Path.class)) {
-                return -1;
-            }
-            // Followed by applications
-            if (class1.isAnnotationPresent(ApplicationPath.class)) {
-                return -1;
-            }
-            // Followed by everything else
-            return 1;
-        });
+        this.classes = new TreeSet<>(Comparator.comparing(Class::getName, String::compareTo));
         this.classes.addAll(allowedClasses);
         addInnerClasses(); // must happen before generating the resource mapping
         this.resourceMapping = generateResourceMapping(classes);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
@@ -1,0 +1,97 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.openapi.impl.visitor;
+
+
+import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.*;
+
+public class OpenApiWalkerTest extends OpenApiApplicationTest {
+
+    /**
+     * When the OpenAPI schema is created, a lot of lookups of classes included in the schema are made.
+     * Therefore, it is required to keep to asymptotic complexity as low as possible. Keeping the classes
+     * sorted in a TreeSet ensures O(log(n)) complexity, as the tree is re-built on insert.
+     * <p>
+     * Inside the Set (the internal contract defined by a private field is Set, not TreeSet), regardless
+     * of the actual implementation used, all the inserted classes should be foundable afterwards.
+     * <p>
+     * This method tests a fix for issue {@link https://github.com/payara/Payara/issues/4489}, which pointed out
+     * the original custom TreeSet comparator did a reduction to the space of possible classes on lookup, making
+     * it impossible for a large subset of classes to be found, even if present in the TreeSet.
+     * <p>
+     * The compared objects inside the internal comparator supplied to the Set implementation are of type "Class".
+     * And classes have no natural distinct ordinal numbers in Java. One way to get an ordinal number for a Class is
+     * to use it's fully qualified name and compare the distance to the other compared class in the space consisting
+     * of other class names. This way, "more similar" strings have closer cartesian distance. And as String
+     * representation of a Classs is used, fast lookup is ensured.
+     */
+    @Test
+    public void testClassOrderingAndSearch() throws NoSuchFieldException, IllegalAccessException {
+        final Set<Class<?>> testedClasssses = new LinkedHashSet<>();
+        testedClasssses.add(String.class);
+        testedClasssses.add(Long.class);
+        testedClasssses.add(Number.class);
+
+        final OpenApiWalker openApiWalker = new OpenApiWalker(getDocument(), testedClasssses);
+        final Field sortedClassesField = OpenApiWalker.class.getDeclaredField("classes");
+        assertEquals(Set.class, sortedClassesField.getType()); // Ensure fast lookup is possible with at least any Set
+        try {
+            sortedClassesField.setAccessible(true);
+            final Object possibleTreeSet = sortedClassesField.get(openApiWalker);
+            assertEquals(TreeSet.class, possibleTreeSet.getClass());
+            final TreeSet<Class<?>> sortedClasses = (TreeSet<Class<?>>) possibleTreeSet;
+            assertNotNull(sortedClasses);
+
+            // All tested Classes must be foundable inside the OpenApi's internal sorted classes
+            testedClasssses.forEach(clazz -> assertTrue(sortedClasses.contains(clazz)));
+        } finally {
+            sortedClassesField.setAccessible(false);
+        }
+    }
+
+}


### PR DESCRIPTION
…eSet of allowed classes

Attempts to fix https://github.com/payara/Payara/issues/4489

# Description
This is a bug fix for  https://github.com/payara/Payara/issues/4489.

As described in JavaDoc above the test for this fix, a TreeSet has been used inside `OpenApiWalker` class to ensure low lookup times during the OpenApi schema creation/generation process. Which is a clever choice, as a `TreeSet` ensures `O(log(n))` asymptotic complexity [source](https://www.baeldung.com/java-collections-complexity).

The previous comparator, with it's limited number of outputs for the whole set of allowed classes with typically high cardinality, was effectively making some classes not foundable on lookup, even though those classes were present. On lookup, the comparator sent the pointer to a completely different direction/tree node.

I believe a cheap and optimal solution would be to compare distance among classes using Strings. To quote the JavaDoc above the test created in this PR:

```
The compared objects inside the internal comparator supplied to the Set implementation are of type "Class".
And classes have no natural distinct ordinal numbers in Java. One way to get an ordinal number for a Class is
to use it's fully qualified name and compare the distance to the other compared class in the space consisting
of other class names. This way, "more similar" strings have closer cartesian distance. And as String 
representation of a Classs is used, fast lookup is ensured.
```
The implementation of `String.compareTo` method is [fast & efficient](http://jniosocket.sourceforge.net/result.html) and is able to quickly send the lookup pointer the right way in the tree by using the whole space of all possible class names. The opposite would be comparing by +1/-1 steps could also mean linear search in worst case.

# Important Info

# Testing

### New tests
`OpenApiWalkerTest` class with one new test named `testClassOrderingAndSearch`.

This class tests:
1. All inserted classes are found afterwards in the internal `TreeSet`
1. Internal contract is defined as `Set`
1. The implementation used is a `TreeSet` - debatable. If anyone changes the implementation, this test will fail and the person changing the code will be forced to change the test and thus cinciously consider the lookup complexity.

### Testing Performed
Created a JUnit test.

### Testing Environment
Oracle JDK 1.8.0_241
Ubuntu 19.10