### PR TITLE
APPSERV-148 Adds MP Metadata as permanent MC annotation

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -41,6 +41,7 @@ package fish.payara.microprofile.metrics;
 
 import fish.payara.microprofile.metrics.admin.MetricsServiceConfiguration;
 import fish.payara.microprofile.metrics.exception.NoSuchRegistryException;
+import fish.payara.microprofile.metrics.impl.MetricRegistrationListener;
 import fish.payara.microprofile.metrics.impl.MetricRegistryImpl;
 import fish.payara.microprofile.metrics.jmx.MBeanMetadata;
 import fish.payara.microprofile.metrics.jmx.MBeanMetadataConfig;
@@ -52,8 +53,11 @@ import java.beans.PropertyChangeEvent;
 
 import org.eclipse.microprofile.metrics.Counting;
 import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.Timer;
 import org.glassfish.api.StartupRunLevel;
@@ -80,6 +84,7 @@ import java.lang.annotation.Annotation;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.metrics.MetricID;
 
@@ -124,7 +129,30 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
 
     private List<MBeanMetadata> unresolvedVendorMetadataList;
 
-    private final Map<String, MetricRegistryImpl> REGISTRIES = new ConcurrentHashMap<>();//stores registries of base, vendor, app1, app2, ... app(n) etc
+    /**
+     * A record per registry so that any registry related state can be created or removed consistently to avoid memory
+     * leaks or complicated cleanup work of related state that can be disposed in connection with the registry.
+     */
+    private static final class MetricRegistryState implements MetricRegistrationListener {
+
+        final MetricRegistryImpl registry = new MetricRegistryImpl();
+        final Queue<MetricID> registeredNotAnnotated = new ConcurrentLinkedQueue<>();
+
+        public MetricRegistryState() {
+            registry.addListener(this);
+        }
+
+        @Override
+        public void onRegistration(MetricID registered, MetricRegistry registry) {
+            registeredNotAnnotated.add(registered);
+        }
+
+    }
+
+    /**
+     * stores registries of base, vendor, app1, app2, ... app(n) etc
+     */
+    private final Map<String, MetricRegistryState> registriesByName = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void init() {
@@ -147,15 +175,16 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
         if (!isEnabled())
             return;
         MonitoringDataCollector metricsCollector = rootCollector.in("metric");
-        for (MetricRegistryImpl registry : REGISTRIES.values()) {
-            collectRegistry(registry, metricsCollector);
+        for (MetricRegistryState state : registriesByName.values()) {
+            collectRegistry(state, metricsCollector);
         }
     }
 
-    private static void collectRegistry(MetricRegistryImpl registry, MonitoringDataCollector collector) {
+    private static void collectRegistry(MetricRegistryState state, MonitoringDataCollector collector) {
+        processMetadataToAnnotations(state, collector);
         // OBS: this way of iterating the metrics in the registry is optimal because of its internal data organisation
-        for (String name : registry.getNames()) {
-            for (Entry<MetricID, Metric> entry : registry.getMetrics(name).entrySet()) {
+        for (String name : state.registry.getNames()) {
+            for (Entry<MetricID, Metric> entry : state.registry.getMetrics(name).entrySet()) {
                 MetricID metricID = entry.getKey();
                 Metric metric = entry.getValue();
                 MonitoringDataCollector metricCollector = tagCollector(metricID, collector);
@@ -171,22 +200,83 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
                 if (metric instanceof Gauge) {
                     Object value = ((Gauge<?>) metric).getValue();
                     if (value instanceof Number) {
-                        metricCollector.collect(toName(metricID, ""), ((Number) value));
+                        metricCollector.collect(toName(metricID,
+                                getMetricUnitSuffix(state.registry.getMetadata(name).getUnit())), ((Number) value));
                     }
                 }
             }
         }
     }
 
+    private static void processMetadataToAnnotations(MetricRegistryState state, MonitoringDataCollector collector) {
+        MetricID metricID = state.registeredNotAnnotated.poll();
+        while (metricID != null) {
+            MonitoringDataCollector metricCollector = tagCollector(metricID, collector);
+            Metadata metadata = state.registry.getMetadata(metricID.getName());
+            String name = "Count";
+            if (metadata.getTypeRaw() == MetricType.GAUGE) {
+                name = getMetricUnitSuffix(metadata.getUnit());
+            }
+            // Note that by convention an annotation with value 0 done before the series collected any value is considered permanent
+            metricCollector.annotate(toName(metricID, name), 0, true, metadataToAnnotations(metadata));
+            metricID = state.registeredNotAnnotated.poll();
+        }
+    }
+
+    private static String getMetricUnitSuffix(Optional<String> unit) {
+        if (!unit.isPresent()) {
+            return "";
+        }
+        String value = unit.get();
+        if (MetricUnits.NONE.equalsIgnoreCase(value) || value.isEmpty()) {
+            return "";
+        }
+        return toFirstLetterUpperCase(value);
+    }
+
+    private static String toFirstLetterUpperCase(String value) {
+        return Character.toUpperCase(value.charAt(0)) + value.substring(1);
+    }
+
+    private static String[] metadataToAnnotations(Metadata metadata) {
+        return new String[] {
+                "Name", metadata.getName(), //
+                "Type", metadata.getType(), //
+                "Unit", metadata.getUnit().orElse(MetricUnits.NONE), //
+                "DisplayName", metadata.getDisplayName(), //
+                "Discription", metadata.getDescription().orElse("")
+        };
+    }
+
     private static String toName(MetricID metric, String suffix) {
         String name = metric.getName();
-        name = name.indexOf(' ') < 0 ? name : name.replace(' ', '.'); // trying to avoid replace
+        if (name.indexOf(' ') >= 0) { // trying to avoid replace
+            name = name.replace(' ', '_');
+        } else {
+            int dotIndex = name.indexOf('.');
+            if (dotIndex > 0) {
+                name = name.substring(dotIndex + 1);
+            }
+            if (name.indexOf('.') > 0) {
+                String[] words = name.split("\\.");
+                name = "";
+                for (String word : words) {
+                    name += toFirstLetterUpperCase(word);
+                }
+            }
+        }
+        name = toFirstLetterUpperCase(name);
         return name.endsWith(suffix) || suffix.isEmpty() ? name : name + suffix;
     }
 
     private static MonitoringDataCollector tagCollector(MetricID metric, MonitoringDataCollector collector) {
         Map<String, String> tags = metric.getTags();
         if (tags.isEmpty()) {
+            String name = metric.getName();
+            int dotIndex = name.indexOf('.');
+            if (dotIndex > 0 ) {
+                return collector.group(name.substring(0, dotIndex));
+            }
             return collector;
         }
         StringBuilder tag = new StringBuilder();
@@ -195,9 +285,9 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
                 tag.append('_');
             }
             if (!"name".equals(e.getKey())) {
-                tag.append(e.getKey().replace(' ', '.'));
+                tag.append(e.getKey().replace(' ', '_'));
             }
-            tag.append(e.getValue().replace(' ', '.'));
+            tag.append(e.getValue().replace(' ', '_'));
         }
         return collector.group(tag);
     }
@@ -331,15 +421,15 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
     }
 
     private MetricRegistryImpl getRegistryInternal(String registryName) throws NoSuchRegistryException {
-        MetricRegistryImpl registry = REGISTRIES.get(registryName.toLowerCase());
-        if (registry == null) {
+        MetricRegistryState state = registriesByName.get(registryName.toLowerCase());
+        if (state == null) {
             throw new NoSuchRegistryException(registryName);
         }
-        return registry;
+        return state.registry;
     }
 
     public Set<String> getAllRegistryNames() {
-        return REGISTRIES.keySet();
+        return registriesByName.keySet();
     }
 
     /**
@@ -354,7 +444,7 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
     }
 
     private MetricRegistryImpl getOrAddRegistryInternal(String registryName) {
-        return REGISTRIES.computeIfAbsent(registryName.toLowerCase(), key -> new MetricRegistryImpl());
+        return registriesByName.computeIfAbsent(registryName.toLowerCase(), key -> new MetricRegistryState()).registry;
     }
 
     public MetricRegistry getApplicationRegistry() {
@@ -368,7 +458,8 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
      * @return
      */
     public MetricRegistry removeRegistry(String registryName) {
-        return REGISTRIES.remove(registryName.toLowerCase());
+        MetricRegistryState state = registriesByName.remove(registryName.toLowerCase());
+        return state == null ? null : state.registry;
     }
 
     /**

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -213,12 +213,15 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
         while (metricID != null) {
             MonitoringDataCollector metricCollector = tagCollector(metricID, collector);
             Metadata metadata = state.registry.getMetadata(metricID.getName());
-            String name = "Count";
-            if (metadata.getTypeRaw() == MetricType.GAUGE) {
-                name = getMetricUnitSuffix(metadata.getUnit());
+            String suffix = "Count";
+            String property = "Count";
+            boolean isGauge = metadata.getTypeRaw() == MetricType.GAUGE;
+            if (isGauge) {
+                suffix = getMetricUnitSuffix(metadata.getUnit());
+                property = "Value";
             }
             // Note that by convention an annotation with value 0 done before the series collected any value is considered permanent
-            metricCollector.annotate(toName(metricID, name), 0, false, metadataToAnnotations(metadata));
+            metricCollector.annotate(toName(metricID, suffix), 0, false, metadataToAnnotations(metadata, property));
             metricID = state.registeredNotAnnotated.poll();
         }
     }
@@ -238,13 +241,14 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
         return Character.toUpperCase(value.charAt(0)) + value.substring(1);
     }
 
-    private static String[] metadataToAnnotations(Metadata metadata) {
+    private static String[] metadataToAnnotations(Metadata metadata, String property) {
         return new String[] {
                 "Name", metadata.getName(), //
                 "Type", metadata.getType(), //
                 "Unit", metadata.getUnit().orElse(MetricUnits.NONE), //
                 "DisplayName", metadata.getDisplayName(), //
-                "Discription", metadata.getDescription().orElse("")
+                "Discription", metadata.getDescription().orElse(""),
+                "Property", property
         };
     }
 

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -218,7 +218,7 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
                 name = getMetricUnitSuffix(metadata.getUnit());
             }
             // Note that by convention an annotation with value 0 done before the series collected any value is considered permanent
-            metricCollector.annotate(toName(metricID, name), 0, true, metadataToAnnotations(metadata));
+            metricCollector.annotate(toName(metricID, name), 0, false, metadataToAnnotations(metadata));
             metricID = state.registeredNotAnnotated.poll();
         }
     }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -247,7 +247,7 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
                 "Type", metadata.getType(), //
                 "Unit", metadata.getUnit().orElse(MetricUnits.NONE), //
                 "DisplayName", metadata.getDisplayName(), //
-                "Discription", metadata.getDescription().orElse(""),
+                "Description", metadata.getDescription().orElse(""),
                 "Property", property
         };
     }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricRegistrationListener.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricRegistrationListener.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.metrics.impl;
+
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+/**
+ * Allows to be notified when a new {@link Metric} is registered with a particular {@link MetricRegistryImpl}.
+ *
+ * @author Jan Bernitt
+ * @since 5.202
+ */
+public interface MetricRegistrationListener {
+
+    /**
+     * Notifies the listener when new {@link Metric} is registered.
+     *
+     * @param registered ID of the newly registered {@link Metric}
+     * @param registry The registry the new {@link Metric} was registered with
+     */
+    void onRegistration(MetricID registered, MetricRegistry registry);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -206,8 +206,8 @@
         <concurrent.version>1.0.payara-p2</concurrent.version>
         <asm.version>7.3.1</asm.version>
         <monitoring-console-api.version>1.0</monitoring-console-api.version>
-        <monitoring-console-process.version>1.1-SNAPSHOT</monitoring-console-process.version>
-        <monitoring-console-webapp.version>1.1-SNAPSHOT</monitoring-console-webapp.version>
+        <monitoring-console-process.version>1.1</monitoring-console-process.version>
+        <monitoring-console-webapp.version>1.1</monitoring-console-webapp.version>
 
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -206,8 +206,8 @@
         <concurrent.version>1.0.payara-p2</concurrent.version>
         <asm.version>7.3.1</asm.version>
         <monitoring-console-api.version>1.0</monitoring-console-api.version>
-        <monitoring-console-process.version>1.0</monitoring-console-process.version>
-        <monitoring-console-webapp.version>1.0</monitoring-console-webapp.version>
+        <monitoring-console-process.version>1.1-SNAPSHOT</monitoring-console-process.version>
+        <monitoring-console-webapp.version>1.1-SNAPSHOT</monitoring-console-webapp.version>
 
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
     </properties>


### PR DESCRIPTION
### Summary
Goal was to make the MicroProfile Metadata of MP metrics available as "related data" for the MC series resulting from each MP metric.

The solution uses the existing concept of MC annotations which are key-value pairs associated with a series at a certain point in time of that series. As annotations are limited to a certain capacity and then replace the oldest the concept of annotation needed to be extended so that annotation could be made that would be permanent. Meaning other non-permanent annotations are disposed to make room for newer annotations before any permanent annotation is replaced. This is done by https://github.com/payara/monitoring-console/pull/9 and used in this PR by the `MetricsService` to add the annotation data.

### CI
Needs https://github.com/payara/monitoring-console/pull/9 and https://github.com/payara/monitoring-console/pull/10 merged before jenkins will succeed to build it.

### Testing
For changes in https://github.com/payara/monitoring-console/pull/9 run
```bash 
/monitoring-console/$ mvn clean install
/monitoring-console/$ cp process/target/monitoring-console-process.jar {payara-home}/glassfish/modules/
```
Deploy the webapp war file built at `monitoring-console/webapp/target`.

Check annotations for a MP metric at `http://localhost:8080/monitoring-console-webapp/api/annotations/data/ns:metric%20@:classloader%20LoadedClassesCount/` (assuming app is deployed in context `monitoring-console-webapp`):

```json
[
    {
        "attrs": {
            "Name": "classloader.loadedClasses.count",
            "Type": "gauge",
            "Unit": "none",
            "DisplayName": "Currently Loaded Class Count",
            "Discription": "Displays the number of classes that are currently loaded in the JVM."
        },
        "instance": "server",
        "permanent": true,
        "series": "ns:metric @:classloader LoadedClassesCount",
        "time": 1588756123000,
        "value": 0
    }
]
```
The `attrs` shows the important `Metadata` information from the `Metric` called `classloader.loadedClasses.count` in MP metrics and which results in a series called `ns:metric @:classloader LoadedClassesCount` in MC.

Create and start another instance and refresh the above URL. The result should be like:
```json
[
    {
        "attrs": {
            "Name": "classloader.loadedClasses.count",
            "Type": "gauge",
            "Unit": "none",
            "DisplayName": "Currently Loaded Class Count",
            "Discription": "Displays the number of classes that are currently loaded in the JVM."
        },
        "instance": "server",
        "permanent": true,
        "series": "ns:metric @:classloader LoadedClassesCount",
        "time": 1588767450000,
        "value": 0
    },
    {
        "attrs": {
            "Name": "classloader.loadedClasses.count",
            "Type": "gauge",
            "Unit": "none",
            "DisplayName": "Currently Loaded Class Count",
            "Discription": "Displays the number of classes that are currently loaded in the JVM."
        },
        "instance": "Lovely-Quillback",
        "permanent": true,
        "series": "ns:metric @:classloader LoadedClassesCount",
        "time": 1588767550000,
        "value": 0
    }
]
```
Check that both the `"server"` and the other instance's annotation have a `"permanent"` field being `true`.