### PR TITLE
CUSTCOM-247: Fix of switched assertions in tests

### DIFF
--- a/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/ejb/EJBEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/ejb/EJBEndpointTest.java
@@ -116,7 +116,7 @@ public class EJBEndpointTest extends JAXWSEndpointTest {
     @RunAsClient
     public void testSoapRequestWithIncorrectCredentials() throws IOException, URISyntaxException {
         serviceConnection = sendSoapHttpRequest("request-with-bad-password.xml");
-        assertResponseFailedWithMessage(serviceConnection, "Client not authorized");
+        assertResponseFailedWithMessage(serviceConnection, "Authentication of Username Password Token Failed");
 
     }
 
@@ -124,7 +124,7 @@ public class EJBEndpointTest extends JAXWSEndpointTest {
     @RunAsClient
     public void testSoapRequestUserNotAllowedExecution() throws IOException, URISyntaxException {
         serviceConnection = sendSoapHttpRequest("request-not-allowed.xml");
-        assertResponseFailedWithMessage(serviceConnection, "Authentication of Username Password Token Failed");
+        assertResponseFailedWithMessage(serviceConnection, "Client not authorized");
     }
 
 }


### PR DESCRIPTION
This is just a fix of my previous PR #4638 where I mistakenly switch 2 assertions in 2 unstable tests.