### PR TITLE
Cleanup Generics in MP Config

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
@@ -81,12 +81,12 @@ public class ConfigProducer {
     public Config getConfig() {
         return new InjectedPayaraConfig(ConfigProvider.getConfig(), im.getCurrentInvocation().getAppName());
     }
-    
+
     /**
      * Producer method for Sets
      * @param <T> Type
      * @param ip Injection Point
-     * @return 
+     * @return
      */
     @Produces
     @ConfigProperty
@@ -98,17 +98,18 @@ public class ConfigProducer {
         if (type instanceof ParameterizedType) {
             // it is an Optional
             // get the class of the generic parameterized Optional
-            Class clazzValue = (Class) ((ParameterizedType) type).getActualTypeArguments()[0];
-            result = config.getSetValues(property.name(),property.defaultValue(), clazzValue);
-        }        
-        return result;        
+            @SuppressWarnings("unchecked")
+            Class<T> clazzValue = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+            result = config.getSetValues(property.name(), property.defaultValue(), clazzValue);
+        }
+        return result;
     }
-    
+
     /**
-     * Producer method for Lists 
+     * Producer method for Lists
      * @param <T> Type
      * @param ip Injection Point
-     * @return 
+     * @return
      */
     @Produces
     @ConfigProperty
@@ -120,9 +121,10 @@ public class ConfigProducer {
         if (type instanceof ParameterizedType) {
             // it is an Optional
             // get the class of the generic parameterized Optional
-            Class clazzValue = (Class) ((ParameterizedType) type).getActualTypeArguments()[0];
+            @SuppressWarnings("unchecked")
+            Class<T> clazzValue = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
             result = config.getListValues(property.name(),property.defaultValue(), clazzValue);
-        }        
+        }
         return result;
     }
 
