### PR TITLE
APPSERV-114 Addresses possible sources of Race Conditions in InvocationManager

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -60,6 +60,7 @@ import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.Events;
+import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.runlevel.RunLevel;
@@ -418,15 +419,16 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
     public String getApplicationName() {
         InvocationManager invocationManager = Globals.getDefaultBaseServiceLocator()
                 .getService(InvocationManager.class);
-        if (invocationManager.getCurrentInvocation() == null) {
+        ComponentInvocation current = invocationManager.getCurrentInvocation();
+        if (current == null) {
             return invocationManager.peekAppEnvironment().getName();
         }
-        String appName = invocationManager.getCurrentInvocation().getAppName();
+        String appName = current.getAppName();
         if (appName == null) {
-            appName = invocationManager.getCurrentInvocation().getModuleName();
+            appName = current.getModuleName();
         }
         if (appName == null) {
-            appName = invocationManager.getCurrentInvocation().getComponentId();
+            appName = current.getComponentId();
         }
         return appName;
     }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -201,7 +201,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
     @Inject
     private Deployment deployment;
-    
+
     @Inject
     private PayaraExecutorService executorService;
 
@@ -298,7 +298,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
             ProxyServices proxyServices = new ProxyServicesImpl(services);
             deploymentImpl.getServices().add(ProxyServices.class, proxyServices);
-            
+
             ExecutorServices executorServices = new ExecutorServicesImpl(executorService);
             deploymentImpl.getServices().add(ExecutorServices.class, executorServices);
 
@@ -318,7 +318,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         externalConfiguration.setBeanIndexOptimization(!deployParams.isAvailabilityEnabled());
         externalConfiguration.setNonPortableMode(false);
         configureConcurrentDeployment(context, externalConfiguration);
-        
+
         deploymentImpl.getServices().add(ExternalConfiguration.class, externalConfiguration);
 
         BeanDeploymentArchive beanDeploymentArchive = deploymentImpl.getBeanDeploymentArchiveForArchive(archiveName);
@@ -499,7 +499,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             // Get current TCL
             ClassLoader oldTCL = Thread.currentThread().getContextClassLoader();
 
-            invocationManager.pushAppEnvironment(() ->  applicationInfo.getName());
+            invocationManager.pushAppEnvironment(applicationInfo::getName);
 
             ComponentInvocation componentInvocation = createComponentInvocation(applicationInfo);
 
@@ -553,7 +553,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         try {
             WeldBootstrap bootstrap = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
             if (bootstrap != null) {
-                invocationManager.pushAppEnvironment(() ->  applicationInfo.getName());
+                invocationManager.pushAppEnvironment(applicationInfo::getName);
 
                 try {
                     doBootstrapShutdown(applicationInfo);
@@ -868,7 +868,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         externalConfiguration.setProbeAllowRemoteAddress(PROBE_ALLOW_REMOTE_ADDRESS);
         deploymentImpl.addDynamicExtension(createProbeExtension());
     }
-    
+
     private void configureConcurrentDeployment(DeploymentContext context, ExternalConfigurationImpl configuration) {
         configuration.setConcurrentDeployment(WeldUtils.isConcurrentDeploymentEnabled());
         configuration.setPreLoaderThreadPoolSize(WeldUtils.getPreLoaderThreads());

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -105,7 +105,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
             <optional>true</optional>
-      </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocation.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocation.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2019-2020] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.api.invocation;
 
@@ -54,10 +54,10 @@ import org.jvnet.hk2.annotations.Service;
 public class ComponentInvocation implements Cloneable {
 
     public enum ComponentInvocationType {
-        SERVLET_INVOCATION, 
-        EJB_INVOCATION, 
-        APP_CLIENT_INVOCATION, 
-        UN_INITIALIZED, 
+        SERVLET_INVOCATION,
+        EJB_INVOCATION,
+        APP_CLIENT_INVOCATION,
+        UN_INITIALIZED,
         SERVICE_STARTUP
     }
 
@@ -140,7 +140,7 @@ public class ComponentInvocation implements Cloneable {
     public ComponentInvocationType getInvocationType() {
         return invocationType;
     }
-    
+
     public void setInvocationType(ComponentInvocationType invocationType) {
         this.invocationType = invocationType;
     }
@@ -160,7 +160,7 @@ public class ComponentInvocation implements Cloneable {
     public Boolean getAuth() {
         return auth;
     }
-    
+
     public void setAuth(Boolean auth) {
         this.auth = auth;
     }
@@ -168,7 +168,7 @@ public class ComponentInvocation implements Cloneable {
     public void setAuth(boolean value) {
         auth = value;
     }
-    
+
     public boolean isPreInvokeDoneStatus() {
         return preInvokeDoneStatus;
     }
@@ -180,7 +180,7 @@ public class ComponentInvocation implements Cloneable {
     public Object getInstance() {
         return instance;
     }
-    
+
     public void setInstance(Object instance) {
         this.instance = instance;
     }
@@ -196,11 +196,11 @@ public class ComponentInvocation implements Cloneable {
     public String getComponentId() {
         return this.componentId;
     }
-    
+
     public void setComponentId(String componentId) {
         this.componentId = componentId;
     }
-    
+
     public Object getJndiEnvironment() {
         return jndiEnvironment;
     }
@@ -220,7 +220,7 @@ public class ComponentInvocation implements Cloneable {
     public Object getContainer() {
         return container;
     }
-    
+
     public void setContainer(Object container) {
         this.container = container;
     }
@@ -236,11 +236,11 @@ public class ComponentInvocation implements Cloneable {
     public void setTransaction(Object t) {
         this.transaction = t;
     }
-    
+
     public void setTransactionCompleting(boolean transactionCompleting) {
         this.transactionCompleting = transactionCompleting;
     }
-    
+
     public Map<Class<?>, Object> getRegistry() {
         return registry;
     }
@@ -258,7 +258,7 @@ public class ComponentInvocation implements Cloneable {
     public String getAppName() {
         return appName;
     }
-    
+
     public void setAppName(String appName) {
         this.appName = appName;
     }
@@ -270,7 +270,7 @@ public class ComponentInvocation implements Cloneable {
     public String getModuleName() {
         return moduleName;
     }
-    
+
     public void setModuleName(String moduleName) {
         this.moduleName = moduleName;
     }
@@ -383,5 +383,16 @@ public class ComponentInvocation implements Cloneable {
 
         return newInv;
     }
-   
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder();
+        str.append(Integer.toHexString(System.identityHashCode(this))).append('@').append(getClass().getName()).append('\n');
+        str.append("\tcomponentId=").append(componentId).append('\n');
+        str.append("\ttype=").append(invocationType).append('\n');
+        str.append("\tinstance=").append(instanceName != null ? instanceName : String.valueOf(instance)).append('\n');
+        str.append("\tcontainer=").append(container).append('\n');
+        str.append("\tappName=").append(appName).append('\n');
+        return str.toString();
+    }
 }

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocationHandler.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocationHandler.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2020 Payara Foundation and/or its affiliates
 package org.glassfish.api.invocation;
 
 import org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType;
@@ -53,43 +54,23 @@ import org.jvnet.hk2.annotations.Contract;
 public interface ComponentInvocationHandler {
 
     /**
-     * Called <b>before</b> the curInv is pushed into the invocation stack.
-     *
-     * @param invType
-     * @param prevInv
-     * @param newInv
-     * @throws InvocationException
+     * Called <b>before</b> the cur is pushed into the invocation stack.
      */
-    void beforePreInvoke(ComponentInvocationType invType, ComponentInvocation prevInv, ComponentInvocation newInv) throws InvocationException;
+    void beforePreInvoke(ComponentInvocationType type, ComponentInvocation prev, ComponentInvocation cur) throws InvocationException;
 
     /**
-     * Called <b>after</b> the curInv has been pushed into the invocation stack.
-     *
-     * @param invType
-     * @param prevInv
-     * @param curInv
-     * @throws InvocationException
+     * Called <b>after</b> the cur has been pushed into the invocation stack.
      */
-    void afterPreInvoke(ComponentInvocationType invType, ComponentInvocation prevInv, ComponentInvocation curInv) throws InvocationException;
+    void afterPreInvoke(ComponentInvocationType type, ComponentInvocation prev, ComponentInvocation cur) throws InvocationException;
 
     /**
-     * Called <b>before</b> the curInv has been popped from the invocation stack.
-     *
-     * @param invType
-     * @param prevInv
-     * @param curInv
-     * @throws InvocationException
+     * Called <b>before</b> the cur has been popped from the invocation stack.
      */
-    void beforePostInvoke(ComponentInvocationType invType, ComponentInvocation prevInv, ComponentInvocation curInv) throws InvocationException;
+    void beforePostInvoke(ComponentInvocationType type, ComponentInvocation prev, ComponentInvocation cur) throws InvocationException;
 
     /**
      * Called <b>after</b> the curInv has been popped from the invocation stack.
-     *
-     * @param invType
-     * @param prevInv
-     * @param curInv
-     * @throws InvocationException
      */
-    void afterPostInvoke(ComponentInvocationType invType, ComponentInvocation prevInv, ComponentInvocation curInv) throws InvocationException;
+    void afterPostInvoke(ComponentInvocationType type, ComponentInvocation prev, ComponentInvocation cur) throws InvocationException;
 
 }

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -41,18 +41,21 @@
 package org.glassfish.api.invocation;
 
 import static java.lang.ThreadLocal.withInitial;
+import static java.util.Collections.emptyList;
 import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.EJB_INVOCATION;
 import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.SERVICE_STARTUP;
 import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION;
 import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.UN_INITIALIZED;
 
 import java.lang.reflect.Method;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Stack;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -68,39 +71,43 @@ import org.jvnet.hk2.annotations.Service;
 @Singleton
 public class InvocationManagerImpl implements InvocationManager {
 
-    // This TLS variable stores an ArrayList.
-    // The ArrayList contains ComponentInvocation objects which represent
-    // the stack of invocations on this thread. Accesses to the ArrayList
-    // don't need to be synchronized because each thread has its own ArrayList.
-    private final InheritableThreadLocal<InvocationArray<ComponentInvocation>> frames;
-
-    private final ThreadLocal<Stack<ApplicationEnvironment>> applicationEnvironments = withInitial(Stack<ApplicationEnvironment>::new);
-    private final ThreadLocal<Deque<Method>> webServiceMethods = withInitial(ArrayDeque<Method>::new);
-
-    private final ConcurrentMap<ComponentInvocationType, ListComponentInvocationHandler> singleTypeHandlers = new ConcurrentHashMap<>();
-    private final ComponentInvocationHandler multiTypeHandler;
+    private final InheritableThreadLocal<InvocationFrames> framesByThread;
+    private final ThreadLocal<Deque<ApplicationEnvironment>> appEnvironments = withInitial(ConcurrentLinkedDeque::new);
+    private final ThreadLocal<Deque<Method>> webServiceMethods = withInitial(ConcurrentLinkedDeque::new);
+    private final ConcurrentMap<ComponentInvocationType, ListComponentInvocationHandler> typeHandlers = new ConcurrentHashMap<>();
+    private final ComponentInvocationHandler allTypesHandler;
 
     public InvocationManagerImpl() {
-        this(null);
+        this((ComponentInvocationHandler) null);
+    }
+
+    public InvocationManagerImpl(ComponentInvocationHandler... handlers) {
+        this(Arrays.asList(handlers));
     }
 
     @Inject
     private InvocationManagerImpl(@Optional IterableProvider<ComponentInvocationHandler> handlers) {
-        this.multiTypeHandler = initInvocationHandlers(handlers);
+        this((Iterable<ComponentInvocationHandler>) handlers);
+    }
 
-        frames = new InheritableThreadLocal<InvocationArray<ComponentInvocation>>() {
+    private InvocationManagerImpl(Iterable<ComponentInvocationHandler> handlers) {
+        this.allTypesHandler = initInvocationHandlers(handlers);
 
-            protected InvocationArray<ComponentInvocation> initialValue() {
-                return new InvocationArray<>();
+        framesByThread = new InheritableThreadLocal<InvocationFrames>() {
+
+            @Override
+            protected InvocationFrames initialValue() {
+                return new InvocationFrames();
             }
 
-            protected InvocationArray<ComponentInvocation> childValue(InvocationArray<ComponentInvocation> parentValue) {
+            @Override
+            protected InvocationFrames childValue(InvocationFrames parentValue) {
                 return computeChildTheadInvocation(parentValue);
             }
         };
     }
 
-    private static ComponentInvocationHandler initInvocationHandlers(IterableProvider<ComponentInvocationHandler> handlers) {
+    private static ComponentInvocationHandler initInvocationHandlers(Iterable<ComponentInvocationHandler> handlers) {
         if (handlers == null) {
             return null;
         }
@@ -115,165 +122,149 @@ public class InvocationManagerImpl implements InvocationManager {
         return new ListComponentInvocationHandler(hs);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void setThreadInheritableInvocation(List<? extends ComponentInvocation> parentValue) {
-        frames.set(computeChildTheadInvocation((InvocationArray<ComponentInvocation>) parentValue));
+        framesByThread.set(computeChildTheadInvocation(InvocationFrames.valueOf(parentValue)));
     }
 
     @Override
     public <T extends ComponentInvocation> void preInvoke(T invocation) throws InvocationException {
 
-        InvocationArray<ComponentInvocation> invocationArray = frames.get();
+        InvocationFrames frames = framesByThread.get();
         if (invocation.getInvocationType() == SERVICE_STARTUP) {
-            invocationArray.setInvocationAttribute(SERVICE_STARTUP);
+            frames.setState(SERVICE_STARTUP);
             return;
         }
 
-        int beforeSize = invocationArray.size();
-        ComponentInvocation previousInvocation = beforeSize > 0 ? invocationArray.get(beforeSize - 1) : null;
-
+        ComponentInvocation prev = frames.peekLast();
         ComponentInvocationType type = invocation.getInvocationType();
-        ComponentInvocationHandler singleTypeHandler = singleTypeHandlers.get(type);
+        ComponentInvocationHandler typeHandler = typeHandlers.get(type);
 
         try {
-            if (multiTypeHandler != null) {
-                multiTypeHandler.beforePreInvoke(type, previousInvocation, invocation);
+            if (allTypesHandler != null) {
+                allTypesHandler.beforePreInvoke(type, prev, invocation);
             }
-            if (singleTypeHandler != null) {
-                singleTypeHandler.beforePreInvoke(type, previousInvocation, invocation);
+            if (typeHandler != null) {
+                typeHandler.beforePreInvoke(type, prev, invocation);
             }
         } finally {
             // Push this invocation on the stack
-            invocationArray.add(invocation);
+            frames.addLast(invocation);
 
-            if (multiTypeHandler != null) {
-                multiTypeHandler.afterPreInvoke(type, previousInvocation, invocation);
+            if (allTypesHandler != null) {
+                allTypesHandler.afterPreInvoke(type, prev, invocation);
             }
-            if (singleTypeHandler != null) {
-                singleTypeHandler.afterPreInvoke(type, previousInvocation, invocation);
+            if (typeHandler != null) {
+                typeHandler.afterPreInvoke(type, prev, invocation);
             }
         }
     }
 
     @Override
     public <T extends ComponentInvocation> void postInvoke(T invocation) throws InvocationException {
-
-        // Get this thread's ArrayList
-        InvocationArray<ComponentInvocation> invocationArray = frames.get();
+        InvocationFrames frames = framesByThread.get();
         if (invocation.getInvocationType() == SERVICE_STARTUP) {
-            invocationArray.setInvocationAttribute(UN_INITIALIZED);
+            frames.setState(UN_INITIALIZED);
             return;
         }
 
-        int beforeSize = invocationArray.size();
-        if (beforeSize == 0) {
+        Iterator<ComponentInvocation> iter = frames.descendingIterator();
+        if (!iter.hasNext()) {
             throw new InvocationException();
         }
 
-        ComponentInvocation prevInv = beforeSize > 1 ? invocationArray.get(beforeSize - 2) : null;
-        ComponentInvocation curInv = invocationArray.get(beforeSize - 1);
+        iter.next(); // the last is the current is "invocation"
+        ComponentInvocation prev = iter.hasNext() ? iter.next() : null;
 
         ComponentInvocationType type = invocation.getInvocationType();
-        ComponentInvocationHandler singleTypeHandler = singleTypeHandlers.get(type);
+        ComponentInvocationHandler typeHandler = typeHandlers.get(type);
         try {
-            if (multiTypeHandler != null) {
-                multiTypeHandler.beforePostInvoke(type, prevInv, curInv);
+            if (allTypesHandler != null) {
+                allTypesHandler.beforePostInvoke(type, prev, invocation);
             }
-            if (singleTypeHandler != null) {
-                singleTypeHandler.beforePostInvoke(type, prevInv, curInv);
+            if (typeHandler != null) {
+                typeHandler.beforePostInvoke(type, prev, invocation);
             }
         } finally {
             // pop the stack
-            invocationArray.remove(beforeSize - 1);
+            frames.removeLast();
 
-            if (multiTypeHandler != null) {
-                multiTypeHandler.afterPostInvoke(type, prevInv, invocation);
+            if (allTypesHandler != null) {
+                allTypesHandler.afterPostInvoke(type, prev, invocation);
             }
-            if (singleTypeHandler != null) {
-                singleTypeHandler.afterPostInvoke(type, prevInv, curInv);
+            if (typeHandler != null) {
+                typeHandler.afterPostInvoke(type, prev, invocation);
             }
         }
     }
 
     /**
-     * return true iff no invocations on the stack for this thread
-     * @return
+     * @return true iff no invocations on the stack for this thread
      */
     @Override
     public boolean isInvocationStackEmpty() {
-        InvocationArray<ComponentInvocation> invocations = frames.get();
-        return invocations == null || invocations.size() == 0;
+        InvocationFrames invocations = framesByThread.get();
+        return invocations == null || invocations.isEmpty();
     }
 
     /**
-     * return the Invocation object of the component being called
-     * @param <T>
-     * @return
+     * @return the Invocation object of the component being called
      */
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ComponentInvocation> T getCurrentInvocation() {
-        InvocationArray<ComponentInvocation> invocations = frames.get();
-        int invocationsSize = invocations.size();
-        if (invocationsSize == 0) {
-            return null;
-        }
-
-        return (T) invocations.get(invocationsSize - 1);
+        return (T) framesByThread.get().peekLast();
     }
 
     /**
-     * return the Invocation object of the caller
-     * return null if none exist (e.g. caller is from another VM)
-     * @param <T>
-     * @return
+     * @return the Invocation object of the caller or null if none exist (e.g. caller is from another VM)
      */
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ComponentInvocation> T getPreviousInvocation() throws InvocationException {
-        InvocationArray<ComponentInvocation> invocations = frames.get();
-        int invocationsSize = invocations.size();
-        if (invocationsSize < 2) {
+        Iterator<ComponentInvocation> iter = framesByThread.get().descendingIterator();
+        if (!iter.hasNext()) {
             return null;
         }
-
-        return (T) invocations.get(invocationsSize - 2);
+        iter.next();
+        if (!iter.hasNext()) {
+            return null;
+        }
+        return (T) iter.next();
     }
 
     @Override
     public List<? extends ComponentInvocation> getAllInvocations() {
-        return frames.get();
+        InvocationFrames frames = framesByThread.get();
+        return frames == null ? emptyList() : new ArrayList<>(frames);
     }
 
     @Override
     public List<? extends ComponentInvocation> popAllInvocations() {
-        List<? extends ComponentInvocation> result = frames.get();
-        frames.set(null);
+        List<? extends ComponentInvocation> result = getAllInvocations();
+        framesByThread.set(null);
         return result;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void putAllInvocations(List<? extends ComponentInvocation> invocations) {
-        frames.set(new InvocationArray<>((List<ComponentInvocation>) invocations));
+        framesByThread.set(InvocationFrames.valueOf(invocations));
     }
 
-    private InvocationArray<ComponentInvocation> computeChildTheadInvocation(InvocationArray<ComponentInvocation> parentValue) {
+    static InvocationFrames computeChildTheadInvocation(InvocationFrames parent) {
+        InvocationFrames childFrames = new InvocationFrames();
+        InvocationFrames parentFrames = parent;
 
-        // Always creates a new ArrayList
-        InvocationArray<ComponentInvocation> childInvocationArray = new InvocationArray<ComponentInvocation>();
-        InvocationArray<ComponentInvocation> parentInvocationArray = parentValue;
-
-        if (parentInvocationArray != null && parentInvocationArray.size() > 0 && parentInvocationArray.outsideStartup()) {
+        if (parentFrames != null && !parentFrames.isEmpty() && !parentFrames.isStartup()) {
 
             // Get current invocation
-            ComponentInvocation parentInvocation = parentInvocationArray.get(parentInvocationArray.size() - 1);
+            ComponentInvocation parentFrame = parentFrames.getLast();
 
             // TODO: The following is ugly. The logic of what needs to be in the
             // new ComponentInvocation should be with the respective container
 
-            if (parentInvocation.getInvocationType() == SERVLET_INVOCATION) {
+            ComponentInvocationType parentType = parentFrame.getInvocationType();
+            if (parentType == SERVLET_INVOCATION) {
 
                 // If this is a thread created by user in servlet's service method
                 // create a new ComponentInvocation with transaction
@@ -281,104 +272,92 @@ public class InvocationManagerImpl implements InvocationManager {
                 // so that the resource won't be enlisted or registered
 
                 ComponentInvocation invocation = new ComponentInvocation();
-                invocation.setComponentInvocationType(parentInvocation.getInvocationType());
-                invocation.setComponentId(parentInvocation.getComponentId());
-                invocation.setAppName(parentInvocation.getAppName());
-                invocation.setModuleName(parentInvocation.getModuleName());
-                invocation.setContainer(parentInvocation.getContainer());
-                invocation.setJndiEnvironment(parentInvocation.getJndiEnvironment());
+                invocation.setComponentInvocationType(parentType);
+                invocation.setComponentId(parentFrame.getComponentId());
+                invocation.setAppName(parentFrame.getAppName());
+                invocation.setModuleName(parentFrame.getModuleName());
+                invocation.setContainer(parentFrame.getContainer());
+                invocation.setJndiEnvironment(parentFrame.getJndiEnvironment());
 
-                childInvocationArray.add(invocation);
-            } else if (parentInvocation.getInvocationType() != EJB_INVOCATION) {
-
+                childFrames.add(invocation);
+            } else if (parentType != EJB_INVOCATION) {
                 // Push a copy of invocation onto the new result
-                // ArrayList
-                ComponentInvocation cpy = new ComponentInvocation();
-                cpy.componentId = parentInvocation.getComponentId();
-                cpy.setComponentInvocationType(parentInvocation.getInvocationType());
-                cpy.instance = parentInvocation.getInstance();
-                cpy.container = parentInvocation.getContainerContext();
-                cpy.transaction = parentInvocation.getTransaction();
-
-                childInvocationArray.add(cpy);
+                childFrames.add(new ComponentInvocation(
+                        parentFrame.getComponentId(),
+                        parentType,
+                        parentFrame.getInstance(),
+                        parentFrame.getContainerContext(),
+                        parentFrame.getTransaction()));
             }
         }
 
-        return childInvocationArray;
+        return childFrames;
     }
 
 
-    static class InvocationArray<T extends ComponentInvocation> extends ArrayList<T> {
+    static final class InvocationFrames extends ConcurrentLinkedDeque<ComponentInvocation> {
 
         private static final long serialVersionUID = 1L;
 
-        private ComponentInvocationType invocationAttribute;
+        private ComponentInvocationType state;
 
-        private InvocationArray(List<T> invocations) {
+        static InvocationFrames valueOf(Collection<? extends ComponentInvocation> invocations) {
+            return invocations instanceof InvocationFrames
+                    ? (InvocationFrames) invocations
+                    : new InvocationFrames(invocations == null ? emptyList() : invocations);
+        }
+
+        private InvocationFrames(Collection<? extends ComponentInvocation> invocations) {
             super(invocations);
         }
 
-        private InvocationArray() {
+        InvocationFrames() {
         }
 
-        public void setInvocationAttribute(ComponentInvocationType attribute) {
-            this.invocationAttribute = attribute;
+        void setState(ComponentInvocationType state) {
+            this.state = state;
         }
 
-        public ComponentInvocationType getInvocationAttribute() {
-            return invocationAttribute;
-        }
-
-        public boolean outsideStartup() {
-            return getInvocationAttribute() != SERVICE_STARTUP;
+        boolean isStartup() {
+            return state == SERVICE_STARTUP;
         }
     }
 
     @Override
     public void registerComponentInvocationHandler(ComponentInvocationType type, RegisteredComponentInvocationHandler handler) {
-        singleTypeHandlers.computeIfAbsent(type,
+        typeHandlers.computeIfAbsent(type,
                 key -> new ListComponentInvocationHandler(new CopyOnWriteArrayList<>())) // OBS! must be thread safe List here
             .add(handler.getComponentInvocationHandler());
     }
 
     @Override
     public void pushAppEnvironment(ApplicationEnvironment env) {
-        applicationEnvironments.get().push(env);
+        appEnvironments.get().addLast(env);
     }
 
     @Override
     public ApplicationEnvironment peekAppEnvironment() {
-        Stack<ApplicationEnvironment> stack = applicationEnvironments.get();
-
-        if (stack.isEmpty()) {
-            return null;
-        }
-
-        return stack.peek();
+        return appEnvironments.get().peekLast();
     }
 
     @Override
     public void popAppEnvironment() {
-        Stack<ApplicationEnvironment> stack = applicationEnvironments.get();
-
-        if (!stack.isEmpty()) {
-            stack.pop();
-        }
+        appEnvironments.get().pollLast();
     }
 
     @Override
     public void pushWebServiceMethod(Method method) {
-        webServiceMethods.get().push(method);
+        webServiceMethods.get().addLast(method);
     }
 
     @Override
     public Method peekWebServiceMethod() {
-        return webServiceMethods.get().peek();
+        return webServiceMethods.get().peekLast();
     }
 
     @Override
     public void popWebServiceMethod() {
-        webServiceMethods.get().pollFirst();
+        webServiceMethods.get().pollLast();
     }
 
     /**

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/invocation/InvocationManagerImplTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/invocation/InvocationManagerImplTest.java
@@ -1,0 +1,437 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.api.invocation;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.APP_CLIENT_INVOCATION;
+import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.EJB_INVOCATION;
+import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.SERVICE_STARTUP;
+import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType;
+import org.junit.Test;
+
+/**
+ * Tests formal correctness of the {@link InvocationManagerImpl}. This includes some multi-threading tests but it does
+ * not verify general thread-safety of the implementation. It does verify that in a controlled multi-threading situation
+ * the implementation shows the expected behaviour.
+ *
+ * @author Jan Bernitt
+ */
+public class InvocationManagerImplTest {
+
+    @Test
+    public void singleHandlerIsCalled() {
+        ComponentInvocationHandler handler = fakeHandler();
+        InvocationManager manager = new InvocationManagerImpl(handler);
+        assertCalledTimes(1, manager, handler, SERVLET_INVOCATION);
+        assertCalledTimes(1, manager, handler, EJB_INVOCATION);
+        assertCalledTimes(1, manager, handler, APP_CLIENT_INVOCATION);
+    }
+
+    @Test
+    public void multipleHandlersAreCalled() {
+        ComponentInvocationHandler handler = fakeHandler();
+        InvocationManager manager = new InvocationManagerImpl(handler, handler, handler);
+        assertCalledTimes(3, manager, handler, SERVLET_INVOCATION);
+        assertCalledTimes(3, manager, handler, EJB_INVOCATION);
+        assertCalledTimes(3, manager, handler, APP_CLIENT_INVOCATION);
+    }
+
+    @Test
+    public void nullHandlerDoesNotCauseErrors() {
+        InvocationManager manager = new InvocationManagerImpl();
+        assertCalledTimes(0, manager, null, SERVLET_INVOCATION);
+        assertCalledTimes(0, manager, null, EJB_INVOCATION);
+        assertCalledTimes(0, manager, null, APP_CLIENT_INVOCATION);
+    }
+
+    @Test
+    public void emptyHandlerDoesNotCauseErrors() {
+        InvocationManager manager = new InvocationManagerImpl(new ComponentInvocationHandler[0]);
+        assertCalledTimes(0, manager, null, SERVLET_INVOCATION);
+        assertCalledTimes(0, manager, null, EJB_INVOCATION);
+        assertCalledTimes(0, manager, null, APP_CLIENT_INVOCATION);
+    }
+
+    @Test
+    public void singleRegisteredHandlerIsCalled() {
+        InvocationManager manager = new InvocationManagerImpl();
+        RegisteredComponentInvocationHandler handler = fakeRegisteredHandler();
+        manager.registerComponentInvocationHandler(SERVLET_INVOCATION, handler);
+        assertCalledTimes(1, manager, handler.getComponentInvocationHandler(), SERVLET_INVOCATION);
+        assertCalledTimes(0, manager, handler.getComponentInvocationHandler(), EJB_INVOCATION);
+        assertCalledTimes(0, manager, handler.getComponentInvocationHandler(), APP_CLIENT_INVOCATION);
+    }
+
+    @Test
+    public void multipleRegisteredHandlersAreCalled() {
+        InvocationManager manager = new InvocationManagerImpl();
+        RegisteredComponentInvocationHandler servletHandler = fakeRegisteredHandler();
+        manager.registerComponentInvocationHandler(SERVLET_INVOCATION, servletHandler);
+        RegisteredComponentInvocationHandler ejbHandler = fakeRegisteredHandler();
+        manager.registerComponentInvocationHandler(EJB_INVOCATION, ejbHandler);
+        assertCalledTimes(1, manager, servletHandler.getComponentInvocationHandler(), SERVLET_INVOCATION);
+        assertCalledTimes(0, manager, servletHandler.getComponentInvocationHandler(), EJB_INVOCATION);
+        assertCalledTimes(0, manager, servletHandler.getComponentInvocationHandler(), APP_CLIENT_INVOCATION);
+        assertCalledTimes(0, manager, ejbHandler.getComponentInvocationHandler(), SERVLET_INVOCATION);
+        assertCalledTimes(1, manager, ejbHandler.getComponentInvocationHandler(), EJB_INVOCATION);
+        assertCalledTimes(0, manager, ejbHandler.getComponentInvocationHandler(), APP_CLIENT_INVOCATION);
+    }
+
+    @Test
+    public void exceptionInHandlerBeforePreInvokeDoesStillPushInvocation() {
+        ComponentInvocationHandler handler = fakeHandler();
+        doThrow(new RuntimeException("error in handler")).when(handler).beforePreInvoke(any(), any(), any());
+        InvocationManager manager = new InvocationManagerImpl(handler);
+        assertCalledTimes(1, manager, handler, SERVLET_INVOCATION);
+    }
+
+    @Test
+    public void exceptionInHandlerAfterPreInvokeDoesStillPushIncocation() {
+        ComponentInvocationHandler handler = fakeHandler();
+        doThrow(new RuntimeException("error in handler")).when(handler).afterPreInvoke(any(), any(), any());
+        InvocationManager manager = new InvocationManagerImpl(handler);
+        assertCalledTimes(1, manager, handler, SERVLET_INVOCATION);
+    }
+
+    @Test
+    public void serviceStartupPreInvokeDoesNotPushInvocation() {
+        InvocationManager manager = new InvocationManagerImpl();
+        manager.preInvoke(newInvocation(SERVICE_STARTUP));
+        assertNull(manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        assertEquals(emptyList(), manager.getAllInvocations());
+    }
+
+    @Test
+    public void serviceStartupPostInvokeDoesNotPopInvocation() {
+        InvocationManager manager = new InvocationManagerImpl();
+        manager.postInvoke(newInvocation(SERVICE_STARTUP));
+        assertNull(manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        assertEquals(emptyList(), manager.getAllInvocations());
+    }
+
+    @Test
+    public void exceptionInHandlerBeforePostInvokeDoesStillPopInvocation() {
+        ComponentInvocationHandler handler = fakeHandler();
+        doThrow(new RuntimeException("error in handler")).when(handler).beforePostInvoke(any(), any(), any());
+        InvocationManager manager = new InvocationManagerImpl(handler);
+        assertCalledTimes(1, manager, handler, SERVLET_INVOCATION);
+    }
+
+    @Test
+    public void exceptionInHandlerAfterPostInvokeDoesStillPopInvocation() {
+        ComponentInvocationHandler handler = fakeHandler();
+        doThrow(new RuntimeException("error in handler")).when(handler).afterPostInvoke(any(), any(), any());
+        InvocationManager manager = new InvocationManagerImpl(handler);
+        assertCalledTimes(1, manager, handler, SERVLET_INVOCATION);
+    }
+
+    @Test(expected = InvocationException.class)
+    public void postInvokeWithoutPreInvokeThrowsException() {
+        InvocationManager manager = new InvocationManagerImpl();
+        manager.postInvoke(newInvocation(SERVLET_INVOCATION));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getAllInvocationsReturnsCopy() {
+        InvocationManager manager = new InvocationManagerImpl();
+        manager.preInvoke(newInvocation(SERVLET_INVOCATION));
+        manager.preInvoke(newInvocation(SERVLET_INVOCATION));
+        List<? extends ComponentInvocation> copy = manager.getAllInvocations();
+        assertEquals(2, copy.size());
+        manager.preInvoke(newInvocation(SERVLET_INVOCATION));
+        assertEquals("copy is not independent", 2, copy.size());
+        assertEquals(3, manager.getAllInvocations().size());
+        ((List<ComponentInvocation>) copy).add(newInvocation(EJB_INVOCATION));
+        assertEquals("changing copy changed inner state", 3, manager.getAllInvocations().size());
+    }
+
+    @Test
+    public void popAllInvocationsPopsAllAndReturnsCopy() {
+        InvocationManager manager = new InvocationManagerImpl();
+        manager.preInvoke(newInvocation(SERVLET_INVOCATION));
+        manager.preInvoke(newInvocation(SERVLET_INVOCATION));
+        List<? extends ComponentInvocation> copy = manager.getAllInvocations();
+        assertEquals(2, copy.size());
+        assertEquals(copy, manager.popAllInvocations());
+        assertEquals(0, manager.getAllInvocations().size());
+    }
+
+    @Test
+    public void putAllInvocationsReplacesInvocationStack() {
+        InvocationManager manager = new InvocationManagerImpl();
+        List<ComponentInvocation> expected = asList(newInvocation(SERVLET_INVOCATION), newInvocation(EJB_INVOCATION));
+        manager.putAllInvocations(expected);
+        assertEquals(expected, manager.getAllInvocations());
+    }
+
+    @Test
+    public void servletInvocationChildThreadInitialisedToCurrentInvocation() throws InterruptedException {
+        InvocationManager manager = new InvocationManagerImpl();
+        ComponentInvocation prev = newInvocation(EJB_INVOCATION);
+        ComponentInvocation cur = newInvocation(SERVLET_INVOCATION);
+        manager.preInvoke(prev);
+        manager.preInvoke(cur);
+        runInChildThread(() -> {
+            List<? extends ComponentInvocation> localFrames = manager.getAllInvocations();
+            assertEquals(1, localFrames.size());
+            assertEquals(SERVLET_INVOCATION, localFrames.get(0).getInvocationType());
+        });
+    }
+
+    @Test
+    public void nonEjbInvocationChildThreadInitialisedToCurrentInvocation() throws InterruptedException {
+        InvocationManager manager = new InvocationManagerImpl();
+        ComponentInvocation prev = newInvocation(SERVLET_INVOCATION);
+        ComponentInvocation cur = newInvocation(APP_CLIENT_INVOCATION);
+        manager.preInvoke(prev);
+        manager.preInvoke(cur);
+        runInChildThread(() -> {
+            List<? extends ComponentInvocation> localFrames = manager.getAllInvocations();
+            assertEquals(1, localFrames.size());
+            assertEquals(APP_CLIENT_INVOCATION, localFrames.get(0).getInvocationType());
+        });
+    }
+
+    @Test
+    public void nullInvocationChildThreadInitialisedToEmptyFrames() throws InterruptedException {
+        InvocationManager manager = new InvocationManagerImpl();
+        runInChildThread(() -> assertEquals(emptyList(), manager.getAllInvocations()));
+    }
+
+    @Test
+    public void emptyInvocationChildThreadInitialisedToEmptyFrames() throws InterruptedException {
+        InvocationManager manager = new InvocationManagerImpl();
+        ComponentInvocation cur = newInvocation(APP_CLIENT_INVOCATION);
+        manager.preInvoke(cur);
+        manager.postInvoke(cur);
+        runInChildThread(() -> assertEquals(emptyList(), manager.getAllInvocations()));
+    }
+
+    @Test
+    public void servletStartupInvocationChildThreadInitialisedToEmptyFrames() throws InterruptedException {
+        InvocationManager manager = new InvocationManagerImpl();
+        ComponentInvocation prev = newInvocation(APP_CLIENT_INVOCATION);
+        ComponentInvocation cur = newInvocation(SERVICE_STARTUP);
+        manager.preInvoke(prev);
+        manager.preInvoke(cur);
+        runInChildThread(() -> assertEquals(emptyList(), manager.getAllInvocations()));
+        manager.postInvoke(cur); // startup is over, should init now
+        runInChildThread(() -> assertEquals(1, manager.getAllInvocations().size()));
+    }
+
+    private static void runInChildThread(Runnable test) throws InterruptedException {
+        AtomicReference<Throwable> thrownByChild = new AtomicReference<>();
+        Thread child = new Thread(() -> {
+            try {
+                test.run();
+            } catch (Throwable e) {
+                thrownByChild.set(e);
+            }
+        });
+        child.start();
+        child.join();
+        Throwable thrown = thrownByChild.get();
+        if (thrown != null) {
+            if (thrown instanceof AssertionError) {
+                throw (AssertionError) thrown;
+            }
+            throw new AssertionError("Child threw", thrown);
+        }
+    }
+
+    private static RegisteredComponentInvocationHandler fakeRegisteredHandler() {
+        ComponentInvocationHandler componentHandler = fakeHandler();
+        RegisteredComponentInvocationHandler handler = mock(RegisteredComponentInvocationHandler.class);
+        when(handler.getComponentInvocationHandler()).thenReturn(componentHandler);
+        return handler;
+    }
+
+    private static ComponentInvocationHandler fakeHandler() {
+        ComponentInvocationHandler handler = mock(ComponentInvocationHandler.class);
+        return handler;
+    }
+
+    private static ComponentInvocation newInvocation(ComponentInvocationType type) {
+        ComponentInvocation cur = new ComponentInvocation();
+        cur.setInvocationType(type);
+        return cur;
+    }
+
+    private static void assertCalledTimes(int times, InvocationManager manager, ComponentInvocationHandler handler,
+            ComponentInvocationType type) {
+        if (handler != null) {
+            reset(handler);
+        }
+        assertCallTimesNonNested(times, manager, handler, type);
+
+        if (handler != null) {
+            reset(handler);
+        }
+        assertCallTimesNested(times, manager, handler, type);
+
+        if (handler != null) {
+            reset(handler);
+        }
+        assertCallTimesNested2Levels(times, manager, handler, type);
+    }
+
+    private static void assertCallTimesNested2Levels(int times, InvocationManager manager,
+            ComponentInvocationHandler handler, ComponentInvocationType type) {
+        ComponentInvocation level1 = newInvocation(type);
+        ComponentInvocation level2 = newInvocation(type);
+        ComponentInvocation level3 = newInvocation(type);
+        manager.preInvoke(level1);
+        assertSame(level1, manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        manager.preInvoke(level2);
+        assertSame(level2, manager.getCurrentInvocation());
+        assertSame(level1, manager.getPreviousInvocation());
+        if (handler != null) {
+            assertPreCalledTimes(times, handler, level1, level2);
+        }
+        manager.preInvoke(level3);
+        assertSame(level3, manager.getCurrentInvocation());
+        assertSame(level2, manager.getPreviousInvocation());
+        if (handler != null) {
+            assertPreCalledTimes(times, handler, level2, level3);
+        }
+        manager.postInvoke(level3);
+        assertSame(level2, manager.getCurrentInvocation());
+        assertSame(level1, manager.getPreviousInvocation());
+        if (handler != null) {
+            assertPostCalledTimes(times, handler, level2, level3);
+        }
+        manager.postInvoke(level2);
+        assertSame(level1, manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        if (handler != null) {
+            assertPostCalledTimes(times, handler, level1, level2);
+        }
+        manager.postInvoke(level2);
+        assertNull(manager.getCurrentInvocation());
+    }
+
+    private static void assertCallTimesNested(int times, InvocationManager manager, ComponentInvocationHandler handler,
+            ComponentInvocationType type) {
+        ComponentInvocation outer = newInvocation(type);
+        ComponentInvocation inner = newInvocation(type);
+        manager.preInvoke(outer);
+        assertSame(outer, manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        assertEquals(singletonList(outer), manager.getAllInvocations());
+        manager.preInvoke(inner);
+        assertSame(inner, manager.getCurrentInvocation());
+        assertSame(outer, manager.getPreviousInvocation());
+        assertEquals(asList(outer, inner), manager.getAllInvocations());
+        if (handler != null) {
+            assertPreCalledTimes(times, handler, outer, inner);
+        }
+        manager.postInvoke(inner);
+        assertSame(outer, manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        assertEquals(singletonList(outer), manager.getAllInvocations());
+        if (handler != null) {
+            assertPostCalledTimes(times, handler, outer, inner);
+        }
+        manager.postInvoke(inner);
+        assertNull(manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        assertEquals(emptyList(), manager.getAllInvocations());
+    }
+
+    private static void assertCallTimesNonNested(int times, InvocationManager manager,
+            ComponentInvocationHandler handler, ComponentInvocationType type) {
+        ComponentInvocation cur = newInvocation(type);
+        assertTrue(manager.isInvocationStackEmpty());
+        manager.preInvoke(cur);
+        assertSame(cur, manager.getCurrentInvocation());
+        assertNull(manager.getPreviousInvocation());
+        assertFalse(manager.isInvocationStackEmpty());
+        assertEquals(singletonList(cur), manager.getAllInvocations());
+        manager.postInvoke(cur);
+        assertNull(manager.getCurrentInvocation());
+        assertTrue(manager.isInvocationStackEmpty());
+        assertEquals(emptyList(), manager.getAllInvocations());
+        if (handler != null) {
+            assertCalledTimes(times, handler, null, cur);
+        }
+    }
+
+    private static void assertCalledTimes(int times, ComponentInvocationHandler handler, ComponentInvocation prev,
+            ComponentInvocation cur) {
+        assertPreCalledTimes(times, handler, prev, cur);
+        assertPostCalledTimes(times, handler, prev, cur);
+    }
+
+    private static void assertPostCalledTimes(int times, ComponentInvocationHandler handler, ComponentInvocation prev,
+            ComponentInvocation cur) {
+        verify(handler, times(times)).beforePostInvoke(any(), eq(prev), eq(cur));
+        verify(handler, times(times)).afterPostInvoke(any(), eq(prev), eq(cur));
+    }
+
+    private static void assertPreCalledTimes(int times, ComponentInvocationHandler handler, ComponentInvocation prev,
+            ComponentInvocation cur) {
+        verify(handler, times(times)).beforePreInvoke(any(), eq(prev), eq(cur));
+        verify(handler, times(times)).afterPreInvoke(any(), eq(prev), eq(cur));
+    }
+}

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/invocation/InvocationManagerImplTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/invocation/InvocationManagerImplTest.java
@@ -422,7 +422,7 @@ public class InvocationManagerImplTest {
         if (handler != null) {
             assertPostCalledTimes(times, handler, level1, level2);
         }
-        manager.postInvoke(level2);
+        manager.postInvoke(level1);
         assertNull(manager.getCurrentInvocation());
     }
 
@@ -448,7 +448,7 @@ public class InvocationManagerImplTest {
         if (handler != null) {
             assertPostCalledTimes(times, handler, outer, inner);
         }
-        manager.postInvoke(inner);
+        manager.postInvoke(outer);
         assertNull(manager.getCurrentInvocation());
         assertNull(manager.getPreviousInvocation());
         assertEquals(emptyList(), manager.getAllInvocations());

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/invocation/InvocationManagerImplTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/invocation/InvocationManagerImplTest.java
@@ -48,6 +48,7 @@ import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocati
 import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -332,6 +333,30 @@ public class InvocationManagerImplTest {
         assertSame(method, manager.peekWebServiceMethod());
         manager.popWebServiceMethod();
         assertNull(manager.peekWebServiceMethod());
+    }
+
+    @Test
+    public void toStringDoesNotThrowException() {
+        ComponentInvocation ci = newInvocation(SERVLET_INVOCATION);
+        assertNotNull(ci.toString()); // test bare instance
+        ci.setAppName("appName");
+        ci.setInstanceName("instanceName");
+        ci.setComponentId("componentId");
+        ci.setContainer("container");
+        assertEquals(Integer.toHexString(System.identityHashCode(ci)) + "@" + ci.getClass().getName() + "\n" +
+                "\tcomponentId=componentId\n" +
+                "\ttype=SERVLET_INVOCATION\n" +
+                "\tinstance=instanceName\n" +
+                "\tcontainer=container\n" +
+                "\tappName=appName\n", ci.toString());
+        ci.setInstanceName(null);
+        ci.setInstance("instance");
+        assertEquals(Integer.toHexString(System.identityHashCode(ci)) + "@" + ci.getClass().getName() + "\n" +
+                "\tcomponentId=componentId\n" +
+                "\ttype=SERVLET_INVOCATION\n" +
+                "\tinstance=instance\n" +
+                "\tcontainer=container\n" +
+                "\tappName=appName\n", ci.toString());
     }
 
     private static void runInChildThread(Runnable test) throws InterruptedException {


### PR DESCRIPTION
### Background
Running FT TCK strongly suggested that a race condition in or around the `InvocationManger` leads to inconsistent context when trying to derive the _current_ application like shown below:
```java
 ComponentInvocation current = invocationManager.getCurrentInvocation();
 if (current == null) {
     return invocationManager.peekAppEnvironment().getName();
 }
 String appName = current.getAppName();
 if (appName == null) {
     appName = current.getModuleName();
 }
 if (appName == null) {
     appName = current.getComponentId();
 }
return appName;
```
The issue observed was that different application names were returned in a non deterministic manner for the actual same application processing tests.

### Summary
The most likely cause is related to the frames that push and pop the stack which is peeked by `getCurrentInvocation()`. But it could also be related to application environment stack peeked by `peekAppEnvironment()` for case that not `ComponentInvocation` was on the stack.
The issue can either be within the implementation of the `InvocationMangerImpl` but also on the outside as the  `ComponentInvocation` is essentially managed from the outside by calling `preInvoke` and `postInvoke`.

Changes:
* removes the unnecessary generic of the `InvocationArray` / `InvocationFrames` (renamed) inner class
* replaces use of `Stack` with `ConcurrentLinkedDeque` (`synchronized` vs. CAS based synchronisation)
* replaces `ArrayList` as bases of frames stack with `ConcurrentLinkedDeque` (as this is only used via thread local non synchronised should not be an issue but to be sure and to provide better readability of the base class was changed)
* replaces `ComponentInvocationHandler[]` handlers with a single `ComponentInvocationHandler` that is initialised with `ListComponentInvocationHandler` in case multiple handlers are actually needed. The underlying `List` uses `ArrayList` as it is read-only after being initialised. This allows to simplify the rest of the implementation that only has to assume a single handler.
* uses `ListComponentInvocationHandler` to manage `RegisteredComponentInvocationHandler`. In this case the underlying `List` uses a `CopyOnWriteArrayList` as multiple threads might register handlers concurrently. 
* replaces the `Map` for `RegisteredComponentInvocationHandler` (that are per type) with a thread-safe `ConcurrentHashMap` as multiple threads can register handlers concurrently.
* adds `try-finally` to `preInvoke` to make sure that any exception thrown by handlers does not prevent adding of the invocation instance (I'd say this is the best candidate for the observed issue)

### Testing
The implementation of `InvocationMangerImpl` got covered with unit tests to a coverage > 95%.
This mostly intends to make sure the changes in the implementation do not cause unexpected behaviour, in particular throwing exceptions when it should not. The tests do include a few tests that include multiple threads to verify the thread parent-child stack inheritance behaviour, not to show that the class is thread-safe. To allow better reasoning about thread safety the implementation was cleaned and simplified so the use of collection becomes more clear. 

#### Testing Performed
The unit tests were added mostly to make sure changes did not introduce new bugs like NPEs and alike and that the implementation does behave as expected from reading the code.

In addition I ran the FT TCK as that had shown issues before and since it deploying lots of applications. 