### PR TITLE
FISH-190 Added man pages for certificate management commands

### DIFF
--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
@@ -5,9 +5,9 @@ NAME
 
 SYNOPSIS
            add-to-keystore [--help]
-           [--domain_name domain-name] [--domaindir domain-dir]
+           [--domainname domain-name] [--domaindir domain-dir]
            [--target instance-name] [--listener listener-name]
-           --file domain-name file
+           --file file
            alias
 
 DESCRIPTION
@@ -22,8 +22,8 @@ OPTIONS
             The certificate file that is to be added to the keystore. The can be in
             .cert or .pem formats.
 
-       --domainname
-           The unique name of the domain to add the certificate for the CSR to.
+       --domainname, --domain_name
+           The unique name of the domain to add the certificate to.
            This operand is optional, defaulting to domain1 if not provided.
 
        --domaindir
@@ -31,6 +31,17 @@ OPTIONS
            target domain. If specified, the path must be accessible in the
            file system. The default location of the domain root directory
            is as-install/domains.
+
+        --node
+           The unique name of the node where the target instance is located.
+           This operand is optional, defaulting to localhost-$domainname
+           if not provided.
+
+       --nodedir
+           The node root directory, which contains the of the target node.
+           If specified, the path must be accessible in the
+           file system. The default location of the node root directory
+           is as-install/nodes.
 
        --target
            The name of the instance to add the certificate to. Defaults to server (the DAS).
@@ -49,14 +60,14 @@ EXAMPLES
 
            This example adds a X509 certificate to the keystore for the DAS.
 
-               asadmin> add-to-keystore ~/example-cert.pem example
+               asadmin> add-to-keystore --file ~/example-cert.pem example
 
        Example 2, Add a certificate for a Listener
 
-           This example adds a self-signed certificate named glassfish-instance in
+           This example adds a self-signed certificate named payara-instance in
            the key store of the http-listener-2 listener of an instance named Instance1
 
-               asadmin> add-to-keystore --target Instance1 --listener http-listener-2 glassfish-instance
+               asadmin> add-to-keystore --target Instance1 --listener http-listener-2 --file ~/payara-instance.crt payara-instance
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
@@ -7,7 +7,7 @@ SYNOPSIS
            add-to-keystore [--help]
            [--domainname domain-name] [--domaindir domain-dir]
            [--target instance-name] [--listener listener-name]
-           --file file
+           [--reload={true|false}] --file file
            alias
 
 DESCRIPTION
@@ -51,6 +51,10 @@ OPTIONS
            Only applicable if the listener has a key or trust store
            different to that of the instance itself.
 
+       --reload
+           If true then the HTTP listeners are restarted after the certificates
+           are removed.
+
 OPERANDS
        alias
            The alias of the certificate to enter into the keystore
@@ -65,9 +69,10 @@ EXAMPLES
        Example 2, Add a certificate for a Listener
 
            This example adds a self-signed certificate named payara-instance in
-           the key store of the http-listener-2 listener of an instance named Instance1
+           the key store of the http-listener-2 listener of an instance named Instance1,
+           then restarts the listener.
 
