### PR TITLE
APPSERV-88 CUSTCOM-213 generate-encryption-key Command Always Creates Key for Default Domain

### DIFF
--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
@@ -747,20 +747,7 @@ public class ServerOperations {
             CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "true");
 
             System.out.println("Stopping Server");
-            String domain = System.getProperty("payara.domain.name");
-            if (domain == null) {
-                domain = getPayaraDomainFromServer();
-                if (domain != null && !domain.equals("null")) {
-                    logger.info("Using domain \"" + domain + "\" obtained from server. " +
-                            "If this is not correct use -Dpayara.domain.name to override.");
-                } else {
-                    // Default to domain1
-                    domain = "domain1";
-                    logger.info("Using default domain \"" + domain + "\".");
-                }
-            } else {
-                logger.info("Using domain \"" + domain + "\" obtained from system property.");
-            }
+            String domain = getDomainName();
             CliCommands.payaraGlassFish("stop-domain", domain);
 
             System.out.println("Generating Encryption Key");
@@ -784,22 +771,7 @@ public class ServerOperations {
         if ("payara-remote".equals(javaEEServer)) {
             System.out.println("Disabling Data Grid Encryption");
             CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "false");
-
-            String domain = System.getProperty("payara.domain.name");
-            if (domain == null) {
-                domain = getPayaraDomainFromServer();
-                if (domain != null && !domain.equals("null")) {
-                    logger.info("Using domain \"" + domain + "\" obtained from server. " +
-                            "If this is not correct use -Dpayara.domain.name to override.");
-                } else {
-                    // Default to domain1
-                    domain = "domain1";
-                    logger.info("Using default domain \"" + domain + "\".");
-                }
-            } else {
-                logger.info("Using domain \"" + domain + "\" obtained from system property.");
-            }
-            restartContainer(domain);
+            restartContainer(getDomainName());
         } else {
             if (javaEEServer == null) {
                 System.out.println("javaEEServer not specified");
@@ -807,6 +779,25 @@ public class ServerOperations {
                 System.out.println(javaEEServer + " not supported");
             }
         }
+    }
+
+    public static String getDomainName() {
+        String domain = System.getProperty("payara.domain.name");
+        if (domain == null) {
+            domain = getPayaraDomainFromServer();
+            if (domain != null) {
+                logger.info("Using domain \"" + domain + "\" obtained from server. " +
+                        "If this is not correct use -Dpayara.domain.name to override.");
+            } else {
+                // Default to domain1
+                domain = "domain1";
+                logger.info("Using default domain \"" + domain + "\".");
+            }
+        } else {
+            logger.info("Using domain \"" + domain + "\" obtained from system property.");
+        }
+
+        return domain;
     }
 }
 

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
@@ -747,8 +747,8 @@ public class ServerOperations {
             CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "true");
 
             System.out.println("Stopping Server");
-            String domain = System.getProperty("payara.domain.name", "domain1");
-            if (domain != null) {
+            String domain = System.getProperty("payara.domain.name");
+            if (domain == null) {
                 domain = getPayaraDomainFromServer();
                 if (domain != null && !domain.equals("null")) {
                     logger.info("Using domain \"" + domain + "\" obtained from server. " +
@@ -756,14 +756,17 @@ public class ServerOperations {
                 } else {
                     // Default to domain1
                     domain = "domain1";
+                    logger.info("Using default domain \"" + domain + "\".");
                 }
+            } else {
+                logger.info("Using domain \"" + domain + "\" obtained from system property.");
             }
             CliCommands.payaraGlassFish("stop-domain", domain);
 
             System.out.println("Generating Encryption Key");
             CliCommands.payaraGlassFish("-W",
                     Paths.get("").toAbsolutePath() + "/src/test/resources/passwordfile.txt",
-                    "generate-encryption-key");
+                    "generate-encryption-key", domain);
 
             System.out.println("Restarting Server");
             CliCommands.payaraGlassFish("start-domain", domain);
@@ -782,8 +785,8 @@ public class ServerOperations {
             System.out.println("Disabling Data Grid Encryption");
             CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "false");
 
-            String domain = System.getProperty("payara.domain.name", "domain1");
-            if (domain != null) {
+            String domain = System.getProperty("payara.domain.name");
+            if (domain == null) {
                 domain = getPayaraDomainFromServer();
                 if (domain != null && !domain.equals("null")) {
                     logger.info("Using domain \"" + domain + "\" obtained from server. " +
@@ -791,7 +794,10 @@ public class ServerOperations {
                 } else {
                     // Default to domain1
                     domain = "domain1";
+                    logger.info("Using default domain \"" + domain + "\".");
                 }
+            } else {
+                logger.info("Using domain \"" + domain + "\" obtained from system property.");
             }
             restartContainer(domain);
         } else {

--- a/nucleus/admin/server-mgmt/src/main/java/fish/payara/admin/servermgmt/cli/GenerateEncryptionKey.java
+++ b/nucleus/admin/server-mgmt/src/main/java/fish/payara/admin/servermgmt/cli/GenerateEncryptionKey.java
@@ -44,6 +44,7 @@ import com.sun.enterprise.admin.servermgmt.cli.LocalDomainCommand;
 import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import com.sun.enterprise.util.HostAndPort;
 import com.sun.enterprise.util.net.NetUtils;
+import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.security.common.FileProtectionUtility;
@@ -72,6 +73,9 @@ import java.util.Random;
 @PerLookup
 public class GenerateEncryptionKey extends LocalDomainCommand {
 
+    @Param(name = "domain_name", primary = true, optional = true)
+    private String domainName;
+
     private static final String DATAGRID_KEY_FILE = "datagrid-key";
     private static final LocalStringsImpl SERVERMGMT_CLI_STRINGS =
             new LocalStringsImpl(ChangeMasterPasswordCommandDAS.class);
@@ -83,8 +87,14 @@ public class GenerateEncryptionKey extends LocalDomainCommand {
     private static final String AES_ALGORITHM = "AES/CBC/PKCS5Padding";
 
     @Override
-    protected int executeCommand() throws CommandException {
+    protected void validate() throws CommandException {
+        setDomainName(domainName);
+        super.validate();
         checkDomainIsNotRunning();
+    }
+
+    @Override
+    protected int executeCommand() throws CommandException {
         char[] masterPasswordChars = verifyMasterPassword();
 
         File datagridKeyFile = new File(getServerDirs().getConfigDir(), DATAGRID_KEY_FILE);


### PR DESCRIPTION
# Description
This is a bug fix.
The `generate-encryption-key` command will only create the key for the default domain due to the _domain_name_ parameter being commented out on its super class.

A workaround to this is to either make sure there’s only one domain in your domain dir (the default domain is always the solitary domain in the specified domain dir - it doesn't need to be called _domain1_), or to simply copy the generated file from the default domain to where you need it.

# Testing
This also fixes the SfsbEncryptionTest so that it isn't always running against the default domain.

### Testing Performed
Ran the SfsbEncryptionTest using server-managed and server-remote profiles, against domain1 and production domains.
