### PR TITLE
FISH-260 QACI-296: Add diagnostics for missing top-level invocation on stack

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -128,5 +128,10 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/extension/MetricCDIExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/extension/MetricCDIExtension.java
@@ -57,7 +57,7 @@ package fish.payara.microprofile.metrics.cdi.extension;
 import fish.payara.microprofile.metrics.MetricsService;
 import fish.payara.microprofile.metrics.cdi.MetricsAnnotationBinding;
 import fish.payara.microprofile.metrics.cdi.AnnotationReader;
-import fish.payara.microprofile.metrics.cdi.interceptor.ConcurrentGuageInterceptor;
+import fish.payara.microprofile.metrics.cdi.interceptor.ConcurrentGaugeInterceptor;
 import fish.payara.microprofile.metrics.cdi.interceptor.CountedInterceptor;
 import fish.payara.microprofile.metrics.cdi.interceptor.MeteredInterceptor;
 import fish.payara.microprofile.metrics.cdi.interceptor.MetricsInterceptor;
@@ -133,7 +133,7 @@ public class MetricCDIExtension<E extends Member & AnnotatedElement> implements 
         beforeBeanDiscovery.addQualifier(org.eclipse.microprofile.metrics.annotation.Metric.class);
 //
         addAnnotatedType(CountedInterceptor.class, manager, beforeBeanDiscovery);
-        addAnnotatedType(ConcurrentGuageInterceptor.class, manager, beforeBeanDiscovery);
+        addAnnotatedType(ConcurrentGaugeInterceptor.class, manager, beforeBeanDiscovery);
         addAnnotatedType(MeteredInterceptor.class, manager, beforeBeanDiscovery);
         addAnnotatedType(TimedInterceptor.class, manager, beforeBeanDiscovery);
         addAnnotatedType(MetricsInterceptor.class, manager, beforeBeanDiscovery);

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/interceptor/ConcurrentGaugeInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/cdi/interceptor/ConcurrentGaugeInterceptor.java
@@ -56,7 +56,7 @@ import fish.payara.microprofile.metrics.cdi.AnnotationReader;
 @ConcurrentGauge
 @Interceptor
 @Priority(Interceptor.Priority.LIBRARY_BEFORE + 1)
-public class ConcurrentGuageInterceptor extends AbstractInterceptor {
+public class ConcurrentGaugeInterceptor extends AbstractInterceptor {
 
     @Override
     protected <E extends Member & AnnotatedElement> Object applyInterceptor(InvocationContext context, E element)

--- a/appserver/web/web-glue/src/main/java/com/sun/web/server/J2EEInstanceListener.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/web/server/J2EEInstanceListener.java
@@ -318,7 +318,11 @@ public final class J2EEInstanceListener implements InstanceListener {
         } catch (Exception ex) {
             String msg = _rb.getString(LogFacade.EXCEPTION_DURING_HANDLE_EVENT);
             msg = MessageFormat.format(msg, new Object[] { eventType, wm });
-            throw new RuntimeException(msg, ex);
+            RuntimeException rethrown = new RuntimeException(msg, ex);
+            if (event.getException() != null) {
+                rethrown.addSuppressed(event.getException());
+            }
+            throw rethrown;
         } finally {
             if (eventType == InstanceEvent.EventType.AFTER_DESTROY_EVENT) {
                 if (tm != null) {

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -175,7 +175,7 @@ public class InvocationManagerImpl implements InvocationManager {
 
         Iterator<ComponentInvocation> iter = frames.descendingIterator();
         if (!iter.hasNext()) {
-            throw new InvocationException();
+            throw new InvocationException("No invocation on invocation stack. Expected invocation: " + invocation);
         }
 
         ComponentInvocation current = iter.next(); // the last is the current is "invocation"

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -902,6 +902,12 @@ Parent is ${project.parent}</echo>
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.0.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>


### PR DESCRIPTION
## Description

In certain build environment we were hitting following exception:

```
java.lang.RuntimeException: Exception during processing of event of type AFTER_FILTER_EVENT for web module StandardEngine[glassfish-web].StandardHost[server].StandardContext/1bbf5b4d-c5b2-4d17-90f9-0c21032d50fe
at com.sun.web.server.J2EEInstanceListener.handleAfterEvent(J2EEInstanceListener.java:321)
at com.sun.web.server.J2EEInstanceListener.instanceEvent(J2EEInstanceListener.java:113)
at org.apache.catalina.util.InstanceSupport.fireInstanceEvent(InstanceSupport.java:317)
at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:260)
at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:211)
at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:257)
at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:161)
at org.apache.catalina.core.StandardPipeline.doInvoke(StandardPipeline.java:757)
at org.apache.catalina.core.StandardPipeline.invoke(StandardPipeline.java:577)
at com.sun.enterprise.web.WebPipeline.invoke(WebPipeline.java:99)
at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:158)
at org.apache.catalina.connector.CoyoteAdapter.doService(CoyoteAdapter.java:371)
at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:238)
at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:182)
at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:156)
at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:218)
at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:524)
at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:89)
at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:94)
at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$100(WorkerThreadIOStrategy.java:33)
at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:114)
at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: org.glassfish.api.invocation.InvocationException
at org.glassfish.api.invocation.InvocationManagerImpl.postInvoke(InvocationManagerImpl.java:178)
at com.sun.web.server.J2EEInstanceListener.handleAfterEvent(J2EEInstanceListener.java:317)
... 31 more
```

The stacktrace reveals two things
* We have no idea what was reason for root `InvocationException`
* The exception that originally caused invocation to fail was superseded by the invocation exception above

The change adds an explanation to root invocation exception along with `ComponentInvocation` that the caller expected to be on top. `J2EEInstanceListener` will pass the original exception as supressed should this situation occur again.

(Un)fortunately, the build started passing after we tried it with these changes, apparently the timing of CI environment changed.

Also included in this change is stability fix for `ConcurrentGaugeInterceptorTest`, instead of fixed `Thread.sleep`s it now uses awaitility to poll until expected result is obtained (or timeout).

## Testing

### Testing Performed
* Build of Payara Micro for testing `microprofile-metrics` change (the test was unstable on windows)
* Build of related project on Github CI (the condition for FISH-260 was not triggered)

### Testing Environment
Windows 10, OpenJDK Runtime Environment (Zulu 8.46.0.19-CA-win64) (build 1.8.0_252-b14), Maven 3.6.3 (QACI-296)
Ubuntu 18.04.4 LTS, AdoptOpenJDK 11 something (not logged), Maven 3.6.3 (FISH-260)
