### PR TITLE
ECOSYS-161 OAuth2AccessToken empty instance injected

### DIFF
--- a/appserver/payara-appserver-modules/security-oauth2/src/main/java/fish/payara/security/oauth2/OAuth2StateHolder.java
+++ b/appserver/payara-appserver-modules/security-oauth2/src/main/java/fish/payara/security/oauth2/OAuth2StateHolder.java
@@ -42,6 +42,7 @@ package fish.payara.security.oauth2;
 import fish.payara.security.oauth2.api.OAuth2AccessToken;
 import java.time.Instant;
 import java.util.Optional;
+import javax.enterprise.context.SessionScoped;
 
 /**
  * Class to hold state of OAuth2 token as returned by the provider

--- a/appserver/payara-appserver-modules/security-oauth2/src/main/java/fish/payara/security/oauth2/OAuth2StateHolder.java
+++ b/appserver/payara-appserver-modules/security-oauth2/src/main/java/fish/payara/security/oauth2/OAuth2StateHolder.java
@@ -49,7 +49,7 @@ import java.util.Optional;
  * @author jonathan
  * @since 4.1.2.172
  */
-//@SessionScoped
+@SessionScoped
 public class OAuth2StateHolder implements OAuth2AccessToken {
 
     /**


### PR DESCRIPTION
# Description
Fixes https://github.com/payara/ecosystem-security-connectors/issues/33, injected OAuth2AccessToken is always empty

### Testing Performed
I applied the patch locally build the module and tested it. 


# Notes for Reviewers
Please, see the github issue.