### PR TITLE
CUSTCOM-264 Client mode debugging (server=no) doesn't work with JDK>=9

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JavaConfig.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JavaConfig.java
@@ -140,11 +140,28 @@ class JavaConfig {
             return empty;
         }
 
-        if(JDK.getMajor() >= 9
-                && debugOptions.contains("address=")
-                && !debugOptions.contains("address=*:")){
-            debugOptions = debugOptions.replace("address=", "address=*:");
+        if (JDK.getMajor() >= 9) {
+            boolean serverMode = false;
+            String address = null;
+            for (String debugOption : debugOptions.split(",")) {
+                if (debugOption.startsWith("server")) {
+                    String[] serverAttr = debugOption.split("=");
+                    serverMode = serverAttr.length > 1 && serverAttr[1].equals("y");
+                }
+                if (debugOption.startsWith("address")) {
+                    String[] addressAttr = debugOption.split("=");
+                    if (addressAttr.length > 1) {
+                        address = addressAttr[1];
+                    }
+                }
+            }
+            if (serverMode && address != null) {
+                if (address.split(":").length < 2) {
+                    debugOptions = debugOptions.replace("address=", "address=*:");
+                }
+            }
         }
+
         String[] debugOptionArray = debugOptions.split(" ");
 
         if(debugOptionArray.length <= 0) {

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/JavaConfigTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/JavaConfigTest.java
@@ -1,0 +1,79 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.enterprise.admin.launcher;
+
+import com.sun.enterprise.universal.xml.MiniXmlParserException;
+import com.sun.enterprise.util.JDK;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author jGauravGupta
+ */
+public class JavaConfigTest {
+    
+    @Test
+    public void debugInClientMode() {
+        String DEBUG_CONFIG = "-agentlib:jdwp=transport=dt_socket,address=9009,server=n,suspend=y";
+        Map<String, String> config = new HashMap<>();
+        config.put("debug-options", DEBUG_CONFIG);
+        JavaConfig javaConfig = new JavaConfig(config);
+        List<String> debugOptions = javaConfig.getDebugOptions();
+        Assert.assertEquals(DEBUG_CONFIG, debugOptions.get(0));
+    }
+
+    @Test
+    public void debugInServerMode() {
+        String DEBUG_CONFIG = "-agentlib:jdwp=transport=dt_socket,address=9009,server=y,suspend=n";
+        Map<String, String> config = new HashMap<>();
+        config.put("debug-options", DEBUG_CONFIG);
+        JavaConfig javaConfig = new JavaConfig(config);
+        List<String> debugOptions = javaConfig.getDebugOptions();
+        if (JDK.getMajor() >= 9) {
+            Assert.assertEquals("-agentlib:jdwp=transport=dt_socket,address=*:9009,server=y,suspend=n", debugOptions.get(0));
+        } else {
+            Assert.assertEquals(DEBUG_CONFIG, debugOptions.get(0));
+        }
+    }
+}


### PR DESCRIPTION
# Description
This is a bug fix. Github ticket: https://github.com/payara/Payara/issues/4619
Since Java 9 JDWP agent listens only local network interface by default so remote connections would be rejected. In this PR, If server mode is enabled then address port is prefixed with `*:` to enable remote connection. Unfortunately, the `*:` syntax is not backward compatible to Java 8 hence debug address requires an update on runtime.

# Important Info

# Testing
### New tests
https://github.com/payara/Payara/blob/8dc6dd06b74eccfd92c10fdb4e91a0f0a40cc12f/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/JavaConfigTest.java#L56-L78

### Testing Performed
Tested manually with IntelliJ IDEA 2020.1 patched with [`glassfishIntegration.jar`](https://youtrack.jetbrains.com/api/files/74-834117?sign=MTU4NzYwMDAwMDAwMHwxMS01MjcxODV8NzQtODM0MTE3fENxVk9wVllnSzV6MGxKVVJFZGZ0NXV6%0D%0AMHNwYUxZVk5mdU9hUG9PZVpqNEUNCg%0D%0A&updated=1586887392899) on JDK8/11.

### Testing Environment
Windows 10, JDK 11.0.3, JDK 1.8.0_172, IntelliJ IDEA 2020.1
