### PR TITLE
ECOSYS-157 OpenID Connect Caller's name and groups are null

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/security/openid/api/OpenIdContext.java
+++ b/api/payara-api/src/main/java/fish/payara/security/openid/api/OpenIdContext.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -40,8 +40,8 @@
 package fish.payara.security.openid.api;
 
 import java.io.Serializable;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.json.JsonObject;
 
 /**
@@ -64,7 +64,7 @@ public interface OpenIdContext extends Serializable {
      *
      * @return
      */
-    String getCallerGroups();
+    Set<String> getCallerGroups();
 
     /**
      * Subject Identifier. A locally unique and never reassigned identifier

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -236,7 +236,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         Optional<OpenIdState> receivedState = OpenIdState.from(request.getParameter(STATE));
         String redirectURI = configuration.buildRedirectURI(request);
-        if (receivedState.isPresent() && redirectURI.contains(request.getServletPath())) {
+        if (receivedState.isPresent()) {
             if (!request.getRequestURL().toString().equals(redirectURI)) {
                 LOGGER.log(INFO, "OpenID Redirect URL {0} not matched with request URL {1}", new Object[]{redirectURI, request.getRequestURL().toString()});
                 return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
@@ -271,7 +271,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
         String errorDescription = request.getParameter(ERROR_DESCRIPTION_PARAM);
         if (!isEmpty(error)) {
             // Error responses sent to the redirect_uri
-            LOGGER.log(WARNING, "Error occurred in reciving Authorization Code : {0} caused by {1}", new Object[]{error, errorDescription});
+            LOGGER.log(WARNING, "Error occurred in receiving Authorization Code : {0} caused by {1}", new Object[]{error, errorDescription});
             return httpContext.notifyContainerAboutLogin(INVALID_RESULT);
         }
         stateController.remove(configuration, httpContext);

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -62,6 +62,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import java.util.Optional;
 import java.util.logging.Level;
+import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import javax.enterprise.inject.Typed;
@@ -235,21 +236,22 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         Optional<OpenIdState> receivedState = OpenIdState.from(request.getParameter(STATE));
         String redirectURI = configuration.buildRedirectURI(request);
-        if (receivedState.isPresent()
-                && request.getRequestURL().toString().equals(redirectURI)) {
-
-            Optional<OpenIdState> expectedState = stateController.get(configuration, httpContext);
-            if (expectedState.isPresent()) {
-                if (expectedState.equals(receivedState)) {
-                    // (3) Successful Authentication Response : redirect_uri?code=abc&state=123
-                    return validateAuthorizationCode(httpContext);
-                } else {
-                    LOGGER.fine("Inconsistent received state, value not matched");
-                    return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
-                }
-            } else {
-                LOGGER.fine("Expected state not found");
+        if (receivedState.isPresent() && redirectURI.contains(request.getServletPath())) {
+            if (!request.getRequestURL().toString().equals(redirectURI)) {
+                LOGGER.log(INFO, "OpenID Redirect URL {0} not matched with request URL {1}", new Object[]{redirectURI, request.getRequestURL().toString()});
+                return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
             }
+            Optional<OpenIdState> expectedState = stateController.get(configuration, httpContext);
+            if (!expectedState.isPresent()) {
+                LOGGER.fine("Expected state not found");
+                return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
+            }
+            if (!expectedState.equals(receivedState)) {
+                LOGGER.fine("Inconsistent received state, value not matched");
+                return httpContext.notifyContainerAboutLogin(INVALID_RESULT);
+            }
+            // (3) Successful Authentication Response : redirect_uri?code=abc&state=123
+            return validateAuthorizationCode(httpContext);
         }
         return httpContext.doNothing();
     }

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -113,9 +113,12 @@ public class OpenIdIdentityStore implements IdentityStore {
             context.setClaims(userInfo);
         }
 
+        context.setCallerName(getCallerName(configuration));
+        context.setCallerGroups(getCallerGroups(configuration));
+
         return new CredentialValidationResult(
-                getCallerName(configuration),
-                getGroups(configuration)
+                context.getCallerName(),
+                context.getCallerGroups()
         );
     }
 
@@ -134,7 +137,7 @@ public class OpenIdIdentityStore implements IdentityStore {
         return callerName;
     }
 
-    private Set<String> getGroups(OpenIdConfiguration configuration) {
+    private Set<String> getCallerGroups(OpenIdConfiguration configuration) {
         Set<String> groups = new HashSet<>();
         String callerGroupsClaim = configuration.getClaimsConfiguration().getCallerGroupsClaim();
         JsonArray groupsUserinfoClaim

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -46,7 +46,6 @@ import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.IdentityTokenImpl;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdContextImpl;
-import java.security.Principal;
 import java.util.HashSet;
 import java.util.Map;
 import static java.util.Objects.isNull;

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -46,6 +46,7 @@ import static fish.payara.security.openid.api.OpenIdConstant.SUBJECT_IDENTIFIER;
 import fish.payara.security.openid.api.OpenIdContext;
 import fish.payara.security.openid.api.RefreshToken;
 import java.util.Optional;
+import java.util.Set;
 import javax.enterprise.context.SessionScoped;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -60,7 +61,7 @@ import javax.json.JsonObject;
 public class OpenIdContextImpl implements OpenIdContext {
 
     private String callerName;
-    private String callerGroups;
+    private Set<String> callerGroups;
     private String tokenType;
     private AccessToken accessToken;
     private IdentityToken identityToken;
@@ -79,11 +80,11 @@ public class OpenIdContextImpl implements OpenIdContext {
     }
 
     @Override
-    public String getCallerGroups() {
+    public Set<String> getCallerGroups() {
         return callerGroups;
     }
 
-    public void setCallerGroups(String callerGroups) {
+    public void setCallerGroups(Set<String> callerGroups) {
         this.callerGroups = callerGroups;
     }
 

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/InvalidRedirectURITest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -71,16 +71,9 @@ import static org.junit.Assert.fail;
 @RunWith(PayaraArquillianTestRunner.class)
 public class InvalidRedirectURITest {
 
-    private WebClient webClient;
-
     @OperateOnDeployment("openid-client")
     @ArquillianResource
     private URL base;
-
-    @Before
-    public void init() {
-        webClient = new WebClient();
-    }
 
     @Deployment(name = "openid-server")
     public static WebArchive createServerDeployment() {
@@ -99,6 +92,7 @@ public class InvalidRedirectURITest {
     @RunAsClient
     public void testOpenIdConnect() throws IOException {
         try {
+            WebClient webClient = new WebClient();
             webClient.getPage(base + "Secured");
             fail("redirect uri is valid");
         } catch (FailingHttpStatusCodeException ex) {

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdDefaultTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdDefaultTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -49,7 +49,6 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -61,16 +60,9 @@ import org.junit.runner.RunWith;
 @RunWith(PayaraArquillianTestRunner.class)
 public class OpenIdDefaultTest {
 
-    private WebClient webClient;
-
     @OperateOnDeployment("openid-client")
     @ArquillianResource
     private URL base;
-
-    @Before
-    public void init() {
-        webClient = new WebClient();
-    }
 
     @Deployment(name = "openid-server")
     public static WebArchive createServerDeployment() {
@@ -85,6 +77,7 @@ public class OpenIdDefaultTest {
     @Test
     @RunAsClient
     public void testOpenIdConnect() throws IOException {
+        WebClient webClient = new WebClient();
         OpenIdTestUtil.testOpenIdConnect(webClient, base);
     }
 

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdTestUtil.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdTestUtil.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -39,7 +39,6 @@
  */
 package fish.payara.security.oidc.test;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebClient;
 import fish.payara.security.oidc.client.Callback;
