### PR TITLE
FISH-31 Upgrade Grizzly to 2.4.4.payara-p3

### DIFF
--- a/nucleus/packager/nucleus-grizzly/pom.xml
+++ b/nucleus/packager/nucleus-grizzly/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-npn-osgi</artifactId>
-            <version>${grizzly.npn.version}</version>
+            <version>${grizzly.npn.osgi.version}</version>
         </dependency>
     </dependencies>
 
@@ -92,7 +92,7 @@
                                 <artifactItem>
                                     <groupId>org.glassfish.grizzly</groupId>
                                     <artifactId>grizzly-npn-api</artifactId>
-                                    <version>1.9</version>
+				    <version>${grizzly.npn.version}</version>
                                     <destFileName>grizzly-npn-api.jar</destFileName>
                                 </artifactItem>
                                 <!-- Default NPN Bootstrap Jar for old domain.xml files -->

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -121,7 +121,8 @@
 
         <!-- Servlet -->
         <!-- Requires JDK8u161 or above-->
-        <grizzly.npn.version>1.8</grizzly.npn.version>
+        <grizzly.npn.version>1.9.payara-p1</grizzly.npn.version>
+        <grizzly.npn.osgi.version>1.9</grizzly.npn.osgi.version>
 
         <!-- Microprofile -->
         <!-- JAX-RS -->

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
-        <grizzly.version>2.4.4.payara-p2</grizzly.version>
+        <grizzly.version>2.4.4.payara-p3</grizzly.version>
         <jax-rs-api.impl.version>2.1.6</jax-rs-api.impl.version>
         <jersey.version>2.30.payara-p2</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is an improvement enabling HTTP/2 when native ALPN APIs are found (8u252+).

## Important Info

Note that Zulu versions with the -XX:+OpenJSSE flag don't support HTTP/2.

### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

Grizzly changes: https://github.com/payara/patched-src-grizzly/pull/23

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
h2spec

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
OpenJDK 11, Zulu JDK 8u252 and Zulu JDK 8u232.

<!-- ## Documentation -->
<!-- Link documentation if a PR exists -->

<!-- ## Notes for Reviewers -->
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
