### PR TITLE
APPSERV-142: Shutdown fault tolerance thread pools on server shutdown

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
@@ -72,6 +72,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.control.RequestContextController;
 import javax.inject.Inject;
 import javax.interceptor.InvocationContext;
@@ -79,6 +80,7 @@ import javax.interceptor.InvocationContext;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.event.EventListener;
+import org.glassfish.api.event.EventTypes;
 import org.glassfish.api.event.Events;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
@@ -197,6 +199,13 @@ public class FaultToleranceServiceImpl
             ApplicationInfo info = (ApplicationInfo) event.hook();
             deregisterApplication(info.getName());
             FaultTolerancePolicy.clean();
+        } else if (event.is(EventTypes.SERVER_SHUTDOWN)) {
+            if (asyncExecutorService != null) {
+                asyncExecutorService.shutdownNow();
+            }
+            if (delayExecutorService != null) {
+                delayExecutorService.shutdownNow();
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This is a bug fix. <!-- delete/modify as applicable-->

<!-- fixes GitHub issue? - provide a link to that issue here -->

<!-- Provide some context here -->
New threadpools for Fault tolerance doesn't shut down cleanly while having a permanent cleanup task scheduled.

There is probably more that should be done (i. e. utilizing `PayaraExecutorService` instead), but it fixes the largest trouble at this moment.

<!--- Please provide enough information here about the what and why of your change. Target for developers of any experience level to understand -->


# Testing

## Testing Performed
`java -jar payara-micro.jar --warmup` didn't terminate before the fix, it does now.

### Test suites executed


### Testing Environment
AdoptOpenJDK 14+36 (by mistake) on Windows 10.
Zulu 11.0.6 in Docker
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
