### PR TITLE
FISH-128 OpenAPI does not include APIs from jars within a war 

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -50,6 +50,7 @@ import fish.payara.microprofile.openapi.impl.processor.FileProcessor;
 import fish.payara.microprofile.openapi.impl.processor.FilterProcessor;
 import fish.payara.microprofile.openapi.impl.processor.ModelReaderProcessor;
 import java.beans.PropertyChangeEvent;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -57,7 +58,10 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.logging.Logger;
@@ -89,6 +93,7 @@ import org.jvnet.hk2.config.UnprocessedChangeEvents;
 
 import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toSet;
+import org.glassfish.hk2.classmodel.reflect.Type;
 
 @Service(name = "microprofile-openapi-service")
 @RunLevel(StartupRunLevel.VAL)
@@ -249,7 +254,11 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
 
                 openapi = new ModelReaderProcessor().process(openapi, appConfig);
                 openapi = new FileProcessor(appInfo.getAppClassLoader()).process(openapi, appConfig);
-                openapi = new ApplicationProcessor(appInfo).process(openapi, appConfig);
+                openapi = new ApplicationProcessor(
+                        appInfo.getTypes(),
+                        filterTypes(appInfo, appConfig),
+                        appInfo.getAppClassLoader()
+                ).process(openapi, appConfig);
                 openapi = new BaseProcessor(baseURLs).process(openapi, appConfig);
                 openapi = new FilterProcessor().process(openapi, appConfig);
             } catch (Throwable t) {
@@ -260,6 +269,52 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
             return openapi;
         }
 
