### PR TITLE
MicroProfile Config Value Resolver API POC

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
@@ -39,8 +39,8 @@
  */
 package fish.payara.microprofile.config.cdi;
 
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
 import fish.payara.nucleus.microprofile.config.spi.InjectedPayaraConfig;
-import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -92,17 +92,20 @@ public class ConfigProducer {
     @ConfigProperty
     public <T> Set<T> getSetProperty(InjectionPoint ip) {
         ConfigProperty property = ip.getAnnotated().getAnnotation(ConfigProperty.class);
-        PayaraConfig config = (PayaraConfig) ConfigProvider.getConfig();
-        Set<T> result = new HashSet<>();
+        Config config = ConfigProvider.getConfig();
         Type type = ip.getType();
         if (type instanceof ParameterizedType) {
-            // it is an Optional
-            // get the class of the generic parameterized Optional
+         // it is an List, get the element type of the List
             @SuppressWarnings("unchecked")
-            Class<T> clazzValue = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
-            result = config.getSetValues(property.name(), property.defaultValue(), clazzValue);
+            Class<T> elementType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+            return config.getValue(property.name(), ConfigValueResolver.class)
+                    .acceptEmpty()
+                    .throwOnFailedConversion()
+                    .throwOnMissingProperty()
+                    .withDefault(property.defaultValue())
+                    .asSet(elementType);
         }
-        return result;
+        return new HashSet<>();
     }
 
     /**
@@ -115,17 +118,20 @@ public class ConfigProducer {
     @ConfigProperty
     public <T> List<T> getListProperty(InjectionPoint ip) {
         ConfigProperty property = ip.getAnnotated().getAnnotation(ConfigProperty.class);
-        PayaraConfig config = (PayaraConfig) ConfigProvider.getConfig();
-        List<T> result = new ArrayList<>();
+        Config config = ConfigProvider.getConfig();
         Type type = ip.getType();
         if (type instanceof ParameterizedType) {
-            // it is an Optional
-            // get the class of the generic parameterized Optional
+            // it is an List, get the element type of the List
             @SuppressWarnings("unchecked")
-            Class<T> clazzValue = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
-            result = config.getListValues(property.name(),property.defaultValue(), clazzValue);
+            Class<T> elementType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+            return config.getValue(property.name(), ConfigValueResolver.class)
+                    .acceptEmpty()
+                    .throwOnFailedConversion()
+                    .throwOnMissingProperty()
+                    .withDefault(property.defaultValue())
+                    .asList(elementType);
         }
-        return result;
+        return new ArrayList<>();
     }
 
     /**
@@ -138,25 +144,26 @@ public class ConfigProducer {
     @Produces
     @ConfigProperty
     public <T> Optional<T> getOptionalProperty(InjectionPoint ip) {
-
-        // gets the config property annotation
         ConfigProperty property = ip.getAnnotated().getAnnotation(ConfigProperty.class);
-        PayaraConfig config = (PayaraConfig) ConfigProvider.getConfig();
-        Optional<T> result = Optional.empty();
+        Config config = ConfigProvider.getConfig();
 
         Type type = ip.getType();
         if (type instanceof ParameterizedType) {
             // it is an Optional
             // get the class of the generic parameterized Optional
             @SuppressWarnings("unchecked")
-            Class<T> clazzValue = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+            Class<T> valueType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
 
-            // use the config to get a converted version of the property
-            T value = config.getValue(property.name(), property.defaultValue(),clazzValue);
-            if (value != null && !value.toString().equals(ConfigProperty.UNCONFIGURED_VALUE)) {
-                result = Optional.ofNullable(value);
+            String defaultValue = property.defaultValue();
+            if (ConfigProperty.UNCONFIGURED_VALUE.equals(defaultValue)) {
+                defaultValue = null;
             }
+            return config.getValue(property.name(), ConfigValueResolver.class)
+                    .acceptEmpty()
+                    .throwOnFailedConversion()
+                    .withDefault(defaultValue)
+                    .as(valueType);
         }
-        return result;
+        return Optional.empty();
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
@@ -98,10 +98,11 @@ public class ConfigProducer {
          // it is an List, get the element type of the List
             @SuppressWarnings("unchecked")
             Class<T> elementType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+            String defaultValue = property.defaultValue();
             return config.getValue(property.name(), ConfigValueResolver.class)
+                    .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
-                    .throwOnMissingProperty()
-                    .withDefault(property.defaultValue())
+                    .withDefault(defaultValue)
                     .asSet(elementType);
         }
         return new HashSet<>();
@@ -123,10 +124,11 @@ public class ConfigProducer {
             // it is an List, get the element type of the List
             @SuppressWarnings("unchecked")
             Class<T> elementType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
+            String defaultValue = property.defaultValue();
             return config.getValue(property.name(), ConfigValueResolver.class)
+                    .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
-                    .throwOnMissingProperty()
-                    .withDefault(property.defaultValue())
+                    .withDefault(defaultValue)
                     .asList(elementType);
         }
         return new ArrayList<>();
@@ -153,9 +155,6 @@ public class ConfigProducer {
             Class<T> valueType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
 
             String defaultValue = property.defaultValue();
-            if (ConfigProperty.UNCONFIGURED_VALUE.equals(defaultValue)) {
-                defaultValue = null;
-            }
             return config.getValue(property.name(), ConfigValueResolver.class)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigProducer.java
@@ -99,7 +99,6 @@ public class ConfigProducer {
             @SuppressWarnings("unchecked")
             Class<T> elementType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
             return config.getValue(property.name(), ConfigValueResolver.class)
-                    .acceptEmpty()
                     .throwOnFailedConversion()
                     .throwOnMissingProperty()
                     .withDefault(property.defaultValue())
@@ -125,7 +124,6 @@ public class ConfigProducer {
             @SuppressWarnings("unchecked")
             Class<T> elementType = (Class<T>) ((ParameterizedType) type).getActualTypeArguments()[0];
             return config.getValue(property.name(), ConfigValueResolver.class)
-                    .acceptEmpty()
                     .throwOnFailedConversion()
                     .throwOnMissingProperty()
                     .withDefault(property.defaultValue())
@@ -159,7 +157,6 @@ public class ConfigProducer {
                 defaultValue = null;
             }
             return config.getValue(property.name(), ConfigValueResolver.class)
-                    .acceptEmpty()
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
                     .as(valueType);

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
@@ -39,7 +39,7 @@
  */
 package fish.payara.microprofile.config.cdi;
 
-import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
 import java.lang.reflect.Member;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -49,6 +49,8 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.enterprise.inject.spi.InjectionPoint;
+
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -72,7 +74,7 @@ public class ConfigPropertyProducer {
     public static final Object getGenericProperty(InjectionPoint ip) {
         Object result = null;
         ConfigProperty property = ip.getAnnotated().getAnnotation(ConfigProperty.class);
-        PayaraConfig config = (PayaraConfig) ConfigProvider.getConfig();
+        Config config = ConfigProvider.getConfig();
 
         String name = property.name();
         if (name.isEmpty()) {
@@ -93,14 +95,26 @@ public class ConfigPropertyProducer {
 
         Type type = ip.getType();
         if (type instanceof Class) {
-            result = config.getValue(name, property.defaultValue(),(Class<?>)type);
+            result = config.getValue(name, ConfigValueResolver.class)
+                    .acceptEmpty()
+                    .throwOnMissingProperty()
+                    .withDefault(property.defaultValue())
+                    .as((Class<?>)type).get();
         } else if ( type instanceof ParameterizedType) {
             ParameterizedType ptype = (ParameterizedType)type;
             Type rawType = ptype.getRawType();
             if (List.class.equals(rawType)) {
-                result = config.getListValues(name, property.defaultValue(), getElementTypeFrom(ptype));
+                result = config.getValue(name, ConfigValueResolver.class)
+                    .acceptEmpty()
+                    .throwOnMissingProperty()
+                    .withDefault(property.defaultValue())
+                    .asList(getElementTypeFrom(ptype));
             } else if (Set.class.equals(rawType)) {
-                result = config.getSetValues(name, property.defaultValue(), getElementTypeFrom(ptype));
+                result = config.getValue(name, ConfigValueResolver.class)
+                    .acceptEmpty()
+                    .throwOnMissingProperty()
+                    .withDefault(property.defaultValue())
+                    .asSet(getElementTypeFrom(ptype));
             } else {
                 result = config.getValue(name, (Class<?>) rawType);
             }

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
@@ -97,7 +97,7 @@ public class ConfigPropertyProducer {
         String defaultValue = property.defaultValue();
         if (type instanceof Class) {
             result = config.getValue(name, ConfigValueResolver.class)
-                    .throwOnMissingProperty()
+                    .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
                     .as((Class<?>)type).get();
@@ -106,13 +106,13 @@ public class ConfigPropertyProducer {
             Type rawType = ptype.getRawType();
             if (List.class.equals(rawType)) {
                 result = config.getValue(name, ConfigValueResolver.class)
-                    .throwOnMissingProperty()
+                    .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
                     .asList(getElementTypeFrom(ptype));
             } else if (Set.class.equals(rawType)) {
                 result = config.getValue(name, ConfigValueResolver.class)
-                    .throwOnMissingProperty()
+                    .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
                     .asSet(getElementTypeFrom(ptype));

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
@@ -94,26 +94,27 @@ public class ConfigPropertyProducer {
         }
 
         Type type = ip.getType();
+        String defaultValue = property.defaultValue();
         if (type instanceof Class) {
             result = config.getValue(name, ConfigValueResolver.class)
-                    .acceptEmpty()
                     .throwOnMissingProperty()
-                    .withDefault(property.defaultValue())
+                    .throwOnFailedConversion()
+                    .withDefault(defaultValue)
                     .as((Class<?>)type).get();
         } else if ( type instanceof ParameterizedType) {
             ParameterizedType ptype = (ParameterizedType)type;
             Type rawType = ptype.getRawType();
             if (List.class.equals(rawType)) {
                 result = config.getValue(name, ConfigValueResolver.class)
-                    .acceptEmpty()
                     .throwOnMissingProperty()
-                    .withDefault(property.defaultValue())
+                    .throwOnFailedConversion()
+                    .withDefault(defaultValue)
                     .asList(getElementTypeFrom(ptype));
             } else if (Set.class.equals(rawType)) {
                 result = config.getValue(name, ConfigValueResolver.class)
-                    .acceptEmpty()
                     .throwOnMissingProperty()
-                    .withDefault(property.defaultValue())
+                    .throwOnFailedConversion()
+                    .withDefault(defaultValue)
                     .asSet(getElementTypeFrom(ptype));
             } else {
                 result = config.getValue(name, (Class<?>) rawType);

--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/cdi/ConfigPropertyProducer.java
@@ -40,6 +40,10 @@
 package fish.payara.microprofile.config.cdi;
 
 import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver.ElementPolicy;
+
+import static fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver.ElementPolicy.FAIL;
+
 import java.lang.reflect.Member;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -100,6 +104,7 @@ public class ConfigPropertyProducer {
                     .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
+                    .withPolicy(FAIL)
                     .as((Class<?>)type).get();
         } else if ( type instanceof ParameterizedType) {
             ParameterizedType ptype = (ParameterizedType)type;
@@ -109,12 +114,14 @@ public class ConfigPropertyProducer {
                     .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
+                    .withPolicy(FAIL)
                     .asList(getElementTypeFrom(ptype));
             } else if (Set.class.equals(rawType)) {
                 result = config.getValue(name, ConfigValueResolver.class)
                     .throwOnMissingProperty(defaultValue == null)
                     .throwOnFailedConversion()
                     .withDefault(defaultValue)
+                    .withPolicy(FAIL)
                     .asSet(getElementTypeFrom(ptype));
             } else {
                 result = config.getValue(name, (Class<?>) rawType);

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/CertificateRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/CertificateRealmIdentityStoreConfiguration.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/CertificateRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/CertificateRealmIdentityStoreConfiguration.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.security.realm.config;
 
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
 import fish.payara.security.annotations.CertificateIdentityStoreDefinition;
 import static fish.payara.security.annotations.CertificateIdentityStoreDefinition.STORE_MP_CERTIFICATE_GROUPS;
 import java.util.List;
@@ -61,8 +62,8 @@ public class CertificateRealmIdentityStoreConfiguration implements RealmConfigur
     private CertificateRealmIdentityStoreConfiguration(CertificateIdentityStoreDefinition definition) {
         Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.assignGroups = asList(config.getOptionalValue(STORE_MP_CERTIFICATE_GROUPS, String[].class)
-                .orElse(definition.assignGroups()));
+        this.assignGroups = config.getValue(STORE_MP_CERTIFICATE_GROUPS, ConfigValueResolver.class)
+                .asList(String.class, asList(definition.assignGroups()));
     }
 
     public static CertificateRealmIdentityStoreConfiguration from(CertificateIdentityStoreDefinition definition) {

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/CertificateRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/CertificateRealmIdentityStoreConfiguration.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -39,12 +39,12 @@
  */
 package fish.payara.security.realm.config;
 
-import com.sun.enterprise.util.StringUtils;
-import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
 import fish.payara.security.annotations.CertificateIdentityStoreDefinition;
 import static fish.payara.security.annotations.CertificateIdentityStoreDefinition.STORE_MP_CERTIFICATE_GROUPS;
 import java.util.List;
-import static java.util.stream.Collectors.toList;
+
+import static java.util.Arrays.asList;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -59,23 +59,22 @@ public class CertificateRealmIdentityStoreConfiguration implements RealmConfigur
     private final List<String> assignGroups;
 
     private CertificateRealmIdentityStoreConfiguration(CertificateIdentityStoreDefinition definition) {
-        Config provider = ConfigProvider.getConfig();
-        PayaraConfig payaraConfig = (PayaraConfig) provider;
+        Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.assignGroups = payaraConfig.getListValues(STORE_MP_CERTIFICATE_GROUPS, String.join(",", definition.assignGroups()), String.class)
-                .stream()
-                .filter(StringUtils::ok)
-                .collect(toList());
+        this.assignGroups = asList(config.getOptionalValue(STORE_MP_CERTIFICATE_GROUPS, String[].class)
+                .orElse(definition.assignGroups()));
     }
 
     public static CertificateRealmIdentityStoreConfiguration from(CertificateIdentityStoreDefinition definition) {
         return new CertificateRealmIdentityStoreConfiguration(definition);
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public List<String> getAssignGroups() {
         return assignGroups;
     }

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/FileRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/FileRealmIdentityStoreConfiguration.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/FileRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/FileRealmIdentityStoreConfiguration.java
@@ -40,6 +40,8 @@
 package fish.payara.security.realm.config;
 
 import com.sun.enterprise.util.StringUtils;
+
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
 import fish.payara.security.annotations.FileIdentityStoreDefinition;
 import static fish.payara.security.annotations.FileIdentityStoreDefinition.STORE_MP_FILE;
 import static fish.payara.security.annotations.FileIdentityStoreDefinition.STORE_MP_FILE_GROUPS;
@@ -67,8 +69,8 @@ public class FileRealmIdentityStoreConfiguration implements RealmConfiguration {
         Config config = ConfigProvider.getConfig();
         this.name = definition.value();
         this.file = getConfiguredValue(String.class, definition.file(), config, STORE_MP_FILE);
-        this.assignGroups = asList(config.getOptionalValue(STORE_MP_FILE_GROUPS, String[].class)
-                .orElse(definition.assignGroups()));
+        this.assignGroups = config.getValue(STORE_MP_FILE_GROUPS, ConfigValueResolver.class)
+                .asList(String.class, asList(definition.assignGroups()));
         this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), config, STORE_MP_FILE_JAAS_CONTEXT);
     }
 

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/FileRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/FileRealmIdentityStoreConfiguration.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -40,14 +40,14 @@
 package fish.payara.security.realm.config;
 
 import com.sun.enterprise.util.StringUtils;
-import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
 import fish.payara.security.annotations.FileIdentityStoreDefinition;
 import static fish.payara.security.annotations.FileIdentityStoreDefinition.STORE_MP_FILE;
 import static fish.payara.security.annotations.FileIdentityStoreDefinition.STORE_MP_FILE_GROUPS;
 import static fish.payara.security.annotations.FileIdentityStoreDefinition.STORE_MP_FILE_JAAS_CONTEXT;
 import static fish.payara.security.realm.RealmUtil.getConfiguredValue;
 import java.util.List;
-import static java.util.stream.Collectors.toList;
+
+import static java.util.Arrays.asList;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -64,21 +64,19 @@ public class FileRealmIdentityStoreConfiguration implements RealmConfiguration {
     private final String jaasContext;
 
     private FileRealmIdentityStoreConfiguration(FileIdentityStoreDefinition definition) {
-        Config provider = ConfigProvider.getConfig();
-        PayaraConfig payaraConfig = (PayaraConfig) provider;
+        Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.file = getConfiguredValue(String.class, definition.file(), provider, STORE_MP_FILE);
-        this.assignGroups = payaraConfig.getListValues(STORE_MP_FILE_GROUPS, String.join(",", definition.assignGroups()), String.class)
-                .stream()
-                .filter(StringUtils::ok)
-                .collect(toList());
-        this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), provider, STORE_MP_FILE_JAAS_CONTEXT);
+        this.file = getConfiguredValue(String.class, definition.file(), config, STORE_MP_FILE);
+        this.assignGroups = asList(config.getOptionalValue(STORE_MP_FILE_GROUPS, String[].class)
+                .orElse(definition.assignGroups()));
+        this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), config, STORE_MP_FILE_JAAS_CONTEXT);
     }
 
     public static FileRealmIdentityStoreConfiguration from(FileIdentityStoreDefinition definition) {
         return new FileRealmIdentityStoreConfiguration(definition);
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -86,11 +84,11 @@ public class FileRealmIdentityStoreConfiguration implements RealmConfiguration {
     public String getFile() {
         if (StringUtils.ok(file)) {
             return file;
-        } else {
-            return name;
         }
+        return name;
     }
 
+    @Override
     public List<String> getAssignGroups() {
         return assignGroups;
     }

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/PamRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/PamRealmIdentityStoreConfiguration.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/PamRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/PamRealmIdentityStoreConfiguration.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -39,14 +39,13 @@
  */
 package fish.payara.security.realm.config;
 
-import com.sun.enterprise.util.StringUtils;
-import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
 import fish.payara.security.annotations.PamIdentityStoreDefinition;
 import static fish.payara.security.annotations.PamIdentityStoreDefinition.STORE_MP_PAM_GROUPS;
 import static fish.payara.security.annotations.PamIdentityStoreDefinition.STORE_MP_PAM_JAAS_CONTEXT;
 import static fish.payara.security.realm.RealmUtil.getConfiguredValue;
 import java.util.List;
-import static java.util.stream.Collectors.toList;
+
+import static java.util.Arrays.asList;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -62,24 +61,23 @@ public class PamRealmIdentityStoreConfiguration implements RealmConfiguration {
     private final String jaasContext;
 
     private PamRealmIdentityStoreConfiguration(PamIdentityStoreDefinition definition) {
-        Config provider = ConfigProvider.getConfig();
-        PayaraConfig payaraConfig = (PayaraConfig) provider;
+        Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.assignGroups = payaraConfig.getListValues(STORE_MP_PAM_GROUPS, String.join(",", definition.assignGroups()), String.class)
-                .stream()
-                .filter(StringUtils::ok)
-                .collect(toList());
-        this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), provider, STORE_MP_PAM_JAAS_CONTEXT);
+        this.assignGroups = asList(config.getOptionalValue(STORE_MP_PAM_GROUPS, String[].class)
+                .orElse(definition.assignGroups()));
+        this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), config, STORE_MP_PAM_JAAS_CONTEXT);
     }
 
     public static PamRealmIdentityStoreConfiguration from(PamIdentityStoreDefinition definition) {
         return new PamRealmIdentityStoreConfiguration(definition);
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public List<String> getAssignGroups() {
         return assignGroups;
     }

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/PamRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/PamRealmIdentityStoreConfiguration.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.security.realm.config;
 
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
 import fish.payara.security.annotations.PamIdentityStoreDefinition;
 import static fish.payara.security.annotations.PamIdentityStoreDefinition.STORE_MP_PAM_GROUPS;
 import static fish.payara.security.annotations.PamIdentityStoreDefinition.STORE_MP_PAM_JAAS_CONTEXT;
@@ -63,8 +64,8 @@ public class PamRealmIdentityStoreConfiguration implements RealmConfiguration {
     private PamRealmIdentityStoreConfiguration(PamIdentityStoreDefinition definition) {
         Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.assignGroups = asList(config.getOptionalValue(STORE_MP_PAM_GROUPS, String[].class)
-                .orElse(definition.assignGroups()));
+        this.assignGroups = config.getValue(STORE_MP_PAM_GROUPS, ConfigValueResolver.class)
+                .asList(String.class, asList(definition.assignGroups()));
         this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), config, STORE_MP_PAM_JAAS_CONTEXT);
     }
 

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/SolarisRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/SolarisRealmIdentityStoreConfiguration.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/SolarisRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/SolarisRealmIdentityStoreConfiguration.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.security.realm.config;
 
+import fish.payara.nucleus.microprofile.config.spi.ConfigValueResolver;
 import fish.payara.security.annotations.SolarisIdentityStoreDefinition;
 import static fish.payara.security.annotations.SolarisIdentityStoreDefinition.STORE_MP_SOLARIS_GROUPS;
 import static fish.payara.security.annotations.SolarisIdentityStoreDefinition.STORE_MP_SOLARIS_JAAS_CONTEXT;
@@ -63,8 +64,8 @@ public class SolarisRealmIdentityStoreConfiguration implements RealmConfiguratio
     private SolarisRealmIdentityStoreConfiguration(SolarisIdentityStoreDefinition definition) {
         Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.assignGroups = asList(config.getOptionalValue(STORE_MP_SOLARIS_GROUPS, String[].class)
-                .orElse(definition.assignGroups()));
+        this.assignGroups = config.getValue(STORE_MP_SOLARIS_GROUPS, ConfigValueResolver.class)
+                .asList(String.class, asList(definition.assignGroups()));
         this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), config, STORE_MP_SOLARIS_JAAS_CONTEXT);
     }
 

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/SolarisRealmIdentityStoreConfiguration.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/config/SolarisRealmIdentityStoreConfiguration.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -39,14 +39,13 @@
  */
 package fish.payara.security.realm.config;
 
-import com.sun.enterprise.util.StringUtils;
-import fish.payara.nucleus.microprofile.config.spi.PayaraConfig;
 import fish.payara.security.annotations.SolarisIdentityStoreDefinition;
 import static fish.payara.security.annotations.SolarisIdentityStoreDefinition.STORE_MP_SOLARIS_GROUPS;
 import static fish.payara.security.annotations.SolarisIdentityStoreDefinition.STORE_MP_SOLARIS_JAAS_CONTEXT;
 import static fish.payara.security.realm.RealmUtil.getConfiguredValue;
 import java.util.List;
-import static java.util.stream.Collectors.toList;
+
+import static java.util.Arrays.asList;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -62,24 +61,23 @@ public class SolarisRealmIdentityStoreConfiguration implements RealmConfiguratio
     private final String jaasContext;
 
     private SolarisRealmIdentityStoreConfiguration(SolarisIdentityStoreDefinition definition) {
-        Config provider = ConfigProvider.getConfig();
-        PayaraConfig payaraConfig = (PayaraConfig) provider;
+        Config config = ConfigProvider.getConfig();
         this.name = definition.value();
-        this.assignGroups = payaraConfig.getListValues(STORE_MP_SOLARIS_GROUPS, String.join(",", definition.assignGroups()), String.class)
-                .stream()
-                .filter(StringUtils::ok)
-                .collect(toList());
-        this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), provider, STORE_MP_SOLARIS_JAAS_CONTEXT);
+        this.assignGroups = asList(config.getOptionalValue(STORE_MP_SOLARIS_GROUPS, String[].class)
+                .orElse(definition.assignGroups()));
+        this.jaasContext = getConfiguredValue(String.class, definition.jaasContext(), config, STORE_MP_SOLARIS_JAAS_CONTEXT);
     }
 
     public static SolarisRealmIdentityStoreConfiguration from(SolarisIdentityStoreDefinition definition) {
         return new SolarisRealmIdentityStoreConfiguration(definition);
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public List<String> getAssignGroups() {
         return assignGroups;
     }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/converters/ArrayConverter.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/converters/ArrayConverter.java
@@ -1,0 +1,121 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.nucleus.microprofile.config.converters;
+
+import java.lang.reflect.Array;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * Converts reference and primitive arrays.
+ *
+ * For convenience the converter skips empty elements as well as elements for which conversion fails. If all
+ * elements fail to convert the conversion exception is forwarded (thrown). Otherwise a warning is logged and the
+ * working elements as kept.
+ *
+ * This is a grey-area in the standard but from a users point of view it most often makes sense to work with the
+ * elements that are well defined and ignore the others.
+ *
+ * Argument for {@link Converter} can only be {@link Object} as both reference and primitive arrays are created.
+ *
+ * @param <T> element type of the array, can be both a primitive or a reference type
+ */
+public final class ArrayConverter<T> implements Converter<Object> {
+
+    private static final Logger LOGGER = Logger.getLogger(ArrayConverter.class.getName());
+
+    public static <E> Converter<Object> createArrayConverter(Class<E> elementType, Converter<E> elementConverter) {
+        return new ArrayConverter<>(elementType, elementConverter);
+    }
+
+    private final Class<T> elementType;
+    private final Converter<T> elementConverter;
+
+    private ArrayConverter(Class<T> elementType, Converter<T> elementConverter) {
+        this.elementType = elementType;
+        this.elementConverter = elementConverter;
+    }
+
+    @Override
+    public Object convert(String value) {
+        String[] sourceValues = splitValue(value);
+        Object array = Array.newInstance(elementType, sourceValues.length);
+        int j = 0;
+        IllegalArgumentException lastConversionException = null;
+        for (int i = 0; i < sourceValues.length; i++) {
+            String sourceValue = sourceValues[i];
+            if (sourceValue != null && !sourceValue.isEmpty()) {
+                try {
+                    T elementValue = elementConverter.convert(sourceValue);
+                    Array.set(array, j++, elementValue);
+                } catch (IllegalArgumentException ex) {
+                    // ignore that value but remember exception
+                    lastConversionException = ex;
+                }
+            }
+        }
+        if (j == sourceValues.length) {
+            return array;
+        }
+        if (lastConversionException != null) {
+            if (j == 0) { // all failed, also fail
+                throw lastConversionException;
+            }
+            LOGGER.log(Level.WARNING,
+                    "Souce value defined a list with illegal elements which are ignored: " + value,
+                    lastConversionException);
+        } else {
+            LOGGER.warning("Souce value defined a list with empty elements which are ignored: " + value);
+        }
+        Object copy = Array.newInstance(elementType, j);
+        System.arraycopy(array, 0, copy, 0, j);
+        return copy;
+    }
+
+    private static String[] splitValue(String value) {
+        String keys[] = value.split("(?<!\\\\),");
+        for (int i=0; i < keys.length; i++) {
+            keys[i] = keys[i].replaceAll("\\\\,", ",");
+        }
+        return keys;
+    }
+}

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/converters/AutomaticConverter.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/converters/AutomaticConverter.java
@@ -92,7 +92,8 @@ public class AutomaticConverter {
             try {
                 return (T) conversionMethod.invoke(null, value);
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-                throw new IllegalArgumentException("Unable to convert value to type  for value " + value, ex);
+                throw new IllegalArgumentException("Unable to convert value to type "
+                        + conversionMethod.getReturnType().getName() + " for value `" + value + "`", ex);
             }
         }
     }
@@ -111,7 +112,8 @@ public class AutomaticConverter {
             try {
                 return constructor.newInstance(value);
             } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-                throw new IllegalArgumentException("Unable to convert value to type  for value " + value, ex);
+                throw new IllegalArgumentException("Unable to convert value to type "
+                        + constructor.getDeclaringClass().getName() + " for value `" + value + "`", ex);
             }
         }
     }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
@@ -438,7 +438,6 @@ public class ConfigProviderResolverImpl extends ConfigProviderResolver {
         result.put(Character.class, new CharacterConverter());
         result.put(Short.class, new ShortConverter());
         return result;
-
     }
 
     Map<Class<?>, Converter<?>> getDiscoveredConverters(ApplicationInfo appInfo) {

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
@@ -92,6 +92,32 @@ import org.eclipse.microprofile.config.Config;
 public interface ConfigValueResolver {
 
     /**
+     * What to do when collection element conversion fails.
+     */
+    enum ElementPolicy {
+        /**
+         * Element conversion failure immediately fails overall array conversion.
+         *
+         * Note that this causes the use of provided defaults unless
+         * {@link ConfigValueResolver#throwOnFailedConversion()} is used as well.
+         */
+        FAIL,
+
+        /**
+         * Element conversion failure skips the failing element in the result array unless all elements fail which also
+         * fails overall conversion.
+         */
+        SKIP,
+
+        /**
+         * Element conversion failure sets null for failing elements in the result array.
+         *
+         * Note that this  fails conversion for primitive arrays as null is not allowed.
+         */
+        NULL
+    }
+
+    /**
      * Use a custom cache TTL for resolution.
      *
      * A cache entry is linked to its TTL. Use a different TTL uses a different cache entry which has the effect of
@@ -115,6 +141,25 @@ public interface ConfigValueResolver {
      * @return This resolver for fluent API usage
      */
     ConfigValueResolver withDefault(String value);
+
+    /**
+     * Change the source level value trimming setting.
+     *
+     * @param trim true to apply trim on source level values (default) or false to disabling applying
+     *             {@link String#trim()} to the source level value
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver withTrimming(boolean trim);
+
+    /**
+     * Change the {@link ElementPolicy} setting.
+     *
+     * This affects array types as well as {@link List} and {@link Set} results.
+     *
+     * @param policy the policy to use when conversion of collection elements fails
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver withPolicy(ElementPolicy policy);
 
     /**
      * Disables the default behaviour of not throwing exceptions and instead returning default values for case of

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
@@ -1,0 +1,302 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.nucleus.microprofile.config.spi;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * <p>
+ * This is an abstraction to resolve {@link Config} values using a fluent API that is used
+ * when the basic {@link Config#getValue(String, Class)} does not suffice
+ * or the user wants to make sure a value is returned without an exception and excluding empty {@link String} values.
+ * The method names are chosen for good readability when used as a fluent API.
+ *
+ * <p>
+ * This API is designed so reliably result in a return value. This means by default it will not throw exceptions for
+ * missing properties or failed conversion but instead return a default value that callers have to provide.
+ * Alternatively to providing a default value a value can be resolved as {@link Optional}.
+ *
+ * <p>
+ * Arrays of values can be resolved as {@link List} or {@link Set}.
+ * By default these return empty lists or sets in case of missing property or failed conversion.
+ *
+ * <p>
+ * Simple value properties defined as empty string by default are considered missing. This can be changed
+ * using {@link #acceptEmpty()}.
+ *
+ * <p>
+ * Should exceptions be thrown for either missing properties or failed conversion the default of not throwing exception
+ * and using default values can be overridden using {@link #throwOnMissingProperty()} and
+ * {@link #throwOnFailedConversion()}.
+ *
+ * <p>
+ * Usually conversion relies on registered {@link org.eclipse.microprofile.config.spi.Converter}s.
+ * Ad-hoc conversion can be done using {@link #asConvertedBy(Converter, Object)}.
+ * Values resolved as {@link String} are not converted.
+ * Values resolved as {@code String[]} are only split but elements are not converted.
+ *
+ * <p>
+ * Typed defaults are provided with one of the {@code as}-methods.
+ * Raw property string defaults can be provided using {@link #withDefault(String)}.
+ * As the API can not capture if such a raw default has been provided it still requires to provide a typed default
+ * or use {@link Optional} to ensure resolution will return a value.
+ * If a raw {@link String} is provided it takes precedence over a typed default.
+ * Should conversion of a raw default fail the typed default is used
+ * or in case of {@link Optional} the property is considered not present.
+ *
+ * <p>
+ * The only way {@code as}-methods might return a {@code null} reference is by using {@code null} as typed default.
+ * In such case it is considered the intention of the caller and therefore not problematic.
+ *
+ * @author Jan Bernitt
+ */
+public interface ConfigValueResolver {
+
+    /**
+     * Provides a raw property value default value.
+     * <p>
+     * The raw default is considered to be on the source level and therefore takes precedence over typed defaults
+     * provided to any of the {@code as}-methods. Should raw default be empty of fail to convert to the target type the
+     * typed default is used.
+     *
+     * @param value raw default value, not {@code null}
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver withDefault(String value);
+
+    /**
+     * Disables the default behaviour of considering properties defined as empty string as being not present (missing).
+     * Effectively this means {@code as}-methods might then return empty things in case the property is defined as empty
+     * in the source.
+     *
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver acceptEmpty();
+
+    /**
+     * Disables the default behaviour of not throwing exceptions and instead returning default values for case of
+     * missing or empty raw value. If used in combination with {@link #acceptEmpty()} empty raw values will not throw an
+     * exception, otherwise they do.
+     *
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver throwOnMissingProperty();
+
+    /**
+     * Disables the default behaviour of not throwing exceptions and instead returning default values for case of failed
+     * conversion or missing converter for the target type.
+     *
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver throwOnFailedConversion();
+
+    /**
+     * Resolves the property as a simple or array type.
+     * <p>
+     * If the property is missing, defined empty, the required converter is missing or conversion fails the provided
+     * default value is returned.
+     *
+     * @param type         target type of the conversion, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or the default value
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <T> T as(Class<T> type, T defaultValue);
+
+    /**
+     * Resolves the property as a simple or array type wrapped in an {@link Optional}.
+     * <p>
+     * If the property is missing, defined empty, the required converter is missing or conversion fails
+     * {@link Optional#empty()} is returned.
+     *
+     * @param type         target type of the conversion, not {@code null}
+     * @return the resolved and converted property value as present or empty {@link Optional}
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <T> Optional<T> as(Class<T> type);
+
+    /**
+     * Resolves the property as converted by the provided converter {@link Function}.
+     * <p>
+     * If the property is missing, defined empty or the conversion fails the provided default value is returned.
+     * <p>
+     * This is meant for ad-hoc conversions using lambda expressions as converter to circumvent the need to register a
+     * special {@link org.eclipse.microprofile.config.spi.Converter} for single case use or to allow using different
+     * converter functions for same target type at multiple usages.
+     * <p>
+     * If this method is used in connection with {@link #acceptEmpty()} the empty {@link String} might be passed to the
+     * provided converter function, otherwise the empty string will be considered missing.
+     *
+     * @param type         target type of the conversion, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or the default value
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <T> T asConvertedBy(Function<String, T> converter, T defaultValue);
+
+    /**
+     * Resolves the property as {@link List}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails an
+     * empty list is returned. The returned list must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #asList(Class, List)} with an empty list as default value.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link List} while also honouring defaults.
+     *
+     * @param elementType type of the list elements, not {@code null}
+     * @return the resolved and converted property value or an empty list
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> List<E> asList(Class<E> elementType);
+
+    /**
+     * Resolves the property as {@link List}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails the
+     * provided default value is returned. The returned list must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link List} while also honouring defaults.
+     *
+     * @param elementType  type of the list elements, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or an empty list
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> List<E> asList(Class<E> elementType, List<E> defaultValue);
+
+    /**
+     * Resolves the property as {@link Set}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails an
+     * empty set is returned. The returned set must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #asSet(Class, Set)} with an empty set as default value.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link Set} while also honouring defaults.
+     *
+     * @param elementType type of the set elements, not {@code null}
+     * @return the resolved and converted property value or an empty set
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> Set<E> asSet(Class<E> elementType);
+
+    /**
+     * Resolves the property as {@link Set}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails an
+     * empty set is returned. The returned set must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #asSet(Class, Set)} with an empty set as default value.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link Set} while also honouring defaults.
+     *
+     * @param elementType  type of the set elements, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or an empty set
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> Set<E> asSet(Class<E> elementType, Set<E> defaultValue);
+
+    /**
+     * Consume successfully converted element values for multi-value properties.
+     *
+     * Resolves the property as if resolving an array of the given element type and passing each of them to the provided
+     * {@link Consumer} action. Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing the action is not called at all.
+     * If conversion fails for an element that element is skipped and not passed to the action.
+     * Other elements are still converted.
+     * <p>
+     * This method might also help avoid creation of intermediate collections to some degree.
+     * Implementations should attempt to avoid such intermediate collections where possible within reason.
+     *
+     * @param elementType type to be consumed by the provided action, not {@code null}
+     * @param action      The action to be performed for each element, not {@code null}
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> void forEach(Class<E> elementType, Consumer<? super E> action);
+}

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
@@ -113,8 +113,12 @@ public interface ConfigValueResolver {
     ConfigValueResolver throwOnMissingProperty();
 
     /**
-     * Disables the default behaviour of not throwing exceptions and instead returning default values for case of failed
-     * conversion or missing converter for the target type.
+     * Disables the default behaviour of not throwing exceptions and instead returning typed default values for case of
+     * failed conversion or missing converter for the target type.
+     *
+     * If a raw value default is provided using {@link #withDefault(String)} conversion of this default is tried in case
+     * conversion of source value failed. With a raw default a exception is only thrown if conversion of raw default
+     * value failed as well and {@link #throwOnFailedConversion()} was used.
      *
      * @return This resolver for fluent API usage
      */

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
@@ -91,6 +91,8 @@ import org.eclipse.microprofile.config.Config;
  */
 public interface ConfigValueResolver {
 
+    ConfigValueResolver withTTL(long ttl);
+
     /**
      * Provides a raw property value default value.
      * <p>
@@ -110,7 +112,11 @@ public interface ConfigValueResolver {
      *
      * @return This resolver for fluent API usage
      */
-    ConfigValueResolver throwOnMissingProperty();
+    default ConfigValueResolver throwOnMissingProperty() {
+        return throwOnMissingProperty(true);
+    }
+
+    ConfigValueResolver throwOnMissingProperty(boolean throwOnMissingProperty);
 
     /**
      * Disables the default behaviour of not throwing exceptions and instead returning typed default values for case of
@@ -122,7 +128,11 @@ public interface ConfigValueResolver {
      *
      * @return This resolver for fluent API usage
      */
-    ConfigValueResolver throwOnFailedConversion();
+    default ConfigValueResolver throwOnFailedConversion() {
+        return throwOnFailedConversion(true);
+    }
+
+    ConfigValueResolver throwOnFailedConversion(boolean throwOnFailedConversion);
 
     /**
      * Resolves the property as a simple or array type.

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolver.java
@@ -91,6 +91,17 @@ import org.eclipse.microprofile.config.Config;
  */
 public interface ConfigValueResolver {
 
+    /**
+     * Use a custom cache TTL for resolution.
+     *
+     * A cache entry is linked to its TTL. Use a different TTL uses a different cache entry which has the effect of
+     * using the current value for the resolved value if that TTL had not been used before.
+     * This usually behaves as intended when a call site uses a relatively stable or hard coded TTL.
+     * Call sites should never use a TTL value that is naturally varying like a value based on the current time.
+     *
+     * @param ttl Cache time to live in milliseconds, 0 to not use caching, negative to use default TTL
+     * @return This resolver for fluent API usage
+     */
     ConfigValueResolver withTTL(long ttl);
 
     /**
@@ -116,6 +127,15 @@ public interface ConfigValueResolver {
         return throwOnMissingProperty(true);
     }
 
+    /**
+     * Disables or enables throwing exceptions for missing properties.
+     *
+     * @see #throwOnMissingProperty()
+     *
+     * @param throwOnMissingProperty true to have exceptions thrown when property does not exist, false to use default
+     *                               values
+     * @return This resolver for fluent API usage
+     */
     ConfigValueResolver throwOnMissingProperty(boolean throwOnMissingProperty);
 
     /**
@@ -132,6 +152,15 @@ public interface ConfigValueResolver {
         return throwOnFailedConversion(true);
     }
 
+    /**
+     * Disables or enables throwing exceptions for failed conversions.
+     *
+     * @see #throwOnFailedConversion()
+     *
+     * @param throwOnFailedConversion true to have exceptions thrown then property conversion fails, false to use
+     *                                defaults
+     * @return This resolver for fluent API usage
+     */
     ConfigValueResolver throwOnFailedConversion(boolean throwOnFailedConversion);
 
     /**

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.nucleus.microprofile.config.spi;
 
 import static java.util.Collections.emptyList;

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
@@ -37,20 +37,26 @@ final class ConfigValueResolverImpl implements ConfigValueResolver {
     }
 
     @Override
+    public ConfigValueResolver withTTL(long ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    @Override
     public ConfigValueResolver withDefault(String value) {
         rawDefault = ConfigProperty.UNCONFIGURED_VALUE.equals(value) ? null : value;
         return this;
     }
 
     @Override
-    public ConfigValueResolver throwOnMissingProperty() {
-        throwsOnMissingProperty = true;
+    public ConfigValueResolver throwOnMissingProperty(boolean throwOnMissingProperty) {
+        this.throwsOnMissingProperty = throwOnMissingProperty;
         return this;
     }
 
     @Override
-    public ConfigValueResolver throwOnFailedConversion() {
-        throwOnFailedConversion = true;
+    public ConfigValueResolver throwOnFailedConversion(boolean throwOnFailedConversion) {
+        this.throwOnFailedConversion = throwOnFailedConversion;
         return this;
     }
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
@@ -1,18 +1,34 @@
 package fish.payara.nucleus.microprofile.config.spi;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * Implementation for the {@link ConfigValueResolver} which uses the non public API of
+ * {@link PayaraConfig#getValue(String, String, Long, String, Supplier)} to implement its utility methods.
+ *
+ * @author Jan Bernitt
+ */
 final class ConfigValueResolverImpl implements ConfigValueResolver {
 
     private final PayaraConfig config;
     private final String propertyName;
-    private boolean acceptEmpty;
     private boolean throwsOnMissingProperty;
     private boolean throwOnFailedConversion;
+    private Long ttl;
     private String rawDefault;
 
     ConfigValueResolverImpl(PayaraConfig config, String propertyName) {
@@ -22,74 +38,128 @@ final class ConfigValueResolverImpl implements ConfigValueResolver {
 
     @Override
     public ConfigValueResolver withDefault(String value) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public ConfigValueResolver acceptEmpty() {
-        // TODO Auto-generated method stub
-        return null;
+        rawDefault = ConfigProperty.UNCONFIGURED_VALUE.equals(value) ? null : value;
+        return this;
     }
 
     @Override
     public ConfigValueResolver throwOnMissingProperty() {
-        // TODO Auto-generated method stub
-        return null;
+        throwsOnMissingProperty = true;
+        return this;
     }
 
     @Override
     public ConfigValueResolver throwOnFailedConversion() {
-        // TODO Auto-generated method stub
-        return null;
+        throwOnFailedConversion = true;
+        return this;
     }
 
     @Override
     public <T> T as(Class<T> type, T defaultValue) {
-        // TODO Auto-generated method stub
-        return null;
+        return asValue(propertyName, getCacheKey(propertyName, type), ttl, defaultValue, () -> config.getConverter(type));
     }
 
     @Override
     public <T> Optional<T> as(Class<T> type) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public <T> T asConvertedBy(Function<String, T> converter, T defaultValue) {
-        // TODO Auto-generated method stub
-        return null;
+        return Optional.ofNullable(as(type, null));
     }
 
     @Override
     public <E> List<E> asList(Class<E> elementType) {
-        // TODO Auto-generated method stub
-        return null;
+        return asList(elementType, emptyList());
     }
 
     @Override
     public <E> List<E> asList(Class<E> elementType, List<E> defaultValue) {
-        // TODO Auto-generated method stub
-        return null;
+        return asValue(propertyName, getCacheKey(propertyName, List.class, elementType), ttl, defaultValue,
+                () -> createListConverter(getArrayConverter(elementType)));
     }
 
     @Override
     public <E> Set<E> asSet(Class<E> elementType) {
-        // TODO Auto-generated method stub
-        return null;
+        return asSet(elementType, emptySet());
     }
 
     @Override
     public <E> Set<E> asSet(Class<E> elementType, Set<E> defaultValue) {
-        // TODO Auto-generated method stub
-        return null;
+        return asValue(propertyName, getCacheKey(propertyName, Set.class, elementType), ttl, defaultValue,
+                () -> createSetConverter(getArrayConverter(elementType)));
     }
 
     @Override
-    public <E> void forEach(Class<E> elementType, Consumer<? super E> action) {
-        // TODO Auto-generated method stub
-
+    public <T> T asConvertedBy(Function<String, T> converter, T defaultValue) {
+        String sourceValue = asValue(propertyName, getCacheKey(propertyName, String.class), ttl, getRawDefault(),
+                () -> value -> value);
+        if (sourceValue == null) {
+            if (throwsOnMissingProperty) {
+                throwWhenNotExists(propertyName, null);
+            }
+            return defaultValue;
+        }
+        try {
+            return converter.apply(sourceValue);
+        } catch (Exception ex) {
+            if (throwOnFailedConversion) {
+                throw ex;
+            }
+            return defaultValue;
+        }
     }
 
+    private <T> T asValue(String propertyName, String cacheKey, Long ttl, T defaultValue, Supplier<? extends Converter<T>> converter) {
+        try {
+            T value = config.getValue(propertyName, cacheKey, ttl, getRawDefault(), converter);
+            if (value != null) {
+                return value;
+            }
+            if (throwsOnMissingProperty) {
+                throwWhenNotExists(propertyName, null);
+            }
+            return defaultValue;
+        } catch (IllegalArgumentException ex) {
+            if (throwOnFailedConversion) {
+                throw ex;
+            }
+            return defaultValue;
+        }
+    }
+
+    private String getRawDefault() {
+        return throwsOnMissingProperty ? null : rawDefault;
+    }
+
+    private <E> Converter<E[]> getArrayConverter(Class<E> elementType) {
+        return config.getConverter(arrayTypeOf(elementType));
+    }
+
+    static void throwWhenNotExists(String propertyName, Object value) {
+        if (value == null) {
+            throw new NoSuchElementException("Unable to find property with name " + propertyName);
+        }
+    }
+
+    static String getCacheKey(String propertyName, Class<?> propertyType) {
+        String key = propertyType.getName() + ":" + propertyName;
+        return key;
+    }
+
+    static <E> String getCacheKey(String propertyName, Class<?> collectionType, Class<E> elementType) {
+        return collectionType.getName() + ":" + getCacheKey(propertyName, elementType);
+    }
+
+    static <E> Converter<List<E>> createListConverter(Converter<E[]> arrayConverter) {
+        return sourceValue -> Arrays.asList(arrayConverter.convert(sourceValue));
+    }
+
+    static <E> Converter<Set<E>> createSetConverter(Converter<E[]> arrayConverter) {
+        return sourceValue ->  new HashSet<>(Arrays.asList(arrayConverter.convert(sourceValue)));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static <E> Class<E[]> arrayTypeOf(Class<E> elementType) {
+        if (elementType.isPrimitive()) {
+            return (Class) arrayTypeOf(PayaraConfig.boxedTypeOf(elementType));
+        }
+        return (Class<E[]>) Array.newInstance(elementType, 0).getClass();
+    }
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
@@ -1,0 +1,95 @@
+package fish.payara.nucleus.microprofile.config.spi;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class ConfigValueResolverImpl implements ConfigValueResolver {
+
+    private final PayaraConfig config;
+    private final String propertyName;
+    private boolean acceptEmpty;
+    private boolean throwsOnMissingProperty;
+    private boolean throwOnFailedConversion;
+    private String rawDefault;
+
+    ConfigValueResolverImpl(PayaraConfig config, String propertyName) {
+        this.config = config;
+        this.propertyName = propertyName;
+    }
+
+    @Override
+    public ConfigValueResolver withDefault(String value) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ConfigValueResolver acceptEmpty() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ConfigValueResolver throwOnMissingProperty() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ConfigValueResolver throwOnFailedConversion() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <T> T as(Class<T> type, T defaultValue) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <T> Optional<T> as(Class<T> type) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <T> T asConvertedBy(Function<String, T> converter, T defaultValue) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <E> List<E> asList(Class<E> elementType) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <E> List<E> asList(Class<E> elementType, List<E> defaultValue) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <E> Set<E> asSet(Class<E> elementType) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <E> Set<E> asSet(Class<E> elementType, Set<E> defaultValue) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <E> void forEach(Class<E> elementType, Consumer<? super E> action) {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
@@ -88,7 +88,7 @@ final class ConfigValueResolverImpl implements ConfigValueResolver {
 
     @Override
     public <T> T asConvertedBy(Function<String, T> converter, T defaultValue) {
-        String sourceValue = asValue(propertyName, getCacheKey(propertyName, String.class), ttl, getRawDefault(),
+        String sourceValue = asValue(propertyName, getCacheKey(propertyName, String.class), ttl, null,
                 () -> value -> value);
         if (sourceValue == null) {
             if (throwsOnMissingProperty) {
@@ -99,8 +99,15 @@ final class ConfigValueResolverImpl implements ConfigValueResolver {
         try {
             return converter.apply(sourceValue);
         } catch (Exception ex) {
+            if (rawDefault != null) {
+                try {
+                    return converter.apply(rawDefault);
+                } catch (Exception e) {
+                    // fall through
+                }
+            }
             if (throwOnFailedConversion) {
-                throw ex;
+                throw new IllegalArgumentException(ex);
             }
             return defaultValue;
         }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverImpl.java
@@ -77,7 +77,7 @@ final class ConfigValueResolverImpl implements ConfigValueResolver {
 
     @Override
     public ConfigValueResolver withTTL(long ttl) {
-        this.ttl = ttl;
+        this.ttl = ttl < 0 ? null : ttl;
         return this;
     }
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/InjectedPayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/InjectedPayaraConfig.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -210,7 +210,7 @@ public class PayaraConfig implements Config {
     }
 
     private <E> Converter<Object> createArrayConverter(Class<E> elementType) {
-        return ArrayConverter.createArrayConverter(elementType, getConverter(elementType));
+        return new ArrayConverter<>(elementType, getConverter(elementType));
     }
 
     static Class<?> boxedTypeOf(Class<?> type) {

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/ConfigTestUtils.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/ConfigTestUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,53 +39,35 @@
  */
 package fish.payara.nucleus.microprofile.config.spi;
 
-import java.io.Serializable;
-import java.util.Optional;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-/**
- *
- * @author Steve Millidge <Payara Services Limited>
- */
-public class InjectedPayaraConfig implements Config, Serializable {
+public final class ConfigTestUtils {
 
-    private transient Config delegate;
-    private String appName;
-
-    public InjectedPayaraConfig(Config delegate, String appName) {
-        this.delegate = delegate;
-        this.appName = appName;
-    }
-    @Override
-    public <T> T getValue(String propertyName, Class<T> propertyType) {
-        ensureDelegate();
-        return delegate.getValue(propertyName, propertyType);
+    static ConfigSource createSource(String name, int ordinal, Map<String, String> properties) {
+        ConfigSource source = mock(ConfigSource.class);
+        when(source.getProperties()).thenReturn(properties);
+        when(source.getOrdinal()).thenReturn(ordinal);
+        when(source.getName()).thenReturn(name);
+        when(source.getPropertyNames()).thenReturn(properties.keySet());
+        when(source.getValue(anyString())).thenAnswer(invocation -> properties.get(invocation.getArgument(0)));
+        return source;
     }
 
-    @Override
-    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
-        ensureDelegate();
-        return delegate.getOptionalValue(propertyName, propertyType);
-    }
-
-    @Override
-    public Iterable<String> getPropertyNames() {
-        ensureDelegate();
-        return delegate.getPropertyNames();
-    }
-
-    @Override
-    public Iterable<ConfigSource> getConfigSources() {
-        ensureDelegate();
-        return delegate.getConfigSources();
-    }
-
-    private void ensureDelegate() {
-        if (delegate == null) {
-            delegate = ((ConfigProviderResolverImpl) ConfigProviderResolver.instance()).getNamedConfig(appName);
+    static void assertException(Class<? extends Exception> expectedException, String expectedMsg, Runnable test) {
+        try {
+            test.run();
+            fail("Expected " + expectedException.getName());
+        } catch (Exception ex) {
+            assertEquals(expectedException, ex.getClass());
+            assertEquals(expectedMsg, ex.getMessage());
         }
     }
-
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverTest.java
@@ -1,0 +1,402 @@
+package fish.payara.nucleus.microprofile.config.spi;
+
+import static fish.payara.nucleus.microprofile.config.spi.ConfigTestUtils.assertException;
+import static fish.payara.nucleus.microprofile.config.spi.ConfigTestUtils.createSource;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests formal correctness of the {@link ConfigValueResolver} API.
+ *
+ * Any property can be resolved as {@link ConfigValueResolver} using {@link Config#getValue(String, Class)} with
+ * {@link ConfigValueResolver} as target type. The returned instance can be used to resolve the value of the property
+ * with more control over the failure behaviour and used defaults.
+ *
+ * @author Jan Bernitt
+ */
+public class ConfigValueResolverTest {
+
+    private static final long CACHE_TTL = 50L;
+
+    private final ConfigSource source1 = createSource("S1", 100, new HashMap<>());
+    private final Config config = new PayaraConfig(asList(source1), emptyMap(), CACHE_TTL);
+
+    @Before
+    public void setUp() {
+        String[][] source =  {
+                {"string1", "str"},
+                {"long1", "42"},
+                {"bool1", "true" },
+                {"int1", "13"},
+                {"brokenlong", "fourtytwo"},
+                {"brokenint", "one" },
+
+        };
+        Map<String, String> properties = source1.getProperties();
+        for (String[] pair : source) {
+            properties.put(pair[0], pair[1]);
+        }
+    }
+
+    private ConfigValueResolver resolve(String propertyName) {
+        return config.getValue(propertyName, ConfigValueResolver.class);
+    }
+
+    @Test
+    public void asString() {
+        assertEquals("str", resolve("string1").as(String.class).get());
+    }
+
+    @Test
+    public void asLong() {
+        assertEquals(Long.valueOf(42L), resolve("long1").as(Long.class).get());
+    }
+
+    @Test
+    public void asBoolean() {
+        assertEquals(Boolean.TRUE, resolve("bool1").as(Boolean.class).get());
+    }
+
+    @Test
+    public void asPrimitiveBoolean() {
+        assertTrue(resolve("bool1").as(boolean.class).get().booleanValue());
+    }
+
+
+    /*
+     * Ineffective Raw and Typed Defaults
+     */
+
+    @Test
+    public void asStringWithTypedDefault() {
+        assertEquals("str", resolve("string1").as(String.class, ""));
+    }
+
+    @Test
+    public void asLongWithTypedDefault() {
+        assertEquals(42L, resolve("long1").as(long.class, -1L).longValue());
+    }
+
+    @Test
+    public void asBooleanWithTypedDefault() {
+        assertEquals(Boolean.TRUE, resolve("bool1").as(Boolean.class, false));
+    }
+
+    @Test
+    public void asPrimitiveIntWithTypedDefault() {
+        assertEquals(13, resolve("int1").as(int.class, -1).intValue());
+    }
+
+    @Test
+    public void asPrimitiveBooleanWithTypedDefault() {
+        assertTrue(resolve("bool1").as(Boolean.class, false).booleanValue());
+    }
+
+
+    /*
+     * Effective Raw and Typed Defaults
+     */
+
+    @Test
+    public void asStringReturnsProvidedTypedDefault() {
+        assertEquals("fallback", resolve("nosuchstr").as(String.class, "fallback"));
+    }
+
+    @Test
+    public void asStringReturnsProvidedRawDefault() {
+        assertEquals("fallback", resolve("nosuchstr").withDefault("fallback").as(String.class).get());
+    }
+
+    @Test
+    public void asStringReturnsProvidedRawDefaultOverProvidedTypedDefault() {
+        assertEquals("fallback", resolve("nosuchstr").withDefault("fallback").as(String.class, "notneeded"));
+    }
+
+    @Test
+    public void asPrimitiveIntReturnsProvidedTypedDefault() {
+        assertEquals(22, resolve("nosuchint").as(int.class, 22).intValue());
+    }
+
+    @Test
+    public void asPrimitiveIntReturnsProvidedRawDefault() {
+        assertEquals(22, resolve("nosuchint").withDefault("22").as(int.class).get().intValue());
+    }
+
+    @Test
+    public void asPrimitiveIntReturnsProvidedRawDefaultOverProvidedTypedDefault() {
+        assertEquals(22, resolve("nosuchint").withDefault("22").as(int.class, 66).intValue());
+    }
+
+    @Test
+    public void asLongReturnsProvidedTypedDefault() {
+        assertEquals(44L, resolve("nosuchlong").as(Long.class, 44L).longValue());
+    }
+
+    @Test
+    public void asLongReturnsProvidedRawDefault() {
+        assertEquals(44L, resolve("nosuchlong").withDefault("44").as(Long.class).get().longValue());
+    }
+
+    @Test
+    public void asLongReturnsProvidedRawDefaultOverProvidedTypedDefault() {
+        assertEquals(44L, resolve("nosuchlong").withDefault("44").as(Long.class, 66L).longValue());
+    }
+
+
+    /*
+     * Arrays with Effective Raw and Typed Defaults
+     */
+
+    @Test
+    public void asStringArrayReturnsProvidedTypedDefault() {
+        assertArrayEquals(new String[] { "fallback" }, resolve("nosuchstr").as(String[].class, new String[] { "fallback" }));
+    }
+
+    @Test
+    public void asStringArrayReturnsProvidedRawDefault() {
+        assertArrayEquals(new String[] { "fallback" }, resolve("nosuchstr").withDefault("fallback").as(String[].class).get());
+    }
+
+    @Test
+    public void asStringArrayReturnsProvidedRawDefaultOverProvidedTypedDefault() {
+        assertArrayEquals(new String[] { "fallback" }, resolve("nosuchstr").withDefault("fallback").as(String[].class, new String[] { "notneeded" }));
+    }
+
+    @Test
+    public void asPrimitiveIntArrayReturnsProvidedTypedDefault() {
+        assertArrayEquals(new int[] { 22 }, resolve("nosuchint").as(int[].class, new int[] { 22 }));
+    }
+
+    @Test
+    public void asPrimitiveIntArrayReturnsProvidedRawDefault() {
+        assertArrayEquals(new int[] { 22 }, resolve("nosuchint").withDefault("22").as(int[].class).get());
+    }
+
+    @Test
+    public void asPrimitiveIntArrayReturnsProvidedRawDefaultOverProvidedTypedDefault() {
+        assertArrayEquals(new int[] { 22 }, resolve("nosuchint").withDefault("22").as(int[].class, null));
+    }
+
+    @Test
+    public void asLongArrayReturnsProvidedTypedDefault() {
+        assertArrayEquals(new Long[] { 11L, 44L }, resolve("nosuchlong").as(Long[].class, new Long[] { 11L, 44L }));
+    }
+
+    @Test
+    public void asLongArrayReturnsProvidedRawDefault() {
+        assertArrayEquals(new Long[] { 11L, 44L }, resolve("nosuchlong").withDefault("11,44").as(Long[].class).get());
+    }
+
+    @Test
+    public void asLongArrayReturnsProvidedRawDefaultOverProvidedTypedDefault() {
+        assertArrayEquals(new Long[] { 11L, 44L }, resolve("nosuchlong").withDefault("11,44").as(Long[].class, null));
+    }
+
+
+    /*
+     * Throwing exceptions on missing properties
+     */
+
+    @Test
+    public void asStringThrowsMissingException() {
+        assertThrowsMissingProperty("nosuchstr",
+                () ->  resolve("nosuchstr").throwOnMissingProperty().as(String.class));
+    }
+
+    @Test
+    public void asLongThrowsMissingException() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().as(Long.class));
+    }
+
+    @Test
+    public void asBooleanThrowsMissingException() {
+        assertThrowsMissingProperty("nosuchbool",
+                () -> resolve("nosuchbool").throwOnMissingProperty().as(Boolean.class));
+    }
+
+    @Test
+    public void asPrimitiveIntThrowsMissingException() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().as(int.class));
+    }
+
+    @Test
+    public void asStringThrowsMissingExceptionWithTypedDefault() {
+        assertThrowsMissingProperty("nosuchstr",
+                () -> resolve("nosuchstr").throwOnMissingProperty().as(String.class, "fallback"));
+    }
+
+    @Test
+    public void asStringThrowsMissingExceptioWithRawDefault() {
+        assertThrowsMissingProperty("nosuchstr",
+                () -> resolve("nosuchstr").throwOnMissingProperty().withDefault("fallback").as(String.class));
+    }
+
+    @Test
+    public void asStringThrowsMissingExceptioWithRawAndTypedDefault() {
+        assertThrowsMissingProperty("nosuchstr",
+                () -> resolve("nosuchstr").throwOnMissingProperty().withDefault("fallback").as(String.class, "notneeded"));
+    }
+
+    @Test
+    public void asPrimitiveIntThrowsMissingExceptioWithTypedDefault() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().as(int.class, 22));
+    }
+
+    @Test
+    public void asPrimitiveIntThrowsMissingExceptioWithRawDefault() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().withDefault("22").as(int.class));
+    }
+
+    @Test
+    public void asPrimitiveIntThrowsMissingExceptioWithRawAndTypedDefault() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().withDefault("22").as(int.class, 66));
+    }
+
+    @Test
+    public void asLongThrowsMissingExceptioWithTypedDefault() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().as(Long.class, 44L));
+    }
+
+    @Test
+    public void asLongThrowsMissingExceptioWithRawDefault() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().withDefault("44").as(Long.class));
+    }
+
+    @Test
+    public void asLongThrowsMissingExceptioWithRawAndTypedDefault() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().withDefault("44").as(Long.class, 66L));
+    }
+
+    @Test
+    public void asStringArrayThrowsMissingExceptioWithTypedDefault() {
+        assertThrowsMissingProperty("nosuchstr",
+                () ->  resolve("nosuchstr").throwOnMissingProperty().as(String[].class, new String[] { "fallback" }));
+    }
+
+    @Test
+    public void asStringArrayThrowsMissingExceptioWithRawDefault() {
+        assertThrowsMissingProperty("nosuchstr",
+                () -> resolve("nosuchstr").throwOnMissingProperty().withDefault("fallback").as(String[].class));
+    }
+
+    @Test
+    public void asStringArrayThrowsMissingExceptioWithRawAndTypedDefault() {
+        assertThrowsMissingProperty("nosuchstr",
+                () -> resolve("nosuchstr").throwOnMissingProperty().withDefault("fallback").as(String[].class, new String[] { "notneeded" }));
+    }
+
+    @Test
+    public void asPrimitiveIntArrayThrowsMissingExceptioWithTypedDefault() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().as(int[].class, new int[] { 22 }));
+    }
+
+    @Test
+    public void asPrimitiveIntArrayThrowsMissingExceptioWithRawDefault() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().withDefault("22").as(int[].class));
+    }
+
+    @Test
+    public void asPrimitiveIntArrayThrowsMissingExceptioWithRawAndTypedDefault() {
+        assertThrowsMissingProperty("nosuchint",
+                () -> resolve("nosuchint").throwOnMissingProperty().withDefault("22").as(int[].class, null));
+    }
+
+    @Test
+    public void asLongArrayThrowsMissingExceptioWithTypedDefault() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().as(Long[].class, new Long[] { 11L, 44L }));
+    }
+
+    @Test
+    public void asLongArrayThrowsMissingExceptioWithRawDefault() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().withDefault("11,44").as(Long[].class));
+    }
+
+    @Test
+    public void asLongArrayThrowsMissingExceptioWithRawDefaultAndTypedDefault() {
+        assertThrowsMissingProperty("nosuchlong",
+                () -> resolve("nosuchlong").throwOnMissingProperty().withDefault("11,44").as(Long[].class, null));
+    }
+
+
+    /*
+     * Not throwing exceptions on failed conversion
+     */
+
+    @Test
+    public void asLongReturnsProvidedTypedDefaultOnConversionFailure() {
+        assertEquals(Long.valueOf(13L), resolve("brokenlong").as(Long.class, 13L));
+    }
+
+    @Test
+    public void asPrimitiveIntReturnsProvidedTypedDefaultOnConversionFailure() {
+        assertEquals(567, resolve("brokenint").as(int.class, 567).intValue());
+    }
+
+    @Test
+    public void asLongArrayReturnsProvidedTypedDefaultOnConversionFailure() {
+        assertArrayEquals(new Long[] { 13L, 14L }, resolve("string1").as(Long[].class, new Long[] { 13L, 14L }));
+    }
+
+    @Test
+    public void asPrimitiveIntArrayReturnsTypedProvidedDefaultOnConversionFailure() {
+        assertArrayEquals(new int[] { 1,2,3 }, resolve("string1").as(int[].class, new int[] { 1,2,3 }));
+    }
+
+    @Test
+    public void asLongReturnsProvidedRawDefaultOnConversionFailure() {
+        assertEquals(Long.valueOf(13L), resolve("brokenlong").withDefault("13").as(Long.class).get());
+    }
+
+    @Test
+    public void asPrimitiveIntReturnsProvidedRawDefaultOnConversionFailure() {
+        assertEquals(567, resolve("brokenint").withDefault("567").as(int.class).get().intValue());
+    }
+
+    @Test
+    public void asLongArrayReturnsProvidedRawDefaultOnConversionFailure() {
+        assertArrayEquals(new Long[] { 13L, 14L }, resolve("brokenlong").withDefault("13,14").as(Long[].class).get());
+    }
+
+    @Test
+    public void asPrimitiveIntArrayReturnsRawProvidedDefaultOnConversionFailure() {
+        assertArrayEquals(new int[] { 1,2,3 }, resolve("brokenint").withDefault("1,2,3").as(int[].class).get());
+    }
+
+    @Test
+    public void asLongReturnsProvidedTypedDefaultOnConversionFailureOfRawDefault() {
+        assertEquals(13L, resolve("brokenlong").withDefault("notalong").as(Long.class, 13L).longValue());
+    }
+
+    /*
+     * Throwing exceptions on failed conversion
+     */
+
+
+    private static void assertThrowsMissingProperty(String propertyName, Runnable test) {
+        assertException(NoSuchElementException.class, "Unable to find property with name " + propertyName, test);
+    }
+}

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/ConfigValueResolverTest.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.nucleus.microprofile.config.spi;
 
 import static fish.payara.nucleus.microprofile.config.spi.ConfigTestUtils.assertException;

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
@@ -80,6 +80,7 @@ public class PayaraConfigTest {
         source1.getProperties().put("int1", "1");
         source2.getProperties().put("int2", "2");
         source2.getProperties().put("bool2", "true,false,true");
+        source2.getProperties().put("brokenarr", "1,a,2");
     }
 
     @Test
@@ -154,7 +155,7 @@ public class PayaraConfigTest {
     public void getPropertyNamesContainsPeopertiesOfAllSources() {
         HashSet<String> actual = new HashSet<>();
         config.getPropertyNames().forEach(e -> actual.add(e));
-        assertEquals(new HashSet<>(asList("key1", "key2", "bool2", "int1", "int2")), actual);
+        assertEquals(new HashSet<>(asList("key1", "key2", "bool2", "int1", "int2", "brokenarr")), actual);
     }
 
     @Test
@@ -221,6 +222,12 @@ public class PayaraConfigTest {
     @Test
     public void undefinedPropertyReturnsEmptyOptional() {
         assertEquals(Optional.empty(), config.getOptionalValue("nonExisting", String.class));
+    }
+
+    @Test
+    public void illegalArrayElementFailsOverallArrayConversion() {
+        assertException(IllegalArgumentException.class, "Unable to convert value to type java.lang.Integer for value `a`",
+                () -> config.getValue("brokenarr", Integer[].class));
     }
 
     @Test

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
@@ -39,22 +39,19 @@
  */
 package fish.payara.nucleus.microprofile.config.spi;
 
+import static fish.payara.nucleus.microprofile.config.spi.ConfigTestUtils.assertException;
+import static fish.payara.nucleus.microprofile.config.spi.ConfigTestUtils.createSource;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.Array;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -74,7 +71,7 @@ public class PayaraConfigTest {
 
     private final ConfigSource source1 = createSource("S1", 100, new HashMap<>());
     private final ConfigSource source2 = createSource("S2", 200, new HashMap<>());
-    private final PayaraConfig config = new PayaraConfig(asList(source1, source2), emptyMap(), CACHE_TTL);
+    private final Config config = new PayaraConfig(asList(source1, source2), emptyMap(), CACHE_TTL);
 
     @Before
     public void setUp() {
@@ -82,6 +79,17 @@ public class PayaraConfigTest {
         source2.getProperties().put("key2", "value2");
         source1.getProperties().put("int1", "1");
         source2.getProperties().put("int2", "2");
+        source2.getProperties().put("bool2", "true,false,true");
+    }
+
+    @Test
+    public void optionalBooleanArrayConversion() {
+        assertArrayEquals(new Boolean[] { true, false, true }, config.getOptionalValue("bool2", Boolean[].class).get());
+    }
+
+    @Test
+    public void booleanArrayConversion() {
+        assertArrayEquals(new boolean[] { true, false, true }, config.getValue("bool2", boolean[].class));
     }
 
     @Test
@@ -146,7 +154,7 @@ public class PayaraConfigTest {
     public void getPropertyNamesContainsPeopertiesOfAllSources() {
         HashSet<String> actual = new HashSet<>();
         config.getPropertyNames().forEach(e -> actual.add(e));
-        assertEquals(new HashSet<>(asList("key1", "key2", "int1", "int2")), actual);
+        assertEquals(new HashSet<>(asList("key1", "key2", "bool2", "int1", "int2")), actual);
     }
 
     @Test
@@ -158,42 +166,50 @@ public class PayaraConfigTest {
 
     @Test
     public void listValueAllowSingleElement() {
-        assertEquals(asList("value1"), config.getListValues("key1", "default", String.class));
-        assertEquals(asList(1), config.getListValues("int1", "42", Integer.class));
+        assertEquals(asList("value1"),
+                config.getValue("key1", ConfigValueResolver.class).withDefault("default").asList(String.class));
+        assertEquals(asList(1),
+                config.getValue("int1", ConfigValueResolver.class).withDefault("42").asList(Integer.class));
     }
 
     @Test
     public void listValueAllowMultipleElements() {
         source1.getProperties().put("key1", "value1,value2");
         source1.getProperties().put("int1", "1,2");
-        assertEquals(asList("value1", "value2"), config.getListValues("key1", "default", String.class));
-        assertEquals(asList(1, 2), config.getListValues("int1", "42", Integer.class));
+        assertEquals(asList("value1", "value2"),
+                config.getValue("key1", ConfigValueResolver.class).withDefault("default").asList(String.class));
+        assertEquals(asList(1, 2),
+                config.getValue("int1", ConfigValueResolver.class).withDefault("42").asList(Integer.class));
     }
 
     @Test
     public void setValueAllowSingleElement() {
-        assertEquals(new HashSet<>(asList("value1")), config.getSetValues("key1", "default", String.class));
-        assertEquals(new HashSet<>(asList(1)), config.getSetValues("int1", "42", Integer.class));
+        assertEquals(new HashSet<>(asList("value1")),
+                config.getValue("key1", ConfigValueResolver.class).withDefault("default").asSet(String.class));
+        assertEquals(new HashSet<>(asList(1)),
+                config.getValue("int1", ConfigValueResolver.class).withDefault("42").asSet(Integer.class));
     }
 
     @Test
     public void setValueAllowMultipleElements() {
         source1.getProperties().put("key1", "value1,value2");
         source1.getProperties().put("int1", "1,2");
-        assertEquals(new HashSet<>(asList("value1", "value2")), config.getSetValues("key1", "default", String.class));
-        assertEquals(new HashSet<>(asList(1, 2)), config.getSetValues("int1", "42", Integer.class));
+        assertEquals(new HashSet<>(asList("value1", "value2")),
+                config.getValue("key1", ConfigValueResolver.class).withDefault("default").asSet(String.class));
+        assertEquals(new HashSet<>(asList(1, 2)),
+                config.getValue("int1", ConfigValueResolver.class).withDefault("42").asSet(Integer.class));
     }
 
     @Test
     public void undefinedSetPropertyThrowsExcetion() {
         assertException(NoSuchElementException.class, "Unable to find property with name undefined-set",
-                () -> config.getListValues("undefined-set", null, String.class));
+                () -> config.getValue("undefined-set", ConfigValueResolver.class).throwOnMissingProperty().asSet(String.class));
     }
 
     @Test
     public void undefinedListPropertyThrowsExcetion() {
         assertException(NoSuchElementException.class, "Unable to find property with name undefined-list",
-                () -> config.getListValues("undefined-list", null, String.class));
+                () -> config.getValue("undefined-list", ConfigValueResolver.class).throwOnMissingProperty().asList(String.class));
     }
 
     @Test
@@ -226,12 +242,15 @@ public class PayaraConfigTest {
 
     private <T> void assertValue(String msg, String key, Class<T> propertyType, T expected) {
         assertEquals(msg, expected, config.getValue(key, propertyType));
-        assertEquals(msg, expected, config.getValue(key, "default", propertyType));
+        assertEquals(msg, expected,
+                config.getValue(key, ConfigValueResolver.class).withDefault("default").as(propertyType).get());
         assertEquals(msg, expected, config.getOptionalValue(key, propertyType).get());
         // as list
-        assertEquals(msg, asList(expected), config.getListValues(key, "default", propertyType));
+        assertEquals(msg, asList(expected),
+                config.getValue(key, ConfigValueResolver.class).withDefault("default").asList(propertyType));
         // as set
-        assertEquals(msg, new HashSet<>(asList(expected)), config.getSetValues(key, "default", propertyType));
+        assertEquals(msg, new HashSet<>(asList(expected)),
+                config.getValue(key, ConfigValueResolver.class).withDefault("default").asSet(propertyType));
 
         if (propertyType.isPrimitive()) {
             return;
@@ -243,23 +262,4 @@ public class PayaraConfigTest {
         assertArrayEquals((Object[]) expectedArray, (Object[]) config.getValue(key, arrayType));
     }
 
-    private static ConfigSource createSource(String name, int ordinal, Map<String, String> properties) {
-        ConfigSource source = mock(ConfigSource.class);
-        when(source.getProperties()).thenReturn(properties);
-        when(source.getOrdinal()).thenReturn(ordinal);
-        when(source.getName()).thenReturn(name);
-        when(source.getPropertyNames()).thenReturn(properties.keySet());
-        when(source.getValue(anyString())).thenAnswer(invocation -> properties.get(invocation.getArgument(0)));
-        return source;
-    }
-
-    private static void assertException(Class<? extends Exception> expectedException, String expectedMsg, Runnable test) {
-        try {
-            test.run();
-            fail("Expected " + expectedException.getName());
-        } catch (Exception ex) {
-            assertEquals(expectedException, ex.getClass());
-            assertEquals(expectedMsg, ex.getMessage());
-        }
-    }
 }


### PR DESCRIPTION
### Background
The programmatic MP `Config` API currently lacks certain capabilities that are granted when accessing configuration properties using CDI and the `@ConfigProperty` annotation. Like injecting `List`s, `Set`s for properties with a value with potentially multiple elements. Or to provide a default value in its raw `String` form as provided by a `ConfigSource`. 
As a consequence there was the need to use non standardised APIs when doing this programmatically. Essentially the `Config` needed to be cast to `PayaraConfig` to access extra methods available that would allow these operations. 
The reason these were needed was also to implement the CDI support. This mismatch between the `Config` API and the standard capabilities granted by the `@ConfigProperty` annotation isn't news to the standard group. Over time there have been different proposals for a configuration resolver API which offers extended capabilities which among other features would close the gap between programmatic API and CDI semantics.

### Description
This PR is a POC for an extended property value access API. It allows...

* use of raw `String` defaults
* use of typed defaults
* use of ad-hoc converters
* use of custom cache TTL
* use trimming on source level values
* conversion to `List`s and `Set`s
* control of exception behaviour
* process resolution semantics once, resolve current value over and over with same semantics

This PR replaces the former "proprietary" `PayaraConfig` specific API with the  `ConfigValueResolver` API and uses it where appropriate. 


#### Exceptions
By default the API is designed so no exception is thrown but instead a default, that must be provided to resolve the value, is returned in case of errors. One can chooses to opt-out of this "non-throwing" behaviour into throwing exceptions for missing properties or failed conversion or both.
By design it is not possible to resolve a value without providing a default.
The idea is to make it easy to always end up with a value that can be used without having to worry to have missed a case that would throw an exception anyway. Only if we decide we'd rather fail we opt-in to exceptions so that they are thrown. This is in contrast to the `Config.getValue` method which can be used if exceptions are preferred and non of the other extended features is needed.

#### Caching
The cache used by Payara caches the final converted return value. Therefore the type of value requested for a property has to be part of the key as any property could be resolved as different types of values. If nothing else you could always resolve it as `T`, `T[]`, `List<T>` and `Set<T>` where `T` is at least `String`; but often at least one other type, say `Integer`, and `String`. 
Similar to this the TTL becomes part of the key so each TTL value ends up created another cache entry. This way there can be multiple call sites using different TTLs as long as the actual TTL isn't a number that is varying by nature. This has the benefit of changes applied to the default ("global") cache duration now have immediate effect as they start to request entries with different TTL as soon as the TTL has been changed.

#### Using Existing Config API
The way the extended API is hooked into the existing `Config` API is by using the existing semantics of the `getValue(String,Class)` method. A property is requested by its name and as the new extended API type `ConfigValueResolver`:

```java
ConfigValueResolver resolver = config.getValue("my.property", ConfigValueResolver.class)
```

The returned `ConfigValueResolver` instance is then used to customise the lookup semantics and finally to resolve the property value. 

```java
List<Integer> ints = resolver.asList(Integer.class);
List<Integer> ints = resolver.throwOnFailedConversion().asList(Integer.class);
```

This isn't meant for any kind of pre-resolution but it can be used to "store and reuse" the semantics of a lookup:

```java
static final ConfigValueResolver myProperty = config.getValue("my.property", ConfigValueResolver.class).withDefault(userInputDefault).throwOnFailedConversion();
//... repeatedly calling 
myProperty.as(int.class, 0)
```

### Goals & Outlook
Main goals are
* to support use cases required to implement CDI
* no longer require direct use of `PayaraConfig` class.

Being a POC the `ConfigValueResolver` API is also a Payara specific API. The POC should help to understand the use cases and see that they can be implemented. In the long run an API such as the `ConfigValueResolver` might be added to the standard allowing to only rely on standard API when accessing properties from MP `Config`. Until then we have the benefit of a more formalised, convenient and less error prone access of configuration property values.

### Testing
#### Testing Performed
Manually running MP Config, MP Metrics and MP FT TCKs.
Detailed instructions can be found in _Testing_ section of #4614.

Please not that it also makes sense to test MP Config with cache enabled (value > 0) and check that only 2 tests (that depend on changing values) do fail. 

In addition more then a hundred unit test cases were added to ensure the correct behaviour of the `ConfigValueResolver`.