### PR TITLE
CUSTCOM-194 The delete-jvm-options command shouldn't require to specify the Java version prefix

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/DeleteJvmOptions.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/DeleteJvmOptions.java
@@ -48,6 +48,7 @@ import com.sun.enterprise.universal.xml.MiniXmlParser.JvmOption;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.i18n.StringManager;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -158,12 +159,22 @@ public final class DeleteJvmOptions implements AdminCommand, AdminCommandSecurit
     }
     */
     //@ForTimeBeing :)
-    private void deleteX(final JvmOptionBag bag, final List<String> toRemove, final ActionReport.MessagePart part) throws Exception {
+    private void deleteX(final JvmOptionBag bag, final List<String> toRemoveOptions, final ActionReport.MessagePart part) throws Exception {
         SingleConfigCode<JvmOptionBag> scc = (JvmOptionBag bag1) -> {
             List<String> jvmopts = new ArrayList<>(bag1.getJvmRawOptions());
             int orig = jvmopts.size();
-            // using new JvmOption(option).toString() (instead op option directly) to make sure the correct formatting is applied.
-            boolean removed = jvmopts.removeIf(option -> toRemove.contains(new JvmOption(option).toString()));
+            boolean removed = false;
+            Iterator<String> iter = jvmopts.iterator();
+            for (String toRemoveOption : toRemoveOptions) {
+                String option = new JvmOption(toRemoveOption).option;
+                while (iter.hasNext()) {
+                    if (new JvmOption(iter.next()).option.equals(option)) {
+                        iter.remove();
+                        removed = true;
+                    }
+                }
+            }
+   
             bag1.setJvmOptions(jvmopts);
             int now = jvmopts.size();
             if (removed) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/DeleteJvmOptions.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/DeleteJvmOptions.java
@@ -164,9 +164,10 @@ public final class DeleteJvmOptions implements AdminCommand, AdminCommandSecurit
             List<String> jvmopts = new ArrayList<>(bag1.getJvmRawOptions());
             int orig = jvmopts.size();
             boolean removed = false;
-            Iterator<String> iter = jvmopts.iterator();
+            Iterator<String> iter;  
             for (String toRemoveOption : toRemoveOptions) {
                 String option = new JvmOption(toRemoveOption).option;
+                iter = jvmopts.iterator();
                 while (iter.hasNext()) {
                     if (new JvmOption(iter.next()).option.equals(option)) {
                         iter.remove();


### PR DESCRIPTION
# Description
This is a bug fix to fix an issue where the `delete-jvm-options` command required the specify Java version prefix to execute successfully. 

# Testing

### New tests
None

### Testing Performed
Build test
Manually tested the `delete-jvm-options` command with and without the Java version prefix with the following commands: 
-  `./asadmin delete-jvm-options '[Azul-1.8.0u222|1.8.0u500]-XX\:+UseOpenJSSE'` 
-  `./asadmin delete-jvm-options '-XX\:+UseOpenJSSE'` 

### Testing Environment

# Documentation
Not required
