### PR TITLE
APPSERV-54 Print a Warning if No Encryption Key Present

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/RestApiHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/RestApiHandlers.java
@@ -272,6 +272,7 @@ public class RestApiHandlers {
             return;
         }
 
+        parseResponse(response, handlerCtx, endpoint, attrs, false, true);
         handlerCtx.setOutputValue("result", endpoint);
     }
 

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/RestApiHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/RestApiHandlers.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2020] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admingui.common.handlers;
 

--- a/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/AsadminTest.java
+++ b/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/AsadminTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/AsadminTest.java
+++ b/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/AsadminTest.java
@@ -147,6 +147,10 @@ public abstract class AsadminTest {
         }
     }
 
+    protected static void assertWarning(CommandResult result) {
+        assertEquals(ExitStatus.WARNING, result.getExitStatus());
+    }
+
     protected static void assertContains(String expected, String actual) {
         assertThat(actual, CoreMatchers.containsString(expected));
     }

--- a/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/SetHazelcastConfigurationTest.java
+++ b/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/SetHazelcastConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -67,5 +67,16 @@ public class SetHazelcastConfigurationTest extends AsadminTest {
                 "--autoIncrementPort", "false");
         assertSuccess(result);
         assertFalse(config.getAutoIncrementPort());
+    }
+
+    @Test
+    public void dataGridEncryptionWarning() {
+        CommandResult result = asadmin("set-hazelcast-configuration",
+                "--encryptdatagrid", "true");
+        assertWarning(result);
+        assertContains("Could not find datagrid-key", result.getOutput());
+        result = asadmin("set-hazelcast-configuration",
+                "--encryptdatagrid", "false");
+        assertSuccess(result);
     }
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
@@ -46,6 +46,7 @@ import fish.payara.nucleus.hazelcast.HazelcastConfigSpecificConfiguration;
 import fish.payara.nucleus.hazelcast.HazelcastCore;
 import fish.payara.nucleus.hazelcast.HazelcastRuntimeConfiguration;
 import java.beans.PropertyVetoException;
+import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -392,6 +393,10 @@ public class SetHazelcastConfiguration implements AdminCommand, DeploymentTarget
                 }
             }
 
+            if (encryptDatagrid && server.isDas()) {
+                checkForDatagridKey(actionReport);
+            }
+
         }
 
     }
@@ -470,5 +475,14 @@ public class SetHazelcastConfiguration implements AdminCommand, DeploymentTarget
             result = target;
         }
         return result;
+    }
+
+    private void checkForDatagridKey(ActionReport actionReport) {
+        File datagridKey = new File(server.getConfigDirPath().getPath() + File.separator + "datagrid-key");
+        if (!datagridKey.exists()) {
+            actionReport.setActionExitCode(ActionReport.ExitCode.WARNING);
+            actionReport.appendMessage("Could not find datagrid-key in domain config directory. Please ensure" +
+                    " that you generate one before restarting the domain.");
+        }
     }
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
@@ -393,7 +393,7 @@ public class SetHazelcastConfiguration implements AdminCommand, DeploymentTarget
                 }
             }
 
-            if (encryptDatagrid && server.isDas()) {
+            if (encryptDatagrid != null && encryptDatagrid) {
                 checkForDatagridKey(actionReport);
             }
 


### PR DESCRIPTION
# Description
Prints a warning on the command line and in the admin console when enabling data grid encryption when a key can't be found.

# Testing

From a clean domain, simply run `set-hazelcast-configuration --encryptdatagrid true` and you should get a warning.
You should get a similar warning when attempting to do the same from the admin console: Domain > Data Grid.

### New tests
New asadmin test added to existing `SetHazelcastConfigurationTest` in payara-samples.
Checks that a warning is given when enabling datagrid encryption without generating a key.

# Notes for Reviewers
Touching such a fundamental method in the admin console (`updateEntity`) worries me a bit, as this can easily ripple outwards in unforeseen ways. I've poked around the admin console and haven't managed to make it throw a wobbly but I can't poke everything.
