### PR TITLE
CUSTCOM-130 Better compatibility of docker images

### DIFF
--- a/appserver/extras/docker-images/basic/pom.xml
+++ b/appserver/extras/docker-images/basic/pom.xml
@@ -6,20 +6,13 @@
         <artifactId>docker-images</artifactId>
         <version>5.202-SNAPSHOT</version>
     </parent>
-    <artifactId>micro-docker-image</artifactId>
+    <artifactId>basic-docker-image</artifactId>
     <packaging>pom</packaging>
-    <name>Payara Docker Images - Micro</name>
+    <name>Payara Docker Images - Basic Image</name>
 
     <properties>
-        <docker.payara.repository>payara/micro</docker.payara.repository>
-        <docker.java.repository>azul/zulu-openjdk-alpine</docker.java.repository>
+        <docker.noCache>false</docker.noCache>
+        <docker.payara.repository>payara/basic</docker.payara.repository>
+        <docker.keyserver.url>hkp://ipv4.pool.sks-keyservers.net</docker.keyserver.url>
     </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>fish.payara.extras</groupId>
-            <artifactId>payara-micro</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/appserver/extras/docker-images/basic/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/basic/src/main/docker/Dockerfile
@@ -1,0 +1,42 @@
+FROM @docker.java.image@
+
+ENV HOME_DIR=/opt/payara
+ENV PAYARA_DIR=${HOME_DIR}/appserver \
+    SCRIPT_DIR=${HOME_DIR}/scripts \
+    CONFIG_DIR=${HOME_DIR}/config \
+    DEPLOY_DIR=${HOME_DIR}/deployments \
+    PASSWORD_FILE=${HOME_DIR}/passwordFile \
+    ADMIN_USER=admin \
+    ADMIN_PASSWORD=admin \
+    JVM_ARGS="" \
+    MEM_MAX_RAM_PERCENTAGE="70.0" \
+    MEM_XSS="512k"
+ENV PATH="${PATH}:${PAYARA_DIR}/bin"
+
+ARG TINI_VERSION=v0.18.0
+
+# Download tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /
+
+RUN true \
+    && apt-get update \
+    && apt-get install -y gpg \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p ${HOME_DIR} \
+    && addgroup --gid 1000 payara \
+    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
+    && echo payara:payara | chpasswd \
+    && mkdir -p ${PAYARA_DIR} \
+    && mkdir -p ${DEPLOY_DIR} \
+    && mkdir -p ${CONFIG_DIR} \
+    && mkdir -p ${SCRIPT_DIR} \
+    && chown -R payara:payara ${HOME_DIR} \
+    # Verify tini
+    && gpg --verbose --keyserver @docker.keyserver.url@ --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+    && gpg --verify /tini.asc \
+    && chmod +x /tini \
+    && true
+
+USER payara
+WORKDIR ${HOME_DIR}

--- a/appserver/extras/docker-images/basic/src/main/docker/assembly.xml
+++ b/appserver/extras/docker-images/basic/src/main/docker/assembly.xml
@@ -1,0 +1,50 @@
+<!--
+  ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~    The contents of this file are subject to the terms of either the GNU
+  ~    General Public License Version 2 only ("GPL") or the Common Development
+  ~    and Distribution License("CDDL") (collectively, the "License").  You
+  ~    may not use this file except in compliance with the License.  You can
+  ~    obtain a copy of the License at
+  ~    https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~    See the License for the specific
+  ~    language governing permissions and limitations under the License.
+  ~
+  ~    When distributing the software, include this License Header Notice in each
+  ~    file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~    GPL Classpath Exception:
+  ~    The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~    file that accompanied this code.
+  ~
+  ~    Modifications:
+  ~    If applicable, add the following below the License Header, with the fields
+  ~    enclosed by brackets [] replaced by your own identifying information:
+  ~    "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~    Contributor(s):
+  ~    If you wish your version of this file to be governed by only the CDDL or
+  ~    only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~    elects to include this software in this distribution under the [CDDL or GPL
+  ~    Version 2] license."  If you don't indicate a single choice of license, a
+  ~    recipient has the option to distribute your version of this file under
+  ~    either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~    its licensees as provided above.  However, if you add GPL Version 2 code
+  ~    and therefore, elected the GPL Version 2 license, then the option applies
+  ~    only if the new code is made subject to such option by the copyright
+  ~    holder.
+  -->
+
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <fileSets>
+        <fileSet>
+            <directory>src/main/docker/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -29,4 +29,5 @@ WORKDIR ${HOME_DIR}
 COPY --chown=payara:payara maven/artifacts/payara-micro.jar .
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 
-ENTRYPOINT "${SCRIPT_DIR}/entrypoint.sh"
+ENTRYPOINT ["/bin/sh", "entrypoint.sh"]
+CMD ["--deploymentDir","/opt/payara/deployments"]

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -26,8 +26,8 @@ RUN true \
 USER payara
 WORKDIR ${HOME_DIR}
 
-COPY --chown=payara:payara maven/artifacts/payara-micro.jar .
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
+COPY --chown=payara:payara maven/artifacts/payara-micro.jar .
 
 ENTRYPOINT ["/bin/sh", "entrypoint.sh"]
 CMD ["--deploymentDir","/opt/payara/deployments"]

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -8,6 +8,7 @@ EXPOSE 6900 8080
 ENV PAYARA_HOME=/opt/payara
 ENV HOME_DIR=${PAYARA_HOME}
 ENV PAYARA_DIR=${HOME_DIR} \
+    SCRIPT_DIR=${HOME_DIR} \
     DEPLOY_DIR=/opt/payara/deployments \
     JVM_ARGS="" \
     MEM_MAX_RAM_PERCENTAGE=70.0 \
