### PR TITLE
CUSTCOM-237 In Weld, parallel execution mode for async observers doesn't trigger all observers

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/SecurityServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/SecurityServicesImpl.java
@@ -64,7 +64,7 @@ public class SecurityServicesImpl implements SecurityServices {
     static class SecurityContextImpl implements org.jboss.weld.security.spi.SecurityContext {
 
         private final SecurityContext myContext;
-        private SecurityContext oldContext;
+        private static ThreadLocal<SecurityContext> oldContext = new ThreadLocal<>();
 
         private SecurityContextImpl() {
             this.myContext = SecurityContext.getCurrent();
@@ -72,8 +72,8 @@ public class SecurityServicesImpl implements SecurityServices {
 
         @Override
         public void associate() {
-            if (oldContext == null) {
-                oldContext = SecurityContext.getCurrent();
+            if (oldContext.get() == null) {
+                oldContext.set(SecurityContext.getCurrent());
             } else {
                 throw new IllegalStateException("Security context is already associated");
             }
@@ -82,8 +82,8 @@ public class SecurityServicesImpl implements SecurityServices {
 
         @Override
         public void dissociate() {
-            SecurityContext.setCurrent(oldContext);
-            oldContext = null;
+            SecurityContext.setCurrent(oldContext.get());
+            oldContext.remove();
         }
 
         @Override


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
When a CDI event is fired in async mode with Weld-specific option to enable parallel execution of events, not all events are triggered as expected if one of them throws an exception.

# Testing

### Testing Performed
- Build test
- Jakarta TCK

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4
