### PR TITLE
CUSTCOM-293: Explicitly register launched PayaraMicro instance to bootstrap API

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/PayaraMicroLauncher.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.micro.boot;
 
+import fish.payara.micro.PayaraMicro;
 import fish.payara.micro.boot.loader.ExecutableArchiveLauncher;
 import fish.payara.micro.boot.loader.archive.Archive;
 import java.lang.reflect.Method;
@@ -88,6 +89,14 @@ public class PayaraMicroLauncher extends ExecutableArchiveLauncher {
     }
 
     /**
+     * Called by Payara Micro implementation, so it can be discovered when not started by this launcher.
+     * @param instance
+     */
+    public static void registerLaunchedInstance(PayaraMicroBoot instance) {
+        bootInstance = instance;
+    }
+
+    /**
      * Boot method via Micro.getInstance()
      * @return
      * @throws InstantiationException
@@ -123,7 +132,7 @@ public class PayaraMicroLauncher extends ExecutableArchiveLauncher {
                 bootInstance = (PayaraMicroBoot) instanceMethod.invoke(null);
             }
         }
-	return bootInstance; 
+        return bootInstance;
     }
 
     @Override

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.micro.impl;
 
+import fish.payara.micro.boot.PayaraMicroLauncher;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -262,6 +263,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     public static PayaraMicroImpl getInstance(boolean create) {
         if (instance == null && create) {
             instance = new PayaraMicroImpl();
+            PayaraMicroLauncher.registerLaunchedInstance(instance);
         }
         return instance;
     }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

RootDirLauncher invokes PayaraMicroImpl directly, and that made instance inaccessible via PayaraMicro API. The change will explicitly set the static instance holder in PayaraMicroLauncher.

The solution is not particulary nice, the entire bootstrap API could use some refactoring, a task for that has been put on backlog

# Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed

Deploying https://github.com/pdudits/data-replication-talk/tree/master/consumer-app into prepared rootdir and waiting for scheduled task to launch (every 15 second) would have one of these outcomes:

```
Caused by: javax.ejb.CreateException: Initialization failed for Singleton UserDataPoller
	at com.sun.ejb.containers.AbstractSingletonContainer.createSingletonEJB(AbstractSingletonContainer.java:542)
	at com.sun.ejb.containers.AbstractSingletonContainer.access$000(AbstractSingletonContainer.java:81)
	at com.sun.ejb.containers.AbstractSingletonContainer$SingletonContextFactory.create(AbstractSingletonContainer.java:687)
	... 62 more
Caused by: java.lang.IllegalStateException: Singleton not set for fish.payara.micro.boot.loader.LaunchedURLClassLoader@5567e26f
	at org.glassfish.weld.ACLSingletonProvider$ACLSingleton.get(ACLSingletonProvider.java:117)
	at org.jboss.weld.Container.instance(Container.java:65)
....
```

```
Caused by: javax.ejb.CreateException: Initialization failed for Singleton UserDataPoller
        at com.sun.ejb.containers.AbstractSingletonContainer.createSingletonEJB(AbstractSingletonContainer.java:542)
        at com.sun.ejb.containers.AbstractSingletonContainer.access$000(AbstractSingletonContainer.java:81)
        at com.sun.ejb.containers.AbstractSingletonContainer$SingletonContextFactory.create(AbstractSingletonContainer.java:687)
        ... 62 more
Caused by: java.lang.IllegalStateException: Payara Micro is not running
        at fish.payara.micro.impl.PayaraMicroImpl.getRuntime(PayaraMicroImpl.java:1078)
        at fish.payara.micro.impl.PayaraMicroImpl.getRuntime(PayaraMicroImpl.java:110)
        at fish.payara.micro.PayaraMicro.getRuntime(PayaraMicro.java:225)
        at fish.payara.micro.cdi.extension.PayaraMicroProducer.getRuntime(PayaraMicroProducer.java:67)
......
```

After the fix both standard startup, nested startup and rootdir launch work, and none of these exceptions are reported in the test app.


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 1.8.0_252, Zulu JDK 11.0.7, Maven 3.6.3, Windows
azul/zulu-openjdk-alpine:11 for tests in docker image and in AKS.