@@ -25,8 +26,7 @@ RUN true \
 USER payara
 WORKDIR ${HOME_DIR}
 
-COPY maven/artifacts/payara-micro.jar .
+COPY --chown=payara:payara maven/artifacts/payara-micro.jar .
+COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 
-# Default command to run
-ENTRYPOINT ["sh", "-c", "java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar"]
-CMD ["--deploymentDir", "/opt/payara/deployments"]
+ENTRYPOINT "${SCRIPT_DIR}/entrypoint.sh"

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -9,8 +9,8 @@ ENV PAYARA_HOME=/opt/payara\
 
 # Create and set the Payara user and working directory owned by the new user
 RUN true \
-    && addgroup payara \
-    && adduser -D -h ${PAYARA_HOME} -H -s /bin/bash payara -G payara \
+    && groupadd --gid 1000 payara \
+    && useradd -u 1000 -M -s /bin/bash -d ${PAYARA_HOME} payara -g payara \
     && echo payara:payara | chpasswd \
     && mkdir -p ${DEPLOY_DIR}  \
     && chown -R payara:payara ${PAYARA_HOME} \

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -4,7 +4,9 @@ FROM @docker.java.image@
 EXPOSE 6900 8080
 
 # Configure environment variables
-ENV HOME_DIR=/opt/payara
+# PAYARA_HOME is deprecated - it is here for backward compatibility
+ENV PAYARA_HOME=/opt/payara
+ENV HOME_DIR=${PAYARA_HOME}
 ENV PAYARA_DIR=${HOME_DIR} \
     DEPLOY_DIR=/opt/payara/deployments
 

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -8,7 +8,10 @@ EXPOSE 6900 8080
 ENV PAYARA_HOME=/opt/payara
 ENV HOME_DIR=${PAYARA_HOME}
 ENV PAYARA_DIR=${HOME_DIR} \
-    DEPLOY_DIR=/opt/payara/deployments
+    DEPLOY_DIR=/opt/payara/deployments \
+    JVM_ARGS="" \
+    MEM_MAX_RAM_PERCENTAGE=70.0 \
+    MEM_XSS=512k
 
 # Create and set the Payara user and working directory owned by the new user
 RUN true \
@@ -25,5 +28,5 @@ WORKDIR ${HOME_DIR}
 COPY maven/artifacts/payara-micro.jar .
 
 # Default command to run
-ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=90.0", "-jar", "payara-micro.jar"]
+ENTRYPOINT ["sh", "-c", "java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar"]
 CMD ["--deploymentDir", "/opt/payara/deployments"]

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -4,20 +4,21 @@ FROM @docker.java.image@
 EXPOSE 6900 8080
 
 # Configure environment variables
-ENV PAYARA_HOME=/opt/payara\
+ENV HOME_DIR=/opt/payara
+ENV PAYARA_DIR=${HOME_DIR} \
     DEPLOY_DIR=/opt/payara/deployments
 
 # Create and set the Payara user and working directory owned by the new user
 RUN true \
-    && groupadd --gid 1000 payara \
-    && useradd -u 1000 -M -s /bin/bash -d ${PAYARA_HOME} payara -g payara \
+    && addgroup --gid 1000 payara \
+    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
     && echo payara:payara | chpasswd \
     && mkdir -p ${DEPLOY_DIR}  \
-    && chown -R payara:payara ${PAYARA_HOME} \
+    && chown -R payara:payara ${HOME_DIR} \
     && true
 
 USER payara
-WORKDIR ${PAYARA_HOME}
+WORKDIR ${HOME_DIR}
 
 COPY maven/artifacts/payara-micro.jar .
 

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM @docker.java.image@
 # Default payara ports to expose
 EXPOSE 6900 8080
 
-# Configure environment variables
 # PAYARA_HOME is deprecated - it is here for backward compatibility
 ENV PAYARA_HOME=/opt/payara
 ENV HOME_DIR=${PAYARA_HOME}
@@ -11,15 +10,17 @@ ENV PAYARA_DIR=${HOME_DIR} \
     SCRIPT_DIR=${HOME_DIR} \
     DEPLOY_DIR=/opt/payara/deployments \
     JVM_ARGS="" \
-    MEM_MAX_RAM_PERCENTAGE=70.0 \
-    MEM_XSS=512k
+    MEM_MAX_RAM_PERCENTAGE="70.0" \
+    MEM_XSS="512k"
 
-# Create and set the Payara user and working directory owned by the new user
 RUN true \
+    && mkdir -p "${HOME_DIR}" \
     && addgroup --gid 1000 payara \
     && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
     && echo payara:payara | chpasswd \
-    && mkdir -p ${DEPLOY_DIR}  \
+    && mkdir -p "${PAYARA_DIR}" \
+    && mkdir -p "${SCRIPT_DIR}" \
+    && mkdir -p "${DEPLOY_DIR}" \
     && chown -R payara:payara ${HOME_DIR} \
     && true
 

--- a/appserver/extras/docker-images/micro/src/main/docker/assembly.xml
+++ b/appserver/extras/docker-images/micro/src/main/docker/assembly.xml
@@ -47,4 +47,11 @@
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
         </dependencySet>
     </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/docker/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/appserver/extras/docker-images/micro/src/main/docker/bin/.gitattributes
+++ b/appserver/extras/docker-images/micro/src/main/docker/bin/.gitattributes
@@ -1,0 +1,1 @@
+*.sh    text eol=lf

--- a/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar --deploymentDir "${DEPLOY_DIR}"
+exec java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar "$@"

--- a/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar --deploymentDir "${DEPLOY_DIR}"

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -83,6 +83,7 @@
                                         <tags>
                                             <tag>${dockerfile.tag}</tag>
                                         </tags>
