### PR TITLE
CLOUD-13 Prevent Hazelcast from being started twice on Payara Micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -76,7 +76,7 @@ Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
         <config name="server-config">
             <payara-executor-service-configuration />
             <cdi-service enable-concurrent-deployment="true" pre-loader-thread-pool-size="2"></cdi-service>
-            <hazelcast-config-specific-configuration enabled="true"></hazelcast-config-specific-configuration>
+            <hazelcast-config-specific-configuration enabled="false"></hazelcast-config-specific-configuration>
             <health-check-service-configuration enabled="false">
                 <log-notifier enabled="true" />
                 <eventbus-notifier enabled="false" />

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -259,7 +259,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     /**
      * Gets the cluster group
      *
-     * @return The Multicast Group that will beused for the Hazelcast clustering
+     * @return The Multicast Group that will be used for the Hazelcast clustering
      */
     @Override
     public String getClusterMulticastGroup() {


### PR DESCRIPTION
# Description
This is a bug fix

As PayaraMicroImpl#L1060 will start Hazelcast whatever, having it
enabled in the domain.xml means that Hazelcast will be started earlier
then restarted when the bootstrap says to enable Hazelcast.

# Testing
### Testing Performed
Start Payara Micro, check the Hazelcast has only been started once.
Tested with reproducer from https://github.com/payara/Payara/pull/4457

### Test Suites Run
 - JavaEE7-Samples
 - JavaEE8-Samples

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.2

# Reviewer notes

This is the same as #4394, which now has a merge conflict.