@@ -131,25 +133,26 @@ public class ConfigProducer {
      * and of the type specified
      * @param <T>
      * @param ip
-     * @return 
+     * @return
      */
     @Produces
     @ConfigProperty
     public <T> Optional<T> getOptionalProperty(InjectionPoint ip) {
-        
+
         // gets the config property annotation
         ConfigProperty property = ip.getAnnotated().getAnnotation(ConfigProperty.class);
         PayaraConfig config = (PayaraConfig) ConfigProvider.getConfig();
-        Optional result = Optional.empty();
-        
+        Optional<T> result = Optional.empty();
+
         Type type = ip.getType();
         if (type instanceof ParameterizedType) {
             // it is an Optional
             // get the class of the generic parameterized Optional
-            Class clazzValue = (Class) ((ParameterizedType) type).getActualTypeArguments()[0];
-            
+            @SuppressWarnings("unchecked")
+            Class<T> clazzValue = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+
             // use the config to get a converted version of the property
-            Object value = config.getValue(property.name(), property.defaultValue(),clazzValue);
+            T value = config.getValue(property.name(), property.defaultValue(),clazzValue);
             if (value != null && !value.toString().equals(ConfigProperty.UNCONFIGURED_VALUE)) {
                 result = Optional.ofNullable(value);
             }

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
@@ -40,7 +40,6 @@
 package fish.payara.microprofile.config.cdi;
 
 import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Member;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -59,14 +58,14 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  * @author Steve Millidge (Payara Foundation)
  */
 public class ConfigPropertyProducer {
-    
+
     /**
-     * General producer method for injecting a property into a field annotated 
+     * General producer method for injecting a property into a field annotated
      * with the @ConfigProperty annotation.
      * Note this does not have @Produces annotation as a synthetic bean using this method
      * is created in the CDI Extension.
      * @param ip
-     * @return 
+     * @return
      */
     @ConfigProperty
     @Dependent
@@ -74,12 +73,12 @@ public class ConfigPropertyProducer {
         Object result = null;
         ConfigProperty property = ip.getAnnotated().getAnnotation(ConfigProperty.class);
         PayaraConfig config = (PayaraConfig) ConfigProvider.getConfig();
-        
+
         String name = property.name();
         if (name.isEmpty()) {
             // derive the property name from the injection point
-            Class beanClass = null;
-            Bean bean = ip.getBean();
+            Class<?> beanClass = null;
+            Bean<?> bean = ip.getBean();
             if (bean == null) {
                 Member member = ip.getMember();
                 beanClass = member.getDeclaringClass();
@@ -91,8 +90,8 @@ public class ConfigPropertyProducer {
             sb.append(ip.getMember().getName());
             name =  sb.toString();
         }
-        
-        Type type = ip.getType();      
+
+        Type type = ip.getType();
         if (type instanceof Class) {
             result = config.getValue(name, property.defaultValue(),(Class<?>)type);
         } else if ( type instanceof ParameterizedType) {
@@ -100,12 +99,12 @@ public class ConfigPropertyProducer {
             if (List.class.equals(ptype.getRawType())) {
                 result = config.getListValues(name, property.defaultValue(), (Class<?>) ptype.getActualTypeArguments()[0]);
             } else if (Set.class.equals(ptype.getRawType())) {
-                result = config.getSetValues(name, property.defaultValue(), (Class<?>) ptype.getActualTypeArguments()[0]);                
+                result = config.getSetValues(name, property.defaultValue(), (Class<?>) ptype.getActualTypeArguments()[0]);
             } else {
                 result = config.getValue(name, (Class<?>)((ParameterizedType)type).getRawType());
             }
         }
-        
+
         if (result == null) {
             throw new DeploymentException("Microprofile Config Property " + property.name() + " can not be found");
         }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ConfigConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/ConfigConfigSource.java
@@ -40,7 +40,6 @@
 package fish.payara.nucleus.microprofile.config.source;
 
 import com.sun.enterprise.config.serverbeans.Config;
-import static fish.payara.nucleus.microprofile.config.source.PayaraConfigSource.PROPERTY_PREFIX;
 import java.beans.PropertyVetoException;
 import java.util.HashMap;
 import java.util.List;

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/MicroprofileConfigConfiguration.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/MicroprofileConfigConfiguration.java
@@ -39,56 +39,63 @@
  */
 package fish.payara.nucleus.microprofile.config.spi;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.glassfish.api.admin.config.ConfigExtension;
 import org.jvnet.hk2.config.Attribute;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.Configured;
 
 /**
+ * The configuration that configures the semantics of the MP {@link Config} implementation.
+ *
+ * First of all this is the ordinality for the different types of {@link ConfigSource}s.
+ * The source with the highest ordinality takes precedence.
+ *
  * @since 4.1.2.173
  * @author Steve Millidge (Payara Foundation)
  */
 @Configured(name="microprofile-config")
 public interface MicroprofileConfigConfiguration extends ConfigBeanProxy, ConfigExtension {
-    
+
     @Attribute(defaultValue = "110", dataType = Integer.class)
     String getDomainOrdinality();
     public void setDomainOrdinality(String message);
 
     @Attribute(defaultValue = "120", dataType = Integer.class)
     String getConfigOrdinality();
-    public void setConfigOrdinality(String message);    
-    
+    public void setConfigOrdinality(String message);
+
     @Attribute(defaultValue = "130", dataType = Integer.class)
     String getServerOrdinality();
     public void setServerOrdinality(String message);
 
     @Attribute(defaultValue = "140", dataType = Integer.class)
     String getApplicationOrdinality();
-    public void setApplicationOrdinality(String message);    
+    public void setApplicationOrdinality(String message);
 
     @Attribute(defaultValue = "150", dataType = Integer.class)
     String getModuleOrdinality();
-    public void setModuleOrdinality(String message);    
+    public void setModuleOrdinality(String message);
 
     @Attribute(defaultValue = "160", dataType = Integer.class)
     String getClusterOrdinality();
-    public void setClusterOrdinality(String message);    
-    
+    public void setClusterOrdinality(String message);
+
     @Attribute(defaultValue = "115", dataType = Integer.class)
     String getJNDIOrdinality();
-    public void setJNDIOrdinality(String message);  
-    
+    public void setJNDIOrdinality(String message);
+
     @Attribute(defaultValue = "secrets", dataType = String.class)
     String getSecretDir();
     public void setSecretDir(String directory);
-    
+
     @Attribute(defaultValue = "90", dataType = Integer.class)
     String getSecretDirOrdinality();
-    public void setSecretDirOrdinality(String message);  
+    public void setSecretDirOrdinality(String message);
 
     @Attribute(defaultValue = "105", dataType = Integer.class)
     public String getPasswordOrdinality();
     public void setPasswordOrdinality(String message);
-    
+
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -67,8 +67,7 @@ public class PayaraConfig implements Config {
 
     public PayaraConfig(List<ConfigSource> configSources, Map<Type,Converter<?>> convertersMap) {
         this.configSources = configSources;
-        this.converters = new ConcurrentHashMap<>();
-        this.converters.putAll(convertersMap);
+        this.converters = new ConcurrentHashMap<>(convertersMap);
         Collections.sort(configSources, new ConfigSourceComparator());
     }
 


### PR DESCRIPTION
My original intention was to add some caching to MP config since I became aware how often e.g. MP metrics is resolving values. I started by cleaning up warnings and then decided to stay there for the moment as I have to rethink if and how to best do caching given the semantics we have to deal with. 

This PR mostly adds missing generics and does some other details like using `final` and visibility modifiers.

**Edit**: Had an idea for cache that I add in another PR on top of this one.