+                                        <cleanup>none</cleanup>
                                         <noCache>${docker.noCache}</noCache>
                                         <dockerFile>Dockerfile</dockerFile>
                                         <assembly>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -29,6 +29,7 @@
         <docker.java.tag>8u232</docker.java.tag>
         <docker.java.image>${docker.java.repository}:${docker.java.tag}</docker.java.image>
         <docker.payara.domainName>production</docker.payara.domainName>
+        <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>
     </properties>
 
     <build>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -46,6 +46,9 @@
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.33.0</version>
                     <extensions>true</extensions>
+                    <configuration>
+                        <verbose>true</verbose>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -11,6 +11,7 @@
     <name>Payara Docker Images</name>
 
     <modules>
+        <module>basic</module>
         <module>server-full</module>
         <module>server-web</module>
         <module>server-node</module>
@@ -20,16 +21,18 @@
 
     <properties>
         <payara.version>${project.version}</payara.version>
-        <dockerBaseDir>${project.build.directory}/docker-work-dir</dockerBaseDir>
-        <dockerRepositoryName>payara/${project.artifactId}</dockerRepositoryName>
-        <!-- use false for faster testing, but you depend on cached results then -->
         <docker.noCache>true</docker.noCache>
-        <dockerfile.tag>${payara.version}</dockerfile.tag>
+
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.java.tag>8u232</docker.java.tag>
         <docker.java.image>${docker.java.repository}:${docker.java.tag}</docker.java.image>
+
         <docker.payara.domainName>production</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>
+
+        <docker.payara.repository>payara/${project.artifactId}</docker.payara.repository>
+        <docker.payara.tag>${payara.version}</docker.payara.tag>
+        <docker.payara.image>${docker.payara.repository}:${docker.payara.tag}</docker.payara.image>
     </properties>
 
     <build>
@@ -79,12 +82,12 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${dockerRepositoryName}</name>
+                                    <name>${docker.payara.repository}</name>
                                     <build>
                                         <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
                                         <filter>@</filter>
                                         <tags>
-                                            <tag>${dockerfile.tag}</tag>
+                                            <tag>${docker.payara.tag}</tag>
                                         </tags>
                                         <cleanup>none</cleanup>
                                         <noCache>${docker.noCache}</noCache>

--- a/appserver/extras/docker-images/server-full/pom.xml
+++ b/appserver/extras/docker-images/server-full/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <dockerRepositoryName>payara/server-full</dockerRepositoryName>
+        <docker.keyserver.url>hkp://ipv4.pool.sks-keyservers.net</docker.keyserver.url>
     </properties>
 
     <dependencies>

--- a/appserver/extras/docker-images/server-full/pom.xml
+++ b/appserver/extras/docker-images/server-full/pom.xml
@@ -11,11 +11,16 @@
     <name>Payara Docker Images - Server Full</name>
 
     <properties>
-        <dockerRepositoryName>payara/server-full</dockerRepositoryName>
-        <docker.keyserver.url>hkp://ipv4.pool.sks-keyservers.net</docker.keyserver.url>
+        <docker.payara.repository>payara/server-full</docker.payara.repository>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>basic-docker-image</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
         <dependency>
             <groupId>fish.payara.distributions</groupId>
             <artifactId>payara</artifactId>

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -13,8 +13,8 @@ ENV DOMAIN_NAME=@docker.payara.domainName@ \
     POSTBOOT_COMMANDS=${CONFIG_DIR}/post-boot-commands.asadmin \
     DEPLOY_PROPS=""
 
-COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
+COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 
 RUN true \
     && echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/tmpfile \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -70,10 +70,8 @@ RUN true \
        do\
          ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
        done \
-    # FIXME: when upgrading this container to Java 10+, this needs to be changed to
-    #        '-XX:+UseContainerSupport' and '-XX:MaxRAMPercentage'
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options \
-      '-XX\:+UnlockExperimentalVMOptions:-XX\:+IgnoreUnrecognizedVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:MaxRAMFraction=1' \
+      '-XX\:+UnlockExperimentalVMOptions:-XX\:+IgnoreUnrecognizedVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=90.0' \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN true \
          ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
        done \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options \
-      '-XX\:+UnlockExperimentalVMOptions:-XX\:+IgnoreUnrecognizedVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=${ENV=MEM_MAX_RAM_PERCENTAGE}:-Xss${ENV=MEM_XSS}' \
+      '-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=${ENV=MEM_MAX_RAM_PERCENTAGE}:-Xss${ENV=MEM_XSS}' \
 
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -74,7 +74,6 @@ RUN true \
        done \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options \
       '-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=${ENV=MEM_MAX_RAM_PERCENTAGE}:-Xss${ENV=MEM_XSS}' \
-
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -54,7 +54,7 @@ RUN true \
 USER payara
 WORKDIR ${HOME_DIR}
 
-COPY --chown=payara:payara maven/artifacts/payara5 ${PAYARA_DIR}/
+COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 
 RUN true \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -29,8 +29,8 @@ ENV PATH="${PATH}:${PAYARA_DIR}/bin"
 ARG TINI_VERSION=v0.18.0
 
 # Download tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /
 
 RUN true \
     # Install dependencies

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -20,6 +20,8 @@ ENV HOME_DIR=/opt/payara\
     ADMIN_PASSWORD=admin \
     # Utility environment variables
     JVM_ARGS=\
+    MEM_MAX_RAM_PERCENTAGE=70.0 \
+    MEM_XSS=512k \
     PAYARA_ARGS=\
     DEPLOY_PROPS=\
     POSTBOOT_COMMANDS=/opt/payara/config/post-boot-commands.asadmin\
