### PR TITLE
CUSTCOM-247 Propagates realm name from WAR module to its application wrapper 

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -275,14 +275,21 @@ public class Application extends CommonResourceBundleDescriptor
      * @return the application
      */
     public static Application createVirtualApplication(String name, ModuleDescriptor<BundleDescriptor> newModule) {
-
+                
         // create a new empty application
         Application application = createApplication();
+        String webBundleRealmName = null;
 
         application.setVirtual(true);
         if (name == null && newModule != null && newModule.getDescriptor() != null) {
             name = newModule.getDescriptor().getDisplayName();
 
+        }
+        if (newModule.getDescriptor() instanceof WebBundleDescriptor) {
+            WebBundleDescriptor webBundleDesc = (WebBundleDescriptor) newModule.getDescriptor();
+            if (webBundleDesc.getLoginConfiguration() != null) {
+                webBundleRealmName = webBundleDesc.getLoginConfiguration().getRealmName();
+            }
         }
         String untaggedName = VersioningUtils.getUntaggedName(name);
         if (name != null) {
@@ -300,6 +307,10 @@ public class Application extends CommonResourceBundleDescriptor
 			}
 			application.addModule(newModule);
 		}
+
+        if (application.getRealm() == null && webBundleRealmName != null) {
+            application.setRealm(webBundleRealmName);
+        }
 
         return application;
     }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.deployment;
 


### PR DESCRIPTION
# Description

This fix allows using a custom realm defined in web.xml in a WAR application for authenticating SOAP requests using the WS policy mechanism. 

Without the fix, the default realm is always used even if a custom realm is defined in the WAR file.

This fixes a customer issue.

### Testing Performed
Manual testing on Payara Server 5.191.7 (Java 8) and 5.201 (Java 11), on Ubuntu Linux.