### PR TITLE
FISH-7 Adds more MP Metrics Metadata as MC Annotation for Query Pages (Virtual Pages)

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricUnitsUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricUnitsUtils.java
@@ -47,7 +47,11 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  *
  * @author Jan Bernitt
  */
-public class MetricUnitsUtils {
+public final class MetricUnitsUtils {
+
+    private MetricUnitsUtils() {
+        throw new UnsupportedOperationException("util");
+    }
 
     public static String baseUnit(String unit) {
         switch (unit) {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricUnitsUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricUnitsUtils.java
@@ -1,0 +1,124 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricUnits;
+
+/**
+ * Utilities around {@link MetricUnits}.
+ *
+ * @author Jan Bernitt
+ */
+public class MetricUnitsUtils {
+
+    public static String baseUnit(String unit) {
+        switch (unit) {
+        case MetricUnits.BITS:
+        case MetricUnits.KILOBITS:
+        case MetricUnits.MEGABITS:
+        case MetricUnits.GIGABITS:
+        case MetricUnits.KIBIBITS:
+        case MetricUnits.MEBIBITS:
+        case MetricUnits.GIBIBITS:
+        case MetricUnits.BYTES:
+        case MetricUnits.KILOBYTES:
+        case MetricUnits.MEGABYTES:
+        case MetricUnits.GIGABYTES:
+            return MetricUnits.BYTES;
+        case MetricUnits.NANOSECONDS:
+        case MetricUnits.MICROSECONDS:
+        case MetricUnits.MILLISECONDS:
+        case MetricUnits.SECONDS:
+        case MetricUnits.MINUTES:
+        case MetricUnits.HOURS:
+        case MetricUnits.DAYS:
+            return MetricUnits.SECONDS;
+        default:
+            return unit;
+        }
+    }
+
+    public static Number scaleToBaseUnit(Number value, Metadata metadata) {
+        if (!metadata.getUnit().isPresent()) {
+            return value;
+        }
+        String unit = metadata.getUnit().get();
+        return scaleToBaseUnit(value, unit);
+    }
+
+    public static Number scaleToBaseUnit(Number value, String unit) {
+        if (unit == null || unit.isEmpty() || unit.equals(MetricUnits.NONE)) {
+            return value;
+        }
+        switch (unit) {
+        // bytes from bits
+        case MetricUnits.BITS: return value.longValue() / 8d;
+        case MetricUnits.KILOBITS: return value.doubleValue() * 1000d / 8d;
+        case MetricUnits.MEGABITS: return value.doubleValue() * 1000d * 1000d / 8d;
+        case MetricUnits.GIGABITS: return value.doubleValue() * 1000d * 1000d * 1000d / 8d;
+        case MetricUnits.KIBIBITS: return value.doubleValue() * 1024d / 8d;
+        case MetricUnits.MEBIBITS: return value.doubleValue() * 1024d * 1024d / 8d;
+        case MetricUnits.GIBIBITS: return value.doubleValue() * 1024d * 1024d * 1024d / 8d;
+
+        // bytes from bytes
+        case MetricUnits.BYTES: return value;
+        case MetricUnits.KILOBYTES: return value.doubleValue() * 1000d;
+        case MetricUnits.MEGABYTES: return value.doubleValue() * 1000d * 1000d;
+        case MetricUnits.GIGABYTES: return value.doubleValue() * 1000d * 1000d * 1000d;
+
+        // seconds from time unit
+        case MetricUnits.NANOSECONDS: return value.longValue()  / 1000d / 1000d / 1000d;
+        case MetricUnits.MICROSECONDS: return value.longValue() / 1000d / 1000d;
+        case MetricUnits.MILLISECONDS: return value.longValue() / 1000d;
+        case MetricUnits.SECONDS: return value;
+        case MetricUnits.MINUTES: return value.doubleValue() * 60d;
+        case MetricUnits.HOURS: return value.doubleValue() * 60d * 60d;
+        case MetricUnits.DAYS: return value.doubleValue() * 60d * 60d * 24d;
+
+        // others
+        case MetricUnits.PERCENT:
+        case MetricUnits.PER_SECOND:
+        default:
+            return value;
+        }
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/MetricsService.java
@@ -242,13 +242,16 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
     }
 
     private static String[] metadataToAnnotations(Metadata metadata, String property) {
+        String unit = metadata.getUnit().orElse(MetricUnits.NONE);
         return new String[] {
                 "Name", metadata.getName(), //
                 "Type", metadata.getType(), //
-                "Unit", metadata.getUnit().orElse(MetricUnits.NONE), //
+                "Unit", unit, //
                 "DisplayName", metadata.getDisplayName(), //
                 "Description", metadata.getDescription().orElse(""),
-                "Property", property
+                "Property", property,
+                "BaseUnit", MetricUnitsUtils.baseUnit(unit),
+                "ScaleToBaseUnit", MetricUnitsUtils.scaleToBaseUnit(1L, unit).toString()
         };
     }
 
@@ -296,7 +299,7 @@ public class MetricsService implements EventListener, ConfigListener, Monitoring
         return collector.group(tag);
     }
 
-    private void checkSystemCpuLoadIssue(MBeanMetadataConfig metadataConfig) {
+    private static void checkSystemCpuLoadIssue(MBeanMetadataConfig metadataConfig) {
         // Could be constant but placed it in method as it is a workaround until fixed in JVM.
         // TODO Make this check dependent on the JDK version (as it hopefully will get solved in the future) -> Azul fix request made.
         String mbeanSystemCPULoad = "java.lang:type=OperatingSystem/SystemCpuLoad";

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/OpenMetricsExporter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/OpenMetricsExporter.java
@@ -39,6 +39,8 @@
  */
 package fish.payara.microprofile.metrics.writer;
 
+import static fish.payara.microprofile.metrics.MetricUnitsUtils.scaleToBaseUnit;
+
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.Arrays;
@@ -63,6 +65,7 @@ import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.Snapshot;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
+
 import org.eclipse.microprofile.metrics.MetricRegistry.Type;
 
 /**
@@ -370,47 +373,6 @@ public class OpenMetricsExporter implements MetricExporter {
         String out = name.replaceAll("[^a-zA-Z0-9_]+", "_");
         //Colon-underscore (:_) is translated to single colon
         return out.replaceAll(":_", ":");
-    }
-
-    private static Number scaleToBaseUnit(Number value, Metadata metadata) {
-        if (!metadata.getUnit().isPresent()) {
-            return value;
-        }
-        String unit = metadata.getUnit().get();
-        if (unit == null || unit.isEmpty() || unit.equals(MetricUnits.NONE)) {
-            return value;
-        }
-        switch (unit) {
-        // bytes from bits
-        case MetricUnits.BITS: return value.longValue() / 8d;
-        case MetricUnits.KILOBITS: return value.doubleValue() * 1000d / 8d;
-        case MetricUnits.MEGABITS: return value.doubleValue() * 1000d * 1000d / 8d;
-        case MetricUnits.GIGABITS: return value.doubleValue() * 1000d * 1000d * 1000d / 8d;
-        case MetricUnits.KIBIBITS: return value.doubleValue() * 1024d / 8d;
-        case MetricUnits.MEBIBITS: return value.doubleValue() * 1024d * 1024d / 8d;
-        case MetricUnits.GIBIBITS: return value.doubleValue() * 1024d * 1024d * 1024d / 8d;
-
-        // bytes from bytes
-        case MetricUnits.BYTES: return value;
-        case MetricUnits.KILOBYTES: return value.doubleValue() * 1000d;
-        case MetricUnits.MEGABYTES: return value.doubleValue() * 1000d * 1000d;
-        case MetricUnits.GIGABYTES: return value.doubleValue() * 1000d * 1000d * 1000d;
-
-        // seconds from time unit
-        case MetricUnits.NANOSECONDS: return value.longValue()  / 1000d / 1000d / 1000d;
-        case MetricUnits.MICROSECONDS: return value.longValue() / 1000d / 1000d;
-        case MetricUnits.MILLISECONDS: return value.longValue() / 1000d;
-        case MetricUnits.SECONDS: return value;
-        case MetricUnits.MINUTES: return value.doubleValue() * 60d;
-        case MetricUnits.HOURS: return value.doubleValue() * 60d * 60d;
-        case MetricUnits.DAYS: return value.doubleValue() * 60d * 60d * 24d;
-
-        // others
-        case MetricUnits.PERCENT:
-        case MetricUnits.PER_SECOND:
-        default:
-            return value;
-        }
     }
 
     private static Tag[] tags(String name, String value, Tag[] rest) {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/MetricUnitsUtilsTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/MetricUnitsUtilsTest.java
@@ -1,0 +1,241 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.microprofile.metrics;
+
+import static fish.payara.microprofile.metrics.MetricUnitsUtils.scaleToBaseUnit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.junit.Test;
+
+/**
+ * Tests correctness of {@link MetricUnitsUtils}.
+ *
+ * @author Jan Bernitt
+ */
+public class MetricUnitsUtilsTest {
+
+    @Test(expected = IllegalAccessException.class)
+    public void utilCannotBeInstantiated() throws InstantiationException, IllegalAccessException {
+        MetricUnitsUtils.class.newInstance();
+    }
+
+    @Test
+    public void anyBitsUnitHasBytesBaseUnit() {
+        assertBaseUnit(MetricUnits.BYTES,
+            MetricUnits.BITS, MetricUnits.KILOBITS, MetricUnits.MEGABITS, MetricUnits.GIGABITS,
+            MetricUnits.KIBIBITS, MetricUnits.MEBIBITS, MetricUnits.GIBIBITS);
+    }
+
+    @Test
+    public void anyBytesUnitHasBytesBaseUnit() {
+        assertBaseUnit(MetricUnits.BYTES,
+                MetricUnits.BYTES, MetricUnits.KILOBYTES, MetricUnits.MEGABYTES, MetricUnits.GIGABYTES);
+    }
+
+    @Test
+    public void anyTimeUnitHasSecondsBaseUnit() {
+        assertBaseUnit(MetricUnits.SECONDS,
+                MetricUnits.NANOSECONDS, MetricUnits.MICROSECONDS, MetricUnits.MILLISECONDS,
+                MetricUnits.SECONDS, MetricUnits.MINUTES, MetricUnits.HOURS, MetricUnits.DAYS);
+    }
+
+    @Test
+    public void anyOtherUnitHasItselfAsBaseUnit() {
+        assertBaseUnit(MetricUnits.NONE, MetricUnits.NONE);
+        assertBaseUnit(MetricUnits.PER_SECOND, MetricUnits.PER_SECOND);
+        assertBaseUnit(MetricUnits.PERCENT, MetricUnits.PERCENT);
+    }
+
+    @Test
+    public void bitsToBytes() {
+        assertScalesToBytes(0.25, 2, MetricUnits.BITS);
+        assertScalesToBytes(1, 8, MetricUnits.BITS);
+        assertScalesToBytes(4, 32, MetricUnits.BITS);
+    }
+
+    @Test
+    public void kilobitsToBytes() {
+        assertScalesToBytes(125, 1, MetricUnits.KILOBITS);
+        assertScalesToBytes(25, 0.2, MetricUnits.KILOBITS);
+    }
+
+    @Test
+    public void megabitsToBytes() {
+        assertScalesToBytes(125000, 1, MetricUnits.MEGABITS);
+        assertScalesToBytes(500000, 4, MetricUnits.MEGABITS);
+        assertScalesToBytes(1250, 0.01, MetricUnits.MEGABITS);
+    }
+
+    @Test
+    public void gigabitsToBytes() {
+        assertScalesToBytes(125000000, 1, MetricUnits.GIGABITS);
+        assertScalesToBytes(1250, 0.00001, MetricUnits.GIGABITS);
+    }
+
+    @Test
+    public void kibibitsToBytes() {
+        assertScalesToBytes(128, 1, MetricUnits.KIBIBITS);
+        assertScalesToBytes(1024, 8, MetricUnits.KIBIBITS);
+    }
+
+    @Test
+    public void mebibitsToBytes() {
+        assertScalesToBytes(128, 1d/1024, MetricUnits.MEBIBITS);
+        assertScalesToBytes(128 * 1024, 1, MetricUnits.MEBIBITS);
+    }
+
+    @Test
+    public void gibibitsToBytes() {
+        assertScalesToBytes(128, 1d/1024/1024, MetricUnits.GIBIBITS);
+        assertScalesToBytes(128 * 1024 * 1024, 1d, MetricUnits.GIBIBITS);
+    }
+
+    @Test
+    public void bytesToBytes() {
+        assertScalesToBytes(13, 13, MetricUnits.BYTES);
+        assertScalesToBytes(42, 42, MetricUnits.BYTES);
+        assertScalesToBytes(0.5, 0.5, MetricUnits.BYTES);
+    }
+
+    @Test
+    public void kilobytesToBytes() {
+        assertScalesToBytes(1000, 1, MetricUnits.KILOBYTES);
+        assertScalesToBytes(42000, 42, MetricUnits.KILOBYTES);
+        assertScalesToBytes(500, 0.5, MetricUnits.KILOBYTES);
+    }
+
+    @Test
+    public void megabytesToBytes() {
+        assertScalesToBytes(1000 * 1000, 1, MetricUnits.MEGABYTES);
+        assertScalesToBytes(100 * 1000, 0.1, MetricUnits.MEGABYTES);
+    }
+
+    @Test
+    public void gigabytesToBytes() {
+        assertScalesToBytes(1000 * 1000 * 1000, 1, MetricUnits.GIGABYTES);
+        assertScalesToBytes(4200L * 1000 * 1000, 4.2, MetricUnits.GIGABYTES);
+    }
+
+    @Test
+    public void nanosecondsToSeconds() {
+        assertScalesToSeconds(0.0000001d, 1000, MetricUnits.NANOSECONDS);
+        assertScalesToSeconds(0.0000421d, 421000, MetricUnits.NANOSECONDS);
+    }
+
+    @Test
+    public void microsecondsToSeconds() {
+        assertScalesToSeconds(0.0000001d, 1, MetricUnits.MICROSECONDS);
+        assertScalesToSeconds(0.0000105d, 105, MetricUnits.MICROSECONDS);
+    }
+
+    @Test
+    public void millisecondsToSeconds() {
+        assertScalesToSeconds(0.0001d, 1, MetricUnits.MILLISECONDS);
+        assertScalesToSeconds(42.5d, 42500, MetricUnits.MILLISECONDS);
+    }
+
+    @Test
+    public void secondsToSeconds() {
+        assertScalesToSeconds(1, 1, MetricUnits.SECONDS);
+        assertScalesToSeconds(42, 42, MetricUnits.SECONDS);
+        assertScalesToSeconds(0.5d, 0.5f, MetricUnits.SECONDS);
+    }
+
+    @Test
+    public void minutesToSeconds() {
+        assertScalesToSeconds(60, 1, MetricUnits.MINUTES);
+        assertScalesToSeconds(30, 0.5, MetricUnits.MINUTES);
+        assertScalesToSeconds(3600, 60, MetricUnits.MINUTES);
+    }
+
+    @Test
+    public void hoursToSeconds() {
+        assertScalesToSeconds(3600, 1, MetricUnits.HOURS);
+        assertScalesToSeconds(1800, 0.5, MetricUnits.HOURS);
+        assertScalesToSeconds(60 * 60 * 5, 5, MetricUnits.HOURS);
+    }
+
+    @Test
+    public void daysToSeconds() {
+        assertScalesToSeconds(24 * 3600, 1, MetricUnits.DAYS);
+        assertScalesToSeconds(12 * 3600, 0.5, MetricUnits.DAYS);
+    }
+
+    @Test
+    public void othersDoNotScale() {
+        assertScalesTo(3, 3, MetricUnits.NONE);
+        assertScalesTo(2, 2, MetricUnits.PER_SECOND);
+        assertScalesTo(100, 100, MetricUnits.PERCENT);
+    }
+
+    @Test
+    public void metadataWithoutUnitDoesNotScaleValues() {
+        Number value = 42.2d;
+        assertSame(value, scaleToBaseUnit(value, Metadata.builder().withName("somename").build()));
+        assertSame(value, scaleToBaseUnit(value, Metadata.builder().withName("somename").withOptionalUnit(null).build()));
+    }
+
+    private static void assertScalesToSeconds(Number expectedSeconds, Number actualValue, String actualUnit) {
+        assertBaseUnit(MetricUnits.SECONDS, actualUnit);
+        assertScalesTo(expectedSeconds, actualValue, actualUnit);
+    }
+
+    private static void assertScalesToBytes(Number expectedBytes, Number actualValue, String actualUnit) {
+        assertBaseUnit(MetricUnits.BYTES, actualUnit);
+        assertScalesTo(expectedBytes, actualValue, actualUnit);
+    }
+
+    private static void assertScalesTo(Number expectedValue, Number actualValue, String actualUnit) {
+        assertEquals(expectedValue.doubleValue(),
+                MetricUnitsUtils.scaleToBaseUnit(actualValue, actualUnit).doubleValue(), 0.001d);
+    }
+
+    private static void assertBaseUnit(String expectedBaseUnit, String... units) {
+        for (String unit : units) {
+            assertEquals(expectedBaseUnit, MetricUnitsUtils.baseUnit(unit));
+        }
+    }
+}


### PR DESCRIPTION
Payara changes for https://github.com/payara/monitoring-console/pull/18, details can be found there.

In this PR the main goal is to provide two additional attributes in the permanent annotation:

* `BaseUnit`: The unit considered base unit for MP Metrics
* `ScaleToBaseUnit`: Factor to convert the metric unit to its base unit as used by MP Metrics

In order to share the code responsible for unit scale factor is extracted to a utility class.