@@ -66,12 +68,13 @@ RUN true \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin \
     && for MEMORY_JVM_OPTION in \
-       $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]"); \
+       $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]\|Xss"); \
        do\
          ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
        done \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options \
-      '-XX\:+UnlockExperimentalVMOptions:-XX\:+IgnoreUnrecognizedVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=90.0' \
+      '-XX\:+UnlockExperimentalVMOptions:-XX\:+IgnoreUnrecognizedVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=${ENV=MEM_MAX_RAM_PERCENTAGE}:-Xss${ENV=MEM_XSS}' \
+
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -29,8 +29,8 @@ ENV PATH="${PATH}:${PAYARA_DIR}/bin"
 ARG TINI_VERSION=v0.18.0
 
 # Download tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
 
 RUN true \
     # Install dependencies
@@ -46,8 +46,8 @@ RUN true \
     && mkdir -p ${SCRIPT_DIR} \
     && chown -R payara: ${HOME_DIR} \
     # Verify tini
-    && gpg --batch --keyserver "hkp://ipv4.pool.sks-keyservers.net" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    && gpg --batch --verify /tini.asc /tini \
+    && gpg --verbose --keyserver @docker.keyserver.url@ --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+    && gpg --verify /tini.asc \
     && chmod +x /tini \
     && true
 

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM @docker.java.image@
+FROM payara/basic:@docker.payara.tag@
 
 # Default payara ports to expose
 # 4848: admin console
@@ -7,63 +7,18 @@ FROM @docker.java.image@
 # 8181: https
 EXPOSE 4848 9009 8080 8181
 
