### PR TITLE
CUSTCOM-133 Fixed jaspic on domain nodes

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbApplication.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbApplication.java
@@ -49,11 +49,13 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.inject.Inject;
+
 import com.sun.ejb.Container;
 import com.sun.ejb.ContainerFactory;
 import com.sun.ejb.containers.AbstractSingletonContainer;
 import com.sun.enterprise.deployment.Application;
-import com.sun.enterprise.security.PolicyLoader;
+import com.sun.enterprise.security.SecurityLifecycle;
 import com.sun.logging.LogDomains;
 import org.glassfish.api.deployment.ApplicationContainer;
 import org.glassfish.api.deployment.ApplicationContext;
@@ -88,6 +90,11 @@ public class EjbApplication
     private static final Logger _logger =
                 LogDomains.getLogger(EjbApplication.class, LogDomains.EJB_LOGGER);
 
+    // must be already set before using this service.
+    @SuppressWarnings("unused")
+    @Inject
+    private SecurityLifecycle securityLifecycle;
+
     private EjbBundleDescriptorImpl ejbBundle;
     private Collection<EjbDescriptor> ejbs;
     private Collection<Container> containers = new ArrayList<>();
@@ -97,8 +104,6 @@ public class EjbApplication
     private ServiceLocator services;
 
     private SingletonLifeCycleManager singletonLCM;
-
-    private PolicyLoader policyLoader;
 
     private boolean initializeInOrder;
 
@@ -120,7 +125,6 @@ public class EjbApplication
         this.ejbAppClassLoader = cl;
         this.dc = dc;
         this.services = services;
-        this.policyLoader = services.getService(PolicyLoader.class);
         Application app = ejbBundle.getApplication();
         initializeInOrder = (app != null) && (app.isInitializeInOrder());
     }
