### PR TITLE
FISH-187 Allow domainname in cert management commands

### DIFF
--- a/appserver/extras/certificate-management/src/main/java/fish/payara/certificate/management/admin/AbstractCertManagementCommand.java
+++ b/appserver/extras/certificate-management/src/main/java/fish/payara/certificate/management/admin/AbstractCertManagementCommand.java
@@ -70,7 +70,7 @@ import java.util.Collection;
  */
 public abstract class AbstractCertManagementCommand extends LocalDomainCommand {
 
-    @Param(name = "domain_name", optional = true)
+    @Param(name = "domain_name", optional = true, alias = "domainname")
     protected String domainName0;
 
     @Param(name = "listener", optional = true)

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/generate-csr.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/generate-csr.1
@@ -6,7 +6,7 @@ NAME
 
 SYNOPSIS
            generate-csr [--help]
-           [--domain_name domain-name] [--domaindir domain-dir]
+           [--domainname domain-name] [--domaindir domain-dir]
            [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
            alias
@@ -23,7 +23,7 @@ OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
-       --domain_name
+       --domainname, --domain_name
            The unique name of the domain to get the certificate for the CSR from.
            This operand is optional, defaulting to domain1 if not provided.
 

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/generate-self-signed-certificate.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/generate-self-signed-certificate.1
@@ -7,7 +7,7 @@ NAME
 
 SYNOPSIS
            generate-self-signed-certificate [--help]
-           [--domain_name domain-name] [--domaindir domain-dir]
+           [--domainname domain-name] [--domaindir domain-dir]
            [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
            [alternativenames (type:value)[;type:value]*]
@@ -30,7 +30,7 @@ OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
-       --domain_name
+       --domainname, --domain_name
            The unique name of the domain to add the certificate to. This operand
            is optional, defaulting to domain1 if not provided.
 


### PR DESCRIPTION
## Description
This is an improvement.

Previously you had to give the domain name as `--domain_name` when using the cert management commands (e.g. `generate-self-signed-certificate`). This simply allows you to also use `domainname`.

## Testing

### Testing Performed
* Ran `generate-self-signed-certificate` using _domainname_ parameter
* Ran `generate-csr` using _domain\_name_ parameter

### Testing Environment
Windows 10, Zulu JDK 8u252

# Documentation
Pending...