### PR TITLE
SERV-25 Document JDBCRealm encoding property

### DIFF
--- a/appserver/admingui/common/src/main/help/en/help/ref-editjdbcrealm.html
+++ b/appserver/admingui/common/src/main/help/en/help/ref-editjdbcrealm.html
@@ -15,7 +15,7 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-
+<!-- Portions Copyright [2020] [Payara Foundation and/or its affiliates] -->
 <p><a id="ref-editjdbcrealm" name="ref-editjdbcrealm"></a><a id="GHCOM00102" name="GHCOM00102"></a></p>
 
 <h4><a id="sthref204" name="sthref204"></a><a id="sthref205" name="sthref205"></a>Properties Specific to the <code>JDBCRealm</code> Class</h4>
@@ -98,7 +98,8 @@ asadmin&gt; <b>get server.security-service.property.default-digest-algorithm</b>
 </dd>
 <dt>Encoding</dt>
 <dd>
-<p>The encoding. Allowed values are <code>Hex</code> and <code>Base64</code>. If <code>digest-algorithm</code> is specified, the default is <code>Hex</code>. If <code>digest-algorithm</code> is not specified, by default no encoding is specified.</p>
+<p>The encoding. Allowed values are <code>Hex</code>, <code>Base64</code> and <code>Hashed</code>. If <code>digest-algorithm</code> is specified, the default is <code>Hex</code>. If <code>digest-algorithm</code> is not specified, by default no encoding is specified.</p>
+<p>If the encoding is <code>Hashed</code>, passwords in the database are assumed to be in format MD5(username:realm:password).</p>
 </dd>
 <dt>Charset</dt>
 <dd>

--- a/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-auth-realm.html
+++ b/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-auth-realm.html
@@ -17,7 +17,7 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-<!-- Portions Copyright [2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2019-2020] [Payara Foundation and/or its affiliates] -->
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
@@ -340,10 +340,13 @@ algorithm.</p>
 <dl>
 <dt class="hdlist1"><code>encoding</code></dt>
 <dd>
-<p>(Optional) Specifies the encoding. Allowed values are <code>Hex</code> and
-<code>Base64</code>. If digest-algorithm is specified, the default is <code>Hex</code>. If
-<code>digest-algorithm</code> is not specified, by default no encoding is
-specified.</p>
+<p>
+	(Optional) Specifies the encoding. Default allowed values are <code>Hex</code> and
+	<code>Base64</code>, although the specific realm class may allow other values.
+	If digest-algorithm is specified, the default is <code>Hex</code>. If
+	<code>digest-algorithm</code> is not specified, by default no encoding is
+	specified.
+</p>
 </dd>
 <dt class="hdlist1"><code>charset</code></dt>
 <dd>


### PR DESCRIPTION
Based off https://stackoverflow.com/questions/48247919/how-to-configure-payara-jdbcrealm-jdbcdigestrealm-to-store-passwords-in-httpd-st