### PR TITLE
FISH-197 Creating a JDBC Realm fails with a NullPointerException

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/AbstractStatefulRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/AbstractStatefulRealm.java
@@ -203,7 +203,7 @@ public abstract class AbstractStatefulRealm extends AbstractRealm implements Com
      */
     protected String getDefaultDigestAlgorithm() {
         String defaultDigestAlgorithm = contextProperties.getProperty(PARAM_DEFAULT_DIGEST_ALGORITHM);
-        return defaultDigestAlgorithm != null ? defaultDigestAlgorithm : DEFAULT_DIG_ALGORITHM;
+        return defaultDigestAlgorithm == null || defaultDigestAlgorithm.trim().isEmpty() ? DEFAULT_DIG_ALGORITHM : defaultDigestAlgorithm;
     }
 
     /**

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/AbstractStatefulRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/AbstractStatefulRealm.java
@@ -202,7 +202,8 @@ public abstract class AbstractStatefulRealm extends AbstractRealm implements Com
      * @return default digest algorithm, for example: {@value #DEFAULT_DIG_ALGORITHM}
      */
     protected String getDefaultDigestAlgorithm() {
-        return contextProperties.getProperty(PARAM_DEFAULT_DIGEST_ALGORITHM);
+        String defaultDigestAlgorithm = contextProperties.getProperty(PARAM_DEFAULT_DIGEST_ALGORITHM);
+        return defaultDigestAlgorithm != null ? defaultDigestAlgorithm : DEFAULT_DIG_ALGORITHM;
     }
 
     /**


### PR DESCRIPTION

## Description
This is a bug fix to fix were creating a JDBC Realm failed with a NullPointerException. This was caused by the default value of the Digest Algorithm being null.


## Testing

### Testing Performed
Ran the following asadmin command:
```
./asadmin create-auth-realm --classname=com.sun.enterprise.security.auth.realm.jdbc.JDBCRealm --property=jaas-context=jdbcRealm:datasource-jndi=jdbc/youtube:user-table=t_user:user-name-column=username:password-column=password:group-table=t_usergroup:group-table-user-name-column=username:group-name-column=groupnames: --target=server-config test
```
### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4