### PR TITLE
CUSTCOM-265 Restarting the domain with the Payara log formatter causes the log to rotate

### DIFF
--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -41,7 +41,7 @@
 
 -->
 
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -100,7 +100,12 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
+        
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
@@ -60,7 +60,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.ErrorManager;
 import java.util.logging.Formatter;
@@ -201,6 +200,7 @@ public class GFFileHandler extends StreamHandler implements
         String strLine;
         int odlFormatter = 0;
         int uniformLogFormatter = 0;
+        int jsonLogFormatter = 0;
         int otherFormatter = 0;
         boolean mustRotate = false;
 
@@ -213,6 +213,9 @@ public class GFFileHandler extends StreamHandler implements
                     } else if (LogFormatHelper.isODLFormatLogHeader(strLine)) {
                         // for ODL formatter
                         odlFormatter++;
+                    } else if (LogFormatHelper.isJSONFormatLogHeader(strLine)) {
+                        //for JSON Log format
+                        jsonLogFormatter++;
                     } else {
                         otherFormatter++;  // for other formatter
                     }
@@ -236,6 +239,8 @@ public class GFFileHandler extends StreamHandler implements
             currentFileHandlerFormatter = "com.sun.enterprise.server.logging.ODLLogFormatter";
         } else if (uniformLogFormatter > 0) {
             currentFileHandlerFormatter = "com.sun.enterprise.server.logging.UniformLogFormatter";
+        } else if (jsonLogFormatter > 0) {
+            currentFileHandlerFormatter = "fish.payara.enterprise.server.logging.JSONLogFormatter";
         }
 
         String propertyValue = manager.getProperty(className + ".logtoFile");

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogFormatHelper.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogFormatHelper.java
@@ -37,11 +37,15 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
+import java.io.StringReader;
 import java.util.regex.Pattern;
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonReader;
 
 /**
  * Helper class that provides methods to detect the log format of a record. 
@@ -85,6 +89,21 @@ public class LogFormatHelper {
                 && countOccurrences(line, '[') > 4) {
             return true;
         } else {
+            return false;
+        }
+    }
+    
+    /**
+     * Determines whether the given line is the beginning of a JSON log record.
+     * @param line String to test if json
+     * @return If the line is valid JSON
+     */
+    public static boolean isJSONFormatLogHeader(String line) {
+        JsonReader reader = Json.createReader(new StringReader(line));
+        try {
+            reader.read();
+            return true;
+        } catch (JsonException ex ) {
             return false;
         }
     }

--- a/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/LogFormatTest.java
+++ b/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/LogFormatTest.java
@@ -1,0 +1,85 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.enterprise.server.logging;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test to ensure that the LogForatHelper correctly works out the log type
+ * @author jonathan coustick
+ */
+public class LogFormatTest {
+    
+    private static final String JSON_RECORD = "{\"Timestamp\":\"2020-04-20T21:53:40.248+0100\",\"Level\":\"INFO\","
+            + "\"Version\":\"Payara 5.202\",\"LoggerName\":\"javax.enterprise.logging\",\"ThreadID\":\"22\",\"ThreadName\":"
+            + "\"RunLevelControllerThread-1587416020198\",\"TimeMillis\":\"1587416020248\",\"LevelValue\":\"800\","
+            + "\"MessageID\":\"NCLS-LOGGING-00009\",\"LogMessage\":\"Running Payara Version: Payara Server  5.202"
+            + " #badassfish (build ${build.number})\"}";
+    private static final String ODL_RECORD = "[2020-04-20T22:05:43.203+0100] [Payara 5.202] [INFO] [NCLS-LOGGING-00009] "
+            + "[javax.enterprise.logging] [tid: _ThreadID=21 _ThreadName=RunLevelControllerThread-1587416743113] "
+            + "[timeMillis: 1587416743203] [levelValue: 800] [[";
+    private static final String ULF_RECORD = "[#|2020-04-20T22:02:35.314+0100|INFO|Payara 5.202|javax.enterprise.logging|_ThreadID=21;"
+            + "_ThreadName=RunLevelControllerThread-1587416555246;_TimeMillis=1587416555314;_LevelValue=800;"
+            + "_MessageID=NCLS-LOGGING-00009;|";
+
+    
+    @Test
+    public void JSONFormatTest() {
+        Assert.assertTrue(LogFormatHelper.isJSONFormatLogHeader(JSON_RECORD));
+        Assert.assertFalse(LogFormatHelper.isODLFormatLogHeader(JSON_RECORD));
+        Assert.assertFalse(LogFormatHelper.isUniformFormatLogHeader(JSON_RECORD));
+    }
+    
+    @Test
+    public void ODLFormatTest() {
+        Assert.assertFalse(LogFormatHelper.isJSONFormatLogHeader(ODL_RECORD));
+        Assert.assertTrue(LogFormatHelper.isODLFormatLogHeader(ODL_RECORD));
+        Assert.assertFalse(LogFormatHelper.isUniformFormatLogHeader(ODL_RECORD));
+    }
+    
+    @Test
+    public void UniformFormatTest() {
+        Assert.assertFalse(LogFormatHelper.isJSONFormatLogHeader(ULF_RECORD));
+        Assert.assertFalse(LogFormatHelper.isODLFormatLogHeader(ULF_RECORD));
+        Assert.assertTrue(LogFormatHelper.isUniformFormatLogHeader(ULF_RECORD));
+    }
+    
+}


### PR DESCRIPTION
# Description
This is a bug fix.

If Payara Server is restarted with the JSON log formatter then the logs would always rotate.

# Testing
### New tests
New test file added in this commit.

### Testing Performed
Tested by restarting the server and checking that no new additional log files are created.

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0