### PR TITLE
Increase FaultTolerance async max pool size from 1000 to 2000

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
@@ -1,8 +1,8 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *    Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
  *     and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *     https://github.com/payara/Payara/blob/master/LICENSE.txt
  *     See the License for the specific
  *     language governing permissions and limitations under the License.
- * 
+ *
  *     When distributing the software, include this License Header Notice in each
  *     file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *     GPL Classpath Exception:
  *     The Payara Foundation designates this particular file as subject to the "Classpath"
  *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *     file that accompanied this code.
- * 
+ *
  *     Modifications:
  *     If applicable, add the following below the License Header, with the fields
  *     enclosed by brackets [] replaced by your own identifying information:
  *     "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *     Contributor(s):
  *     If you wish your version of this file to be governed by only the CDDL or
  *     only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -68,7 +68,7 @@ public interface FaultToleranceServiceConfiguration extends ConfigExtension {
      *         executor will vary the actual pool size depending on demand up to this upper limit. If no demand exist
      *         the actual pool size is zero.
      */
-    @Attribute(defaultValue = "1000", dataType = Integer.class)
+    @Attribute(defaultValue = "2000", dataType = Integer.class)
     @Min(value = 20)
     String getAsyncMaxPoolSize();
     void setAsyncMaxPoolSize(String asyncMaxPoolSize);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
@@ -91,7 +91,7 @@ import org.jvnet.hk2.annotations.Service;
 
 /**
  * Base Service for MicroProfile Fault Tolerance.
- * 
+ *
  * @author Andrew Pielage
  * @author Jan Bernitt (2.0)
  */
@@ -160,7 +160,7 @@ public class FaultToleranceServiceImpl
         int cleaned = 0;
         for (String key : new HashSet<>(methodByTargetObjectAndName.keySet())) {
             try {
-                Object newValue = methodByTargetObjectAndName.compute(key, 
+                Object newValue = methodByTargetObjectAndName.compute(key,
                         (k, methodContext) -> methodContext.isExpired(ttl) ? null : methodContext);
                 if (newValue == null) {
                     cleaned++;
@@ -180,7 +180,7 @@ public class FaultToleranceServiceImpl
     }
 
     private int getMaxAsyncPoolSize() {
-        return config == null ? 1000 : parseInt(config.getAsyncMaxPoolSize());
+        return config == null ? 2000 : parseInt(config.getAsyncMaxPoolSize());
     }
 
     private int getAsyncPoolKeepAliveInSeconds() {
@@ -240,7 +240,7 @@ public class FaultToleranceServiceImpl
 
     @Override
     public FaultToleranceConfig getConfig(InvocationContext context, Stereotypes stereotypes) {
-        return configByApplication.computeIfAbsent(getApplicationContext(context), 
+        return configByApplication.computeIfAbsent(getApplicationContext(context),
                 key -> new BindableFaultToleranceConfig(stereotypes)).bindTo(context);
     }
 
@@ -270,7 +270,7 @@ public class FaultToleranceServiceImpl
     private String getApplicationContext(InvocationContext context) {
         ComponentInvocation currentInvocation = invocationManager.getCurrentInvocation();
         String appName = currentInvocation.getAppName();
-        return appName != null ? appName : "common"; 
+        return appName != null ? appName : "common";
     }
 
     @Override
@@ -288,7 +288,7 @@ public class FaultToleranceServiceImpl
         }
     }
 
-    private void addGenericFaultToleranceRequestTracingDetails(RequestTraceSpan span, 
+    private void addGenericFaultToleranceRequestTracingDetails(RequestTraceSpan span,
             InvocationContext context) {
         ComponentInvocation currentInvocation = invocationManager.getCurrentInvocation();
         span.addSpanTag("App Name", currentInvocation.getAppName());
@@ -310,7 +310,7 @@ public class FaultToleranceServiceImpl
     private FaultToleranceMethodContextImpl createMethodContext(String methodId, InvocationContext context,
             RequestContextController requestContextController) {
         MetricRegistry metricRegistry = getApplicationMetricRegistry();
-        FaultToleranceMetrics metrics = metricRegistry == null 
+        FaultToleranceMetrics metrics = metricRegistry == null
                 ? FaultToleranceMetrics.DISABLED
                 : new MethodFaultToleranceMetrics(metricRegistry, FaultToleranceUtils.getCanonicalMethodName(context));
         asyncExecutorService.setMaximumPoolSize(getMaxAsyncPoolSize()); // lazy update of max size


### PR DESCRIPTION
To avoid TCK runs failing due to pool rejecting execution the default is increased to 2000. The TCK at some point uses 1000 threads in a single test. Local tests with a max of 2000 has shown to avoid this issue.