@@ -49,12 +48,11 @@ import fish.payara.security.oidc.server.ApplicationConfig;
 import fish.payara.security.oidc.server.OidcProvider;
 import java.io.IOException;
 import java.net.URL;
+import javax.ws.rs.core.Response.Status;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
 
 /**
  *
@@ -86,20 +84,13 @@ public class OpenIdTestUtil {
     }
 
     public static void testOpenIdConnect(WebClient webClient, URL base) throws IOException {
-        String result = ((TextPage) webClient.getPage(base + "Unsecured")).getContent();
-        assertEquals("This is an unsecured web page", result);
+        TextPage unsecuredPage = (TextPage) webClient.getPage(base + "Unsecured");
+        assertEquals(Status.OK.getStatusCode(), unsecuredPage.getWebResponse().getStatusCode());
+        assertEquals("This is an unsecured web page", unsecuredPage.getContent());
 
-        TextPage page = (TextPage) webClient.getPage(base + "Secured");
-        assertEquals("/openid-client/Callback", page.getUrl().getPath());
-        assertNotEquals("null", page.getContent());
-
-        try {
-            webClient.getPage(base + "Secured");
-            fail("Roles test failed");
-        } catch (FailingHttpStatusCodeException e) {
-            System.out.println("Successfully forbidden from accessing page because of " + e.getStatusMessage());
-        }
-
+        TextPage securedPage = (TextPage) webClient.getPage(base + "Secured");
+        assertEquals(Status.OK.getStatusCode(), securedPage.getWebResponse().getStatusCode());
+        assertEquals("/openid-client/Callback", securedPage.getUrl().getPath());
     }
 
 }

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -45,7 +45,6 @@ import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.ServerOperations;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 
@@ -55,7 +54,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,13 +67,9 @@ import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OP
 @RunWith(PayaraArquillianTestRunner.class)
 public class UseCookiesTest {
 
-    private WebClient webClient;
-
     @OperateOnDeployment("openid-client")
     @ArquillianResource
     private URL base;
-
-    private URL baseHttps;
 
     private static String clientKeyStorePath;
 
@@ -93,15 +87,11 @@ public class UseCookiesTest {
                 .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties");
     }
 
-    @Before
-    public void setup() throws FileNotFoundException, IOException {
-        webClient = new WebClient();
-        baseHttps = ServerOperations.createClientTrustStore(webClient, base, clientKeyStorePath);
-    }
-
     @Test
     @RunAsClient
     public void testOpenIdConnect() throws IOException {
+        WebClient webClient = new WebClient();
+        URL baseHttps = ServerOperations.createClientTrustStore(webClient, base, clientKeyStorePath);
         OpenIdTestUtil.testOpenIdConnect(webClient, baseHttps);
     }
 

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/WithoutNonceTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -53,10 +53,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE;
 
 /**
@@ -67,16 +65,9 @@ import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OP
 @RunWith(PayaraArquillianTestRunner.class)
 public class WithoutNonceTest {
 
-    private WebClient webClient;
-
     @OperateOnDeployment("openid-client")
     @ArquillianResource
     private URL base;
-
-    @Before
-    public void init() {
-        webClient = new WebClient();
-    }
 
     @Deployment(name = "openid-server")
     public static WebArchive createServerDeployment() {
@@ -94,6 +85,7 @@ public class WithoutNonceTest {
     @Test
     @RunAsClient
     public void testOpenIdConnect() throws IOException {
+        WebClient webClient = new WebClient();
         OpenIdTestUtil.testOpenIdConnect(webClient, base);
     }
 


### PR DESCRIPTION
# Description
This is a fix to set the caller's name & groups after the authentication in `OpenIdContext` and error message logged if redirect URL not matched with request URL.

# Testing
### Testing Performed
Manually Tested, Payara-Samples

