### PR TITLE
Manage assertj in top parent

### DIFF
--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -80,8 +80,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.9.1</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- JSONP Provider -->

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -154,12 +154,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>3.9.1</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.omnifaces</groupId>
                 <artifactId>omniutils</artifactId>
                 <version>0.11</version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -990,6 +990,12 @@ Parent is ${project.parent}</echo>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.9.1</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -194,6 +194,7 @@
         <xpp3.version>1.1.4c_7</xpp3.version>
         <snmp4j.version>2.5.3-payara.p1</snmp4j.version>
         <mockito.version>2.2.6</mockito.version>
+        <assertj.version>3.9.1</assertj.version>
 
         <!-- Build -->
 
@@ -993,7 +994,7 @@ Parent is ${project.parent}</echo>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.9.1</version>
+                <version>${assertj.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
# Description
This is refactoring.

Currently assertj-core is managed in:
https://github.com/payara/Payara/blob/4102c23c975e3cfdf041203985d80a71848890b1/appserver/tests/payara-samples/pom.xml#L156-L161 and then used in https://github.com/payara/Payara/blob/4102c23c975e3cfdf041203985d80a71848890b1/appserver/tests/payara-samples/samples/ejb-http-remoting/client/pom.xml#L91-L95 and used directly (un-managed) in https://github.com/payara/Payara/blob/4102c23c975e3cfdf041203985d80a71848890b1/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml#L80-L85

I propose to manage it once (like mockito).

# Important Info

# Testing

### Testing Performed
`mvn clean install`

<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Linux, openjdk version "1.8.0_242", maven 3.6.3

