### PR TITLE
CUSTCOM-75 Fix Payara System Property REST API

### DIFF
--- a/appserver/admingui/common/src/main/resources/configuration/sysInstanceValues.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/sysInstanceValues.jsf
@@ -38,6 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2020] [Payara Foundation and/or its affiliates]
 -->
 
 <!initPage
@@ -45,7 +46,7 @@
     setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings")
     setResourceBundle(key="help_common" bundle="org.glassfish.common.admingui.Helplinks");
 />
-<!composition template="/templates/default.layout"  guiTitle="$resource{i18n.instanceValues.PageTitle}" >
+<!composition template="/templates/default.layout"  guiTitle="$resource{i18n.instanceValues.PageTitle,$pageSession{propName}}" >
 <!define name="content">
     <event>
         <!beforeCreate

--- a/appserver/admingui/common/src/main/resources/configuration/systemPropertiesButtons.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/systemPropertiesButtons.jsf
@@ -38,6 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2020] [Payara Foundation and/or its affiliates]
 -->
 <sun:panelGroup id="topButtons">
     <sun:button id="saveButton" text="$resource{i18n.button.Save}" >
@@ -46,7 +47,7 @@
             foreach (var="row", list="#{pageSession.tableList}") {
                 mapPut(map="#{requestScope.data}", key="#{row.name}", value="#{row.overrideValue}");
             }
-            gf.restRequest(endpoint="#{pageSession.selfUrl}", method="POST", attrs="#{requestScope.data}", contentType="application/x-www-form-urlencoded", result="#{requestScope.restResponse}");
+            gf.restRequest(endpoint="#{pageSession.selfUrl}", method="PUT", attrs="#{requestScope.data}", contentType="application/x-www-form-urlencoded", result="#{requestScope.restResponse}");
             prepareSuccessfulMsg();
             gf.redirect(page="#{pageSession.selfPage}&alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}");
         />

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/HttpResponsesTest.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/HttpResponsesTest.java
@@ -41,16 +41,11 @@ package fish.payara.samples.rest.management;
 
 import static org.junit.Assert.assertEquals;
 
-import com.gargoylesoftware.htmlunit.HttpMethod;
-
 import org.junit.Test;
-
-import fish.payara.samples.NotMicroCompatible;
 
 /**
  * Test the REST management interface for it's basic HTTP responses
  */
