### PR TITLE
APPSERV-124 Monitoring-Console: Adds server side page configuration

### DIFF
--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/admin/SetMonitoringConsoleConfigurationCommand.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/admin/SetMonitoringConsoleConfigurationCommand.java
@@ -115,6 +115,18 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
     @Param(optional = true, alias = "remove-watch")
     private String _removeWatch;
 
+    @SuppressWarnings("squid:S116")
+    @Param(optional = true, alias = "add-page-name")
+    private String _addPageName;
+
+    @SuppressWarnings("squid:S116")
+    @Param(optional = true, alias = "add-page-json")
+    private String _addPageJson;
+
+    @SuppressWarnings("squid:S116")
+    @Param(optional = true, alias = "remove-page")
+    private String _removePage;
+
     @Inject
     protected CommandRunner commandRunner;
 
@@ -155,35 +167,45 @@ public class SetMonitoringConsoleConfigurationCommand implements AdminCommand {
                         configProxy.getDisabledWatchNames().remove(_enableWatch);
                     }
                     if (isDefined(_addWatchName) && isDefined(_addWatchJson)) {
-                        List<String> customWatchNames = configProxy.getCustomWatchNames();
-                        List<String> customWatchValues = configProxy.getCustomWatchValues();
-                        int index = customWatchNames.indexOf(_addWatchName);
-                        if (index >= 0) {
-                            customWatchNames.remove(index);
-                            if (index < customWatchValues.size()) {
-                                customWatchValues.remove(index);
-                            }
-                        } 
-                        customWatchNames.add(_addWatchName);
-                        customWatchValues.add(_addWatchJson);
+                        add(_addWatchName, _addWatchJson, configProxy.getCustomWatchNames(), configProxy.getCustomWatchValues());
                     }
                     if (isDefined(_removeWatch)) {
-                        List<String> customWatchNames = configProxy.getCustomWatchNames();
-                        int index = customWatchNames.indexOf(_removeWatch);
-                        if (index >= 0) {
-                            customWatchNames.remove(index);
-                            List<String> customWatchValues = configProxy.getCustomWatchValues();
-                            if (index < customWatchValues.size()) {
-                                customWatchValues.remove(index);
-                            }
-                        }
+                        remove(_removeWatch, configProxy.getCustomWatchNames(), configProxy.getCustomWatchValues());
                         configProxy.getDisabledWatchNames().remove(_removeWatch);
+                    }
+                    if (isDefined(_addPageName) && isDefined(_addPageJson)) {
+                        add(_addPageName, _addPageJson, configProxy.getPageNames(), configProxy.getPageValues());
+                    }
+                    if (isDefined(_removePage)) {
+                        remove(_removePage, configProxy.getPageNames(), configProxy.getPageValues());
                     }
                     return null;
                 }
             }, config);
         } catch (TransactionFailure ex) {
             context.getActionReport().failure(LOGGER, "Failed to update Monitoring Console configuration", ex);
+        }
+    }
+
+    static void add(String name, String value, List<String> names, List<String> values) {
+        int index = names.indexOf(name);
+        if (index >= 0) {
+            names.remove(index);
+            if (index < values.size()) {
+                values.remove(index);
+            }
+        }
+        names.add(name);
+        values.add(value);
+    }
+
+    static void remove(String name, List<String> names, List<String> values) {
+        int index = names.indexOf(name);
+        if (index >= 0) {
+            names.remove(index);
+            if (index < values.size()) {
+                values.remove(index);
+            }
         }
     }
 

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/configuration/MonitoringConsoleConfiguration.java
@@ -51,7 +51,7 @@ import com.sun.enterprise.config.serverbeans.DomainExtension;
 /**
  * Configuration for the monitoring console core.
  * This is first of all the data and watch collection and evaluation.
- * 
+ *
  * @author Jan Bernitt
  * @since 5.201
  */
