### PR TITLE
CUSTCOM-223 Move log message into if block

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -172,7 +172,9 @@ public class HazelcastCore implements EventListener, ConfigListener {
         }
 
         datagridEncryptionValue = Boolean.parseBoolean(configuration.getDatagridEncryptionEnabled());
-        Logger.getLogger(HazelcastCore.class.getName()).log(Level.INFO, "Data grid encryption is enabled");
+        if (datagridEncryptionValue) {
+            Logger.getLogger(HazelcastCore.class.getName()).log(Level.INFO, "Data grid encryption is enabled");
+        }
     }
 
     /**


### PR DESCRIPTION
This is a bug fix

The message stating that encryption is enabled is printed regardless of whether or not it is actually enabled.