### PR TITLE
APPSERV-87 Remove trailing space

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/fish/payara/api/admin/config/NameGenerator.java
+++ b/nucleus/common/glassfish-api/src/main/java/fish/payara/api/admin/config/NameGenerator.java
@@ -49,7 +49,7 @@ public final class NameGenerator {
             "Drab", "Distinct", "Dull", "Elegant", "Excited", "Fancy", "Filthy", "Glamorous", "Gleaming", "Gorgeous",
             "Graceful", "Grotesque", "Handsome", "Heavy", "Homely", "Light", "Magnificent", "Misty", "Motionless", "Muddy",
             "Old-fashioned", "Plain", "Poised", "Precious", "Quaint", "Shiny", "Sparkling", "Spotless", "Stormy",
-            "Strange", "Ugly", "Unusual", "Wide-eyed ", "Annoying", "Bad", "Beautiful", "Brainy", "Breakable", "Busy",
+            "Strange", "Ugly", "Unusual", "Wide-eyed", "Annoying", "Bad", "Beautiful", "Brainy", "Breakable", "Busy",
             "Careful", "Cautious", "Clever", "Clumsy", "Concerned", "Crazy", "Curious", "Dead", "Different", "Difficult",
             "Doubtful", "Easy", "Famous", "Fragile", "Frail", "Gifted", "Helpful", "Helpless", "Horrible", "Important",
             "Impossible", "Innocent", "Inquisitive", "Modern", "Mushy", "Odd", "Open", "Outstanding", "Poor", "Powerful",


### PR DESCRIPTION
This is a bug fix.

The "Wide-eyed" adjective for the auto name generation has a trailing space, leading it to create names like "Wide-eyed -Ladyfish", which breaks stuff.

# Testing
None