@@ -61,7 +61,7 @@ public interface MonitoringConsoleConfiguration extends DomainExtension {
     /**
      * Note that this is not reflecting whether or not the monitoring data is collected.
      * This is controlled by the general monitoring configuration.
-     * 
+     *
      * @return True, if monitoring console web-app is deployed, else false.
      */
     @Attribute(defaultValue = "false", dataType = Boolean.class)
@@ -85,5 +85,17 @@ public interface MonitoringConsoleConfiguration extends DomainExtension {
      */
     @Element
     List<String> getCustomWatchValues();
+
+    /**
+     * @return Names of MC (client) pages
+     */
+    @Element
+    List<String> getPageNames();
+
+    /**
+     * @return JSON values of the MC (client) pages (index is same in {@link #getPageNames()})
+     */
+    @Element
+    List<String> getPageValues();
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -205,9 +205,9 @@
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.0.payara-p2</concurrent.version>
         <asm.version>7.3.1</asm.version>
-        <monitoring-console-api.version>1.0</monitoring-console-api.version>
-        <monitoring-console-process.version>1.0</monitoring-console-process.version>
-        <monitoring-console-webapp.version>1.0</monitoring-console-webapp.version>
+        <monitoring-console-api.version>1.3</monitoring-console-api.version>
+        <monitoring-console-process.version>1.2-SNAPSHOT</monitoring-console-process.version>
+        <monitoring-console-webapp.version>1.2-SNAPSHOT</monitoring-console-webapp.version>
 
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -205,9 +205,9 @@
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.0.payara-p2</concurrent.version>
         <asm.version>7.3.1</asm.version>
-        <monitoring-console-api.version>1.3</monitoring-console-api.version>
-        <monitoring-console-process.version>1.2-SNAPSHOT</monitoring-console-process.version>
-        <monitoring-console-webapp.version>1.2-SNAPSHOT</monitoring-console-webapp.version>
+        <monitoring-console-api.version>1.1</monitoring-console-api.version>
+        <monitoring-console-process.version>1.2</monitoring-console-process.version>
+        <monitoring-console-webapp.version>1.2</monitoring-console-webapp.version>
 
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
     </properties>


### PR DESCRIPTION
### Summary
This PR adds the page names (IDs) and values to the server side monitoring console configurations which is used by https://github.com/payara/monitoring-console/pull/11 to provide a fully integrated server side page configuration for MC. Requires https://github.com/payara/monitoring-console/pull/11 and https://github.com/payara/monitoring-console/pull/15 to be merged first and release 1.2 of MC implementation made.

### Testing
Assuming MC changes are released (or build locally) build this PR and install it.

* start server
* enable monitoring console
* open monitoring console webapp in the browser
* clear browsers local storage for the page
* refresh the page, check the role selection popup is shown

![mc_dia_role](https://user-images.githubusercontent.com/309438/81926924-145d6000-95e3-11ea-8758-1cfeb83c23b2.png)

* select _User_ role
* check that the page synchronisation popup is shown

![mc_dia_pages](https://user-images.githubusercontent.com/309438/81927002-3656e280-95e3-11ea-9ebd-45652c8bb3f2.png)

* with no previous pages shared the list should be empty. press update or cancel.
* change the core page (e.g. add or remove a widget), open settings and expand the _Page_ settings, click _Push_ button.
* open MC in another browser, the page synchronisation now should show the changed and pushed page

Now the basic principle of page synchronisation was tested. There are many possible scenarios from here using the different roles.

As a _Guest_ the idea is that by default all updates shared by other are applied at the beginning so you work with the latest persistent settings. Guests change their local pages but don't share any changes. Buttons to push are not available. Automatic pushes do not occur.

As a _User_ the idea is that by default all updates are applied as long as they do not override a page that has been changed locally. This is reflected in the checkbox being checked or not by default when doing the page synchronisation. Obviously users can chose which pages to override or not. User can also manually push pages to the persistent configuration by using the _Push_ button in the _Page_ _Sync_ setting.

As an _Administrator_ the idea is that the role is used to configure the configuration that acts as base for other users. When pulling changes defaults work similar to users. But any change done to local page is automatically shared (pushed) when the _Page_ _Sync_ _auto_ setting is checked for the modified page (which it is by default). Administrator can also explicitly update already shared paged by using the _Update Remote Pages_ button in the _Global_ _Page Sync_ settings or push an individual page explicitly by using the _Push_ button (same as users).

Note also that once a user preferred a locally changed page over a remotely updated one this choice is considered in later updates by default that page will not be updated as long as the remote page is not updated with an even newer version.

In general "versions" are identical to moment of change. More recent changes are considered newer.  

See also the documentation https://github.com/payara/Payara-Server-Documentation-Antora/pull/6