-               asadmin> add-to-keystore --target Instance1 --listener http-listener-2 --file ~/payara-instance.crt payara-instance
+               asadmin> add-to-keystore --target Instance1 --listener http-listener-2 --reload true --file ~/payara-instance.crt payara-instance
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
@@ -1,0 +1,68 @@
+add-to-keystore(1)  asadmin Utility Subcommands add-to-keystore(1)
+
+NAME
+       add-to-keystore - adds a key or certificate to the target instance or listener's key store.
+
+SYNOPSIS
+           add-to-keystore [--help]
+           [--domain_name domain-name] [--domaindir domain-dir]
+           [--target instance-name] [--listener listener-name]
+           --file domain-name file
+           alias
+
+DESCRIPTION
+       The add-to-keystore subcommand adds a security certificate to the specified keystore, or the
+       default one if none is specified..
+
+OPTIONS
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --file
+            The certificate file that is to be added to the keystore. The can be in
+            .cert or .pem formats.
+
+       --domainname
+           The unique name of the domain to add the certificate for the CSR to.
+           This operand is optional, defaulting to domain1 if not provided.
+
+       --domaindir
+           The domain root directory, which contains the directory of the
+           target domain. If specified, the path must be accessible in the
+           file system. The default location of the domain root directory
+           is as-install/domains.
+
+       --target
+           The name of the instance to add the certificate to. Defaults to server (the DAS).
+
+       --listener
+           The name of the HTTP or IIOP listener to add the certificate to.
+           Only applicable if the listener has a key or trust store
+           different to that of the instance itself.
+
+OPERANDS
+       alias
+           The alias of the certificate to enter into the keystore
+
+EXAMPLES
+       Example 1, Add a X509 Certificate to the DAS
+
+           This example adds a X509 certificate to the keystore for the DAS.
+
+               asadmin> add-to-keystore ~/example-cert.pem example
+
+       Example 2, Add a certificate for a Listener
+
+           This example adds a self-signed certificate named glassfish-instance in
+           the key store of the http-listener-2 listener of an instance named Instance1
+
+               asadmin> add-to-keystore --target Instance1 --listener http-listener-2 glassfish-instance
+
+EXIT STATUS
+       0
+           command executed successfully
+
+       1
+           error in executing the command
+
+

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-keystore.1
@@ -38,7 +38,7 @@ OPTIONS
            if not provided.
 
        --nodedir
-           The node root directory, which contains the of the target node.
+           The node root directory, which contains the target node.
            If specified, the path must be accessible in the
            file system. The default location of the node root directory
            is as-install/nodes.

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
@@ -39,7 +39,7 @@ OPTIONS
            if not provided.
            
        --nodedir
