### PR TITLE
FISH-219 Indicate missing default value when using custom template for domain creation

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/LocalStrings.properties
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/LocalStrings.properties
@@ -110,6 +110,7 @@ MutuallyExclusiveOption=CLI169: Options {0} and {1} are mutually exclusive.  You
 UnsupportedLegacyCommand=CLI194: Previously supported command: {0} is not supported for this release.
 NoScope=CLI195: Implementation for the command {0} exists in the system,\nbut it has no @Scoped annotation
 HasParams=CLI196: Implementation for the command {0} exists in the system,\nbut it's a singleton that also has parameters
+MissingDefaultPort=No (default) value specific for {0}
 
 ###
 listCommands.notBoth=You can't specify both --localonly and --remoteonly as true at the same time.

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainPortValidator.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainPortValidator.java
@@ -208,6 +208,9 @@ public class DomainPortValidator {
             portNotSpecified = true;
         }
         if (portNotSpecified) {
+            if (defaultPort == null || defaultPort.trim().isEmpty()) {
+                throw new DomainException(STRINGS.get("MissingDefaultPort", key));
+            }
             port = convertPortStr(defaultPort);
             defaultPortUsed = true;
         }


### PR DESCRIPTION

## Description
Now missing default value will be indicated when using custom template for domain creation.

## Testing

### Testing Performed

- Copy `/glassfish/common/templates/appserver-domain.jar` form previous Payara release into `<payara-5.2020.2>/glassfish/common/templates/appserver-domain.jar`

- Run command: `./asadmin create-domain --nopassword test`

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4
