### PR TITLE
QACI-262 Quicklook is broken on Public Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,6 @@ pipeline {
         stage('Setup for Quicklook Tests') {
             steps {
                 sh "rm -f -v *.zip"
-                sh "rm -f '$HOME/test|sa.mv.db'"
                 setupDomain()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,7 @@ pipeline {
         stage('Setup for Quicklook Tests') {
             steps {
                 sh "rm -f -v *.zip"
+                sh "rm -f '$HOME/test|sa.mv.db'"
                 setupDomain()
             }
         }

--- a/appserver/tests/quicklook/gfproject/h2.properties
+++ b/appserver/tests/quicklook/gfproject/h2.properties
@@ -49,6 +49,6 @@ db.driver=org.h2.Driver
 db.datasource=org.h2.jdbcx.JdbcDataSource
 db.delimiter=;
 db.name=test
-db.url=jdbc:h2:tcp://localhost:${db.port}/~/${db.name}|sa;
+db.url=jdbc:h2:tcp://localhost:${db.port}/${basedir}/target/${db.name}|sa;
 h2.home=${glassfish.home}/h2db
 ##Edit asadminpassword.txt file in same directory


### PR DESCRIPTION
Delete the test|sa.mv.db file during setup, as it keeps getting corrupted