-           The node root directory, which contains the of the target node.
+           The node root directory, which contains the target node.
            If specified, the path must be accessible in the
            file system. The default location of the node root directory
            is as-install/nodes.

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
@@ -8,7 +8,7 @@ SYNOPSIS
            [--domain_name domain-name] [--domaindir domain-dir]
            [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
-           --file file
+           [--reload={true|false}] --file file
            alias
 
 DESCRIPTION
@@ -53,6 +53,10 @@ OPTIONS
            Only applicable if the listener has a key or trust store
            different to that of the instance itself.
 
+       --reload
+           If true then the HTTP listeners are restarted after the certificates
+           are removed.
+
 OPERANDS
        alias
            The alias of the certificate to enter into the truststore
@@ -67,9 +71,10 @@ EXAMPLES
        Example 2, Add a certificate for a Listener
 
            This example adds a X509 certificate to the truststore of the 
-           http-listener-2 listener of an instance named Instance1
+           http-listener-2 listener of an instance named Instance1, then
+           restarts the listener.
 
-               asadmin> add-to-truststore --target Instance1 --listener http-listener-2 --file ~/example-cert.pem example
+               asadmin> add-to-truststore --target Instance1 --listener http-listener-2 --reload true --file ~/example-cert.pem example
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
@@ -6,24 +6,25 @@ NAME
 SYNOPSIS
            add-to-truststore [--help]
            [--domain_name domain-name] [--domaindir domain-dir]
+           [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
-           --file domain-name file
+           --file file
            alias
 
 DESCRIPTION
-       The add-to-truststore subcommand adds a security certificate to the specified truststore, or the
-       default one if none is specified.
+       The add-to-truststore subcommand adds a security certificate to the target instance or listener's truststore,
+       or that of the DAS if none is specifed.
 
 OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
        --file
-            The certificate file that is to be added to the truststore. The can be in
+            The certificate file that is to be added to the truststore. These can be in
             .cert or .pem formats.
 
-       --domainname
-           The unique name of the domain to ad the certificate for the CSR to.
+       --domainname --domain_name
+           The unique name of the domain to add the certificate to.
            This operand is optional, defaulting to domain1 if not provided.
 
        --domaindir
@@ -32,13 +33,24 @@ OPTIONS
            file system. The default location of the domain root directory
            is as-install/domains.
 
+        --node
+           The unique name of the node where the target instance is located.
+           This operand is optional, defaulting to localhost-$domainname
+           if not provided.
+           
+       --nodedir
+           The node root directory, which contains the of the target node.
+           If specified, the path must be accessible in the
+           file system. The default location of the node root directory
+           is as-install/nodes.
+
        --target
            The name of the instance to add the certificate to.
            Defaults to server (the DAS).
 
        --listener
-           The name of the HTTP or IIOP listener to add the certificate for the
-           CSR to. Only applicable if the listener has a key or trust store
+           The name of the HTTP or IIOP listener to add the certificate to.
+           Only applicable if the listener has a key or trust store
            different to that of the instance itself.
 
 OPERANDS
@@ -50,14 +62,14 @@ EXAMPLES
 
            This example adds a X509 certificate to the truststore for the DAS.
 
-               asadmin> add-to-truststore ~/example-cert.pem example
+               asadmin> add-to-truststore --file ~/example-cert.pem example
 
        Example 2, Add a certificate for a Listener
 
-           This example adds a self-signed certificate named glassfish-instance in
-           the key store of the http-listener-2 listener of an instance named Instance1
+           This example adds a X509 certificate to the truststore of the 
+           http-listener-2 listener of an instance named Instance1
 
-               asadmin> add-to-truststore --target Instance1 --listener http-listener-2 glassfish-instance
+               asadmin> add-to-truststore --target Instance1 --listener http-listener-2 --file ~/example-cert.pem example
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/add-to-truststore.1
@@ -1,0 +1,67 @@
+add-to-truststore(1)  asadmin Utility Subcommands add-to-truststore(1)
+
+NAME
+       add-to-truststore - adds a key or certificate to the target instance or listener's key store.
+
+SYNOPSIS
+           add-to-truststore [--help]
+           [--domain_name domain-name] [--domaindir domain-dir]
+           [--target instance-name] [--listener listener-name]
+           --file domain-name file
+           alias
+
+DESCRIPTION
+       The add-to-truststore subcommand adds a security certificate to the specified truststore, or the
+       default one if none is specified.
+
+OPTIONS
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --file
+            The certificate file that is to be added to the truststore. The can be in
+            .cert or .pem formats.
+
+       --domainname
+           The unique name of the domain to ad the certificate for the CSR to.
+           This operand is optional, defaulting to domain1 if not provided.
+
+       --domaindir
+           The domain root directory, which contains the directory of the
+           target domain. If specified, the path must be accessible in the
+           file system. The default location of the domain root directory
+           is as-install/domains.
+
+       --target
+           The name of the instance to add the certificate to.
+           Defaults to server (the DAS).
+
+       --listener
+           The name of the HTTP or IIOP listener to add the certificate for the
+           CSR to. Only applicable if the listener has a key or trust store
+           different to that of the instance itself.
+
+OPERANDS
+       alias
+           The alias of the certificate to enter into the truststore
+
+EXAMPLES
+       Example 1, Add a X509 Certificate to the DAS
+
+           This example adds a X509 certificate to the truststore for the DAS.
+
+               asadmin> add-to-truststore ~/example-cert.pem example
+
+       Example 2, Add a certificate for a Listener
+
+           This example adds a self-signed certificate named glassfish-instance in
+           the key store of the http-listener-2 listener of an instance named Instance1
+
+               asadmin> add-to-truststore --target Instance1 --listener http-listener-2 glassfish-instance
+
+EXIT STATUS
+       0
+           command executed successfully
+
+       1
+           error in executing the command

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
@@ -8,6 +8,7 @@ SYNOPSIS
            [--domainname domain-name] [--domaindir domain-dir]
            [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
+           [--reload={true|false}]
 
 DESCRIPTION
        The remove-expired-certificates subcommand removes all expired certificates
@@ -46,6 +47,10 @@ OPTIONS
            The name of the HTTP or IIOP listener to remove the certificates
            from. Only applicable if the listener has a key or trust store
            different to that of the instance itself.
+        
+       --reload
+           If true then the HTTP listeners are restarted after the certificates
+           are removed.
 
 EXAMPLES
        Example 1, Remove expired certificates from the DAS
@@ -58,9 +63,10 @@ EXAMPLES
        Example 2, Remove expired certificates for a Listener
 
            This example removes all expired certificates from the keystore and
-           truststore of the http-listener-2 listener of an instance named Instance1
+           truststore of the http-listener-2 listener of an instance named Instance1,
+           then restarts the listener.
 
-               asadmin> remove-expired-certificates --target Instance1 --listener http-listener-2
+               asadmin> remove-expired-certificates --target Instance1 --listener http-listener-2 --reload true
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
@@ -5,7 +5,8 @@ NAME
 
 SYNOPSIS
            add-to-truststore [--help]
-           [--domain_name domain-name] [--domaindir domain-dir]
+           [--domainname domain-name] [--domaindir domain-dir]
+           [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
 
 DESCRIPTION
@@ -16,7 +17,7 @@ OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
-       --domainname
+       --domainname, --domaine_name
            The unique name of the domain to remove the certificates from.
            This operand is optional, defaulting to domain1 if not provided.
 
@@ -25,6 +26,17 @@ OPTIONS
            target domain. If specified, the path must be accessible in the
            file system. The default location of the domain root directory
            is as-install/domains.
+
+        --node
+           The unique name of the node where the target instance is located.
+           This operand is optional, defaulting to localhost-$domainname
+           if not provided.
+           
+       --nodedir
+           The node root directory, which contains the of the target node.
+           If specified, the path must be accessible in the
+           file system. The default location of the node root directory
+           is as-install/nodes.
 
        --target
            The name of the instance to remove the certificates from. 
@@ -43,7 +55,7 @@ EXAMPLES
 
                asadmin> remove-expired-certificates
 
-       Example 2, emove expired certificates for a Listener
+       Example 2, Remove expired certificates for a Listener
 
            This example removes all expired certificates from the keystore and
            truststore of the http-listener-2 listener of an instance named Instance1

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
@@ -1,0 +1,58 @@
+remove-expired-certificates(1)  asadmin Utility Subcommands remove-expired-certificates(1)
+
+NAME
+       remove-expired-certificates - removes all expired certificates
+
+SYNOPSIS
+           add-to-truststore [--help]
+           [--domain_name domain-name] [--domaindir domain-dir]
+           [--target instance-name] [--listener listener-name]
+
+DESCRIPTION
+       The remove-expired-certificates subcommand removes all expired certificates
+       from the target's keystore and truststore.
+
+OPTIONS
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --domainname
+           The unique name of the domain to remove the certificates from.
+           This operand is optional, defaulting to domain1 if not provided.
+
+       --domaindir
+           The domain root directory, which contains the directory of the
+           target domain. If specified, the path must be accessible in the
+           file system. The default location of the domain root directory
+           is as-install/domains.
+
+       --target
+           The name of the instance to remove the certificates from. 
+           Defaults to server (the DAS).
+
+       --listener
+           The name of the HTTP or IIOP listener to remove the certificates
+           from. Only applicable if the listener has a key or trust store
+           different to that of the instance itself.
+
+EXAMPLES
+       Example 1, Remove expired certificates from the DAS
+
+           This example removes all expired certificates from the keystore
+           and truststore for the DAS.
+
+               asadmin> remove-expired-certificates
+
+       Example 2, emove expired certificates for a Listener
+
+           This example removes all expired certificates from the keystore and
+           truststore of the http-listener-2 listener of an instance named Instance1
+
+               asadmin> remove-expired-certificates --target Instance1 --listener http-listener-2
+
+EXIT STATUS
+       0
+           command executed successfully
+
+       1
+           error in executing the command

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-expired-certificates.1
@@ -33,7 +33,7 @@ OPTIONS
            if not provided.
            
        --nodedir
-           The node root directory, which contains the of the target node.
+           The node root directory, which contains the target node.
            If specified, the path must be accessible in the
            file system. The default location of the node root directory
            is as-install/nodes.

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
@@ -5,20 +5,21 @@ NAME
 
 SYNOPSIS
            remove-from-keystore [--help]
-           [--domain_name domain-name] [--domaindir domain-dir]
+           [--domainname domain-name] [--domaindir domain-dir]
+           [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
            --file domain-name file
            alias
 
 DESCRIPTION
-       The remove-from-keystore subcommand removes a security certificate from the specified keystore, or the
-       default one if none is specified.
+       The remove-from-keystore subcommand removes a security certificate from the target instance or listener's keystore.
+       If there is none specifed then this applies to the DAS.
 
 OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
-       --domainname
+       --domainname, --domain_name
            The unique name of the domain to remove the certificate for the CSR from.
            This operand is optional, defaulting from domain1 if not provided.
 
@@ -27,6 +28,17 @@ OPTIONS
            target domain. If specified, the path must be accessible in the
            file system. The default location of the domain root directory
            is as-install/domains.
+
+        --node
+           The unique name of the node where the target instance is located.
+           This operand is optional, defaulting to localhost-$domainname
+           if not provided.
+           
+       --nodedir
+           The node root directory, which contains the of the target node.
+           If specified, the path must be accessible in the
+           file system. The default location of the node root directory
+           is as-install/nodes.
 
        --target
            The name of the instance to remove the certificate from. Defaults from server (the DAS).
@@ -41,18 +53,18 @@ OPERANDS
            The alias of the certificate to remove from the keystore
 
 EXAMPLES
-       Example 1, Add a X509 Certificate from the DAS
+       Example 1, Remove a X509 Certificate from the DAS
 
            This example removes a X509 certificate from the keystore for the DAS.
 
-               asadmin> remove-from-keystore ~/example-cert.pem example
+               asadmin> remove-from-keystore example
 
-       Example 2, Add a certificate for a Listener
+       Example 2, Remove a certificate for a Listener
 
-           This example removes a self-signed certificate named glassfish-instance in
+           This example removes a self-signed certificate named payara-instance in
            the key store of the http-listener-2 listener of an instance named Instance1
 
-               asadmin> remove-from-keystore --target Instance1 --listener http-listener-2 glassfish-instance
+               asadmin> remove-from-keystore --target Instance1 --listener http-listener-2 payara-instance
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
@@ -35,7 +35,7 @@ OPTIONS
            if not provided.
            
        --nodedir
-           The node root directory, which contains the of the target node.
+           The node root directory, which contains the target node.
            If specified, the path must be accessible in the
            file system. The default location of the node root directory
            is as-install/nodes.

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
@@ -8,7 +8,7 @@ SYNOPSIS
            [--domainname domain-name] [--domaindir domain-dir]
            [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
-           --file domain-name file
+           [--reload={true|false}] --file domain-name file
            alias
 
 DESCRIPTION
@@ -48,6 +48,10 @@ OPTIONS
            Only applicable if the listener has a key or trust store
            different from that of the instance itself.
 
+       --reload
+           If true then the HTTP listeners are restarted after the certificates
+           are removed.
+
 OPERANDS
        alias
            The alias of the certificate to remove from the keystore
@@ -63,8 +67,9 @@ EXAMPLES
 
            This example removes a self-signed certificate named payara-instance in
            the key store of the http-listener-2 listener of an instance named Instance1
+           then restarts the listener.
 
-               asadmin> remove-from-keystore --target Instance1 --listener http-listener-2 payara-instance
+               asadmin> remove-from-keystore --target Instance1 --listener http-listener-2 payara-instance --reload true
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-keystore.1
@@ -1,0 +1,62 @@
+remove-from-keystore(1)  asadmin Utility Subcommands remove-from-keystore(1)
+
+NAME
+       remove-from-keystore - removes a key or certificate from the target instance or listener's key store.
+
+SYNOPSIS
+           remove-from-keystore [--help]
+           [--domain_name domain-name] [--domaindir domain-dir]
+           [--target instance-name] [--listener listener-name]
+           --file domain-name file
+           alias
+
+DESCRIPTION
+       The remove-from-keystore subcommand removes a security certificate from the specified keystore, or the
+       default one if none is specified.
+
+OPTIONS
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --domainname
+           The unique name of the domain to remove the certificate for the CSR from.
+           This operand is optional, defaulting from domain1 if not provided.
+
+       --domaindir
+           The domain root directory, which contains the directory of the
+           target domain. If specified, the path must be accessible in the
+           file system. The default location of the domain root directory
+           is as-install/domains.
+
+       --target
+           The name of the instance to remove the certificate from. Defaults from server (the DAS).
+
+       --listener
+           The name of the HTTP or IIOP listener to remove the certificate from.
+           Only applicable if the listener has a key or trust store
+           different from that of the instance itself.
+
+OPERANDS
+       alias
+           The alias of the certificate to remove from the keystore
+
+EXAMPLES
+       Example 1, Add a X509 Certificate from the DAS
+
+           This example removes a X509 certificate from the keystore for the DAS.
+
+               asadmin> remove-from-keystore ~/example-cert.pem example
+
+       Example 2, Add a certificate for a Listener
+
+           This example removes a self-signed certificate named glassfish-instance in
+           the key store of the http-listener-2 listener of an instance named Instance1
+
+               asadmin> remove-from-keystore --target Instance1 --listener http-listener-2 glassfish-instance
+
+EXIT STATUS
+       0
+           command executed successfully
+
+       1
+           error in executing the command

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
@@ -1,11 +1,12 @@
 remove-from-truststore(1)  asadmin Utility Subcommands remove-from-truststore(1)
 
 NAME
-       remove-from-truststore - removes a key or certificate from the target instance or listener's key store.
+       remove-from-truststore - removes a key or certificate from the target instance or listener's trust store.
 
 SYNOPSIS
            remove-from-truststore [--help]
-           [--domain_name domain-name] [--domaindir domain-dir]
+           [--domainname domain-name] [--domaindir domain-dir]
+           [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
            --file domain-name file
            alias
@@ -18,7 +19,7 @@ OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
-       --domainname
+       --domainname, --domain_name
            The unique name of the domain to remove the certificate for the CSR from.
            This operand is optional, defaulting from domain1 if not provided.
 
@@ -28,8 +29,19 @@ OPTIONS
            file system. The default location of the domain root directory
            is as-install/domains.
 
+       --node
+           The unique name of the node where the target instance is located.
+           This operand is optional, defaulting to localhost-$domainname
+           if not provided.
+           
+       --nodedir
+           The node root directory, which contains the of the target node.
+           If specified, the path must be accessible in the
+           file system. The default location of the node root directory
+           is as-install/nodes.
+
        --target
-           The name of the instance to remove the certificate from. Defaults from server (the DAS).
+           The name of the instance to remove the certificate from. Defaults to server (the DAS).
 
        --listener
            The name of the HTTP or IIOP listener to remove the certificate from.
@@ -41,18 +53,18 @@ OPERANDS
            The alias of the certificate to remove from the truststore
 
 EXAMPLES
-       Example 1, Add a X509 Certificate from the DAS
+       Example 1, Remove a X509 Certificate from the DAS
 
-           This example removes a X509 certificate from the truststore for the DAS.
+           This example removes a X509 certificate from the truststore for the DAS which has the alias example.
 
-               asadmin> remove-from-truststore ~/example-cert.pem example
+               asadmin> remove-from-truststore example
 
-       Example 2, Add a certificate for a Listener
+       Example 2, Remove a certificate for a Listener
 
-           This example removes a self-signed certificate named glassfish-instance in
+           This example removes a self-signed certificate named payara-instance in
            the key store of the http-listener-2 listener of an instance named Instance1
 
-               asadmin> remove-from-truststore --target Instance1 --listener http-listener-2 glassfish-instance
+               asadmin> remove-from-truststore --target Instance1 --listener http-listener-2 payara-instance
 
 EXIT STATUS
        0

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
@@ -35,7 +35,7 @@ OPTIONS
            if not provided.
            
        --nodedir
-           The node root directory, which contains the of the target node.
+           The node root directory, which contains the target node.
            If specified, the path must be accessible in the
            file system. The default location of the node root directory
            is as-install/nodes.

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
@@ -1,0 +1,62 @@
+remove-from-truststore(1)  asadmin Utility Subcommands remove-from-truststore(1)
+
+NAME
+       remove-from-truststore - removes a key or certificate from the target instance or listener's key store.
+
+SYNOPSIS
+           remove-from-truststore [--help]
+           [--domain_name domain-name] [--domaindir domain-dir]
+           [--target instance-name] [--listener listener-name]
+           --file domain-name file
+           alias
+
+DESCRIPTION
+       The remove-from-truststore subcommand removes a security certificate from the specified truststore, or the
+       default one if none is specified.
+
+OPTIONS
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --domainname
+           The unique name of the domain to remove the certificate for the CSR from.
+           This operand is optional, defaulting from domain1 if not provided.
+
+       --domaindir
+           The domain root directory, which contains the directory of the
+           target domain. If specified, the path must be accessible in the
+           file system. The default location of the domain root directory
+           is as-install/domains.
+
+       --target
+           The name of the instance to remove the certificate from. Defaults from server (the DAS).
+
+       --listener
+           The name of the HTTP or IIOP listener to remove the certificate from.
+           Only applicable if the listener has a key or trust store
+           different from that of the instance itself.
+
+OPERANDS
+       alias
+           The alias of the certificate to remove from the truststore
+
+EXAMPLES
+       Example 1, Add a X509 Certificate from the DAS
+
+           This example removes a X509 certificate from the truststore for the DAS.
+
+               asadmin> remove-from-truststore ~/example-cert.pem example
+
+       Example 2, Add a certificate for a Listener
+
+           This example removes a self-signed certificate named glassfish-instance in
+           the key store of the http-listener-2 listener of an instance named Instance1
+
+               asadmin> remove-from-truststore --target Instance1 --listener http-listener-2 glassfish-instance
+
+EXIT STATUS
+       0
+           command executed successfully
+
+       1
+           error in executing the command

--- a/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
+++ b/appserver/extras/certificate-management/src/main/manpages/fish/payara/certificate/management/admin/remove-from-truststore.1
@@ -8,7 +8,7 @@ SYNOPSIS
            [--domainname domain-name] [--domaindir domain-dir]
            [--node node-name] [--nodedir node-dir]
            [--target instance-name] [--listener listener-name]
-           --file domain-name file
+           [--reload={true|false}] --file domain-name file
            alias
 
 DESCRIPTION
@@ -48,6 +48,10 @@ OPTIONS
            Only applicable if the listener has a key or trust store
            different from that of the instance itself.
 
+       --reload
+           If true then the HTTP listeners are restarted after the certificates
+           are removed.
+
 OPERANDS
        alias
            The alias of the certificate to remove from the truststore
@@ -63,8 +67,9 @@ EXAMPLES
 
            This example removes a self-signed certificate named payara-instance in
            the key store of the http-listener-2 listener of an instance named Instance1
+           then restarts the listener.
 
-               asadmin> remove-from-truststore --target Instance1 --listener http-listener-2 payara-instance
+               asadmin> remove-from-truststore --target Instance1 --listener http-listener-2 --reload true payara-instance
 
 EXIT STATUS
        0


### PR DESCRIPTION
## Description

Original PR by Jonathan.
This is a feature.

## Testing

### Testing Performed

Manually tested with --help option for the commands

### Test suites executed

    Java EE7 Samples

### Testing Environment

Zulu JDK 1.8_212 on Ubuntu 20.04 with Maven 3.6.3

## Documentation

This PR adds documentation in the form of man pages