### PR TITLE
APPSERV-141 Fixes undefined behaviour of PayaraConfig 

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -116,7 +116,8 @@ public class PayaraConfig implements Config {
     }
 
     private <T> T getValueUncached(String propertyName, Class<T> propertyType) {
-        return convertString(getStringValue(propertyName), propertyType);
+        String stringValue = getStringValue(propertyName);
+        return stringValue == null ? null : convertString(stringValue, propertyType);
     }
 
     @SuppressWarnings("unchecked")
@@ -177,6 +178,9 @@ public class PayaraConfig implements Config {
     }
 
     private <T> List<T> convertToList(String stringValue, Class<T> elementType) {
+        if (stringValue == null) {
+            return null;
+        }
         String keys[] = splitValue(stringValue);
         List<T> result = new ArrayList<>(keys.length);
         for (String key : keys) {
@@ -201,6 +205,9 @@ public class PayaraConfig implements Config {
     }
 
     private <T> Set<T> convertToSet(String stringValue, Class<T> elementType) {
+        if (stringValue == null) {
+            return null;
+        }
         String keys[] = splitValue(stringValue);
         Set<T> result = new HashSet<>(keys.length);
         for (String key : keys) {
@@ -215,7 +222,7 @@ public class PayaraConfig implements Config {
             if (stringValue == null) {
                 stringValue = defaultValue;
             }
-            return convertString(stringValue, type);
+            return stringValue == null ? null : convertString(stringValue, type);
         });
     }
 
@@ -308,9 +315,6 @@ public class PayaraConfig implements Config {
     }
 
     private static String[] splitValue(String value) {
-        if (value == null) {
-            return new String[0];
-        }
         String keys[] = value.split("(?<!\\\\),");
         for (int i=0; i < keys.length; i++) {
             keys[i] = keys[i].replaceAll("\\\\,", ",");

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
@@ -131,23 +131,15 @@ public class PayaraConfigTest {
     }
 
     @Test
-    public void undefinedPropertiesThrowsExcetion() {
-        try {
-            config.getValue("undefined", String.class);
-            fail("Expected NoSuchElementException");
-        } catch (NoSuchElementException ex) {
-            assertEquals("Unable to find property with name undefined", ex.getMessage());
-        }
+    public void undefinedPropertyThrowsExcetion() {
+        assertException(NoSuchElementException.class, "Unable to find property with name undefined",
+                () -> config.getValue("undefined", String.class));
     }
 
     @Test
     public void unknownConversionThrowsExcetion() {
-        try {
-            config.getValue("key1", CharSequence.class);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException ex) {
-            assertEquals("Unable to convert value to type java.lang.CharSequence", ex.getMessage());
-        }
+        assertException(IllegalArgumentException.class, "Unable to convert value to type java.lang.CharSequence",
+                () -> config.getValue("key1", CharSequence.class));
     }
 
     @Test
@@ -179,7 +171,7 @@ public class PayaraConfigTest {
     }
 
     @Test
-    public void steValueAllowSingleElement() {
+    public void setValueAllowSingleElement() {
         assertEquals(new HashSet<>(asList("value1")), config.getSetValues("key1", "default", String.class));
         assertEquals(new HashSet<>(asList(1)), config.getSetValues("int1", "42", Integer.class));
     }
@@ -193,7 +185,25 @@ public class PayaraConfigTest {
     }
 
     @Test
-    public void nonExistingPropertyReturnsEmptyOptional() {
+    public void undefinedSetPropertyThrowsExcetion() {
+        assertException(NoSuchElementException.class, "Unable to find property with name undefined-set",
+                () -> config.getListValues("undefined-set", null, String.class));
+    }
+
+    @Test
+    public void undefinedListPropertyThrowsExcetion() {
+        assertException(NoSuchElementException.class, "Unable to find property with name undefined-list",
+                () -> config.getListValues("undefined-list", null, String.class));
+    }
+
+    @Test
+    public void undefinedArrayPropertyThrowsExcetion() {
+        assertException(NoSuchElementException.class, "Unable to find property with name undefined-array",
+                () -> config.getValue("undefined-array", String[].class));
+    }
+
+    @Test
+    public void undefinedPropertyReturnsEmptyOptional() {
         assertEquals(Optional.empty(), config.getOptionalValue("nonExisting", String.class));
     }
 
@@ -241,5 +251,15 @@ public class PayaraConfigTest {
         when(source.getPropertyNames()).thenReturn(properties.keySet());
         when(source.getValue(anyString())).thenAnswer(invocation -> properties.get(invocation.getArgument(0)));
         return source;
+    }
+
+    private static void assertException(Class<? extends Exception> expectedException, String expectedMsg, Runnable test) {
+        try {
+            test.run();
+            fail("Expected " + expectedException.getName());
+        } catch (Exception ex) {
+            assertEquals(expectedException, ex.getClass());
+            assertEquals(expectedMsg, ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
### Summary
Fixes behaviour for undefined properties of `PayaraConfig` for arrays, lists and sets.
If an undefined property is resolved the `Config` implementation should always throw an `NoSuchElementException`. This behaviour was changed unintentional and incorrectly by #4614 .

### Testing
Added unit tests for undefined property lookup.

#### Testing Performed
Running MP TCKs https://github.com/payara/MicroProfile-TCK-Runners :

```bash
# setup environment for TCKs
export my_int_property=45
export MY_BOOLEAN_PROPERTY=true
export my_string_property=haha
export MY_STRING_PROPERTY=woohoo
export MP_CONFIG_CACHE_DURATION=0
export MP_METRICS_TAGS=tier=integration

# start server
{payara-bin-dir}/asadmin start-domain

# run different MP TCKs
cd {tck--runner-base-dir}/tck-runner/
mvn clean install "-Ppayara-server-remote" "-Dpayara.version=5.202"
```
This is used to run MP Config, MP Metrics, MP Rest Client and MP FaultTolerance TCKs.
This will run all TCK with cache disabled (`MP_CONFIG_CACHE_DURATION=0`). This configuration is only needed for the MP Config TCK. Other TCKs should also pass with cache enabled (do `export MP_CONFIG_CACHE_DURATION=30` and restart the server).
Note that both starting the server and running the TCK should be done in same console to avoid having to setup same environment in multiple shells.

I did run both with and without caching enabled (except the MP Config TCK that requires cache to be disabled as otherwise 2 tests will fail)