### PR TITLE
QACI-262 - Remove exisiting EE8 .zip log before archiving new log

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,6 +103,7 @@ pipeline {
         }
         stage('Setup for EE8 Tests') {
             steps {
+                sh "rm -f -v *.zip"
                 setupDomain()
             }
         }
@@ -161,6 +162,7 @@ pipeline {
         }
         stage('Setup for EE7 Tests') {
             steps {
+                sh "rm -f -v *.zip"
                 setupDomain()
             }
         }


### PR DESCRIPTION
# Description
EE8 failed due to log already existing. Quicklook removed all .zips in its setup which is now commented out.