### PR TITLE
CUSTCOM-262 HZ_LISTENER_PORT property error when setting system properties via the admin console

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -553,7 +553,7 @@
             <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686" />
             <system-property name="OSGI_SHELL_TELNET_PORT" value="26666" />
             <system-property name="JAVA_DEBUGGER_PORT" value="29009" />
-            <system-property name="HZ_LISTENER_PORT" value="" />
+            <system-property name="HZ_LISTENER_PORT" value="5900" />
         </config>
     </configs>
     <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%" />

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -543,7 +543,7 @@
       <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686" />
       <system-property name="OSGI_SHELL_TELNET_PORT" value="26666" />
       <system-property name="JAVA_DEBUGGER_PORT" value="29009" />
-      <system-property name="HZ_LISTENER_PORT" value="" />
+      <system-property name="HZ_LISTENER_PORT" value="5900" />
     </config>
   </configs>
   <property name="administrative.domain.name" value="%%%DOMAIN_NAME%%%" />

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -486,7 +486,7 @@
       <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686" />
       <system-property name="OSGI_SHELL_TELNET_PORT" value="26666" />
       <system-property name="JAVA_DEBUGGER_PORT" value="29009" />
-      <system-property name="HZ_LISTENER_PORT" value="" />
+      <system-property name="HZ_LISTENER_PORT" value="5900" />
       <system-property name="fish.payara.classloading.delegate" value="false" />
       <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".." />
     </config>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -502,7 +502,7 @@
       <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686" />
       <system-property name="OSGI_SHELL_TELNET_PORT" value="26666" />
       <system-property name="JAVA_DEBUGGER_PORT" value="29009" />
-      <system-property name="HZ_LISTENER_PORT" value="" />
+      <system-property name="HZ_LISTENER_PORT" value="5900" />
       <system-property name="fish.payara.classloading.delegate" value="false" />
       <system-property name="org.jboss.weld.clustering.rollingUpgradesIdDelimiter" value=".." />
     </config>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
When trying to set the values of one or more system properties for a non-DAS instance (or through its configuration) in the admin console, an error is thrown.

### Testing Performed

- Build test

<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Documentation
<!-- Link documentation if a PR exists -->

# Notes for Reviewers
**Steps to reproduce:**
1. Start the default Payara Server domain.
2. Launch the admin console. Proceed to create a new configuration called instance-config that copies the default configuration.
3. Head to the System Properties option of this new configuration, add a new property called fish.payara.properties.sample and set its value to example. Hit the Save button, which will cause the error to appear.