### PR TITLE
FISH-243 Use monitoring console 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,8 +216,8 @@
         <concurrent.version>1.0.payara-p2</concurrent.version>
         <asm.version>7.3.1</asm.version>
         <monitoring-console-api.version>1.1</monitoring-console-api.version>
-        <monitoring-console-process.version>1.2</monitoring-console-process.version>
-        <monitoring-console-webapp.version>1.2</monitoring-console-webapp.version>
+        <monitoring-console-process.version>1.2.1</monitoring-console-process.version>
+        <monitoring-console-webapp.version>1.2.1</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
     </properties>
 


### PR DESCRIPTION
## Description
This is a bug fix.
There was an issue with the Monitoring console 1.2 release where it was missing some changes it should have had that prevented it from working.