### PR TITLE
FISH-13 Disabling applications via their deployment group targets not working

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
@@ -140,6 +140,7 @@ public class SetCommand extends V2DottedNameSupport implements AdminCommand, Pos
         targetLevel.put("clusters", 3);
         targetLevel.put("servers", 3);
         targetLevel.put("nodes", 3);
+        targetLevel.put("deployment-groups", 3);
     }
 
     @Override

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -438,13 +438,11 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
 
     private boolean isTargetDeploymentGroup() {
         List<DeploymentGroup> deploymentGroups = server.getDeploymentGroup();
-        if (!deploymentGroups.isEmpty()) {
             for (DeploymentGroup deploymentGroup : deploymentGroups) {
                 if (deploymentGroup.getName().equals(target)) {
                     return true;
                 }
             }
-        }
         
         return false;
     }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

# Description
This fixes an issue where disabling applications via their deployment group target didn't work.

# Testing

### Testing Performed
- Created an instance
- Created a deployment group, added he instances to it and started it
-  Deployed a web application targeting the deployment group
- Disabled the application using the following commands:

1. `asadmin set deployment-groups.deployment-group.<dg-name>.application-ref.<appname>.enabled=false`
2. `asadmin disable --target <dg-name> <appname>`


### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4

# Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->