### PR TITLE
FISH-42 OpenAPI document has duplicate Tag items

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
@@ -44,6 +44,7 @@ import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.ExternalDocumentationImpl;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import java.util.List;
+import java.util.Objects;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
@@ -139,14 +140,43 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
         }
 
         if (from.getName()!= null && !from.getName().isEmpty()) {
-            // Create the new tag
-            Tag newTag = new TagImpl();
-            merge(from, newTag, true);
-            apiTags.add(newTag);
+            if (!apiTags.contains(from)) {
+                // Create the new tag
+                Tag newTag = new TagImpl();
+                merge(from, newTag, true);
+                apiTags.add(newTag);
+            }
 
             // Reference the new tag
-            to.addTag(newTag.getName());
+            to.addTag(from.getName());
         }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 83 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final TagImpl other = (TagImpl) obj;
+        return Objects.equals(this.name, other.name);
+    }
+
+    @Override
+    public String toString() {
+        return "TagImpl{" + "name=" + name + ", description=" + description + ", externalDocs=" + externalDocs + ", ref=" + ref + '}';
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/TagExampleTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/TagExampleTest.java
@@ -1,0 +1,81 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.openapi.test.app.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
+import fish.payara.microprofile.openapi.test.util.JsonUtils;
+import javax.json.Json;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ *
+ * @author gaurav.gupta@payara.fish
+ */
+@Path("/weather")
+@Tag(name = "Weather API", description = "A simple Weather API")
+public class TagExampleTest extends OpenApiApplicationTest {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getWeather() {
+        return Json.createObjectBuilder()
+                .add("city", "Budapest")
+                .add("temperature", 11)
+                .build()
+                .toString();
+    }
+
+    @Test
+    public void fieldSchemaExampleIsRendered() {
+        JsonNode tags = JsonUtils.path(getOpenAPIJson(), "tags");
+        assertNotNull(tags);
+        assertEquals(1, tags.size());
+        assertEquals("Weather API", tags.get(0).get("name").textValue());
+        assertEquals("A simple Weather API", tags.get(0).get("description").textValue());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>


## Description
This is a fix to exclude duplicate tags from OpenAPI metadata.

## Important Info

## Testing
### New tests
Unit test

### Testing Performed
Unit tests
MP OPEN API TCK Runner

### Testing Environment
Windows 10, JDK 11.0
