### PR TITLE
CUSTCOM-195 Fixed throwing exceptions with disabled port check

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/CustomTokenClient.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/CustomTokenClient.java
@@ -101,7 +101,8 @@ public class CustomTokenClient {
                 // Check presence of token place-holder
                 Set<Integer> usedPorts = new HashSet<Integer>();
                 Properties domainProps = domainConfig.getDomainProperties();
-                String portBase = (String)domainConfig.get(DomainConfig.K_PORTBASE);
+                String portBase = (String) domainConfig.get(DomainConfig.K_PORTBASE);
+                boolean checkPorts = (Boolean) domainConfig.getOrDefault(DomainConfig.K_VALIDATE_PORTS, Boolean.TRUE);
 
                 Map<String, String> filePaths = new HashMap<String, String>(3, 1);
                 filePaths.put(SystemPropertyConstants.INSTALL_ROOT_PROPERTY, System.getProperty(SystemPropertyConstants.INSTALL_ROOT_PROPERTY));
@@ -119,7 +120,7 @@ public class CustomTokenClient {
                             Integer port = null;
                             if (domainProps.containsKey(name)) {
                                 port = Integer.valueOf(domainProps.getProperty(token.getName()));
-                                if (!NetUtils.isPortFree(port)) {
+                                if (checkPorts && !NetUtils.isPortFree(port)) {
                                     throw new DomainException(_strings.get("unavailablePort", port));
                                 }
                             } else {


### PR DESCRIPTION
# Description

Fixes situation when you call create-domain while other instance uses same ports, you disable port checking, but it fails because 7676 is still checked.

Use cases: 
* upgrading Payara and creating new domain by some script while previous version is still running.
* running build of Payara while there is any running instance using default ports

# Testing

1. asadmin start-domain domain1
2. asadmin create-domain --checkports false ouiehwefwf

Result of checkports=true behaves same in both versions (will generate other ports automatically).

Result from 5.194.2
```
Enter admin user name [Enter to accept default "admin" / no password]>
Using default port 4848 for Admin.
Using default port 8080 for HTTP Instance.
Using default port 7676 for JMS.
Using default port 3700 for IIOP.
Using default port 8181 for HTTP_SSL.
Using default port 3820 for IIOP_SSL.
Using default port 3920 for IIOP_MUTUALAUTH.
Using default port 8686 for JMX_ADMIN.
Using default port 6666 for OSGI_SHELL.
Using default port 9009 for JAVA_DEBUGGER.
Using default port 4900 for Hazelcast DAS.
Using default port 5900 for Hazelcast Start.
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dmatej-G5-5587,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dmatej-G5-5587-instance,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Given port 7 676 is not free.
CLI130: Could not create domain, ouiehwefwf
Command create-domain failed.
```

Result from fixed master
```
Enter admin user name [Enter to accept default "admin" / no password]>
Using default port 4848 for Admin.
Using default port 8080 for HTTP Instance.
Using default port 7676 for JMS.
Using default port 3700 for IIOP.
Using default port 8181 for HTTP_SSL.
Using default port 3820 for IIOP_SSL.
Using default port 3920 for IIOP_MUTUALAUTH.
Using default port 8686 for JMX_ADMIN.
Using default port 6666 for OSGI_SHELL.
Using default port 9009 for JAVA_DEBUGGER.
Using default port 4900 for Hazelcast DAS.
Using default port 5900 for Hazelcast Start.
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dmatej-G5-5587,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Distinguished Name of the self-signed X.509 Server Certificate is:
[CN=dmatej-G5-5587-instance,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK]
Domain unchecked created.
Domain unchecked admin port is 4848.
Domain unchecked allows admin login as user "admin" with no password.
Command create-domain executed successfully.
```





### Test suites executed

- main build with running domain1 on same computer
