### PR TITLE
APPSERV-57 Updates to MicroProfile Fault Tolerance 2.1

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceConfig.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceConfig.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceConfig.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceConfig.java
@@ -188,6 +188,10 @@ public interface FaultToleranceConfig {
         return annotation.failOn();
     }
 
+    default Class<? extends Throwable>[] skipOn(CircuitBreaker annotation) {
+        return annotation.skipOn();
+    }
+
     default long delay(CircuitBreaker annotation) {
         return annotation.delay();
     }
@@ -245,5 +249,13 @@ public interface FaultToleranceConfig {
 
     default String fallbackMethod(Fallback annotation) {
         return annotation.fallbackMethod();
+    }
+
+    default Class<? extends Throwable>[] applyOn(Fallback annotation) {
+        return annotation.applyOn();
+    }
+
+    default Class<? extends Throwable>[] skipOn(Fallback annotation) {
+        return annotation.skipOn();
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMethodContext.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMethodContext.java
@@ -142,7 +142,7 @@ public interface FaultToleranceMethodContext {
      * @return the result returned by the invoked {@link FallbackHandler}
      * @throws Exception in case resolving, instantiating or invoking the handler method fails
      */
-    Object fallbackHandle(Class<? extends FallbackHandler<?>> fallbackClass, Exception ex)
+    Object fallbackHandle(Class<? extends FallbackHandler<?>> fallbackClass, Throwable ex)
             throws Exception;
 
     /**

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceService.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceService.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.faulttolerance;
 
+import javax.enterprise.context.control.RequestContextController;
 import javax.interceptor.InvocationContext;
 
 import fish.payara.microprofile.faulttolerance.policy.FaultTolerancePolicy;
@@ -69,9 +70,14 @@ public interface FaultToleranceService {
      * 
      * @param context represents the FT annotated method being called
      * @param policy  the policy being used for this execution
+     * @param requestContextController the controller to use or null
      * @return the {@link FaultToleranceMethodContext} to use to process the method invocation with FT semantics. This
      *         is a context specific to the target object and called method.
      */
-    FaultToleranceMethodContext getMethodContext(InvocationContext context, FaultTolerancePolicy policy);
+    FaultToleranceMethodContext getMethodContext(InvocationContext context, FaultTolerancePolicy policy,
+            RequestContextController requestContextController);
 
+    default FaultToleranceMethodContext getMethodContext(InvocationContext context, FaultTolerancePolicy policy) {
+        return getMethodContext(context, policy, null);
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/BulkheadPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/BulkheadPolicy.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/BulkheadPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/BulkheadPolicy.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.faulttolerance.policy;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
 
 import javax.interceptor.InvocationContext;
 
@@ -56,12 +57,14 @@ public final class BulkheadPolicy extends Policy {
 
     public final int value;
     public final int waitingTaskQueue;
+    public final boolean exitOnCompletion;
 
     public BulkheadPolicy(Method annotatedMethod, int value, int waitingTaskQueue) {
         checkAtLeast(1, annotatedMethod, Bulkhead.class, "value", value);
         checkAtLeast(0, annotatedMethod, Bulkhead.class, "waitingTaskQueue", waitingTaskQueue);
         this.value = value;
         this.waitingTaskQueue = waitingTaskQueue;
+        this.exitOnCompletion = annotatedMethod.getReturnType() == CompletionStage.class;
     }
 
     public static BulkheadPolicy create(InvocationContext context, FaultToleranceConfig config) {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerPolicy.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerPolicy.java
@@ -41,7 +41,6 @@ package fish.payara.microprofile.faulttolerance.policy;
 
 import java.lang.reflect.Method;
 import java.time.temporal.ChronoUnit;
-import java.util.logging.Logger;
 
 import javax.interceptor.InvocationContext;
 
@@ -56,23 +55,24 @@ import fish.payara.microprofile.faulttolerance.FaultToleranceConfig;
  */
 public final class CircuitBreakerPolicy extends Policy {
 
-    static final Logger logger = Logger.getLogger(CircuitBreakerPolicy.class.getName());
-
-    public final Class<? extends Throwable>[] failOn;
+    private final Class<? extends Throwable>[] failOn;
+    private final Class<? extends Throwable>[] skipOn;
     public final long delay;
     public final ChronoUnit delayUnit;
     public final int requestVolumeThreshold;
     public final double failureRatio;
     public final int successThreshold;
 
-    public CircuitBreakerPolicy(Method annotatedMethod, Class<? extends Throwable>[] failOn, long delay, ChronoUnit delayUnit,
-            int requestVolumeThreshold, double failureRatio, int successThreshold) {
+    public CircuitBreakerPolicy(Method annotatedMethod, Class<? extends Throwable>[] failOn,
+            Class<? extends Throwable>[] skipOn, long delay, ChronoUnit delayUnit, int requestVolumeThreshold,
+            double failureRatio, int successThreshold) {
         checkAtLeast(0, annotatedMethod, CircuitBreaker.class, "delay", delay);
         checkAtLeast(1, annotatedMethod, CircuitBreaker.class, "requestVolumeThreshold", requestVolumeThreshold);
         checkAtLeast(0d, annotatedMethod, CircuitBreaker.class, "failureRatio", failureRatio);
         checkAtMost(1.0d, annotatedMethod, CircuitBreaker.class, "failureRatio", failureRatio);
         checkAtLeast(1, annotatedMethod, CircuitBreaker.class, "successThreshold", successThreshold);
         this.failOn = failOn;
+        this.skipOn = skipOn;
         this.delay = delay;
         this.delayUnit = delayUnit;
         this.requestVolumeThreshold = requestVolumeThreshold;
@@ -85,6 +85,7 @@ public final class CircuitBreakerPolicy extends Policy {
             CircuitBreaker annotation = config.getAnnotation(CircuitBreaker.class);
             return new CircuitBreakerPolicy(context.getMethod(),
                     config.failOn(annotation),
+                    config.skipOn(annotation),
                     config.delay(annotation),
                     config.delayUnit(annotation),
                     config.requestVolumeThreshold(annotation),
@@ -95,12 +96,23 @@ public final class CircuitBreakerPolicy extends Policy {
     }
 
     /**
-     * Helper method that checks whether or not the given exception is included in the failOn parameter.
+     * Helper method that checks whether or not the given exception is considered a success or failure.
+     * 
+     * Relevant part from the {@link CircuitBreaker} documentation:
+     * <blockquote>
+     * When a method returns a result, the following rules are applied to determine whether the result is a success or a failure:
+     * <ul>
+     * <li>If the method does not throw a {@link Throwable}, it is considered a success
+     * <li>Otherwise, if the thrown object is assignable to any value in the {@link #skipOn()} parameter, is is considered a success
+     * <li>Otherwise, if the thrown object is assignable to any value in the {@link #failOn()} parameter, it is considered a failure
+     * <li>Otherwise it is considered a success
+     * </ul>
+     * </blockquote>
      * 
      * @param ex The exception to check
-     * @return True if the exception is covered by {@link #failOn} list of this policy
+     * @return True if the exception is considered a failure, false if it is considered a success (anyway).
      */
-    public boolean failOn(Exception ex) {
-        return Policy.isCaught(ex, failOn);
+    public boolean isFailure(Throwable ex) {
+        return !Policy.isCaught(ex, skipOn) && Policy.isCaught(ex, failOn);
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerPolicy.java
@@ -110,7 +110,7 @@ public final class CircuitBreakerPolicy extends Policy {
      * </blockquote>
      * 
      * @param ex The exception to check
-     * @return True if the exception is considered a failure, false if it is considered a success (anyway).
+     * @return True if the exception is considered a failure, false if it is considered a success.
      */
     public boolean isFailure(Throwable ex) {
         return !Policy.isCaught(ex, skipOn) && Policy.isCaught(ex, failOn);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FallbackPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FallbackPolicy.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FallbackPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FallbackPolicy.java
@@ -62,8 +62,16 @@ public final class FallbackPolicy extends Policy {
     public final Class<? extends FallbackHandler<?>> value;
     public final String fallbackMethod;
     public final Method method;
+    private final Class<? extends Throwable>[] applyOn;
+    private final Class<? extends Throwable>[] skipOn;
 
+    @SuppressWarnings("unchecked")
     public FallbackPolicy(Method annotated, Class<? extends FallbackHandler<?>> value, String fallbackMethod) {
+        this(annotated, value, fallbackMethod, new Class[] { Throwable.class }, new Class[0]);
+    }
+
+    public FallbackPolicy(Method annotated, Class<? extends FallbackHandler<?>> value, String fallbackMethod,
+            Class<? extends Throwable>[] applyOn, Class<? extends Throwable>[] skipOn) {
         checkUnambiguous(annotated, value, fallbackMethod);
         this.value = value;
         this.fallbackMethod = fallbackMethod;
@@ -81,6 +89,8 @@ public final class FallbackPolicy extends Policy {
         if (isHandlerPresent()) {
             checkReturnsSameAs(annotated, Fallback.class, "value", value, "handle", ExecutionContext.class);
         }
+        this.applyOn = applyOn;
+        this.skipOn = skipOn;
     }
 
     public static FallbackPolicy create(InvocationContext context, FaultToleranceConfig config) {
@@ -88,7 +98,9 @@ public final class FallbackPolicy extends Policy {
             Fallback annotation = config.getAnnotation(Fallback.class);
             return new FallbackPolicy(context.getMethod(),
                     config.value(annotation),
-                    config.fallbackMethod(annotation));
+                    config.fallbackMethod(annotation),
+                    config.applyOn(annotation),
+                    config.skipOn(annotation));
         }
         return null;
     }
@@ -117,4 +129,25 @@ public final class FallbackPolicy extends Policy {
         return value != null && value != Fallback.DEFAULT.class;
     }
 
+    /**
+     * Helper method that checks whether or not the given exception is should trigger applying the fallback or not.
+     * 
+     * Relevant section from {@link Fallback} javadocs:
+     * <blockquote>
+     * When a method returns and the Fallback policy is present, the following rules are applied:
+     * <ol>
+     * <li>If the method returns normally (doesn't throw), the result is simply returned.
+     * <li>Otherwise, if the thrown object is assignable to any value in the {@link #skipOn()} parameter, the thrown object will be rethrown.
+     * <li>Otherwise, if the thrown object is assignable to any value in the {@link #applyOn()} parameter, 
+     * the Fallback policy, detailed above, will be applied.
+     * <li>Otherwise the thrown object will be rethrown.
+     * </ol>
+     * </blockquote>
+     * 
+     * @param ex The exception to check
+     * @return true, when fallback should be applied, false to rethrow the exception
+     */
+    public boolean isFallbackApplied(Throwable ex) {
+        return !Policy.isCaught(ex, skipOn) && Policy.isCaught(ex, applyOn);
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FaultTolerancePolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FaultTolerancePolicy.java
@@ -605,7 +605,7 @@ public final class FaultTolerancePolicy implements Serializable {
                         if (!exitOnCompletion) {
                             return res;
                         }
-                        return ((CompletionStage<?>) res).whenComplete((value, excetion) -> {
+                        return ((CompletionStage<?>) res).whenComplete((value, exception) -> {
                             invocation.metrics.addBulkheadExecutionDuration(Math.max(1, System.nanoTime() - executionSince));
                             // successful or not, we are out...
                             running.remove(currentThread);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FaultTolerancePolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/FaultTolerancePolicy.java
@@ -265,9 +265,9 @@ public final class FaultTolerancePolicy implements Serializable {
         try {
             metrics.incrementInvocationsTotal();
             return processAsynchronousStage(ftmContext, metrics);
-        } catch (Exception e) {
+        } catch (Exception | Error ex) {
             metrics.incrementInvocationsFailedTotal();
-            throw e;
+            throw ex;
         }
     }
 
@@ -328,7 +328,10 @@ public final class FaultTolerancePolicy implements Serializable {
         invocation.trace("executeFallbackMethod");
         try {
             return processRetryStage(invocation);
-        } catch (Exception ex) {
+        } catch (Exception | Error ex) {
+            if (!fallback.isFallbackApplied(ex)) {
+                throw ex;
+            }
             invocation.metrics.incrementFallbackCallsTotal();
             if (fallback.isHandlerPresent()) {
                 logger.log(Level.FINE, "Using fallback class: {0}", fallback.value.getName());
@@ -368,9 +371,12 @@ public final class FaultTolerancePolicy implements Serializable {
                     invocation.metrics.incrementRetryCallsSucceededRetriedTotal();
                 }
                 return resultValue;
-            } catch (Exception ex) {
+            } catch (Exception | Error ex) {
                 boolean timedOut = retryTimeoutTime != null && System.currentTimeMillis() >= retryTimeoutTime;
-                if (attemptsLeft <= 0 || !retry.retryOn(ex) || timedOut) {
+                if (!timedOut && !retry.retryOn(ex)) {
+                    throw ex; // counts as "success"
+                }
+                if (timedOut || attemptsLeft <= 0) {
                     logger.log(Level.FINE, "Retry attemp failed. Giving up{0}", timedOut ? " due to time-out." : ".");
                     invocation.metrics.incrementRetryCallsFailedTotal();
                     throw ex;
@@ -394,17 +400,29 @@ public final class FaultTolerancePolicy implements Serializable {
             invocation.timeoutIfConcludedConcurrently();
             return asyncAttempt;
         } catch (ExecutionException ex) { // this ExecutionException is from calling get() above in case completed exceptionally
-            if (ex.getCause() instanceof ExecutionException) { 
+            Throwable cause = ex.getCause();
+            if (cause instanceof ExecutionException) { 
                 // this cause ExecutionException is caused by annotated method returned a Future that completed exceptionally
                 if (asynchronous.isSuccessWhenCompletedExceptionally()) {
                     CompletableFuture<Object> exceptionalResult = new CompletableFuture<>();
-                    exceptionalResult.completeExceptionally(ex.getCause().getCause()); // unwrap
+                    exceptionalResult.completeExceptionally(cause.getCause()); // unwrap
                     return exceptionalResult;
                 }
-                throw (Exception) ex.getCause().getCause(); // for retry handling return plain cause
+                rethrow(cause.getCause()); // for retry handling return plain cause
             }
-            throw (Exception) ex.getCause();
+            rethrow(cause);
+            return null; // not reachable
         }
+    }
+
+    private static void rethrow(Throwable t) throws Exception {
+        if (t instanceof Exception) {
+            throw (Exception)t;
+        }
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        throw new ExecutionException(t);
     }
 
     /**
@@ -432,9 +450,9 @@ public final class FaultTolerancePolicy implements Serializable {
             logger.log(Level.FINER, "Proceeding half open CircuitBreaker context");
             try {
                 resultValue = processTimeoutStage(invocation, asyncAttempt);
-            } catch (Exception ex) {
+            } catch (Exception | Error ex) {
                 invocation.metrics.incrementCircuitbreakerCallsFailedTotal();
-                if (circuitBreaker.failOn(ex)) {
+                if (circuitBreaker.isFailure(ex)) {
                     logger.log(Level.FINE, "Exception causes CircuitBreaker to transit: half-open => open");
                     openCircuit(invocation, state);
                 }
@@ -447,15 +465,16 @@ public final class FaultTolerancePolicy implements Serializable {
             return resultValue;
         case CLOSED:
             logger.log(Level.FINER, "Proceeding closed CircuitBreaker context");
-            Exception failedOn = null;
+            Throwable failedOn = null;
             try {
                 resultValue = processTimeoutStage(invocation, asyncAttempt);
                 state.recordClosedOutcome(true);
-            } catch (Exception ex) {
-                if (circuitBreaker.failOn(ex)) {
+            } catch (Exception | Error ex) {
+                if (circuitBreaker.isFailure(ex)) {
                     state.recordClosedOutcome(false);
                     invocation.metrics.incrementCircuitbreakerCallsFailedTotal();
                 } else {
+                    state.recordClosedOutcome(true);
                     invocation.metrics.incrementCircuitbreakerCallsSucceededTotal();
                 }
                 failedOn = ex;
@@ -465,7 +484,7 @@ public final class FaultTolerancePolicy implements Serializable {
                 openCircuit(invocation, state);
             }
             if (failedOn != null) {
-                throw failedOn;
+                rethrow(failedOn);
             }
             invocation.metrics.incrementCircuitbreakerCallsSucceededTotal();
             return resultValue;
@@ -518,7 +537,7 @@ public final class FaultTolerancePolicy implements Serializable {
         } catch (TimeoutException ex) {
             logger.log(Level.FINE, "Execution timed out.");
             throw ex;
-        } catch (Exception ex) {
+        } catch (Exception | Error ex) {
             if (timedOut.get() || System.currentTimeMillis() > timeoutTime) {
                 logger.log(Level.FINE, "Execution timed out.");
                 throw new TimeoutException(ex);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/Policy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/Policy.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/Policy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/Policy.java
@@ -43,6 +43,7 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
@@ -52,6 +53,8 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
  * @author Jan Bernitt
  */
 public abstract class Policy implements Serializable {
+
+    private static final Logger logger = Logger.getLogger(Policy.class.getName());
 
     public static void checkAtLeast(long minimum, Method annotatedMethod, Class<? extends Annotation> annotationType,
             String attribute, long value) {
@@ -114,7 +117,7 @@ public abstract class Policy implements Serializable {
         return "value".equals(attribute) ? "" : attribute + " ";
     }
 
-    public static boolean isCaught(Exception ex, Class<? extends Throwable>[] caught) {
+    public static boolean isCaught(Throwable ex, Class<? extends Throwable>[] caught) {
         if (caught.length == 0) {
             return false;
         }
@@ -122,13 +125,14 @@ public abstract class Policy implements Serializable {
             return true;
         }
         for (Class<? extends Throwable> caughtType : caught) {
-            if (ex.getClass() == caughtType) {
-                CircuitBreakerPolicy.logger.log(Level.FINER, "Exception {0} matches a Throwable", ex.getClass().getSimpleName());
+            Class<? extends Throwable> errorType = ex.getClass();
+            if (errorType == caughtType) {
+                logger.log(Level.FINER, "Exception {0} matches a Throwable", errorType.getSimpleName());
                 return true;
             }
-            if (caughtType.isAssignableFrom(ex.getClass())) {
-                CircuitBreakerPolicy.logger.log(Level.FINER, "Exception {0} is a child of a Throwable: {1}",
-                        new String[] { ex.getClass().getSimpleName(), caughtType.getSimpleName() });
+            if (caughtType.isAssignableFrom(errorType)) {
+                logger.log(Level.FINER, "Exception {0} is a child of a Throwable: {1}",
+                        new String[] { errorType.getSimpleName(), caughtType.getSimpleName() });
                 return true;
             }
         }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/RetryPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/RetryPolicy.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/RetryPolicy.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/policy/RetryPolicy.java
@@ -113,8 +113,25 @@ public final class RetryPolicy extends Policy {
         return this != NONE;
     }
 
-    public boolean retryOn(Exception ex) {
-        return isCaught(ex, retryOn) && !isCaught(ex, abortOn);
+    /**
+     * Should a retry occur then the given {@link Throwable} is thrown?
+     *
+     * Relevant section from {@link Retry} javadocs:
+     * <blockquote>
+     * When a method returns and the retry policy is present, the following rules are applied:
+     * <ol>
+     * <li>If the method returns normally (doesn't throw), the result is simply returned.
+     * <li>Otherwise, if the thrown object is assignable to any value in the {@link #abortOn()} parameter, the thrown object is rethrown.
+     * <li>Otherwise, if the thrown object is assignable to any value in the {@link #retryOn()} parameter, the method call is retried.
+     * <li>Otherwise the thrown object is rethrown.
+     * </ol>
+     * </blockquote>
+     * 
+     * @param ex an {@link Error} or an {@link Exception}
+     * @return true, if a retry should occur, else false.
+     */
+    public boolean retryOn(Throwable ex) {
+        return !isCaught(ex, abortOn) && isCaught(ex, retryOn);
     }
 
     public Long timeoutTimeNow() {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/BindableFaultToleranceConfig.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/BindableFaultToleranceConfig.java
@@ -241,6 +241,11 @@ final class BindableFaultToleranceConfig implements FaultToleranceConfig {
     }
 
     @Override
+    public Class<? extends Throwable>[] skipOn(CircuitBreaker annotation) {
+        return getClassArrayValue(CircuitBreaker.class, "skipOn", annotation.skipOn());
+    }
+
+    @Override
     public long delay(CircuitBreaker annotation) {
         return longValue(CircuitBreaker.class, "delay", annotation.delay());
     }
@@ -319,6 +324,16 @@ final class BindableFaultToleranceConfig implements FaultToleranceConfig {
     @Override
     public String fallbackMethod(Fallback annotation) {
         return value(Fallback.class, "fallbackMethod", String.class, annotation.fallbackMethod());
+    }
+
+    @Override
+    public Class<? extends Throwable>[] applyOn(Fallback annotation) {
+        return getClassArrayValue(Fallback.class, "applyOn", annotation.applyOn());
+    }
+
+    @Override
+    public Class<? extends Throwable>[] skipOn(Fallback annotation) {
+        return getClassArrayValue(Fallback.class, "skipOn", annotation.skipOn());
     }
 
 

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceUtils.java
@@ -230,7 +230,7 @@ public class FaultToleranceUtils {
             // Remove any curly or square brackets from the string, as well as any spaces and ".class"es
             for (String className : classNames.replaceAll("[\\{\\[ \\]\\}]", "").replaceAll("\\.class", "")
                     .split(",")) {
-                classList.add(Class.forName(className));
+                classList.add(Class.forName(className, false, Thread.currentThread().getContextClassLoader()));
             }
             return classList.toArray(defaultValue);
         } catch (ClassNotFoundException cnfe) {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractBulkheadTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractBulkheadTest.java
@@ -358,6 +358,27 @@ abstract class AbstractBulkheadTest {
         }
     }
 
+    CompletionStage<String> bodyReturnThenWaitOnCompletionWithSuccess(Future<Void> waiter) {
+        return bodyReturnThenWaitOnCompletion(waiter, () -> "Success");
+    }
+
+    <T> CompletionStage<T> bodyReturnThenWaitOnCompletion(Future<Void> waiter, Supplier<T> result) {
+        Thread currentThread = Thread.currentThread();
+        try {
+            threadsEntered.add(currentThread);
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    waiter.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw null;
+                }
+                return result.get();
+            });
+        } finally {
+            threadsExited.add(currentThread);
+        }
+    }
+
     void assertFurtherThreadThrowsBulkheadException() {
         int attemptCount = 10;
         Method annotatedMethod = TestUtils.getAnnotatedMethod();

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractBulkheadTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractBulkheadTest.java
@@ -333,7 +333,7 @@ abstract class AbstractBulkheadTest {
         return policy.proceed(context, () -> service.getMethodContext(context, policy));
     }
 
-    CompletionStage<String> bodyWaitThenReturnSuccess(Future<Void> waiter) throws Exception {
+    CompletableFuture<String> bodyWaitThenReturnSuccess(Future<Void> waiter) throws Exception {
         return bodyWaitThenReturn(waiter, () -> CompletableFuture.completedFuture("Success"));
     }
 

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadBasicTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadBasicTest.java
@@ -179,7 +179,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
 
     @Asynchronous
     @Bulkhead(value = 2, waitingTaskQueue = 2)
-    public CompletionStage<String> bulkheadWithQueueInterruptQueueing_Method(Future<Void> waiter) throws Exception {
+    public Future<String> bulkheadWithQueueInterruptQueueing_Method(Future<Void> waiter) throws Exception {
         return bodyWaitThenReturnSuccess(waiter);
     }
 
@@ -217,7 +217,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
 
     @Asynchronous
     @Bulkhead(value = 2, waitingTaskQueue = 2)
-    public CompletionStage<String> bulkheadWithQueueInterruptExecuting_Method(Future<Void> waiter) throws Exception {
+    public Future<String> bulkheadWithQueueInterruptExecuting_Method(Future<Void> waiter) throws Exception {
         return bodyWaitThenReturnSuccess(waiter);
     }
 
@@ -249,7 +249,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
 
     @Asynchronous
     @Bulkhead(value = 2, waitingTaskQueue = 2)
-    public CompletionStage<String> bulkheadWithQueueCompleteWithException_Method(Future<Void> waiter) throws Exception {
+    public Future<String> bulkheadWithQueueCompleteWithException_Method(Future<Void> waiter) throws Exception {
         if (waiter == this.commonWaiter)
             return bodyWaitThenReturnSuccess(waiter);
         return bodyWaitThenReturn(waiter, () -> {
@@ -287,7 +287,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
 
     @Asynchronous
     @Bulkhead(value = 2, waitingTaskQueue = 2)
-    public CompletionStage<String> bulkheadWithQueueThrowsException_Method(Future<Void> waiter) throws Exception {
+    public Future<String> bulkheadWithQueueThrowsException_Method(Future<Void> waiter) throws Exception {
         if (waiter == this.commonWaiter) {
             return bodyWaitThenReturnSuccess(waiter);
         }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceMethodContextStub.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceMethodContextStub.java
@@ -137,8 +137,7 @@ public class FaultToleranceMethodContextStub implements FaultToleranceMethodCont
     }
 
     @Override
-    public Object fallbackHandle(Class<? extends FallbackHandler<?>> fallbackClass,
-            Exception ex) throws Exception {
+    public Object fallbackHandle(Class<? extends FallbackHandler<?>> fallbackClass, Throwable ex) throws Exception {
         return fallbackClass.newInstance()
                 .handle(new FaultToleranceExecutionContext(context.getMethod(), context.getParameters(), ex));
     }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceStub.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceStub.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.enterprise.context.control.RequestContextController;
 import javax.interceptor.InvocationContext;
 
 import fish.payara.microprofile.faulttolerance.FaultToleranceConfig;
@@ -77,7 +78,8 @@ public class FaultToleranceServiceStub implements FaultToleranceService {
     }
 
     @Override
-    public FaultToleranceMethodContext getMethodContext(InvocationContext context, FaultTolerancePolicy policy) {
+    public FaultToleranceMethodContext getMethodContext(InvocationContext context, FaultTolerancePolicy policy,
+            RequestContextController requestContextController) {
         return new FaultToleranceMethodContextStub(context, state, concurrentExecutions, waitingQueuePopulation);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
         <microprofile-config.version>1.3</microprofile-config.version>
         <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
-        <microprofile-fault-tolerance.version>2.0.1</microprofile-fault-tolerance.version>
+        <microprofile-fault-tolerance.version>2.1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
         <microprofile-healthcheck.version>2.1</microprofile-healthcheck.version>
         <microprofile-metrics.version>2.2.payara-p1</microprofile-metrics.version>


### PR DESCRIPTION
### Summary
A good summary on the spec changes can be found https://download.eclipse.org/microprofile/microprofile-fault-tolerance-2.1/microprofile-fault-tolerance-spec.html#release_notes_21

Changes for Payara FT:
* adds of new exception handling properties to `@Fallback` (`applyOn` and `skipOn`) and `@CircuitBreaker` (`skipOn`)
* adds: CDI `@RequestScope` context is now activated for worker threads working `@Asynchronous` computation
* adds: `@Bulkhead` and `@Asynchronous` annotated methods returning `CompletionStage` now semantically exit the bulkhead when they complete (not when the annotated method returns a value).
* fixes: exception handling corrected to handle both `Exception` and `Error` (missed `Error` before which wasn't spec compliant before but went unnoticed until 2.1 that clarified exception behaviour)
* fixes: `Class` name overrides via configuration now use context `ClassLoader` (failed to load application specific classes before)

### Testing
Adds additional unit test for the new bulkhead semantics where the bulkhead context is exited on completion of the returned `CompletionStage`.

#### Tests Performed
Running TCK 2.1 (needs https://github.com/payara/MicroProfile-TCK-Runners/pull/102) against locally running server:
```bash
cd MicroProfile-Fault-Tolerance/tck-runner
mvn clean install "-Ppayara-server-remote" "-Dpayara.version=5.202"
``` 
The important part is that the TCK runner prints API and TCK version 2.1 as shown below:
```bash
     [echo] FT version     2.1
     [echo] FT TCK version 2.1
     [echo] FT suite       tck-suite2.1-stable.xml
```