### PR TITLE
CUSTCOM-266: Fix HK2 Config when Payara Micro is launched via Root Dir Launcher

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/JarManifestHk2Factory.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/JarManifestHk2Factory.java
@@ -1,0 +1,97 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.micro.boot.runtime;
+
+import com.sun.enterprise.module.ModuleDefinition;
+import com.sun.enterprise.module.ModulesRegistry;
+import com.sun.enterprise.module.common_impl.AbstractFactory;
+import com.sun.enterprise.module.common_impl.ModuleId;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+class JarManifestHk2Factory extends AbstractFactory {
+
+    private final ClassLoader classLoader;
+    private final JarManifestModuleRegistry modulesRegistry;
+
+    static synchronized void initialize(ClassLoader cl, URI bootJar) throws IOException {
+        // we need to get absolute paths of the jar our classpath is made of to make ClassPathModulesRegistry
+        // reliably create modules
+        URI[] locations = Stream.of(readClassPath(bootJar).split(" "))
+                .map(bootJar::resolve)
+                .toArray(URI[]::new);
+
+
+        JarManifestHk2Factory factory = new JarManifestHk2Factory(cl, locations);
+        Instance = factory;
+        factory.modulesRegistry.initialize();
+    }
+
+    private static String readClassPath(URI bootJar) throws IOException {
+        try (JarFile bootJarFile = new JarFile(new File(bootJar))) {
+            return bootJarFile.getManifest().getMainAttributes().getValue("Class-Path");
+        }
+    }
+
+    public JarManifestHk2Factory(ClassLoader cl, URI[] locations) throws IOException {
+        this.classLoader = cl;
+        this.modulesRegistry = new JarManifestModuleRegistry(cl, locations);
+    }
+
+    @Override
+    public ModulesRegistry createModulesRegistry() {
+        return modulesRegistry;
+    }
+
+    @Override
+    public ModuleId createModuleId(String name, String version) {
+        return new ModuleId(name);
+    }
+
+    @Override
+    public ModuleId createModuleId(ModuleDefinition md) {
+        return new ModuleId(md.getName());
+    }
+}

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/JarManifestModuleRegistry.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/boot/runtime/JarManifestModuleRegistry.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package fish.payara.micro.boot.runtime;
+
+import com.sun.enterprise.module.HK2Module;
+import com.sun.enterprise.module.ModuleDefinition;
+import com.sun.enterprise.module.ResolveError;
+import com.sun.enterprise.module.impl.ModulesRegistryImpl;
+import com.sun.enterprise.module.single.ManifestProxy;
+import com.sun.enterprise.module.single.ProxyModule;
+import com.sun.enterprise.module.single.ProxyModuleDefinition;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.DynamicConfigurationService;
+import org.glassfish.hk2.api.Populator;
+import org.glassfish.hk2.api.PopulatorPostProcessor;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.bootstrap.impl.Hk2LoaderPopulatorPostProcessor;
+import org.glassfish.hk2.utilities.ClasspathDescriptorFileFinder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Normal modules registry with configuration handling backed up
+ * by a single class loader. There is one virtual module available in the modules
+ * registry and that module's class loader is the single class loader used to
+ * load all artifacts.
+ *
+ * This is adaptation of HK2's SingleModulesRegistry for cases where modules are defined by Manifest's Class-Path attribute.
+ *
+ * @author Jerome Dochez
+ * @author Patrik Dudits
+ */
+class JarManifestModuleRegistry extends ModulesRegistryImpl {
+
+    final ClassLoader singleClassLoader;
+    final ProxyModule module;
+    final Collection<HK2Module> singleton;
+
+    public JarManifestModuleRegistry(ClassLoader singleCL, URI[] locations) {
+        this(singleCL, null, locations);
+    }
+
+
+    public JarManifestModuleRegistry(ClassLoader singleCL, List<ManifestProxy.SeparatorMappings> mappings, URI[] locations) {
+
+        super(null);
+        this.singleClassLoader = singleCL;
+        setParentClassLoader(singleClassLoader);
+
+        ModuleDefinition moduleDef = null;
+        try {
+            moduleDef = new ProxyModuleDefinition(singleClassLoader, mappings) {
+                @Override
+                public URI[] getLocations() {
+                    return locations;
+                }
+            };
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        module = new ProxyModule(this, moduleDef, singleClassLoader);
+        singleton = Collections.singleton(module);
+    }
+
+    void initialize() {
+        add(module.getModuleDefinition());
+    }
+
+    @Override
+    public HK2Module find(Class clazz) {
+        HK2Module m = super.find(clazz);
+        if (m == null)
+            return module;
+        return m;
+    }
+
+    @Override
+    public Collection<HK2Module> getModules(String moduleName) {
+        // I could not care less about the modules names
+        return getModules();
+    }
+
+    @Override
+    public Collection<HK2Module> getModules() {
+        return singleton;
+    }
+
+    @Override
+    public HK2Module makeModuleFor(String name, String version, boolean resolve) throws ResolveError {
+        return module;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    protected List<ActiveDescriptor> parseInhabitants(HK2Module module, String name, ServiceLocator serviceLocator, List<PopulatorPostProcessor> postProcessors)
+            throws IOException {
+
+        ArrayList<PopulatorPostProcessor> allPostProcessors = new ArrayList<PopulatorPostProcessor>();
+
+        allPostProcessors.add(new Hk2LoaderPopulatorPostProcessor(singleClassLoader));
+        if (postProcessors != null) {
+          allPostProcessors.addAll(postProcessors);
+        }
+
+        DynamicConfigurationService dcs = serviceLocator.getService(DynamicConfigurationService.class);
+        Populator populator = dcs.getPopulator();
+        
+    	List<ActiveDescriptor<?>> retVal = populator.populate(
+                new ClasspathDescriptorFileFinder(singleClassLoader, name),
+                allPostProcessors.toArray(new PopulatorPostProcessor[allPostProcessors.size()]));
+    	
+    	return (List<ActiveDescriptor>) ((List) retVal);
+    }
+
+}

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1048,7 +1048,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             return runtime;
         } catch (Exception ex) {
             try {
-                gf.dispose();
+                if (gf != null) {
+                    gf.dispose();
+                }
             } catch (GlassFishException ex1) {
                 LOGGER.log(Level.SEVERE, null, ex1);
             }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description

SingleModuleHK2Registry assumes that all runtime jars are enumerated by
context class loader, which is only true when Payara Micro's special
classloader is involved. When launched with RootDir launcher, classpath
only contains launcher jar, and the module list need to be read from
its manifest.

# Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
Testing was done by trying to start a JSF application in rootdir mode:

```
java -jar $micro --rootDir root --deploy jsf-app.war --nocluster --warmup
java -jar $micro --rootDir root --outputlauncher
java -jar root/launch-micro.jar --nocluster --warmup
```

Application would not start up in third case, it didn't before, because `FacesContext.getCurrentContext()` would fail.

<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
Tested multiple JVMs on Windows, as this relates to root classloader:
* Zulu11.37+17-CA
* Zulu 8.46.0.19-CA-win64
* AdoptOpenJDK (build 11.0.6+10) / openj9-0.18.0
* AdoptOpenJDK (build 1.8.0_242-b08) / openj9-0.18.1

# Notes for Reviewers

`JarManifestModuleRegistry` is a modification of HK2's `SingleModuleRegistry`, therefore the Eclipse license.