### PR TITLE
CUSTCOM-261: Remove jakarta.transaction.cdi:jakarta.transaction.cdi-api from Payara BOM as it is wrong.

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -329,11 +329,6 @@
                 <version>${jakarta.transaction-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.transaction.cdi</groupId>
-                <artifactId>jakarta.transaction.cdi-api</artifactId>
-                <version>${jakarta.transaction.cdi-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.xml.rpc</groupId>
                 <artifactId>jakarta.xml.rpc-api</artifactId>
                 <version>${jakarta.xml.rpc-api.version}</version>


### PR DESCRIPTION
# Description
Payara BOM contains a referene to a non existent Maven dependency.

Fixes #4618.

### Testing Performed
mvn validate

### Testing Environment
Oracle 1.8.0_181 on Mac 10.14.6 with Maven 3.5.4