+    }
+
+    /**
+     * @return a list of all classes in the archive.
+     */
+    private Set<Type> filterTypes(ApplicationInfo appInfo, OpenApiConfiguration config) {
+        ReadableArchive archive = appInfo.getSource();
+
+        Set<Type> types = new HashSet<>();
+        if (config != null && config.getScanLib()) {
+            Iterator<String> subArchiveItr = archive.entries().asIterator();
+            while (subArchiveItr.hasNext()) {
+                String subArchive = subArchiveItr.next();
+                if (subArchive.startsWith("WEB-INF/lib/") && subArchive.endsWith(".jar")) {
+                    try {
+                        Iterator<String> classItr = archive.getSubArchive(subArchive).entries().asIterator();
+                        while (classItr.hasNext()) {
+                            String clazz = classItr.next();
+                            if (clazz.endsWith(".class")) {
+                                clazz = clazz.replace("/", ".").replace(".class", "");
+                                Type type = appInfo.getTypes().getBy(clazz);
+                                if (type != null) {
+                                    types.add(type);
+                                }
+                            }
+                        }
+                    } catch (IOException ex) {
+                        throw new IllegalStateException(ex);
+                    }
+                }
+            }
+        }
+
+        types.addAll(
+                Collections.list(archive.entries()).stream()
+                        // Only use the classes
+                        .filter(clazz -> clazz.endsWith(".class"))
+                        // Remove the WEB-INF/classes and return the proper class name format
+                        .map(clazz -> clazz.replaceAll("WEB-INF/classes/", "").replace("/", ".").replace(".class", ""))
+                        // Fetch class type
+                        .map(clazz -> appInfo.getTypes().getBy(clazz))
+                        // Don't return null classes
+                        .filter(Objects::nonNull)
+                        .collect(toSet())
+        );
+        return config == null ? types : config.getValidClasses(types);
     }
 
     private List<URL> getServerURL(String contextRoot) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -296,9 +296,9 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
     private Set<Type> filterLibTypes(ApplicationInfo appInfo, OpenApiConfiguration config, ReadableArchive archive) {
         Set<Type> types = new HashSet<>();
         if (config != null && config.getScanLib()) {
-            Iterator<String> subArchiveItr = archive.entries().asIterator();
-            while (subArchiveItr.hasNext()) {
-                String subArchiveName = subArchiveItr.next();
+            Enumeration<String> subArchiveItr = archive.entries();
+            while (subArchiveItr.hasMoreElements()) {
+                String subArchiveName = subArchiveItr.nextElement();
                 if (subArchiveName.startsWith("WEB-INF/lib/") && subArchiveName.endsWith(".jar")) {
                     try {
                         ReadableArchive subArchive = archive.getSubArchive(subArchiveName);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
@@ -63,6 +63,7 @@ public class OpenApiConfiguration {
 
     private static final String MODEL_READER_KEY = "mp.openapi.model.reader";
     private static final String FILTER_KEY = "mp.openapi.filter";
+    private static final String SCAN_LIB_KEY = "mp.openapi.scan.lib";
     private static final String SCAN_DISABLE_KEY = "mp.openapi.scan.disable";
     private static final String SCAN_PACKAGES_KEY = "mp.openapi.scan.packages";
     private static final String SCAN_CLASSES_KEY = "mp.openapi.scan.classes";
@@ -75,6 +76,7 @@ public class OpenApiConfiguration {
     private final Class<? extends OASModelReader> modelReader;
     private final Class<? extends OASFilter> filter;
     private final boolean scanDisable;
+    private final boolean scanLib;
     private List<String> scanPackages = new ArrayList<>();
     private List<String> scanClasses = new ArrayList<>();
     private List<String> excludePackages = new ArrayList<>();
@@ -94,6 +96,7 @@ public class OpenApiConfiguration {
         this.modelReader = findModelReaderFromConfig(config, applicationClassLoader);
         this.filter = findFilterFromConfig(config, applicationClassLoader);
         this.scanDisable = findScanDisableFromConfig(config);
+        this.scanLib = findScanLibFromConfig(config);
         this.scanPackages = findScanPackagesFromConfig(config);
         this.scanClasses = findScanClassesFromConfig(config);
         this.excludePackages = findExcludePackages(config);
@@ -122,6 +125,13 @@ public class OpenApiConfiguration {
      */
     public boolean getScanDisable() {
         return scanDisable;
+    }
+
+    /**
+     * @return whether to disable packaged libraries scanning.
+     */
+    public boolean getScanLib() {
+        return scanLib;
     }
 
     /**
@@ -227,6 +237,15 @@ public class OpenApiConfiguration {
     private static boolean findScanDisableFromConfig(Config config) {
         try {
             return config.getValue(SCAN_DISABLE_KEY, Boolean.class);
+        } catch (NoSuchElementException ex) {
+            // Ignore
+        }
+        return false;
+    }
+
+    private static boolean findScanLibFromConfig(Config config) {
+        try {
+            return config.getValue(SCAN_LIB_KEY, Boolean.class);
         } catch (NoSuchElementException ex) {
             // Ignore
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -64,15 +64,18 @@ import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.AnnotationInfo;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import fish.payara.microprofile.openapi.impl.visitor.OpenApiWalker;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
@@ -124,10 +127,6 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     private final ClassLoader appClassLoader;
 
-    public ApplicationProcessor(ApplicationInfo appInfo) {
-        this(appInfo.getTypes(), filterTypes(appInfo), appInfo.getAppClassLoader());
-    }
-
     /**
      * @param types parsed application classes
      * @param appClassLoader the class loader for the application.
@@ -136,23 +135,6 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
         this.allTypes = allTypes;
         this.allowedTypes = allowedTypes;
         this.appClassLoader = appClassLoader;
-    }
-
-    /**
-     * @return a list of all classes in the archive.
-     */
-    private static Set<Type> filterTypes(ApplicationInfo appInfo) {
-        ReadableArchive archive = appInfo.getSource();
-        return Collections.list(archive.entries()).stream()
-                // Only use the classes
-                .filter(clazz -> clazz.endsWith(".class"))
-                // Remove the WEB-INF/classes and return the proper class name format
-                .map(clazz -> clazz.replaceAll("WEB-INF/classes/", "").replace("/", ".").replace(".class", ""))
-                // Fetch class type
-                .map(clazz -> appInfo.getTypes().getBy(clazz))
-                // Don't return null classes
-                .filter(Objects::nonNull)
-                .collect(toSet());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>

## Description
This is a feature to include classes for OpenAPI Metadata scanning from the packaged jar within a  war.

## Testing
### Testing Performed
Unit tests, Manual testing, MP OpenAPI TCK Runner

### Testing Environment
Windows 10, JDK 11.0

## Documentation
TODO
