### PR TITLE
CUSTOM-271: Support multiple media type parameters

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -122,5 +122,11 @@
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Needed for static initialization of MetricsResource in a test -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/rest/MetricsResource.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/rest/MetricsResource.java
@@ -218,7 +218,7 @@ public class MetricsResource extends HttpServlet {
                 .filter(Matcher::find)
                 .mapToDouble(m -> toDouble(m.group(1)))
                 .findFirst()
-                .orElse(0);
+                .orElse(1);
     }
 
     private static double toDouble(final String text) {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/rest/AcceptContentTypeTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/rest/AcceptContentTypeTest.java
@@ -1,0 +1,73 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package fish.payara.microprofile.metrics.rest;
+
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+import static fish.payara.microprofile.metrics.rest.MetricsResource.parseMetricsAcceptHeader;
+import static org.junit.Assert.assertEquals;
+
+public class AcceptContentTypeTest {
+    @Test
+    public void startingWithDecimalDot() {
+        // application/json;q=0.1,text/plain;q=.9 or application/json; q=0.1, text/plain; q=.9
+        assertEquals(Optional.of("text/plain"),
+                parseMetricsAcceptHeader("application/json;q=0.1,text/plain;q=.9"));
+        assertEquals(Optional.of("text/plain"),
+                parseMetricsAcceptHeader("application/json;q=0.1,text/plain; q=.9"));
+    }
+
+    @Test
+    public void withMultipleQualifiers() {
+        assertEquals(Optional.of("text/plain"),
+                parseMetricsAcceptHeader("application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;" +
+                        "encoding=delimited;q=0.7,text/plain;version=0.0.4;charset=utf-8;q=0.3"));
+    }
+
+    @Test
+    public void withWildcard() {
+        assertEquals(Optional.of("text/plain"),
+                parseMetricsAcceptHeader("text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"));
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/rest/AcceptContentTypeTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/rest/AcceptContentTypeTest.java
@@ -70,4 +70,22 @@ public class AcceptContentTypeTest {
         assertEquals(Optional.of("text/plain"),
                 parseMetricsAcceptHeader("text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"));
     }
+
+    @Test
+    public void withoutPreference() {
+        assertEquals(Optional.of("text/plain"),
+                parseMetricsAcceptHeader("application/json, text/plain"));
+    }
+
+    @Test
+    public void withDefaultPreference() {
+        assertEquals(Optional.of("application/json"),
+                parseMetricsAcceptHeader("text/plain;q=0.5, application/json"));
+    }
+
+    @Test
+    public void usualBrowserAccept() {
+        assertEquals(Optional.of("text/plain"),
+                parseMetricsAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"));
+    }
 }


### PR DESCRIPTION
# Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Metrics endpoint's parsing of accept header was incomplete, and failed on media type requests with multiple parameters, like
` application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;charset=utf-8;q=0.3`

# Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
`AcceptContentTypeTest` tests known corner scenarios

### Testing Performed
`AcceptContentTypeTest` and curl with mentioned accept header

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
OpenJDK 64-Bit Server VM (Zulu 8.46.0.19-CA-win64) (build 25.252-b14, mixed mode)
Apache Maven 3.6.3
Windows 10