### PR TITLE
APPSERV-157 preInvoke/postInvoke ComponentInvocation logging

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
@@ -162,6 +162,11 @@ public class WebComponentInvocation extends ComponentInvocation {
     }
 
     @Override
+    public int hashCode() {
+        return instance == null ? container.hashCode() : container.hashCode() ^ instance.hashCode();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof WebComponentInvocation)) {
             return false;

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
@@ -47,7 +47,6 @@ import javax.servlet.Filter;
 import javax.servlet.Servlet;
 import javax.servlet.SingleThreadModel;
 import java.lang.reflect.Method;
-import java.util.Objects;
 
 public class WebComponentInvocation extends ComponentInvocation {
 
@@ -70,12 +69,12 @@ public class WebComponentInvocation extends ComponentInvocation {
         container = wm;
         this.instance = instance;
         setResourceTableKey(_getResourceTableKey());
-
+        
         moduleName = wm.getModuleName();
         appName = wm.getWebBundleDescriptor().getApplication().getAppName();
         registrationName = wm.getWebBundleDescriptor().getApplication().getRegistrationName();
     }
-
+    
     public WebComponentInvocation(WebModule wm, Object instance, String instanceName) {
       this(wm, instance);
       setInstanceName(instanceName);
@@ -160,19 +159,5 @@ public class WebComponentInvocation extends ComponentInvocation {
             }
             return eq;
         }
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(container, instance);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof WebComponentInvocation)) {
-            return false;
-        }
-        WebComponentInvocation other = (WebComponentInvocation) obj;
-        return container == other.container && instance == other.instance;
     }
 }

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
@@ -69,12 +69,12 @@ public class WebComponentInvocation extends ComponentInvocation {
         container = wm;
         this.instance = instance;
         setResourceTableKey(_getResourceTableKey());
-        
+
         moduleName = wm.getModuleName();
         appName = wm.getWebBundleDescriptor().getApplication().getAppName();
         registrationName = wm.getWebBundleDescriptor().getApplication().getRegistrationName();
     }
-    
+
     public WebComponentInvocation(WebModule wm, Object instance, String instanceName) {
       this(wm, instance);
       setInstanceName(instanceName);
@@ -159,5 +159,14 @@ public class WebComponentInvocation extends ComponentInvocation {
             }
             return eq;
         }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof WebComponentInvocation)) {
+            return false;
+        }
+        WebComponentInvocation other = (WebComponentInvocation) obj;
+        return container == other.container && instance == other.instance;
     }
 }

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebComponentInvocation.java
@@ -47,6 +47,7 @@ import javax.servlet.Filter;
 import javax.servlet.Servlet;
 import javax.servlet.SingleThreadModel;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 public class WebComponentInvocation extends ComponentInvocation {
 
@@ -163,7 +164,7 @@ public class WebComponentInvocation extends ComponentInvocation {
 
     @Override
     public int hashCode() {
-        return instance == null ? container.hashCode() : container.hashCode() ^ instance.hashCode();
+        return Objects.hash(container, instance);
     }
 
     @Override

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -178,9 +178,9 @@ public class InvocationManagerImpl implements InvocationManager {
         }
 
         ComponentInvocation current = iter.next(); // the last is the current is "invocation"
-        if (invocation != current) {
-            LOGGER.log(WARNING, "postInvoke not called with top of the invocation stack. Expected {0} but was: {1}",
-                    new Object[] { current, invocation });
+        if (!isEqual(invocation, current)) {
+            LOGGER.log(WARNING, "postInvoke not called with top of the invocation stack. Expected:\n{0}\nbut was:\n{1}\nfor caller:\n{2}",
+                    new Object[] { current, invocation, Arrays.toString(Thread.currentThread().getStackTrace()) });
         }
         ComponentInvocation prev = iter.hasNext() ? iter.next() : null;
 
@@ -204,6 +204,10 @@ public class InvocationManagerImpl implements InvocationManager {
                 typeHandler.afterPostInvoke(type, prev, invocation);
             }
         }
+    }
+
+    private static boolean isEqual(ComponentInvocation a, ComponentInvocation b) {
+        return a == b || a.getClass() == b.getClass() && a.equals(b);
     }
 
     /**

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
@@ -179,8 +180,10 @@ public class InvocationManagerImpl implements InvocationManager {
 
         ComponentInvocation current = iter.next(); // the last is the current is "invocation"
         if (!isEqual(invocation, current)) {
-            LOGGER.log(WARNING, "postInvoke not called with top of the invocation stack. Expected:\n{0}\nbut was:\n{1}\nfor caller:\n{2}",
-                    new Object[] { current, invocation, Arrays.toString(Thread.currentThread().getStackTrace()) });
+            LOGGER.log(WARNING, "postInvoke not called with top of the invocation stack. Expected:\n{0}\nbut was:\n{1}",
+                    new Object[] { current, invocation });
+            LOGGER.log(Level.FINE, "Stacktrace: ",
+                    new IllegalStateException("This exception is not thrown, it is only to trace the invocation"));
         }
         ComponentInvocation prev = iter.hasNext() ? iter.next() : null;
 


### PR DESCRIPTION
### Summary
Strictly it would be correct to assume that the `ComponentInocation` passed to `preInvoke` should be the same as the one passed to `postInvoke`. This however is difficult to do in some cases (see #4646). Relaxing expectations `equal` is also problematic as `WebComponentInocation#equal` would need to change. To avoid introducing new issues `WebComponentInocation`s will be excluded from the logging. This needs to be done matching the class name as string as the module making the check cannot become dependent on the module defining that class. I figured that checking the simple class name is sufficient here.

I also improved the formatting of the log message and added the strack trace as it is important to find where the inconsistent call is coming from.

After revisiting this and with the greater insight gained over time spent looking at the invocation manager I also decided to use the `current` instance from internal stack (that is the `ComponentInvocation` passed to `preInvoke`) for the `postInvoke` to the listeners. 
The implementation did that in 3/4 of calls before and I replaced that with the argument passed to `postInvoke`, that was used 1/4 as back then I felt this would be more consistent with `preInvoke`. But now I think that "more consistent" means passing the instanced passed to `preInvoke` also to `postInvoke` listeners as originally done for 3/4 of listener notifications.

### Testing
* start server
* open admin-gui
* check that no warning has been logged (related to `ComponentInocation`)