-# Initialize the configurable environment variables
-ENV HOME_DIR=/opt/payara\
-    PAYARA_DIR=/opt/payara/appserver\
-    SCRIPT_DIR=/opt/payara/scripts\
-    CONFIG_DIR=/opt/payara/config\
-    DEPLOY_DIR=/opt/payara/deployments\
-    PASSWORD_FILE=/opt/payara/passwordFile\
-    # Payara Server Domain options
-    DOMAIN_NAME=@docker.payara.domainName@\
-    ADMIN_USER=admin\
-    ADMIN_PASSWORD=admin \
-    # Utility environment variables
-    JVM_ARGS=\
-    MEM_MAX_RAM_PERCENTAGE=70.0 \
-    MEM_XSS=512k \
-    PAYARA_ARGS=\
-    DEPLOY_PROPS=\
-    POSTBOOT_COMMANDS=/opt/payara/config/post-boot-commands.asadmin\
-    PREBOOT_COMMANDS=/opt/payara/config/pre-boot-commands.asadmin
-ENV PATH="${PATH}:${PAYARA_DIR}/bin"
-
-ARG TINI_VERSION=v0.18.0
-
-# Download tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /
-
-RUN true \
-    # Install dependencies
-    && apt-get update \
-    && apt-get install -y gpg \
-    && rm -rf /var/lib/apt/lists/* \
-    # Create and set the Payara user and working directory owned by the new user
-    && addgroup --gid 1000 payara \
-    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
-    && echo payara:payara | chpasswd \
-    && mkdir -p ${DEPLOY_DIR} \
-    && mkdir -p ${CONFIG_DIR} \
-    && mkdir -p ${SCRIPT_DIR} \
-    && chown -R payara: ${HOME_DIR} \
-    # Verify tini
-    && gpg --verbose --keyserver @docker.keyserver.url@ --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    && gpg --verify /tini.asc \
-    && chmod +x /tini \
-    && true
-
-USER payara
-WORKDIR ${HOME_DIR}
+ENV DOMAIN_NAME=@docker.payara.domainName@ \
+    PAYARA_ARGS="" \
+    PREBOOT_COMMANDS=${CONFIG_DIR}/pre-boot-commands.asadmin \
+    POSTBOOT_COMMANDS=${CONFIG_DIR}/post-boot-commands.asadmin \
+    DEPLOY_PROPS=""
 
 COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 
 RUN true \
-    # Configure the password file for configuring Payara
     && echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/tmpfile \
     && echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> ${PASSWORD_FILE} \
-    # Configure the payara domain
     && ${PAYARA_DIR}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/tmp/tmpfile change-admin-password --domain_name=${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin \
@@ -77,7 +32,6 @@ RUN true \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} \
-    # Cleanup after initialization
     && rm -rf \
         /tmp/tmpFile \
         ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache \

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -35,11 +35,11 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /
 RUN true \
     # Install dependencies
     && apt-get update \
-    && apt-get install -y coreutils gpg \
+    && apt-get install -y gpg \
     && rm -rf /var/lib/apt/lists/* \
     # Create and set the Payara user and working directory owned by the new user
-    && groupadd --gid 1000 payara \
-    && useradd -u 1000 -M -s /bin/bash -d ${HOME_DIR} payara -g payara \
+    && addgroup --gid 1000 payara \
+    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
     && echo payara:payara | chpasswd \
     && mkdir -p ${DEPLOY_DIR} \
     && mkdir -p ${CONFIG_DIR} \

--- a/appserver/extras/docker-images/server-full/src/main/docker/assembly.xml
+++ b/appserver/extras/docker-images/server-full/src/main/docker/assembly.xml
@@ -47,7 +47,7 @@
             <unpack>true</unpack>
             <unpackOptions>
                 <excludes>
-                    <exclude>payara5/glassfish/domains/domain1/**</exclude>
+                    <exclude>**/glassfish/domains/domain1/**</exclude>
                 </excludes>
             </unpackOptions>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>

--- a/appserver/extras/docker-images/server-node/pom.xml
+++ b/appserver/extras/docker-images/server-node/pom.xml
@@ -11,10 +11,16 @@
     <name>Payara Docker Images - Server Node</name>
 
     <properties>
-        <dockerRepositoryName>payara/server-node</dockerRepositoryName>
+        <docker.payara.repository>payara/server-node</docker.payara.repository>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>basic-docker-image</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
         <dependency>
             <groupId>fish.payara.distributions</groupId>
             <artifactId>payara</artifactId>

--- a/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
@@ -1,9 +1,6 @@
-FROM @docker.java.image@
+FROM payara/basic:@docker.payara.tag@
 
-ENV HOME_DIR=/opt/payara
-ENV PAYARA_DIR=${HOME_DIR}/@docker.payara.rootDirectoryName@ \
-    SCRIPT_DIR=${HOME_DIR} \
-    PAYARA_DAS_HOST="localhost" \
+ENV PAYARA_DAS_HOST="localhost" \
     PAYARA_DAS_PORT="4848" \
     PAYARA_NODE_NAME="" \
     PAYARA_CONFIG_NAME="" \
@@ -14,20 +11,10 @@ ENV PAYARA_PASSWORD_FILE=${PAYARA_PASSWORD_FILE_DIR}/passwordfile.txt
 
 # Create and set the Payara user and working directory owned by the new user
 RUN true \
-    && mkdir ${HOME_DIR} \
-    && mkdir ${PAYARA_DIR} \
-    && mkdir ${PAYARA_PASSWORD_FILE_DIR} \
-    && addgroup --gid 1000 payara \
-    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
-    && echo payara:payara | chpasswd \
-    && chown -R payara:payara ${HOME_DIR} \
+    && mkdir -p ${PAYARA_PASSWORD_FILE_DIR} \
     && true
 
-USER payara
-WORKDIR ${HOME_DIR}
-
 COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}
-COPY --chown=payara:payara maven/bin/* ${HOME_DIR}
+COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}
 
-# Start the instance
 ENTRYPOINT "${SCRIPT_DIR}/entrypoint.sh"

--- a/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM @docker.java.image@
 
 ENV HOME_DIR=/opt/payara
-ENV PAYARA_DIR=${HOME_DIR}/payara5 \
+ENV PAYARA_DIR=${HOME_DIR}/@docker.payara.rootDirectoryName@ \
     SCRIPT_DIR=/opt/payara\
     PAYARA_DAS_HOST="localhost" \
     PAYARA_DAS_PORT="4848" \
@@ -26,7 +26,7 @@ RUN true \
 USER payara
 WORKDIR ${HOME_DIR}
 
-COPY --chown=payara:payara maven/artifacts/payara5 ${PAYARA_DIR}
+COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}
 COPY --chown=payara:payara maven/bin/* ${HOME_DIR}
 
 # Start the instance

--- a/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM @docker.java.image@
 
 ENV HOME_DIR=/opt/payara
 ENV PAYARA_DIR=${HOME_DIR}/@docker.payara.rootDirectoryName@ \
-    SCRIPT_DIR=/opt/payara\
+    SCRIPT_DIR=${HOME_DIR} \
     PAYARA_DAS_HOST="localhost" \
     PAYARA_DAS_PORT="4848" \
     PAYARA_NODE_NAME="" \

--- a/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
@@ -17,8 +17,8 @@ RUN true \
     && mkdir ${HOME_DIR} \
     && mkdir ${PAYARA_DIR} \
     && mkdir ${PAYARA_PASSWORD_FILE_DIR} \
-    && groupadd -g 1000 payara \
-    && useradd -u 1000 -M -s /bin/bash -d ${HOME_DIR} payara -g payara \
+    && addgroup --gid 1000 payara \
+    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
     && echo payara:payara | chpasswd \
     && chown -R payara:payara ${HOME_DIR} \
     && true
@@ -27,7 +27,7 @@ USER payara
 WORKDIR ${HOME_DIR}
 
 COPY --chown=payara:payara maven/artifacts/payara5 ${PAYARA_DIR}
-COPY --chown=payara:payara  maven/bin/* ${HOME_DIR}
+COPY --chown=payara:payara maven/bin/* ${HOME_DIR}
 
 # Start the instance
 ENTRYPOINT "${SCRIPT_DIR}/entrypoint.sh"

--- a/appserver/extras/docker-images/server-web/pom.xml
+++ b/appserver/extras/docker-images/server-web/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <dockerRepositoryName>payara/server-web</dockerRepositoryName>
+        <docker.keyserver.url>hkp://ipv4.pool.sks-keyservers.net</docker.keyserver.url>
     </properties>
 
     <dependencies>

--- a/appserver/extras/docker-images/server-web/pom.xml
+++ b/appserver/extras/docker-images/server-web/pom.xml
@@ -11,11 +11,16 @@
     <name>Payara Docker Images - Server Web</name>
 
     <properties>
-        <dockerRepositoryName>payara/server-web</dockerRepositoryName>
-        <docker.keyserver.url>hkp://ipv4.pool.sks-keyservers.net</docker.keyserver.url>
+        <docker.payara.repository>payara/server-web</docker.payara.repository>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>basic-docker-image</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
         <dependency>
             <groupId>fish.payara.distributions</groupId>
             <artifactId>payara-web</artifactId>

--- a/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
@@ -13,8 +13,8 @@ ENV DOMAIN_NAME=@docker.payara.domainName@ \
     POSTBOOT_COMMANDS=${CONFIG_DIR}/post-boot-commands.asadmin \
     DEPLOY_PROPS=""
 
-COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
+COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 
 RUN true \
     && echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/tmpfile \

--- a/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
@@ -20,6 +20,8 @@ ENV HOME_DIR=/opt/payara\
     ADMIN_PASSWORD=admin \
     # Utility environment variables
     JVM_ARGS=\
+    MEM_MAX_RAM_PERCENTAGE=70.0 \
+    MEM_XSS=512k \
     PAYARA_ARGS=\
     DEPLOY_PROPS=\
     POSTBOOT_COMMANDS=/opt/payara/config/post-boot-commands.asadmin\
@@ -35,26 +37,26 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
 RUN true \
     # Install dependencies
     && apt-get update \
-    && apt-get install -y coreutils gpg \
+    && apt-get install -y gpg \
     && rm -rf /var/lib/apt/lists/* \
     # Create and set the Payara user and working directory owned by the new user
-    && groupadd --gid 1000 payara \
-    && useradd -u 1000 -M -s /bin/bash -d ${HOME_DIR} payara -g payara \
+    && addgroup --gid 1000 payara \
+    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
     && echo payara:payara | chpasswd \
     && mkdir -p ${DEPLOY_DIR} \
     && mkdir -p ${CONFIG_DIR} \
     && mkdir -p ${SCRIPT_DIR} \
     && chown -R payara: ${HOME_DIR} \
     # Verify tini
-    && gpg --batch --keyserver "hkp://ipv4.pool.sks-keyservers.net" --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    && gpg --batch --verify /tini.asc /tini \
+    && gpg --verbose --keyserver @docker.keyserver.url@ --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+    && gpg --verify /tini.asc \
     && chmod +x /tini \
     && true
 
 USER payara
 WORKDIR ${HOME_DIR}
 
-COPY --chown=payara:payara maven/artifacts/payara5 ${PAYARA_DIR}/
+COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 
 RUN true \
@@ -66,14 +68,12 @@ RUN true \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin \
     && for MEMORY_JVM_OPTION in \
-       $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]"); \
+       $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]\|Xss"); \
        do\
          ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
        done \
-    # FIXME: when upgrading this container to Java 10+, this needs to be changed to
-    #        '-XX:+UseContainerSupport' and '-XX:MaxRAMPercentage'
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options \
-      '-XX\:+UnlockExperimentalVMOptions:-XX\:+IgnoreUnrecognizedVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:MaxRAMFraction=1' \
+      '-XX\:+UseContainerSupport:-XX\:MaxRAMPercentage=${ENV=MEM_MAX_RAM_PERCENTAGE}:-Xss${ENV=MEM_XSS}' \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} \

--- a/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM @docker.java.image@
+FROM payara/basic:@docker.payara.tag@
 
 # Default payara ports to expose
 # 4848: admin console
@@ -7,63 +7,18 @@ FROM @docker.java.image@
 # 8181: https
 EXPOSE 4848 9009 8080 8181
 
-# Initialize the configurable environment variables
-ENV HOME_DIR=/opt/payara\
-    PAYARA_DIR=/opt/payara/appserver\
-    SCRIPT_DIR=/opt/payara/scripts\
-    CONFIG_DIR=/opt/payara/config\
-    DEPLOY_DIR=/opt/payara/deployments\
-    PASSWORD_FILE=/opt/payara/passwordFile\
-    # Payara Server Domain options
-    DOMAIN_NAME=@docker.payara.domainName@\
-    ADMIN_USER=admin\
-    ADMIN_PASSWORD=admin \
-    # Utility environment variables
-    JVM_ARGS=\
-    MEM_MAX_RAM_PERCENTAGE=70.0 \
-    MEM_XSS=512k \
-    PAYARA_ARGS=\
-    DEPLOY_PROPS=\
-    POSTBOOT_COMMANDS=/opt/payara/config/post-boot-commands.asadmin\
-    PREBOOT_COMMANDS=/opt/payara/config/pre-boot-commands.asadmin
-ENV PATH="${PATH}:${PAYARA_DIR}/bin"
-
-ARG TINI_VERSION=v0.18.0
-
-# Download tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /
-
-RUN true \
-    # Install dependencies
-    && apt-get update \
-    && apt-get install -y gpg \
-    && rm -rf /var/lib/apt/lists/* \
-    # Create and set the Payara user and working directory owned by the new user
-    && addgroup --gid 1000 payara \
-    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
-    && echo payara:payara | chpasswd \
-    && mkdir -p ${DEPLOY_DIR} \
-    && mkdir -p ${CONFIG_DIR} \
-    && mkdir -p ${SCRIPT_DIR} \
-    && chown -R payara: ${HOME_DIR} \
-    # Verify tini
-    && gpg --verbose --keyserver @docker.keyserver.url@ --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    && gpg --verify /tini.asc \
-    && chmod +x /tini \
-    && true
-
-USER payara
-WORKDIR ${HOME_DIR}
+ENV DOMAIN_NAME=@docker.payara.domainName@ \
+    PAYARA_ARGS="" \
+    PREBOOT_COMMANDS=${CONFIG_DIR}/pre-boot-commands.asadmin \
+    POSTBOOT_COMMANDS=${CONFIG_DIR}/post-boot-commands.asadmin \
+    DEPLOY_PROPS=""
 
 COPY --chown=payara:payara maven/artifacts/@docker.payara.rootDirectoryName@ ${PAYARA_DIR}/
 COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 
 RUN true \
-    # Configure the password file for configuring Payara
     && echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/tmpfile \
     && echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> ${PASSWORD_FILE} \
-    # Configure the payara domain
     && ${PAYARA_DIR}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/tmp/tmpfile change-admin-password --domain_name=${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin \
@@ -77,7 +32,6 @@ RUN true \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
       set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} \
-    # Cleanup after initialization
     && rm -rf \
         /tmp/tmpFile \
         ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache \

--- a/appserver/extras/docker-images/server-web/src/main/docker/assembly.xml
+++ b/appserver/extras/docker-images/server-web/src/main/docker/assembly.xml
@@ -47,7 +47,7 @@
             <unpack>true</unpack>
             <unpackOptions>
                 <excludes>
-                    <exclude>payara5/glassfish/domains/domain1/**</exclude>
+                    <exclude>**/glassfish/domains/domain1/**</exclude>
                 </excludes>
             </unpackOptions>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -92,7 +92,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                    -Ddockerfile.tag=${dockerfile.tag}
+                    -Ddocker.payara.tag=${docker.payara.tag}
                     -Dpasswordfile=${project.build.testOutputDirectory}/passwordfile.txt
                     -DtestContainersWorkDir=${project.build.directory}/test-containers
                     </argLine>

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.12.5</version>
+            <version>1.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -65,6 +65,24 @@
             <version>1.7.28</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+            <version>3.1.3</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.13.0</version>
+            <version>1.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.12.3</version>
+            <version>1.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -94,6 +94,7 @@
                     <argLine>
                     -Ddockerfile.tag=${dockerfile.tag}
                     -Dpasswordfile=${project.build.testOutputDirectory}/passwordfile.txt
+                    -DtestContainersWorkDir=${project.build.directory}/test-containers
                     </argLine>
                 </configuration>
             </plugin>

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraContainer.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraContainer.java
@@ -63,7 +63,7 @@ public class PayaraContainer extends GenericContainer<PayaraContainer> {
 
     /**
      * Container created from basic repository name, tag is detected from JVM option
-     * - use -Ddockerfile.tag set to test options (see maven surefire documentation or pom.xml)
+     * - use -Ddocker.payara.tag set to test options (see maven surefire documentation or pom.xml)
      *
      * @param baseRepositoryName
      */
