### PR TITLE
CLOUD-13 Remove command that restarts Hazelcast, so it is only started once

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1057,11 +1057,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             postBootCommands.executeCommands(gf.getCommandRunner());
             this.runtime = new PayaraMicroRuntimeImpl(gf, gfruntime);
 
-            // Enable hazelcast
-            if (!noCluster) {
-                gf.getCommandRunner().run("set-hazelcast-configuration", "--enabled", "true", "--dynamic", "true", "--target", "server-config", "--hostawarepartitioning", Boolean.toString(hostAware), "--lite", Boolean.toString(liteMember));
-            }
-
             // deploy all applications and then initialize them
             deployAll();
             // These steps are separated in case any steps need to be done in between


### PR DESCRIPTION
# Description
This is a bug fix.

This removed the command that will restart Hazelcast, as it is already started during boot.

# Important Info
Alternative to #4576 

# Testing

### Testing Performed
Start Payara Micro, check the Hazelcast has only been started once.
Tested with reproducer from #4457

### Test suites executed
- Java EE7 Samples
- Java EE8 Samples

### Testing Environment
Zulu JDK 1.8_232 on Ubuntu 19.10 with Maven 3.6.2

# Notes for Reviewers
<!-- Please give notes for any reviewers. The code should explain itself, but where should they start? Do you want feedback on anything specific? -->
<!-- Have you tagged any appropriate reviewers?-->