@@ -208,8 +212,6 @@ public class EjbApplication
         }
 
         try {
-            policyLoader.loadPolicy();
-
             for (EjbDescriptor desc : ejbs) {
 
                 // Initialize each ejb container (setup component environment, register JNDI objects, etc.)

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/JavaEESecurityLifecycle.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/JavaEESecurityLifecycle.java
@@ -37,66 +37,76 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security.ee;
 
-import static java.util.logging.Level.WARNING;
-import static javax.security.auth.message.config.AuthConfigFactory.DEFAULT_FACTORY_SECURITY_PROPERTY;
+import com.sun.enterprise.security.ContainerSecurityLifecycle;
+import com.sun.enterprise.security.jaspic.config.GFAuthConfigFactory;
+import com.sun.logging.LogDomains;
 
 import java.security.Security;
 import java.util.logging.Logger;
 
 import javax.inject.Singleton;
 
+import org.glassfish.common.util.Constants;
 import org.glassfish.hk2.api.PostConstruct;
+import org.glassfish.hk2.api.Rank;
+import org.glassfish.internal.api.InitRunLevel;
 import org.jvnet.hk2.annotations.Service;
 
-import com.sun.enterprise.security.ContainerSecurityLifecycle;
-import com.sun.enterprise.security.jaspic.config.GFAuthConfigFactory;
-import com.sun.logging.LogDomains;
+import static java.util.logging.Level.WARNING;
+import static javax.security.auth.message.config.AuthConfigFactory.DEFAULT_FACTORY_SECURITY_PROPERTY;
+
 
 /**
- *
  * @author vbkumarjayanti
+ * @author David Matejcek
  */
+@InitRunLevel
+@Rank(Constants.IMPORTANT_RUN_LEVEL_SERVICE)
 @Service
 @Singleton
 public class JavaEESecurityLifecycle implements ContainerSecurityLifecycle, PostConstruct {
 
-    private static final Logger _logger = LogDomains.getLogger(JavaEESecurityLifecycle.class, LogDomains.SECURITY_LOGGER);
+    private static final Logger LOG = LogDomains.getLogger(JavaEESecurityLifecycle.class, LogDomains.SECURITY_LOGGER);
+
+    @Override
+    public void postConstruct() {
+        onInitialization();
+    }
+
 
     @Override
     public void onInitialization() {
-        java.lang.SecurityManager systemSecurityManager = System.getSecurityManager();
+        LOG.finest(() -> "Initializing " + getClass());
 
         // TODO: Need some way to not override the security manager if the EmbeddedServer was
         // run with a different non-default security manager.
         //
         // Right now there seems no way to find out if the security manager is the VM's default security manager.
+        final SecurityManager systemSecurityManager = System.getSecurityManager();
         if (systemSecurityManager != null && !(J2EESecurityManager.class.equals(systemSecurityManager.getClass()))) {
             J2EESecurityManager eeSecurityManager = new J2EESecurityManager();
             try {
                 System.setSecurityManager(eeSecurityManager);
+                LOG.config(() -> "System security manager has been set to " + eeSecurityManager);
             } catch (SecurityException ex) {
-                _logger.log(WARNING, "security.secmgr.could.not.override");
+                LOG.log(WARNING, "security.secmgr.could.not.override", ex);
             }
         }
-        
         initializeJASPIC();
     }
 
     private void initializeJASPIC() {
         // Define default factory if it is not already defined.
         // The factory will be constructed on the first getFactory call.
-
-        String defaultFactory = Security.getProperty(DEFAULT_FACTORY_SECURITY_PROPERTY);
+        final String defaultFactory = Security.getProperty(DEFAULT_FACTORY_SECURITY_PROPERTY);
         if (defaultFactory == null) {
-            Security.setProperty(DEFAULT_FACTORY_SECURITY_PROPERTY, GFAuthConfigFactory.class.getName());
+            final String defaultAuthConfigProvideFactoryClassName = GFAuthConfigFactory.class.getName();
+            Security.setProperty(DEFAULT_FACTORY_SECURITY_PROPERTY, defaultAuthConfigProvideFactoryClassName);
+            LOG.config(() -> String.format("System JVM option '%s' has been set to '%s'",
+                DEFAULT_FACTORY_SECURITY_PROPERTY, defaultAuthConfigProvideFactoryClassName));
         }
-    }
-
-    @Override
-    public void postConstruct() {
-        onInitialization();
     }
 }

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecurityDeployer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecurityDeployer.java
@@ -37,16 +37,24 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.security.ee;
 
-import static com.sun.enterprise.deployment.WebBundleDescriptor.AFTER_SERVLET_CONTEXT_INITIALIZED_EVENT;
-import static com.sun.enterprise.security.ee.SecurityUtil.getContextID;
-import static java.util.logging.Level.WARNING;
-import static org.glassfish.internal.deployment.Deployment.APPLICATION_LOADED;
-import static org.glassfish.internal.deployment.Deployment.APPLICATION_PREPARED;
-import static org.glassfish.internal.deployment.Deployment.MODULE_LOADED;
+import com.sun.enterprise.deployment.Application;
+import com.sun.enterprise.deployment.EjbBundleDescriptor;
+import com.sun.enterprise.deployment.WebBundleDescriptor;
+import com.sun.enterprise.deployment.web.LoginConfiguration;
+import com.sun.enterprise.security.AppCNonceCacheMap;
+import com.sun.enterprise.security.CNonceCacheFactory;
+import com.sun.enterprise.security.EjbSecurityPolicyProbeProvider;
+import com.sun.enterprise.security.SecurityLifecycle;
+import com.sun.enterprise.security.WebSecurityDeployerProbeProvider;
+import com.sun.enterprise.security.jacc.JaccWebAuthorizationManager;
+import com.sun.enterprise.security.util.IASSecurityException;
+import com.sun.enterprise.security.web.integration.WebSecurityManagerFactory;
+import com.sun.logging.LogDomains;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,31 +85,31 @@ import org.glassfish.security.common.CNonceCache;
 import org.glassfish.security.common.HAUtil;
 import org.jvnet.hk2.annotations.Service;
 
-import com.sun.enterprise.deployment.Application;
-import com.sun.enterprise.deployment.EjbBundleDescriptor;
-import com.sun.enterprise.deployment.WebBundleDescriptor;
-import com.sun.enterprise.deployment.web.LoginConfiguration;
-import com.sun.enterprise.security.AppCNonceCacheMap;
-import com.sun.enterprise.security.CNonceCacheFactory;
-import com.sun.enterprise.security.EjbSecurityPolicyProbeProvider;
-import com.sun.enterprise.security.WebSecurityDeployerProbeProvider;
-import com.sun.enterprise.security.jacc.JaccWebAuthorizationManager;
-import com.sun.enterprise.security.util.IASSecurityException;
-import com.sun.enterprise.security.web.integration.WebSecurityManagerFactory;
-import com.sun.logging.LogDomains;
+import static com.sun.enterprise.deployment.WebBundleDescriptor.AFTER_SERVLET_CONTEXT_INITIALIZED_EVENT;
+import static com.sun.enterprise.security.ee.SecurityUtil.getContextID;
+import static java.util.logging.Level.WARNING;
+import static org.glassfish.internal.deployment.Deployment.APPLICATION_LOADED;
+import static org.glassfish.internal.deployment.Deployment.APPLICATION_PREPARED;
+import static org.glassfish.internal.deployment.Deployment.MODULE_LOADED;
 
 /**
  * Security Deployer which generate and clean the security policies
- * 
+ *
  * <p>
- * This contains many JACC life cycle methods which can/should be moved to the JACC package 
+ * This contains many JACC life cycle methods which can/should be moved to the JACC package
  *
  */
 @Service(name = "Security")
 public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApplication> implements PostConstruct {
 
     private static final Logger _logger = LogDomains.getLogger(SecurityDeployer.class, LogDomains.SECURITY_LOGGER);
-    
+
+
+    // must be already set before using this service.
+    @SuppressWarnings("unused")
+    @Inject
+    private SecurityLifecycle securityLifecycle;
+
     @Inject
     private ServerContext serverContext;
 
@@ -139,7 +147,7 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
         @Override
         public void event(Event event) {
             Application app = null;
-            
+
             if (MODULE_LOADED.equals(event.type())) {
                 ModuleInfo moduleInfo = (ModuleInfo) event.hook();
                 if (moduleInfo instanceof ApplicationInfo) {
@@ -158,7 +166,7 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
                 Set<WebBundleDescriptor> webBundleDescriptors = app.getBundleDescriptors(WebBundleDescriptor.class);
                 linkPolicies(app, webBundleDescriptors);
                 commitEjbPolicies(app);
-                
+
                 if (webBundleDescriptors != null && !webBundleDescriptors.isEmpty()) {
                     // Register the WebSecurityComponentInvocationHandler
                     RegisteredComponentInvocationHandler handler = registeredComponentInvocationHandlerProvider.get();
@@ -170,8 +178,8 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
                 commitWebPolicy((WebBundleDescriptor) event.hook());
             }
         }
-    };
-    
+    }
+
     @Override
     public void postConstruct() {
         listener = new AppDeployEventListener();
@@ -185,7 +193,7 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
         if (params.origin.isArtifactsPresent()) {
             return;
         }
-        
+
         String appName = params.name();
         try {
             Application app = context.getModuleMetaData(Application.class);
@@ -208,7 +216,7 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
     protected void cleanArtifacts(DeploymentContext context) throws DeploymentException {
         removePolicy(context);
         SecurityUtil.removeRoleMapper(context);
-        
+
         OpsParams params = context.getCommandParameters(OpsParams.class);
         if (this.appCnonceMap != null) {
             CNonceCache cache = appCnonceMap.remove(params.name());
@@ -231,15 +239,15 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
     public void unload(DummyApplication container, DeploymentContext context) {
         cleanSecurityContext(context.getCommandParameters(OpsParams.class).name());
     }
-    
+
     @Override
     public MetaData getMetaData() {
         return new MetaData(false, null, new Class[] { Application.class });
     }
-    
+
     /**
      * Translate Web Bundle Policy
-     * 
+     *
      * @param webDescriptor
      * @param remove boolean indicated whether any existing policy statements are removed form context before translation
      * @throws DeploymentException
@@ -260,15 +268,15 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
             throw new DeploymentException("Error in generating security policy for " + webDescriptor.getModuleDescriptor().getModuleName(), se);
         }
     }
-    
-    
-    
+
+
+
     // ### Private methods
- 
+
 
     /**
      * Puts Web Bundle Policy In Service, repeats translation is Descriptor indicate policy was changed by ContextListener.
-     * 
+     *
      * @param webBundleDescriptor
      * @throws DeploymentException
      */
@@ -279,14 +287,13 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
                     // redo policy translation for web module
                     loadPolicy(webBundleDescriptor, true);
                 }
-                
+
                 String contextId = SecurityUtil.getContextID(webBundleDescriptor);
-                
+
                 websecurityProbeProvider.policyCreationStartedEvent(contextId);
                 SecurityUtil.generatePolicyFile(contextId);
                 websecurityProbeProvider.policyCreationEndedEvent(contextId);
                 websecurityProbeProvider.policyCreationEvent(contextId);
-
             }
         } catch (Exception se) {
             String msg = "Error in generating security policy for " + webBundleDescriptor.getModuleDescriptor().getModuleName();
@@ -297,19 +304,18 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
     /**
      * commits ejb policy contexts. This should occur in EjbApplication, being done here until issue with
      * ejb-ejb31-singleton-multimoduleApp.ear is resolved
-     * 
+     *
      * @param ejbs
      */
     private void commitEjbPolicies(Application app) throws DeploymentException {
         try {
             for (EjbBundleDescriptor ejbBD : app.getBundleDescriptors(EjbBundleDescriptor.class)) {
                 String contextId = SecurityUtil.getContextID(ejbBD);
-                
+
                 ejbProbeProvider.policyCreationStartedEvent(contextId);
                 SecurityUtil.generatePolicyFile(contextId);
                 ejbProbeProvider.policyCreationEndedEvent(contextId);
                 ejbProbeProvider.policyCreationEvent(contextId);
-
             }
         } catch (Exception se) {
             String msg = "Error in committing security policy for ejbs of " + app.getRegistrationName();
@@ -353,20 +359,19 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
         if (!params.origin.needsCleanArtifacts()) {
             return;
         }
-        
+
         String appName = params.name();
         // Monitoring
-
         // Remove policy files only if managers are not destroyed by cleanup
         try {
             String[] webcontexts = webSecurityManagerFactory.getContextsForApp(appName, false);
             if (webcontexts != null) {
-                for (int i = 0; i < webcontexts.length; i++) {
-                    if (webcontexts[i] != null) {
-                        websecurityProbeProvider.policyDestructionStartedEvent(webcontexts[i]);
-                        SecurityUtil.removePolicy(webcontexts[i]);
-                        websecurityProbeProvider.policyDestructionEndedEvent(webcontexts[i]);
-                        websecurityProbeProvider.policyDestructionEvent(webcontexts[i]);
+                for (String webcontext : webcontexts) {
+                    if (webcontext != null) {
+                        websecurityProbeProvider.policyDestructionStartedEvent(webcontext);
+                        SecurityUtil.removePolicy(webcontext);
+                        websecurityProbeProvider.policyDestructionEndedEvent(webcontext);
+                        websecurityProbeProvider.policyDestructionEvent(webcontext);
                     }
                 }
             }
@@ -384,24 +389,24 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
      * Clean security policy generated at deployment time. NOTE: This routine calls destroy on the WebSecurityManagers, but
      * that does not cause deletion of the underlying policy (files). The underlying policy is deleted when removePolicy (in
      * AppDeployerBase and WebModuleDeployer) is called.
-     * 
+     *
      * @param appName the app name
      */
     private boolean cleanSecurityContext(String appName) {
         boolean cleanUpDone = false;
-        
+
         List<JaccWebAuthorizationManager> managers = webSecurityManagerFactory.getManagersForApp(appName, false);
         if (managers == null) {
             return false;
         }
-        
+
         for (JaccWebAuthorizationManager manager : managers) {
             try {
                 websecurityProbeProvider.securityManagerDestructionStartedEvent(appName);
                 manager.destroy();
                 websecurityProbeProvider.securityManagerDestructionEndedEvent(appName);
                 websecurityProbeProvider.securityManagerDestructionEvent(appName);
-                
+
                 cleanUpDone = true;
             } catch (Exception pce) {
                 // Log it and continue
@@ -409,14 +414,14 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
             }
 
         }
-        
+
         return cleanUpDone;
     }
 
     public static List<EventTypes> getDeploymentEvents() {
-        List<EventTypes> events = new ArrayList<EventTypes>();
+        List<EventTypes> events = new ArrayList<>();
         events.add(APPLICATION_PREPARED);
-        
+
         return events;
     }
 
@@ -440,10 +445,9 @@ public class SecurityDeployer extends SimpleDeployer<SecurityContainer, DummyApp
                 CNonceCache cache = cnonceCacheFactory.createCNonceCache(appName, clusterName, instanceName, HA_CNONCE_BS_NAME);
                 this.appCnonceMap.put(appName, cache);
             }
-
         }
     }
-    
+
     private boolean isHaEnabled() {
         boolean haEnabled = false;
         // lazily init the required services instead of

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -203,7 +203,6 @@ import com.sun.enterprise.container.common.spi.util.JavaEEIOUtils;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.WebBundleDescriptor;
 import com.sun.enterprise.deployment.WebComponentDescriptor;
-import com.sun.enterprise.security.PolicyLoader;
 import com.sun.enterprise.security.ee.SecurityDeployer;
 import com.sun.enterprise.security.integration.RealmInitializer;
 import com.sun.enterprise.server.logging.LoggingRuntime;
@@ -236,11 +235,11 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     public static final String DISPATCHER_MAX_DEPTH = "dispatcher-max-depth";
     public static final String JWS_APPCLIENT_EAR_NAME = "__JWSappclients";
     public static final String JWS_APPCLIENT_WAR_NAME = "sys";
-    
+
     private static final String JWS_APPCLIENT_MODULE_NAME = JWS_APPCLIENT_EAR_NAME + ":" + JWS_APPCLIENT_WAR_NAME + ".war";
     private static final String DOL_DEPLOYMENT = "com.sun.enterprise.web.deployment.backend";
     private static final String MONITORING_NODE_SEPARATOR = "/";
-    
+
     private static final Logger logger = LogFacade.getLogger();
     private static final ResourceBundle rb = logger.getResourceBundle();
 
@@ -306,7 +305,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     @Inject
     private LoggingRuntime loggingRuntime;
 
-    private Map<String, WebConnector> connectorMap = new HashMap<String, WebConnector>();
+    private final Map<String, WebConnector> connectorMap = new HashMap<>();
 
     private EmbeddedWebContainer _embedded;
 
@@ -317,7 +316,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     private WebConnector jkConnector;
 
     private String logLevel = "INFO";
-    
+
     /**
      * Allow disabling accessLog mechanism
      */
@@ -337,7 +336,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      * AccessLog prefix
      */
     protected String globalAccessLogPrefix;
-    
+
     /**
      * The default-redirect port
      */
@@ -393,9 +392,6 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     @Inject
     ServerConfigLookup serverConfigLookup;
-
-    @Inject
-    private PolicyLoader policyLoader;
 
     @Inject
     private SecurityDeployer securityDeployer;
@@ -487,11 +483,11 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             String maxDepth = null;
             org.glassfish.web.config.serverbeans.WebContainer configWC = serverConfig
                     .getExtensionByType(org.glassfish.web.config.serverbeans.WebContainer.class);
-            
+
             if (configWC != null) {
                 maxDepth = configWC.getPropertyValue(DISPATCHER_MAX_DEPTH);
             }
-            
+
             if (maxDepth != null) {
                 int depth = -1;
                 try {
@@ -514,7 +510,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             if (level != null) {
                 logLevel = level.getName();
             }
-            
+
             _embedded = serviceLocator.getService(EmbeddedWebContainer.class);
             _embedded.setWebContainer(this);
             _embedded.setLogServiceFile(logServiceFile);
@@ -528,7 +524,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             if (_debug > 1) {
                 _embedded.setDebug(_debug);
             }
-            
+
             _embedded.setLogger(new IASLogger(logger));
             engine = _embedded.createEngine();
             engine.setParentClassLoader(EmbeddedWebContainer.class.getClassLoader());
@@ -613,7 +609,6 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
                 createHosts(httpService, securityService);
             }
 
-            policyLoader.loadPolicy();
             loadSystemDefaultWebModules();
 
             // _lifecycle.fireLifecycleEvent(START_EVENT, null);
@@ -693,7 +688,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Returns true if the container has been shut down.
-     * 
+     *
      * @return false if the container has never been started.
      */
     public boolean isShutdown() {
@@ -706,7 +701,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Gets the probe provider for servlet related events.
-     * 
+     *
      * @return
      */
     public ServletProbeProvider getServletProbeProvider() {
@@ -715,7 +710,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Gets the probe provider for jsp related events.
-     * 
+     *
      * @return
      */
     public JspProbeProvider getJspProbeProvider() {
@@ -724,7 +719,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Gets the probe provider for session related events.
-     * 
+     *
      * @return
      */
     public SessionProbeProvider getSessionProbeProvider() {
@@ -733,7 +728,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Gets the probe provider for request/response related events.
-     * 
+     *
      * @return
      */
     public RequestProbeProvider getRequestProbeProvider() {
@@ -742,7 +737,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Gets the probe provider for web module related events.
-     * 
+     *
      * @return
      */
     public WebModuleProbeProvider getWebModuleProbeProvider() {
@@ -777,7 +772,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     <T extends Servlet> T createServletInstance(WebModule module, Class<T> clazz) throws Exception {
         validateJSR299Scope(clazz);
         WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-        
+
         try {
             invocationMgr.preInvoke(webComponentInvocation);
             return injectionMgr.createManagedObject(clazz);
@@ -792,7 +787,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     <T extends Filter> T createFilterInstance(WebModule module, Class<T> clazz) throws Exception {
         validateJSR299Scope(clazz);
         WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-        
+
         try {
             invocationMgr.preInvoke(webComponentInvocation);
             return injectionMgr.createManagedObject(clazz);
@@ -807,7 +802,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     <T extends java.util.EventListener> T createListenerInstance(WebModule module, Class<T> clazz) throws Exception {
         validateJSR299Scope(clazz);
         WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-        
+
         try {
             invocationMgr.preInvoke(webComponentInvocation);
             return injectionMgr.createManagedObject(clazz);
@@ -822,7 +817,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     <T extends HttpUpgradeHandler> T createHttpUpgradeHandlerInstance(WebModule module, Class<T> clazz) throws Exception {
         validateJSR299Scope(clazz);
         WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-        
+
         try {
             invocationMgr.preInvoke(webComponentInvocation);
             return injectionMgr.createManagedObject(clazz);
@@ -833,7 +828,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Instantiates and injects the given tag handler class for the given WebModule
-     * 
+     *
      * @param <T>
      * @param module
      * @param clazz
@@ -885,7 +880,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
         String defaultVirtualServer = listener.findHttpProtocol().getHttp().getDefaultVirtualServer();
         if (!defaultVirtualServer.equals(ADMIN_VS)) {
-            
+
             // Before we start a WebConnector, let's makes sure there is
             // not another Container already listening on that port
             DataChunk host = DataChunk.newInstance();
@@ -918,7 +913,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         if (isSecure && defaultRedirectPort == -1) {
             defaultRedirectPort = port;
         }
-        
+
         String address = listener.getAddress();
         if ("any".equals(address) || "ANY".equals(address) || "INADDR_ANY".equals(address)) {
             address = null;
@@ -961,7 +956,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Starts the AJP connector that will listen to call from Apache using mod_jk, mod_jk2 or mod_ajp.
-     * 
+     *
      * @param listener
      * @param httpService
      * @return
@@ -1015,11 +1010,11 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             jkConnectorName = listener.getName();
             jkConnector.configure(listener, isSecure, httpService);
             connectorMap.put(listener.getName(), jkConnector);
-            
+
             if (logger.isLoggable(INFO)) {
                 logger.log(INFO, JK_LISTENER_CREATED, new Object[] { listener.getName(), listener.getAddress(), listener.getPort() });
             }
-            
+
             for (Mapper mapper : serviceLocator.getAllServices(Mapper.class)) {
                 if (mapper.getPort() == port && mapper instanceof ContextMapper) {
                     ContextMapper contextMapper = (ContextMapper) mapper;
@@ -1035,7 +1030,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         jkConnector.setName(jkConnectorName);
 
         _embedded.addConnector(jkConnector);
-        
+
         return jkConnector;
     }
 
@@ -1069,6 +1064,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      * @param connector
      * @deprecated most of these properties are handled elsewhere. validate and remove outdated properties checks
      */
+    @Deprecated
     public void configureHttpServiceProperties(HttpService httpService, PECoyoteConnector connector) {
         // Configure Connector with <http-service> properties
         List<Property> httpServiceProps = httpService.getProperty();
@@ -1108,7 +1104,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
                 } else {
                     String msg = rb.getString(LogFacade.INVALID_HTTP_SERVICE_PROPERTY);
                     logger.log(Level.WARNING, MessageFormat.format(msg, httpServiceProp.getName()));
-                    ;
+
                 }
             }
         }
@@ -1120,7 +1116,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      *
      * @param listenerId The id of the HTTP listener whose associated virtual servers are checked for uniqueness of host
      * names
-     * 
+     *
      * @param httpService The http-service element whose virtual servers are checked
      */
 
@@ -1134,14 +1130,14 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             for (int j = 0; networkListeners != null && j < networkListeners.size(); j++) {
                 if (listenerId.equals(networkListeners.get(j))) {
                     if (listenerVirtualServers == null) {
-                        listenerVirtualServers = new ArrayList<com.sun.enterprise.config.serverbeans.VirtualServer>();
+                        listenerVirtualServers = new ArrayList<>();
                     }
                     listenerVirtualServers.add(virtualServer);
                     break;
                 }
             }
         }
-        
+
         if (listenerVirtualServers == null) {
             return;
         }
@@ -1150,12 +1146,12 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             com.sun.enterprise.config.serverbeans.VirtualServer vs = listenerVirtualServers.get(i);
             List<String> hosts = parseStringList(vs.getHosts(), ",");
             for (int j = 0; hosts != null && j < hosts.size(); j++) {
-                String host = (String) hosts.get(j);
+                String host = hosts.get(j);
                 for (int k = 0; k < listenerVirtualServers.size(); k++) {
                     if (k <= i) {
                         continue;
                     }
-                    
+
                     com.sun.enterprise.config.serverbeans.VirtualServer otherVs = listenerVirtualServers.get(k);
                     List<String> otherHosts = parseStringList(otherVs.getHosts(), ",");
                     for (int l = 0; otherHosts != null && l < otherHosts.size(); l++) {
@@ -1216,7 +1212,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         boolean startAccessLog = accessLogValve.configure(
                 virtualServerId, vsBean, httpService, domain, serviceLocator, webContainerFeatureFactory, globalAccessLogBufferSize,
                 globalAccessLogWriteInterval, globalAccessLogPrefix);
-        
+
         if (startAccessLog && virtualServer.isAccessLoggingEnabled(globalAccessLoggingEnabled)) {
             virtualServer.addValve((GlassFishValve) accessLogValve);
         }
@@ -1245,7 +1241,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Validate the docroot properties of a virtual-server.
-     * 
+     *
      * @param docroot
      * @param virtualServerId
      * @param defaultWebModule
@@ -1277,7 +1273,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             return;
         }
 
-        HashSet<NetworkListener> httpListeners = new HashSet<NetworkListener>();
+        HashSet<NetworkListener> httpListeners = new HashSet<>();
         for (String listener : listeners) {
             boolean found = false;
             for (NetworkListener httpListener : serverConfig.getNetworkConfig().getNetworkListeners().getNetworkListener()) {
@@ -1307,7 +1303,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     protected void configureHostPortNumbers(VirtualServer virtualServer, HashSet<NetworkListener> listeners) {
         boolean addJkListenerName = jkConnector != null && !virtualServer.getName().equalsIgnoreCase(ADMIN_VS);
 
-        List<String> listenerNames = new ArrayList<String>();
+        List<String> listenerNames = new ArrayList<>();
         for (NetworkListener listener : listeners) {
             if (Boolean.valueOf(listener.getEnabled())) {
                 listenerNames.add(listener.getName());
@@ -1333,7 +1329,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Create a virtual server/host.
-     * 
+     *
      * @param virtualServerId
      * @param virtualServerBean
      * @param docroot
@@ -1344,7 +1340,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
         // Initialize the docroot
         VirtualServer virtualServer = (VirtualServer) _embedded.createHost(virtualServerId, virtualServerBean, docroot, virtualServerBean.getLogFile(), mimeMap);
-        
+
         virtualServer.configureState();
         virtualServer.configureRemoteAddressFilterValve();
         virtualServer.configureRemoteHostFilterValve();
@@ -1420,7 +1416,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         }
 
     }
-    
+
     private List<VirtualServer> getVirtualServers() {
         return stream(getEngine().findChildren())
                 .filter(e -> e instanceof VirtualServer)
@@ -1435,7 +1431,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         for (Container container : getEngine().findChildren()) {
             if (container instanceof VirtualServer) {
                 VirtualServer virtualServer = (VirtualServer) container;
-                
+
                 /*
                  * Let AdminConsoleAdapter handle any requests for the root context of the '__asadmin' virtual-server, see
                  * https://glassfish.dev.java.net/issues/show_bug.cgi?id=5664
@@ -1443,24 +1439,24 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
                 if (ADMIN_VS.equals(virtualServer.getName())) {
                     continue;
                 }
-                
+
                 WebModuleConfig webModuleConfig = virtualServer.getDefaultWebModule(domain, serviceLocator.getService(WebArchivist.class), appRegistry);
                 if (webModuleConfig != null) {
                     String defaultPath = webModuleConfig.getContextPath();
-                    
+
                     // Virtual server declares default-web-module
                     try {
                         updateDefaultWebModule(virtualServer, virtualServer.getNetworkListenerNames(), webModuleConfig);
                     } catch (LifecycleException le) {
                         logger.log(SEVERE, MessageFormat.format(rb.getString(DEFAULT_WEB_MODULE_ERROR), defaultPath, virtualServer.getName()), le);
                     }
-                    
+
                     if (logger.isLoggable(INFO)) {
                         logger.log(INFO, VIRTUAL_SERVER_LOADED_DEFAULT_WEB_MODULE, new Object[] { virtualServer.getName(), defaultPath });
                     }
 
                 }
-                
+
                 // No need to create default web module off of virtual
                 // server's docroot since system web modules are already
                 // created in WebContainer.postConstruct
@@ -1470,7 +1466,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Load a default-web-module on the specified virtual server.
-     * 
+     *
      * @param vsBean
      */
     public void loadDefaultWebModule(com.sun.enterprise.config.serverbeans.VirtualServer vsBean) {
@@ -1483,7 +1479,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Load a default-web-module on the specified virtual server.
-     * 
+     *
      * @param virtualServer
      */
     public void loadDefaultWebModule(VirtualServer virtualServer) {
@@ -1516,7 +1512,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Load the specified web module as a standalone module on the specified virtual server.
-     * 
+     *
      * @param virtualServer
      * @param webModuleConfig
      */
@@ -1544,7 +1540,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      * Creates and configures a web module for each virtual server that the web module is hosted under.
      * <p/>
      * If no virtual servers have been specified, then the web module will not be loaded.
-     * 
+     *
      * @param webModuleConfig
      * @param j2eeApplication
      * @param deploymentProperties
@@ -1552,7 +1548,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      */
     public List<Result<WebModule>> loadWebModule(WebModuleConfig webModuleConfig, String j2eeApplication, Properties deploymentProperties) {
         List<Result<WebModule>> results = new ArrayList<>();
-        
+
         String virtualServerIds = webModuleConfig.getVirtualServers();
         List<String> virtualServers = parseStringList(virtualServerIds, " ,");
         if (virtualServers == null || virtualServers.isEmpty()) {
@@ -1567,22 +1563,22 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         List<String> nonProcessedVirtualServers = new ArrayList<>(virtualServers);
         Container[] containers = getEngine().findChildren();
         List<VirtualServer> virtualServersToDeploy = new ArrayList<>(containers.length);
-        
+
         for (Container container : containers) {
             if (container instanceof VirtualServer) {
                 VirtualServer virtualServer = (VirtualServer) container;
-                
+
                 boolean eqVS = virtualServers.contains(virtualServer.getID());
                 if (eqVS) {
                     nonProcessedVirtualServers.remove(virtualServer.getID());
                 }
-                
+
                 Set<String> matchedAliases = matchAlias(virtualServers, virtualServer);
                 boolean hasMatchedAlias = matchedAliases.size() > 0;
                 if (hasMatchedAlias) {
                     nonProcessedVirtualServers.removeAll(matchedAliases);
                 }
-                
+
                 if (eqVS || hasMatchedAlias) {
                     virtualServersToDeploy.add(virtualServer);
                 }
@@ -1598,15 +1594,15 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
                     WebappClassLoader virtualServerClassLoader = new WebappClassLoader(
                         appClassLoader,
                         webModuleConfig.getDeploymentContext().getModuleMetaData(Application.class));
-                    
+
                     virtualServerClassLoader.start();
-                    
+
                     // For every virtual server, JSF and other extensions expect a separate class loader
                     webModuleConfig.setAppClassLoader(virtualServerClassLoader);
                 }
-                
+
                 webModule = loadWebModule(virtualServerToDeploy, webModuleConfig, j2eeApplication, deploymentProperties);
-                
+
                 results.add(new Result<>(webModule));
             } catch (Throwable t) {
                 if (webModule != null) {
@@ -1632,7 +1628,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             }
             logger.log(SEVERE, WEB_MODULE_NOT_LOADED_TO_VS, new Object[]{ webModuleConfig.getName(), sb.toString() });
         }
-        
+
         return results;
     }
 
@@ -1652,7 +1648,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      * Find all matched aliases. This is more expensive than verifyAlias.
      */
     private Set<String> matchAlias(List<String> vsList, VirtualServer vs) {
-        Set<String> matched = new HashSet<String>();
+        Set<String> matched = new HashSet<>();
         for (String alias : vs.getAliases()) {
             if (vsList.contains(alias)) {
                 matched.add(alias);
@@ -1750,7 +1746,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             logger.log(FINEST, WEB_MODULE_LOADING, new Object[]{ webModuleName, virtualServer.getID(), displayContextPath });
         }
 
-        webModule = (WebModule) 
+        webModule = (WebModule)
             _embedded.createContext(
                 webModuleName, webModuleContextPath, docBase, virtualServer.getDefaultContextXmlLocation(), virtualServer.getDefaultWebXmlLocation(),
                 useDOLforDeployment, webModuleConfig);
@@ -1822,7 +1818,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         if (webBundleDescriptor != null) {
             String resourceType = webModuleConfig.getObjectType();
             boolean isSystem = resourceType != null && resourceType.startsWith("system-");
-            
+
             // Security will generate policy for system default web module
             // TODO : v3 : dochez Need to remove dependency on security
             Realm realm = serviceLocator.getService(Realm.class);
@@ -1852,7 +1848,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
         String moduleName = Constants.DEFAULT_WEB_MODULE_NAME;
         String monitoringNodeName = moduleName;
-        
+
         if (webBundleDescriptor != null && webBundleDescriptor.getApplication() != null) {
             // Not a dummy web module
             com.sun.enterprise.deployment.Application app = webBundleDescriptor.getApplication();
@@ -1931,10 +1927,10 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             }
         }
     }
-    
+
     private List<String> getServletNames(WebBundleDescriptor webBundleDescriptor) {
         List<String> servletNames = new ArrayList<>();
-        
+
         if (webBundleDescriptor != null) {
             for (WebComponentDescriptor webComponentDescriptor : webBundleDescriptor.getWebComponentDescriptors()) {
                 if (webComponentDescriptor.isServlet()) {
@@ -1942,7 +1938,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
                 }
             }
         }
-        
+
         return servletNames;
     }
 
@@ -1953,9 +1949,9 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      * has been designated as the virtual server's new default-web-module.
      *
      * @param virtualServer The virtual server to update
-     * 
+     *
      * @param ports The port numbers of the HTTP listeners with which the given virtual server is associated
-     * 
+     *
      * @param defaultContextPath The context path of the web module that has been designated as the virtual server's new
      * default web module, or null if the virtual server no longer has any default-web-module
      */
@@ -1966,7 +1962,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         if (webModuleConfig != null) {
             defaultContextPath = webModuleConfig.getContextPath();
         }
-        
+
         if (defaultContextPath != null && !defaultContextPath.startsWith("/")) {
             defaultContextPath = "/" + defaultContextPath;
             webModuleConfig.getDescriptor().setContextRoot(defaultContextPath);
@@ -1995,7 +1991,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Utility Method to access the ServerContext
-     * 
+     *
      * @return
      */
     public ServerContext getServerContext() {
@@ -2008,7 +2004,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Returns the folder where library files are to be found
-     * 
+     *
      * @return
      */
     File getLibPath() {
@@ -2017,7 +2013,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * The application id for this web module HERCULES:add
-     * 
+     *
      * @param webModule
      * @return
      */
@@ -2027,7 +2023,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Return the Absolute path for location where all the deployed standalone modules are stored for this Server Instance.
-     * 
+     *
      * @return
      */
     public File getModulesRoot() {
@@ -2149,7 +2145,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         if (contextRoot.length() != 0 && !contextRoot.startsWith("/")) {
             contextRoot = "/" + contextRoot;
         }
-        
+
         VirtualServer host = null;
         Context context = null;
         for (Container aHostArray : getEngine().findChildren()) {
@@ -2192,20 +2188,21 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      */
     private void setDebugLevel() {
         Level logLevel = logger.getLevel() != null ? logger.getLevel() : Level.INFO;
-        if (logLevel.equals(Level.FINE))
+        if (logLevel.equals(Level.FINE)) {
             _debug = 1;
-        else if (logLevel.equals(Level.FINER))
+        } else if (logLevel.equals(Level.FINER)) {
             _debug = 2;
-        else if (logLevel.equals(Level.FINEST))
+        } else if (logLevel.equals(Level.FINEST)) {
             _debug = 5;
-        else
+        } else {
             _debug = 0;
+        }
     }
 
     /**
      * Get the lifecycle listeners associated with this lifecycle. If this Lifecycle has no listeners registered, a
      * zero-length array is returned.
-     * 
+     *
      * @return
      */
     public LifecycleListener[] findLifecycleListeners() {
@@ -2221,7 +2218,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             return null;
         }
 
-        List<VirtualServer> result = new ArrayList<VirtualServer>();
+        List<VirtualServer> result = new ArrayList<>();
 
         for (com.sun.enterprise.config.serverbeans.VirtualServer vs : httpService.getVirtualServer()) {
             List<String> listeners = StringUtils.parseStringList(vs.getNetworkListeners(), ",");
@@ -2264,7 +2261,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Return the parent/top-level container in _embedded for virtual servers.
-     * 
+     *
      * @return
      */
     public Engine getEngine() {
@@ -2303,12 +2300,12 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
                 // Do not deploy on admin vs
                 continue;
             }
-            
+
             WebModule webModule = (WebModule) virtualServer.findChild(ctxtRoot);
             if (webModule == null) {
                 webModule = createAdHocWebModule(virtualServer, ctxtRoot, appName);
             }
-            
+
             webModule.addAdHocPathAndSubtree(path, subtree, servletInfo);
         }
     }
@@ -2333,24 +2330,24 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     public void unregisterAdHocPathAndSubtree(String path, String subtree, String ctxtRoot) {
         for (Container container : getEngine().findChildren()) {
             VirtualServer virtualServer = (VirtualServer) container;
-            
+
             if (virtualServer.getName().equalsIgnoreCase(ADMIN_VS)) {
                 // Do not undeploy from admin vs, because we never deployed onto it
                 continue;
             }
-            
+
             WebModule webModule = (WebModule) virtualServer.findChild(ctxtRoot);
             if (webModule == null) {
                 continue;
             }
-            
+
             /*
              * If the web module was created by the container for the sole purpose of mapping ad-hoc paths and subtrees, and does no
              * longer contain any ad-hoc paths or subtrees, remove the web module.
              */
             webModule.removeAdHocPath(path);
             webModule.removeAdHocSubtree(subtree);
-            
+
             if (webModule instanceof AdHocWebModule && !webModule.hasAdHocPaths() && !webModule.hasAdHocSubtrees()) {
                 virtualServer.removeChild(webModule);
                 try {
@@ -2594,7 +2591,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         List<String> oldListenerList = StringUtils.parseStringList(vsBean.getNetworkListeners(), ",");
         String[] oldListeners = (oldListenerList != null) ? oldListenerList.toArray(new String[oldListenerList.size()]) : new String[0];
         // new listener config
-        HashSet<NetworkListener> networkListeners = new HashSet<NetworkListener>();
+        HashSet<NetworkListener> networkListeners = new HashSet<>();
         if (oldListenerList != null) {
             for (String listener : oldListeners) {
                 boolean found = false;
@@ -2716,7 +2713,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Update virtual-server properties.
-     * 
+     *
      * @param vsBean
      * @param name
      * @param value
@@ -2728,7 +2725,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         if (virtualServer == null) {
             return;
         }
-        
+
         virtualServer.setBean(vsBean);
 
         if (name == null) {
@@ -2746,7 +2743,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         } else if (ACCESS_LOG_WRITE_INTERVAL_PROPERTY.equals(name)) {
             virtualServer.reconfigureAccessLog(globalAccessLogBufferSize, globalAccessLogWriteInterval, serviceLocator, domain, globalAccessLoggingEnabled, globalAccessLogPrefix);
         } else if (ACCESS_LOG_BUFFER_SIZE_PROPERTY.equals(name)) {
-            virtualServer.reconfigureAccessLog(globalAccessLogBufferSize, globalAccessLogWriteInterval, serviceLocator, domain, globalAccessLoggingEnabled, globalAccessLogPrefix); 
+            virtualServer.reconfigureAccessLog(globalAccessLogBufferSize, globalAccessLogWriteInterval, serviceLocator, domain, globalAccessLoggingEnabled, globalAccessLogPrefix);
         } else if (ACCESS_LOG_PREFIX.equals(name)) {
             virtualServer.reconfigureAccessLog(globalAccessLogBufferSize, globalAccessLogWriteInterval, serviceLocator, domain, globalAccessLoggingEnabled, globalAccessLogPrefix);
         } else if ("allowRemoteHost".equals(name) || "denyRemoteHost".equals(name)) {
@@ -2777,7 +2774,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Processes an update to the http-service element
-     * 
+     *
      * @param httpService
      * @throws org.apache.catalina.LifecycleException
      */
@@ -2818,7 +2815,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
      */
     public void updateConnectorProperty(NetworkListener listener, String propName, String propValue) throws LifecycleException {
         WebConnector connector = connectorMap.get(listener.getName());
-        
+
         if (connector != null) {
             connector.configHttpProperties(listener.findHttpProtocol().getHttp(), listener.findTransport(), listener.findHttpProtocol().getSsl());
             connector.configureHttpListenerProperty(propName, propValue);
@@ -2970,7 +2967,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Stops and deletes the specified http listener.
-     * 
+     *
      * @param connector
      * @throws org.apache.catalina.LifecycleException
      */
@@ -2988,7 +2985,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Stops and deletes the specified http listener.
-     * 
+     *
      * @param httpListener
      * @throws org.apache.catalina.LifecycleException
      */
@@ -3008,7 +3005,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     /**
      * Reconfigures the access log valve of each virtual server with the updated attributes of the <access-log> element from
      * domain.xml.
-     * 
+     *
      * @param httpService
      */
     public void updateAccessLog(HttpService httpService) {
@@ -3126,7 +3123,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     /**
      * Return the WebContainerFeatureFactory according to the configuration.
-     * 
+     *
      * @return WebContainerFeatuerFactory
      */
     private WebContainerFeatureFactory getWebContainerFeatureFactory() {


### PR DESCRIPTION
- JVM global security objects and JVM options must be configured before
  first usage
- it is hard to control the right point in the startup sequence, previous
  version relied on some side effects (admin gui initiated it, but on
  domain nodes it is not deployed).

# Important Info

Depends on PAYARA-4176, see testing how to use it for testing.

# Testing

### New tests

```
cd /repo/git
git clone git@github.com:dmatej/arquillian-junit5-extension.git
cd arquillian-junit5-extension
mvn clean install
cd ..
git clone git@github.com:payara/Payara.git payara-cc133
cd payara-cc133
git remote add dmatej git@github.com:dmatej/Payara.git
git fetch --all
```
This should fail:
```
git checkout origin/master
mvn clean install -PQuickBuild,fastest
git checkout dmatej/PAYARA-4176-TestContainers-prototype
mvn clean install -Ptest-containers  -pl :test-containers -Dit.test=MetricsSecurityITest,JaspicSamAuthenticationITest # fails on unfixed versions
```
This should pass:
```
git checkout dmatej/CUSTCOM-133-fix-metrics-AND-jaspic
mvn clean install -PQuickBuild,fastest
git checkout dmatej/PAYARA-4176-TestContainers-prototype
mvn clean install -Ptest-containers  -pl :test-containers -Dit.test=MetricsSecurityITest,JaspicSamAuthenticationITest # should pass
```

# Note about tests

These tests will be merged later in standalone PR, because they have yet unreleased dependencies