@@ -100,7 +100,7 @@ public class PayaraContainer extends GenericContainer<PayaraContainer> {
 
 
     private static String getTagFromJvmOption() {
-        final String tag = System.getProperty("dockerfile.tag");
+        final String tag = System.getProperty("docker.payara.tag");
         return Objects.requireNonNull(tag, "tag is null");
     }
 

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
@@ -40,13 +40,17 @@
 
 package fish.payara.distributions.docker;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import fish.payara.distributions.docker.war.TestServlet;
+
+import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
+import java.util.Scanner;
 
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,32 +60,70 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.testcontainers.containers.BindMode.READ_ONLY;
 
+/**
+ * Test for Payara Micro docker container basic functionality.
+ *
+ * @author David Matejcek
+ */
 @Testcontainers
 public class PayaraMicroTest {
+
     private static final Logger LOG = LoggerFactory.getLogger(PayaraMicroTest.class);
+    private static final Class<TestServlet> SERVLET_CLASS = TestServlet.class;
+    private static final File WAR_FILE = createWar();
+    private static final String WEBAPP_CONTEXT = "/" + WAR_FILE.getName().substring(0, WAR_FILE.getName().length() - 4);
 
     @Container
-    private static final PayaraContainer CONTAINER = new PayaraContainer("payara/micro") //
-            .withExposedPorts(8080)
-            .withLogConsumer(new Slf4jLogConsumer(LOG))
-            .waitingFor(Wait.forLogMessage(".*Payara Micro.+ ready.+\\n", 1));
+    private final PayaraContainer container = new PayaraContainer("payara/micro") //
+        .withExposedPorts(8080)
+        .withLogConsumer(new Slf4jLogConsumer(LOG))
+        .withFileSystemBind(WAR_FILE.getAbsolutePath(), "/opt/payara/deployments/" + WAR_FILE.getName(), READ_ONLY)
+        .waitingFor(Wait.forLogMessage(".*Payara Micro.+ ready.+\\n", 1));
 
-    @Test
-    public void testStartedServerEndpoints() throws Exception {
-        assertTrue(CONTAINER.isRunning(), "server is running");
-        assertAll( //
-                () -> assertNotNull(CONTAINER.getMappedPort(8080), "http port") //
-        );
-        // health url is not present without a deployment so that's all we'd test for now
+    private static File createWar() {
+        try {
+            final WebArchive war = ShrinkWrap.create(WebArchive.class).addClass(SERVLET_CLASS);
+            final File warFileOnHost = File.createTempFile(TestServlet.class.getSimpleName(), ".war");
+            war.as(ZipExporter.class).exportTo(warFileOnHost, true);
+            return warFileOnHost;
+        } catch (Exception e) {
+            return fail(e);
+        }
     }
 
-    private String getPageContent(final URL url) throws IOException {
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(url.openConnection().getInputStream(), StandardCharsets.UTF_8))) {
-            return reader.lines().collect(Collectors.joining("\n"));
+
+    /**
+     * Tests if Micro can be started and it the war application has been deployed and works.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testServlet() throws Exception {
+        assertTrue(container.isRunning(), "server is running");
+        assertAll( //
+            () -> assertNotNull(container.getMappedPort(8080), "http port"), //
+            () -> assertEquals(TestServlet.RESPONSE_TEXT, download()) //
+        );
+    }
+
+
+    private String download() throws Exception {
+        final URL url = new URL("http", container.getContainerIpAddress(), container.getMappedPort(8080), WEBAPP_CONTEXT);
+        final Object object = url.getContent();
+        if (object instanceof InputStream) {
+            final InputStream input = (InputStream) object;
+            try (Scanner scanner = new Scanner(input, StandardCharsets.UTF_8.name())) {
+                return scanner.nextLine();
+            } finally {
+                input.close();
+            }
         }
+        return fail("Expected input stream, but received this: " + object.toString());
     }
 }

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
@@ -76,6 +76,7 @@ public class PayaraMicroTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(PayaraMicroTest.class);
     private static final Class<TestServlet> SERVLET_CLASS = TestServlet.class;
+    private static final File TC_DIR = new File(System.getProperty("testContainersWorkDir"));
     private static final File WAR_FILE = createWar();
     private static final String WEBAPP_CONTEXT = "/" + WAR_FILE.getName().substring(0, WAR_FILE.getName().length() - 4);
 
@@ -89,7 +90,8 @@ public class PayaraMicroTest {
     private static File createWar() {
         try {
             final WebArchive war = ShrinkWrap.create(WebArchive.class).addClass(SERVLET_CLASS);
-            final File warFileOnHost = File.createTempFile(TestServlet.class.getSimpleName(), ".war");
+            TC_DIR.mkdirs();
+            final File warFileOnHost = new File(TC_DIR, TestServlet.class.getSimpleName() + "WebApp.war");
             war.as(ZipExporter.class).exportTo(warFileOnHost, true);
             return warFileOnHost;
         } catch (Exception e) {

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
@@ -40,7 +40,13 @@
 
 package fish.payara.distributions.docker;
 
-import org.junit.jupiter.api.BeforeAll;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,20 +55,9 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @Testcontainers
 public class PayaraMicroTest {

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerNodeTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerNodeTest.java
@@ -46,11 +46,13 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -83,7 +85,8 @@ public class PayaraServerNodeTest {
     private final PayaraContainer node = new PayaraContainer("payara/server-node").withExposedPorts(NODE_HTTP_PORT) //
         .withEnv("PAYARA_DAS_HOST", "host.testcontainers.internal")
         .withEnv("PAYARA_DAS_PORT", Integer.toString(DAS.getMappedPort(DAS_ADMIN_PORT)))
-        .withEnv("DOCKER_CONTAINER_IP", "host.testcontainers.internal");
+        .withEnv("DOCKER_CONTAINER_IP", "host.testcontainers.internal") //
+        .withStartupTimeout(Duration.ofSeconds(10));
 
     @BeforeAll
     public static void initDAS() throws Exception {
@@ -99,6 +102,7 @@ public class PayaraServerNodeTest {
 
 
     @Test
+    @Timeout(value = 15)
     public void testStartedServerEndpoints() throws Exception {
         assertTrue(node.isRunning(), "server is running");
         assertAll( //

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerNodeTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerNodeTest.java
@@ -86,7 +86,7 @@ public class PayaraServerNodeTest {
         .withEnv("PAYARA_DAS_HOST", "host.testcontainers.internal")
         .withEnv("PAYARA_DAS_PORT", Integer.toString(DAS.getMappedPort(DAS_ADMIN_PORT)))
         .withEnv("DOCKER_CONTAINER_IP", "host.testcontainers.internal") //
-        .withStartupTimeout(Duration.ofSeconds(10));
+        .withStartupTimeout(Duration.ofSeconds(30));
 
     @BeforeAll
     public static void initDAS() throws Exception {
@@ -102,7 +102,7 @@ public class PayaraServerNodeTest {
 
 
     @Test
-    @Timeout(value = 15)
+    @Timeout(value = 30)
     public void testStartedServerEndpoints() throws Exception {
         assertTrue(node.isRunning(), "server is running");
         assertAll( //

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/war/TestServlet.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/war/TestServlet.java
@@ -1,0 +1,65 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.distributions.docker.war;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author David Matejcek
+ */
+@WebServlet(urlPatterns = "/")
+public class TestServlet extends HttpServlet {
+
+
+    public static final String RESPONSE_TEXT = "This is a response from " + TestServlet.class;
+
+    @Override
+    public void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        resp.setStatus(200);
+        resp.setContentType("text/plain");
+        resp.getOutputStream().println(RESPONSE_TEXT);
+    }
+}


### PR DESCRIPTION
# Description

* Fixes incompatibility with debian/ubuntu based JDK11 images
* Fixes warning about unsupported JVM option
* Adds features - JVM memory settings for Micro and Server-Full and JVM_ARGS for Micro
* All Dockerfiles use same commands for same things
* URL for gpg can be changed with -D parameter

# Important Info

# Testing

## JDK8
`mvn clean install -PBuildExtras,BuildDockerImages -pl :docker-images -amd`

## JDK11

`mvn clean install -PBuildExtras,BuildDockerImages -pl :docker-images -amd -Ddocker.payara.tag=5.202-SNAPSHOT-JDK11 -Ddocker.java.repository=adoptopenjdk/openjdk11 -Ddocker.java.tag=jdk-11.0.6_10-debian-slim`

## Payara4

1. Build some Payara4 versions including all required distribution packages
2. This will generate docker images
3. PayaraServerNodeTest will fail, because there is a difference in syntax, but other images should pass their respective tests

`mvn clean install -PBuildExtras,BuildDockerImages -pl :docker-images -amd -Dpayara.version=4.1.2.191.14-SNAPSHOT -Ddocker.payara.tag=4.1.2.191.14-SNAPSHOT -Ddocker.payara.rootDirectoryName=payara41 -Ddocker.payara.domainName=payaradomain`

## Changing env variables, extending

```
docker create --name payaramicroxxx --env "MEM_XSS=2m" --env MEM_MAX_RAM_PERCENTAGE=25.0 payara/micro:latest
# replace dcb7e7328f90 with a result of docker create
docker start dcb7e7328f90
docker logs dcb7e7328f90
```

# Notes

* I need a tester with Mac and Windows, all tests were done on Linux, but I know that other systems have limitations on Docker and TestContainers.
* EDIT: passed on  Kubuntu, Windows 10 and Mac