### PR TITLE
QACI-242 Payara Samples Tests Are Attempting to Run Micro Tests for Remote Profile

### DIFF
--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -36,11 +36,16 @@
     <modules>
         <module>test-utils</module>
         <module>samples</module>
-        <module>samples-programmatic</module>
         <module>classpath</module>
     </modules>
     
     <profiles>
+        <profile>
+            <id>micro-tests</id>
+            <modules>
+                <module>samples-programmatic</module>
+            </modules>
+        </profile>
     	<profile>
     		<id>unstable</id>
     		<modules>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -41,7 +41,7 @@
     
     <profiles>
         <profile>
-            <id>micro-tests</id>
+            <id>payara-micro-managed</id>
             <modules>
                 <module>samples-programmatic</module>
             </modules>

--- a/appserver/tests/payara-samples/samples-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/samples-programmatic/pom.xml
@@ -29,26 +29,4 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>payara-server-remote</id>
-            <properties>
-                <exclude.tests>**/programatic/**.java</exclude.tests>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>${exclude.tests}</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>

--- a/appserver/tests/payara-samples/samples-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/samples-programmatic/pom.xml
@@ -29,4 +29,26 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>payara-server-remote</id>
+            <properties>
+                <exclude.tests>**/programatic/**.java</exclude.tests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>${exclude.tests}</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

Quick fix to stop micro tests on running on remote profile

# Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Tested and passed locally

Ran maven clean install;

```mvn -V -B -fae help:active-profiles clean install -f appserver/tests/payara-samples -Dpayara.version=5.2020.2-SNAPSHOT -Dpayara_domain=test-domain -Dglassfish.home=/home/alanroth/Workspace/Payara/appserver/distributions/payara/target/stage/payara5 -Ppayara-server-remote```

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

Openjdk 11.0.7
Ubuntu 64 bit
Maven 3.6.3

# Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->

This isn't designed to be a permanent solution, origionally planned on having a annotation like 'NotMicroCompatible' but for remote, 'NotRemoteCompatible'