### PR TITLE
APPSERV-60 Update MP Health to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
         <microprofile-fault-tolerance.version>2.1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.1.payara-p1</microprofile-jwt-auth.version>
-        <microprofile-healthcheck.version>2.1</microprofile-healthcheck.version>
+        <microprofile-healthcheck.version>2.2</microprofile-healthcheck.version>
         <microprofile-metrics.version>2.2.payara-p1</microprofile-metrics.version>
         <microprofile-rest-client.version>1.3.4</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>


### PR DESCRIPTION
# Description
This is a feature.

Updates MicroProfile Health to 2.2.
No other changes required for this update, it updates it to require CDI 2.0 which we already provide.

### Dependant PRs 
[MP TCK Runner PR](https://github.com/payara/MicroProfile-TCK-Runners/pull/105)

# Testing
Build Tests.
MP Health, all permutations.

### Testing Environment
Windows 10, JDK 8u242.

# Documentation
https://github.com/payara/Payara-Server-Documentation/pull/727