-@NotMicroCompatible
 public class HttpResponsesTest extends RestManagementTest {
 
     /**
@@ -59,7 +54,11 @@ public class HttpResponsesTest extends RestManagementTest {
      */
     @Test
     public void when_DELETE_non_existent_resource_expect_404() {
-        int status = request(HttpMethod.DELETE, "servers/server/server/application-ref/non-existent-application-ref").getStatus();
+        int status = target
+                .path("servers/server/server/application-ref/non-existent-application-ref")
+                .request()
+                .delete()
+                .getStatus();
         assertEquals("A non-existent resource should return a 404.", 404, status);
     }
 

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/SystemPropertyTest.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/SystemPropertyTest.java
@@ -1,0 +1,160 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rest.management;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toMap;
+import static javax.ws.rs.client.Entity.entity;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.json.JsonObject;
+import javax.json.JsonString;
+
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+
+import fish.payara.samples.rest.management.extension.TemporaryInstance;
+
+/**
+ * Test the system property endpoint of the REST management interface
+ */
+public class SystemPropertyTest extends RestManagementTest {
+
+    @ArquillianResource
+    private TemporaryInstance instance;
+
+    /**
+     * Tests that when a POST request is made to the endpoint the system properties
+     * posted are added.
+     */
+    @Test
+    @InSequence(1)
+    public void when_POST_system_properties_expect_success() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("ASADMIN_LISTENER_PORT", 12345);
+        properties.put("HTTP_LISTENER_PORT", 23456);
+        properties.put("HTTP_SSL_LISTENER_PORT", 34567);
+
+        target.path(systemPropertiesEndpoint())
+            .request()
+            .post(entity(properties, APPLICATION_JSON));
+
+        Map<String, String> systemProperties = getSystemProperties();
+
+        verifySystemProperty("ASADMIN_LISTENER_PORT", properties, systemProperties);
+        verifySystemProperty("HTTP_LISTENER_PORT", properties, systemProperties);
+        verifySystemProperty("HTTP_SSL_LISTENER_PORT", properties, systemProperties);
+        assertEquals("No other system properties should exist before they've been added.", 3, systemProperties.size());
+    }
+
+    /**
+     * Tests that when a PUT request is made all other system properties are
+     * overwritten. See CUSTCOM-75 for details.
+     */
+    @Test
+    @InSequence(2)
+    public void when_PUT_system_property_expect_others_are_deleted() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("HTTP_LISTENER_PORT", 45678);
+        properties.put("HTTP_SSL_LISTENER_PORT", 56789);
+
+        target.path(systemPropertiesEndpoint())
+            .request()
+            .put(entity(properties, APPLICATION_JSON));
+
+        Map<String, String> systemProperties = getSystemProperties();
+
+        verifySystemProperty("HTTP_LISTENER_PORT", properties, systemProperties);
+        verifySystemProperty("HTTP_SSL_LISTENER_PORT", properties, systemProperties);
+        assertEquals("No other system properties should exist after a PUT.", 2, systemProperties.size());
+    }
+
+    /**
+     * Tests that when a POST request is made the posted variables are updated and
+     * the others remain. See CUSTCOM-75 for details.
+     */
+    @Test
+    @InSequence(3)
+    public void when_POST_system_property_expect_only_change_submitted() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("HTTP_LISTENER_PORT", 67891);
+
+        target.path(systemPropertiesEndpoint())
+                .request()
+                .post(entity(properties, APPLICATION_JSON));
+
+        Map<String, String> systemProperties = getSystemProperties();
+
+        verifySystemProperty("HTTP_LISTENER_PORT", properties, systemProperties);
+        assertEquals("All other system properties should be maintained after a POST.", 2, systemProperties.size());
+    }
+
+    private Map<String, String> getSystemProperties() {
+        return target.path(systemPropertiesEndpoint())
+            .request()
+            .get(JsonObject.class)
+            .getJsonObject("extraProperties")
+            .getJsonArray("systemProperties")
+            .parallelStream()
+            .filter(value -> value.asJsonObject().get("value") != null)
+            .collect(toMap(
+                    value -> ((JsonString) value.asJsonObject().get("name")).getString(),
+                    value -> ((JsonString) value.asJsonObject().get("value")).getString()));
+    }
+
+    private String systemPropertiesEndpoint() {
+        return format("servers/server/%s/system-properties", instance.getName());
+    }
+
+    private static void verifySystemProperty(String propertyName, Map<String, ? extends Object> localMap, Map<String, ? extends Object> systemProperties) {
+        assertTrue(String.format("The %s system property wasn't found.", propertyName),
+                systemProperties.containsKey(propertyName));
+        assertEquals(String.format("The %s system property was incorrect.", propertyName),
+                localMap.get(propertyName).toString(),
+                systemProperties.get(propertyName).toString());
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/extension/TemporaryInstance.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/extension/TemporaryInstance.java
@@ -1,0 +1,147 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rest.management.extension;
+
+import static java.lang.String.format;
+import static java.util.logging.Level.WARNING;
+import static javax.ws.rs.client.Entity.entity;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import javax.json.JsonObject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Form;
+
+import fish.payara.samples.ServerOperations;
+import fish.payara.samples.rest.management.util.RestManagementClientBuilder;
+
+/**
+ * An Arquillian resource that will create an instance on the target server
+ * using the REST management interface if it is reachable. A new instance will
+ * be created for each test class.
+ */
+public class TemporaryInstance {
+
+    private static final Logger LOGGER = Logger.getLogger(TemporaryInstance.class.getName());
+
+    private boolean initialized;
+    private boolean created;
+
+    private String name;
+
+    private WebTarget target;
+
+    protected void initialise(URL arquillianURL) {
+        initialized = true;
+
+        URI adminBaseUri;
+        try {
+            adminBaseUri = ServerOperations.toAdminPort(arquillianURL).toURI();
+        } catch (Exception ex) {
+            LOGGER.log(WARNING, "Unable to find admin base URL. Should this profile have an admin console?", ex);
+            return;
+        }
+
+        this.target = RestManagementClientBuilder.newClient(adminBaseUri);
+
+        name = "test-instance-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        // Get the default node name
+        String nodeName = target.path("nodes/node").request()
+                .get(JsonObject.class)
+                .getJsonObject("extraProperties")
+                .getJsonObject("childResources")
+                .keySet().iterator().next();
+
+        Form form = new Form();
+        form.param("node", nodeName);
+        form.param("name", name);
+
+        JsonObject response = target.path("create-instance")
+                .request()
+                .post(entity(form, APPLICATION_FORM_URLENCODED), JsonObject.class);
+        
+        if (!"SUCCESS".equals(response.getString("exit_code"))) {
+            LOGGER.warning(format("Failed to create instance %s. Response from endpoint: %s.", name, response));
+        } else {
+            created = true;
+        }
+    }
+
+    protected void destroy() {
+        Form form = new Form();
+        form.param("instance_name", name);
+
+        JsonObject response = target.path(format("servers/server/%s/delete-instance", name))
+                .request()
+                .post(entity(form, APPLICATION_FORM_URLENCODED), JsonObject.class);
+
+        if (!"SUCCESS".equals(response.getString("exit_code"))) {
+            LOGGER.warning(format("Failed to delete instance %s. Response from endpoint: %s.", name, response));
+        }
+    }
+
+    /**
+     * @return if this object has had an initialisation attempt, successful or
+     *         otherwise.
+     */
+    protected boolean isInitialized() {
+        return initialized;
+    }
+
+    /**
+     * @return true if the instance has been created on the server, or false otherwise.
+     */
+    public boolean isCreated() {
+        return created;
+    }
+
+    /**
+     * @return the name of the instance created, or null if it hasn't been created.
+     */
+    public String getName() {
+        return name;
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/extension/TemporaryInstanceExtension.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/extension/TemporaryInstanceExtension.java
@@ -37,49 +37,16 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.samples.rest.management;
+package fish.payara.samples.rest.management.extension;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-import javax.ws.rs.client.WebTarget;
+public class TemporaryInstanceExtension implements LoadableExtension {
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Before;
-import org.junit.runner.RunWith;
-
-import fish.payara.samples.NotMicroCompatible;
-import fish.payara.samples.PayaraArquillianTestRunner;
-import fish.payara.samples.PayaraTestShrinkWrap;
-import fish.payara.samples.ServerOperations;
-import fish.payara.samples.rest.management.util.RestManagementClientBuilder;
-
-@RunWith(PayaraArquillianTestRunner.class)
-@NotMicroCompatible
-public abstract class RestManagementTest {
-
-    protected WebTarget target;
-
-    @ArquillianResource
-    private URL baseUrl;
-
-    @Deployment(testable = false)
-    public static Archive<?> deploy() {
-        return PayaraTestShrinkWrap.getWebArchive()
-            .addClass(RestManagementTest.class);
-    }
-
-    @Before
-    public final void setUpFields() throws URISyntaxException {
-        URI adminBaseUri;
-        try {
-            adminBaseUri = ServerOperations.toAdminPort(baseUrl).toURI();
-        } catch (Exception ex) {
-            throw new IllegalStateException("Unable to find admin base URL. Should this profile have an admin console?", ex);
-        }
-        target = RestManagementClientBuilder.newClient(adminBaseUri);
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ResourceProvider.class, TemporaryInstanceProvider.class)
+                .observer(TemporaryInstanceProvider.class);
     }
 }

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/util/RestManagementClientBuilder.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/util/RestManagementClientBuilder.java
@@ -37,49 +37,20 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.samples.rest.management;
+package fish.payara.samples.rest.management.util;
 
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+public abstract class RestManagementClientBuilder {
 
-import fish.payara.samples.NotMicroCompatible;
-import fish.payara.samples.PayaraArquillianTestRunner;
-import fish.payara.samples.PayaraTestShrinkWrap;
-import fish.payara.samples.ServerOperations;
-import fish.payara.samples.rest.management.util.RestManagementClientBuilder;
+    private RestManagementClientBuilder() {}
 
-@RunWith(PayaraArquillianTestRunner.class)
-@NotMicroCompatible
-public abstract class RestManagementTest {
-
-    protected WebTarget target;
-
-    @ArquillianResource
-    private URL baseUrl;
-
-    @Deployment(testable = false)
-    public static Archive<?> deploy() {
-        return PayaraTestShrinkWrap.getWebArchive()
-            .addClass(RestManagementTest.class);
+    public static WebTarget newClient(URI adminBaseUrl) {
+        return new RestManagementWebTarget(
+                ClientBuilder.newClient().target(adminBaseUrl.resolve("/management/domain/").toString()));
     }
-
-    @Before
-    public final void setUpFields() throws URISyntaxException {
-        URI adminBaseUri;
-        try {
-            adminBaseUri = ServerOperations.toAdminPort(baseUrl).toURI();
-        } catch (Exception ex) {
-            throw new IllegalStateException("Unable to find admin base URL. Should this profile have an admin console?", ex);
-        }
-        target = RestManagementClientBuilder.newClient(adminBaseUri);
-    }
+    
 }

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/util/RestManagementRequestBuilder.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/util/RestManagementRequestBuilder.java
@@ -1,0 +1,295 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rest.management.util;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.util.Locale;
+
+import javax.ws.rs.client.AsyncInvoker;
+import javax.ws.rs.client.CompletionStageRxInvoker;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.client.RxInvoker;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+public class RestManagementRequestBuilder implements Builder {
+
+    private final Builder proxy;
+
+    protected RestManagementRequestBuilder(Builder proxy) {
+        this.proxy = proxy;
+        accept(APPLICATION_JSON, TEXT_PLAIN);
+        header("X-Requested-By", "Payara");
+    }
+
+    @Override
+    public Response get() {
+        return proxy.get();
+    }
+
+    @Override
+    public <T> T get(Class<T> responseType) {
+        return proxy.get(responseType);
+    }
+
+    @Override
+    public <T> T get(GenericType<T> responseType) {
+        return proxy.get(responseType);
+    }
+
+    @Override
+    public Response put(Entity<?> entity) {
+        return proxy.put(entity);
+    }
+
+    @Override
+    public <T> T put(Entity<?> entity, Class<T> responseType) {
+        return proxy.put(entity, responseType);
+    }
+
+    @Override
+    public <T> T put(Entity<?> entity, GenericType<T> responseType) {
+        return proxy.put(entity, responseType);
+    }
+
+    @Override
+    public Response post(Entity<?> entity) {
+        return proxy.post(entity);
+    }
+
+    @Override
+    public <T> T post(Entity<?> entity, Class<T> responseType) {
+        return proxy.post(entity, responseType);
+    }
+
+    @Override
+    public <T> T post(Entity<?> entity, GenericType<T> responseType) {
+        return proxy.post(entity, responseType);
+    }
+
+    @Override
+    public Response delete() {
+        return proxy.delete();
+    }
+
+    @Override
+    public <T> T delete(Class<T> responseType) {
+        return proxy.delete(responseType);
+    }
+
+    @Override
+    public <T> T delete(GenericType<T> responseType) {
+        return proxy.delete(responseType);
+    }
+
+    @Override
+    public Response head() {
+        return proxy.head();
+    }
+
+    @Override
+    public Response options() {
+        return proxy.options();
+    }
+
+    @Override
+    public <T> T options(Class<T> responseType) {
+        return proxy.options(responseType);
+    }
+
+    @Override
+    public <T> T options(GenericType<T> responseType) {
+        return proxy.options(responseType);
+    }
+
+    @Override
+    public Response trace() {
+        return proxy.trace();
+    }
+
+    @Override
+    public <T> T trace(Class<T> responseType) {
+        return proxy.trace(responseType);
+    }
+
+    @Override
+    public <T> T trace(GenericType<T> responseType) {
+        return proxy.trace(responseType);
+    }
+
+    @Override
+    public Response method(String name) {
+        return proxy.method(name);
+    }
+
+    @Override
+    public <T> T method(String name, Class<T> responseType) {
+        return proxy.method(name, responseType);
+    }
+
+    @Override
+    public <T> T method(String name, GenericType<T> responseType) {
+        return proxy.method(name, responseType);
+    }
+
+    @Override
+    public Response method(String name, Entity<?> entity) {
+        return proxy.method(name, entity);
+    }
+
+    @Override
+    public <T> T method(String name, Entity<?> entity, Class<T> responseType) {
+        return proxy.method(name, entity, responseType);
+    }
+
+    @Override
+    public <T> T method(String name, Entity<?> entity, GenericType<T> responseType) {
+        return proxy.method(name, entity, responseType);
+    }
+
+    @Override
+    public Invocation build(String method) {
+        return proxy.build(method);
+    }
+
+    @Override
+    public Invocation build(String method, Entity<?> entity) {
+        return proxy.build(method, entity);
+    }
+
+    @Override
+    public Invocation buildGet() {
+        return proxy.buildGet();
+    }
+
+    @Override
+    public Invocation buildDelete() {
+        return proxy.buildDelete();
+    }
+
+    @Override
+    public Invocation buildPost(Entity<?> entity) {
+        return proxy.buildPost(entity);
+    }
+
+    @Override
+    public Invocation buildPut(Entity<?> entity) {
+        return proxy.buildPut(entity);
+    }
+
+    @Override
+    public AsyncInvoker async() {
+        return proxy.async();
+    }
+
+    @Override
+    public Builder accept(String... mediaTypes) {
+        return proxy.accept(mediaTypes);
+    }
+
+    @Override
+    public Builder accept(MediaType... mediaTypes) {
+        return proxy.accept(mediaTypes);
+    }
+
+    @Override
+    public Builder acceptLanguage(Locale... locales) {
+        return proxy.acceptLanguage(locales);
+    }
+
+    @Override
+    public Builder acceptLanguage(String... locales) {
+        return proxy.acceptLanguage(locales);
+    }
+
+    @Override
+    public Builder acceptEncoding(String... encodings) {
+        return proxy.acceptEncoding(encodings);
+    }
+
+    @Override
+    public Builder cookie(Cookie cookie) {
+        return proxy.cookie(cookie);
+    }
+
+    @Override
+    public Builder cookie(String name, String value) {
+        return proxy.cookie(name, value);
+    }
+
+    @Override
+    public Builder cacheControl(CacheControl cacheControl) {
+        return proxy.cacheControl(cacheControl);
+    }
+
+    @Override
+    public Builder header(String name, Object value) {
+        return proxy.header(name, value);
+    }
+
+    @Override
+    public Builder headers(MultivaluedMap<String, Object> headers) {
+        return proxy.headers(headers);
+    }
+
+    @Override
+    public Builder property(String name, Object value) {
+        return proxy.property(name, value);
+    }
+
+    @Override
+    public CompletionStageRxInvoker rx() {
+        return proxy.rx();
+    }
+
+    @Override
+    public <T extends RxInvoker> T rx(Class<T> clazz) {
+        return proxy.rx(clazz);
+    }
+    
+}

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/util/RestManagementWebTarget.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/util/RestManagementWebTarget.java
@@ -1,0 +1,179 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rest.management.util;
+
+import java.net.URI;
+import java.util.Map;
+
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+
+public class RestManagementWebTarget implements WebTarget {
+
+    private final WebTarget proxy;
+
+    protected RestManagementWebTarget(WebTarget proxy) {
+        this.proxy = proxy;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return proxy.getConfiguration();
+    }
+
+    @Override
+    public WebTarget property(String name, Object value) {
+        return new RestManagementWebTarget(proxy.property(name, value));
+    }
+
+    @Override
+    public WebTarget register(Class<?> componentClass) {
+        return new RestManagementWebTarget(proxy.register(componentClass));
+    }
+
+    @Override
+    public WebTarget register(Class<?> componentClass, int priority) {
+        return new RestManagementWebTarget(proxy.register(componentClass, priority));
+    }
+
+    @Override
+    public WebTarget register(Class<?> componentClass, Class<?>... contracts) {
+        return new RestManagementWebTarget(proxy.register(componentClass, contracts));
+    }
+
+    @Override
+    public WebTarget register(Class<?> componentClass, Map<Class<?>, Integer> contracts) {
+        return new RestManagementWebTarget(proxy.register(componentClass, contracts));
+    }
+
+    @Override
+    public WebTarget register(Object component) {
+        return new RestManagementWebTarget(proxy.register(component));
+    }
+
+    @Override
+    public WebTarget register(Object component, int priority) {
+        return new RestManagementWebTarget(proxy.register(component, priority));
+    }
+
+    @Override
+    public WebTarget register(Object component, Class<?>... contracts) {
+        return new RestManagementWebTarget(proxy.register(component, contracts));
+    }
+
+    @Override
+    public WebTarget register(Object component, Map<Class<?>, Integer> contracts) {
+        return new RestManagementWebTarget(proxy.register(component, contracts));
+    }
+
+    @Override
+    public URI getUri() {
+        return proxy.getUri();
+    }
+
+    @Override
+    public UriBuilder getUriBuilder() {
+        return proxy.getUriBuilder();
+    }
+
+    @Override
+    public WebTarget path(String path) {
+        return new RestManagementWebTarget(proxy.path(path));
+    }
+
+    @Override
+    public WebTarget resolveTemplate(String name, Object value) {
+        return new RestManagementWebTarget(proxy.resolveTemplate(name, value));
+    }
+
+    @Override
+    public WebTarget resolveTemplate(String name, Object value, boolean encodeSlashInPath) {
+        return new RestManagementWebTarget(proxy.resolveTemplate(name, value, encodeSlashInPath));
+    }
+
+    @Override
+    public WebTarget resolveTemplateFromEncoded(String name, Object value) {
+        return new RestManagementWebTarget(proxy.resolveTemplateFromEncoded(name, value));
+    }
+
+    @Override
+    public WebTarget resolveTemplates(Map<String, Object> templateValues) {
+        return new RestManagementWebTarget(proxy.resolveTemplates(templateValues));
+    }
+
+    @Override
+    public WebTarget resolveTemplates(Map<String, Object> templateValues, boolean encodeSlashInPath) {
+        return new RestManagementWebTarget(proxy.resolveTemplates(templateValues, encodeSlashInPath));
+    }
+
+    @Override
+    public WebTarget resolveTemplatesFromEncoded(Map<String, Object> templateValues) {
+        return new RestManagementWebTarget(proxy.resolveTemplatesFromEncoded(templateValues));
+    }
+
+    @Override
+    public WebTarget matrixParam(String name, Object... values) {
+        return new RestManagementWebTarget(proxy.matrixParam(name, values));
+    }
+
+    @Override
+    public WebTarget queryParam(String name, Object... values) {
+        return new RestManagementWebTarget(proxy.queryParam(name, values));
+    }
+
+    @Override
+    public Builder request() {
+        return new RestManagementRequestBuilder(proxy.request());
+    }
+
+    @Override
+    public Builder request(String... acceptedResponseTypes) {
+        return new RestManagementRequestBuilder(proxy.request(acceptedResponseTypes));
+    }
+
+    @Override
+    public Builder request(MediaType... acceptedResponseTypes) {
+        return new RestManagementRequestBuilder(proxy.request(acceptedResponseTypes));
+    }
+    
+}

--- a/appserver/tests/payara-samples/samples/rest-management/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+fish.payara.samples.rest.management.extension.TemporaryInstanceExtension

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/NotMicroCompatible.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/NotMicroCompatible.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -40,6 +40,7 @@
 package fish.payara.samples;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -56,4 +57,6 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
+
 public @interface NotMicroCompatible {}

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/SincePayara.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/SincePayara.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -40,6 +40,7 @@
 package fish.payara.samples;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -53,6 +54,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface SincePayara {
     
     String value();

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/SystemPropertiesCliResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/SystemPropertiesCliResource.java
@@ -38,19 +38,21 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admin.rest.resources.custom;
 
-import com.sun.enterprise.config.serverbeans.Cluster;
-import com.sun.enterprise.config.serverbeans.Domain;
-import com.sun.enterprise.config.serverbeans.Server;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -63,12 +65,18 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
-import org.glassfish.admin.rest.utils.ResourceUtil;
+
+import com.sun.enterprise.config.serverbeans.Cluster;
+import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.config.serverbeans.Server;
+
 import org.glassfish.admin.rest.resources.TemplateExecCommand;
 import org.glassfish.admin.rest.results.ActionReportResult;
 import org.glassfish.admin.rest.results.OptionsResult;
+import org.glassfish.admin.rest.utils.ResourceUtil;
 import org.glassfish.admin.rest.utils.xml.RestActionReporter;
 import org.glassfish.api.ActionReport;
+import org.glassfish.api.ActionReport.ExitCode;
 import org.glassfish.api.admin.CommandLock;
 import org.glassfish.api.admin.ExecuteOn;
 import org.glassfish.api.admin.ParameterMap;
@@ -127,7 +135,7 @@ public class SystemPropertiesCliResource extends TemplateExecCommand {
         RestActionReporter actionReport = new RestActionReporter();
         getSystemProperties(properties, getEntity(), false);
 
-        actionReport.getExtraProperties().put("systemProperties", new ArrayList(properties.values()));
+        actionReport.getExtraProperties().put("systemProperties", new ArrayList<>(properties.values()));
         if (properties.isEmpty()) {
             actionReport.getTopMessagePart().setMessage("Nothing to list."); // i18n
         }
@@ -136,13 +144,14 @@ public class SystemPropertiesCliResource extends TemplateExecCommand {
 
     @POST
     public Response create(Map<String, String> data) {
-	Response resp = deleteRemovedProperties(data);
-        return (resp == null) ? saveProperties(data) : resp;
+        return saveProperties(data);
     }
 
     @PUT
     public Response update(Map<String, String> data) {
-        return saveProperties(data);
+        data.entrySet().removeIf(entry -> entry.getValue() == null || entry.getValue().isEmpty());
+        Response resp = deleteRemovedProperties(data);
+        return (resp == null) ? saveProperties(data) : resp;
     }
 
     @Path("{Name}/")
@@ -262,6 +271,27 @@ public class SystemPropertiesCliResource extends TemplateExecCommand {
     }
 
     protected Response saveProperties(String parent, Map<String, String> data) {
+
+        // Prepare all empty properties for explicit deletion
+        Collection<String> emptyProps = new HashSet<>();
+        Iterator<Entry<String, String>> dataIterator = data.entrySet().iterator();
+        while (dataIterator.hasNext()) {
+            Entry<String, String> dataEntry = dataIterator.next();
+            String value = dataEntry.getValue();
+            if (value == null || value.isEmpty()) {
+                dataIterator.remove();
+                emptyProps.add(dataEntry.getKey());
+            }
+        }
+
+        // Delete the prepared properties for deletion
+        if (!emptyProps.isEmpty()) {
+            Response response = deleteProperties(parent, emptyProps);
+            if (data.isEmpty() || response.getStatus() != HttpURLConnection.HTTP_OK) {
+                return response;
+            }
+        }
+
         String propertiesString = convertPropertyMapToString(data);
 
         data = new HashMap<String, String>();
@@ -278,6 +308,39 @@ public class SystemPropertiesCliResource extends TemplateExecCommand {
         }
 
         return Response.status(status).entity(results).build();
+    }
+
+    protected Response deleteProperties(String parent, Collection<String> propNames) {
+        int status = HttpURLConnection.HTTP_OK;
+
+        // Prepare a report for aggregating results
+        RestActionReporter report = new RestActionReporter();
+        report.setActionExitCode(ExitCode.SUCCESS);
+        report.setMessage("");
+
+        for (String propName : propNames) {
+            // Delete the property
+            Response response = deleteProperty(null, propName);
+
+            ActionReportResult result = (ActionReportResult) response.getEntity();
+            ActionReport resultReport = result.getActionReport();
+            ExitCode responseExitCode = resultReport.getActionExitCode();
+
+            // Put the results into the aggregator report
+            if (!responseExitCode.equals(ExitCode.SUCCESS)) {
+                report.setActionExitCode(responseExitCode);
+                if (responseExitCode.equals(ExitCode.FAILURE)) {
+                    status = HttpURLConnection.HTTP_INTERNAL_ERROR;
+                }
+            }
+            report.getExtraProperties().putAll(resultReport.getExtraProperties());
+            report.setMessage((report.getMessage() + "\n" + resultReport.getMessage()).trim());
+            if (response.getStatus() != HttpURLConnection.HTTP_OK){
+                return response;
+            }
+        }
+
+        return Response.status(status).entity(report).build();
     }
 
     protected Response deleteProperty(String parent, String propName) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

This change allows instance property overrides to be created without deleting all the other instance properties by using the REST endpoint correctly. It also allows empty property fields to be submitted to remove the property.

Firstly the PUT and POST methods were the wrong way around, so they've been swapped. Secondly, the POST method didn't allow empty fields, which meant that instance property overrides couldn't be removed. To stop this, empty properties are now treated as properties to be removed.

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->
# Testing

### Testing Performed
Setting up domain with:

~~~
asadmin copy-config default-config test-config
asadmin create-instance --node localhost-domain1 --config test-config instance1
asadmin create-system-properties --target instance1 ASADMIN_LISTENER_PORT=12345
asadmin create-system-properties --target instance1 HTTP_LISTENER_PORT=23456
~~~

From the admin console tried:

- removing an instance property from test-config -> system-properties -> instance values
- creating an instance property from test-config -> system-properties -> instance values
- removing an instance property from instances -> instance1 -> properties
- creating an instance property from instances -> instance1 -> properties

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
N/A