### PR TITLE
APPSERV-70 Remove unnecessary test dependency

### DIFF
--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -142,11 +142,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.stream</groupId>
-            <artifactId>sjsxp</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
             <scope>test</scope>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -731,11 +731,6 @@ Parent is ${project.parent}</echo>
             </dependency>
 
             <dependency>
-                <groupId>com.sun.xml.stream</groupId>
-                <artifactId>sjsxp</artifactId>
-                <version>1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>antlr</groupId>
                 <artifactId>antlr</artifactId>
                 <version>${antlr.version}</version>


### PR DESCRIPTION
# Description
This is an improvement.
During our attempts to update this component to 1.0.2, it started throwing errors due to unsupported operations.
Upon further investigation I'm not convinced we need this dependency any more - it's only test scoped and the test works fine without it.

See related PR from Susan: https://github.com/payara/Payara/pull/4507

# Testing
Build Payara Server and don't skip tests - the relevant module is config-api.