### PR TITLE
FISH-162 OpenAPI Class Data Processing

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -196,27 +196,27 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
     public OpenAPI getDocument() throws OpenAPIBuildException {
         if (mappings.isEmpty() || !isEnabled()) {
             return null;
-        } else if (mappings.size() == 1) {
+        }
+        if (mappings.size() == 1) {
             OpenAPI document = mappings.peekLast().getDocument();
-            if(document == null) {
-               document = mappings.peekLast().buildDocument();
+            if (document == null) {
+                document = mappings.peekLast().buildDocument();
             }
             return document;
-        } else {
-            List<OpenAPI> docs = new ArrayList<>();
-            for (OpenApiMapping mapping : mappings) {
-                if(mapping.getDocument() == null) {
-                    allDocuments = null;
-                    mapping.buildDocument();
-                }
-                docs.add(mapping.getDocument());
-            }
-            if(allDocuments == null) {
-                allDocuments = new OpenAPIImpl();
-                OpenAPIImpl.merge(allDocuments, docs, true);
-            }
-            return allDocuments;
         }
+        List<OpenAPI> docs = new ArrayList<>();
+        for (OpenApiMapping mapping : mappings) {
+            if (mapping.getDocument() == null) {
+                allDocuments = null;
+                mapping.buildDocument();
+            }
+            docs.add(mapping.getDocument());
+        }
+        if (allDocuments == null) {
+            allDocuments = new OpenAPIImpl();
+            OpenAPIImpl.merge(allDocuments, docs, true);
+        }
+        return allDocuments;
     }
 
     /**

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -60,7 +60,6 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -70,7 +69,6 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ServerEnvironment;
-import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.Events;
 import org.glassfish.grizzly.config.dom.NetworkListener;
@@ -91,9 +89,9 @@ import org.jvnet.hk2.config.ConfigListener;
 import org.jvnet.hk2.config.ConfigSupport;
 import org.jvnet.hk2.config.NotProcessed;
 import org.jvnet.hk2.config.UnprocessedChangeEvents;
-
 import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toSet;
+import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.hk2.classmodel.reflect.Type;
 
 @Service(name = "microprofile-openapi-service")
@@ -101,6 +99,8 @@ import org.glassfish.hk2.classmodel.reflect.Type;
 public class OpenApiService implements PostConstruct, PreDestroy, EventListener, ConfigListener {
 
     private static final Logger LOGGER = Logger.getLogger(OpenApiService.class.getName());
+
+    private OpenAPI allDocuments;
 
     private Deque<OpenApiMapping> mappings;
 
@@ -174,12 +174,14 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
             if (isValidApp(appInfo)) {
                 // Store the application mapping in the list
                 mappings.add(new OpenApiMapping(appInfo));
+                allDocuments = null;
             }
         } else if (event.is(Deployment.APPLICATION_UNLOADED)) {
             ApplicationInfo appInfo = (ApplicationInfo) event.hook();
             for (OpenApiMapping mapping : mappings) {
                 if (mapping.getAppInfo().equals(appInfo)) {
                     mappings.remove(mapping);
+                    allDocuments = null;
                     break;
                 }
             }
@@ -187,15 +189,34 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
     }
 
     /**
-     * @return the document for the most recently deployed application. Creates
-     * one if it hasn't already been created.
+     * @return the document If multiple application deployed then merge all the
+     * documents. Creates one if it hasn't already been created.
      * @throws OpenAPIBuildException if creating the document failed.
      */
     public OpenAPI getDocument() throws OpenAPIBuildException {
         if (mappings.isEmpty() || !isEnabled()) {
             return null;
+        } else if (mappings.size() == 1) {
+            OpenAPI document = mappings.peekLast().getDocument();
+            if(document == null) {
+               document = mappings.peekLast().buildDocument();
+            }
+            return document;
+        } else {
+            List<OpenAPI> docs = new ArrayList<>();
+            for (OpenApiMapping mapping : mappings) {
+                if(mapping.getDocument() == null) {
+                    allDocuments = null;
+                    mapping.buildDocument();
+                }
+                docs.add(mapping.getDocument());
+            }
+            if(allDocuments == null) {
+                allDocuments = new OpenAPIImpl();
+                OpenAPIImpl.merge(allDocuments, docs, true);
+            }
+            return allDocuments;
         }
-        return mappings.peekLast().getDocument();
     }
 
     /**
@@ -240,34 +261,31 @@ public class OpenApiService implements PostConstruct, PreDestroy, EventListener,
         }
 
         private synchronized OpenAPI getDocument() throws OpenAPIBuildException {
-            if (document == null) {
-                document = buildDocument();
-            }
             return document;
         }
 
         private OpenAPI buildDocument() throws OpenAPIBuildException {
-            OpenAPI openapi = new OpenAPIImpl();
+            document = new OpenAPIImpl();
 
             try {
                 String contextRoot = getContextRoot(appInfo);
                 List<URL> baseURLs = getServerURL(contextRoot);
 
-                openapi = new ModelReaderProcessor().process(openapi, appConfig);
-                openapi = new FileProcessor(appInfo.getAppClassLoader()).process(openapi, appConfig);
-                openapi = new ApplicationProcessor(
+                document = new ModelReaderProcessor().process(document, appConfig);
+                document = new FileProcessor(appInfo.getAppClassLoader()).process(document, appConfig);
+                document = new ApplicationProcessor(
                         appInfo.getTypes(),
                         filterTypes(appInfo, appConfig),
                         appInfo.getAppClassLoader()
-                ).process(openapi, appConfig);
-                openapi = new BaseProcessor(baseURLs).process(openapi, appConfig);
-                openapi = new FilterProcessor().process(openapi, appConfig);
+                ).process(document, appConfig);
+                document = new BaseProcessor(baseURLs).process(document, appConfig);
+                document = new FilterProcessor().process(document, appConfig);
             } catch (Throwable t) {
                 throw new OpenAPIBuildException(t);
             }
 
             LOGGER.info("OpenAPI document created.");
-            return openapi;
+            return document;
         }
 
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -46,6 +46,7 @@ import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.openapi.models.Components;
@@ -220,10 +221,18 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
         this.components = components;
     }
 
+    public static OpenAPI merge(OpenAPI parent, List<OpenAPI> children, boolean override) {
+        for (OpenAPI child : children) {
+            OpenAPIImpl.merge(child, parent, override, null);
+        }
+        return parent;
+    }
+
     public static void merge(OpenAPI from, OpenAPI to, boolean override, ApiContext context) {
         if (from == null) {
             return;
         }
+        to.setOpenapi(mergeProperty(to.getOpenapi(), from.getOpenapi(), override));
         // Handle @Info
         if (from.getInfo() != null) {
             if (to.getInfo() == null) {
@@ -277,6 +286,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
         }
         // Handle @Components
         ComponentsImpl.merge(from.getComponents(), to.getComponents(), override, context);
+        PathsImpl.merge(from.getPaths(), to.getPaths(), override);
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
@@ -70,7 +70,7 @@ public class SecuritySchemeImpl extends ExtensibleImpl<SecurityScheme> implement
             from.setType(SecurityScheme.Type.valueOf(type.getValue()));
         }
         from.setDescription(annotation.getValue("description", String.class));
-        from.setName(annotation.getValue("securitySchemeName", String.class));
+        from.setName(annotation.getValue("apiKeyName", String.class));
         String ref = annotation.getValue("ref", String.class);
         if (ref != null && !ref.isEmpty()) {
             from.setRef(ref);
@@ -86,7 +86,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl<SecurityScheme> implement
             from.setFlows(OAuthFlowsImpl.createInstance(flowsAnnotation));
         }
         from.setOpenIdConnectUrl(annotation.getValue("openIdConnectUrl", String.class));
-        from.setApiKeyName(annotation.getValue("apiKeyName", String.class));
         return from;
     }
 
@@ -183,14 +182,6 @@ public class SecuritySchemeImpl extends ExtensibleImpl<SecurityScheme> implement
         this.ref = ref;
     }
 
-    public String getApiKeyName() {
-        return apiKeyName;
-    }
-
-    public void setApiKeyName(String apiKeyName) {
-        this.apiKeyName = apiKeyName;
-    }
-
     public static void merge(SecurityScheme from, SecurityScheme to, boolean override) {
         if (from == null) {
             return;
@@ -201,10 +192,7 @@ public class SecuritySchemeImpl extends ExtensibleImpl<SecurityScheme> implement
             return;
         }
 
-        if (from instanceof SecuritySchemeImpl) {
-            to.setName(mergeProperty(to.getName(), ((SecuritySchemeImpl) from).getApiKeyName(), override));
-        }
-
+        to.setName(mergeProperty(to.getName(), from.getName(), override));
         to.setDescription(mergeProperty(to.getDescription(), from.getDescription(), override));
         to.setScheme(mergeProperty(to.getScheme(), from.getScheme(), override));
         to.setBearerFormat(mergeProperty(to.getBearerFormat(), from.getBearerFormat(), override));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -41,11 +41,9 @@ package fish.payara.microprofile.openapi.impl.model.util;
 
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.OperationImpl;
-import fish.payara.microprofile.openapi.impl.visitor.OpenApiContext;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -54,7 +52,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import javax.inject.Inject;
@@ -82,6 +79,7 @@ import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.PathItem.HttpMethod;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
+import org.glassfish.hk2.classmodel.reflect.AnnotatedElement;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 import org.glassfish.hk2.classmodel.reflect.ClassModel;
 import org.glassfish.hk2.classmodel.reflect.MethodModel;
@@ -598,57 +596,6 @@ public final class ModelUtils {
                 }
             }
         }
-    }
-
-    public static org.eclipse.microprofile.openapi.models.Operation getOperation(
-            MethodModel method,
-            OpenAPI api,
-            Map<String, Set<Type>> resourceMapping) {
-        String path = getResourcePath(method, resourceMapping);
-        if (path != null) {
-            PathItem pathItem = api.getPaths().getPathItem(path);
-            if (pathItem != null) {
-                PathItem.HttpMethod httpMethod = getHttpMethod(method);
-                return pathItem.getOperations().get(httpMethod);
-            }
-        }
-        return null;
-    }
-
-    public static String getResourcePath(Type declaration, Map<String, Set<Type>> resourceMapping) {
-        if (declaration instanceof MethodModel) {
-            return getResourcePath((MethodModel) declaration, resourceMapping);
-        } else if (declaration instanceof ClassModel) {
-            return getResourcePath((ClassModel) declaration, resourceMapping);
-        }
-        return null;
-    }
-
-    public static String getResourcePath(ClassModel clazz, Map<String, Set<Type>> resourceMapping) {
-        // If the class is a resource and contains a mapping
-        AnnotationInfo annotations = AnnotationInfo.valueOf(clazz);
-        if (annotations.isAnnotationPresent(Path.class)) {
-            for (Map.Entry<String, Set<Type>> entry : resourceMapping.entrySet()) {
-                if (entry.getValue() != null && entry.getValue().contains(clazz)) {
-                    return normaliseUrl(entry.getKey() + "/" + annotations.getAnnotationValue(Path.class));
-                }
-            }
-        }
-        return null;
-    }
-
-    public static String getResourcePath(MethodModel method, Map<String, Set<Type>> resourceMapping) {
-        AnnotationInfo annotations = AnnotationInfo.valueOf(method.getDeclaringType());
-        if (annotations.isAnyAnnotationPresent(method,
-                GET.class, POST.class, PUT.class, DELETE.class, HEAD.class, OPTIONS.class, PATCH.class)) {
-            if (annotations.isAnnotationPresent(Path.class, method)) {
-                // If the method is a valid resource
-                return normaliseUrl(getResourcePath(method.getDeclaringType(), resourceMapping) + "/"
-                        + annotations.getAnnotationValue(Path.class, method));
-            }
-            return normaliseUrl(getResourcePath(method.getDeclaringType(), resourceMapping));
-        }
-        return null;
     }
 
     public static String getSimpleName(String fqn) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -1077,6 +1077,8 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
                         visitSchema(schemaAnnotation, referenceClass, context);
                     } else if(referenceClassType instanceof ClassModel) {
                         apiWalker.processAnnotation((ClassModel)referenceClassType, this);
+                    } else {
+                        LOGGER.log(FINE, "Unrecognised schema {0} class found.", new Object[]{referenceClassName});
                     }
                 }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -42,7 +42,6 @@ package fish.payara.microprofile.openapi.impl.processor;
 import fish.payara.microprofile.openapi.api.processor.OASProcessor;
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor;
-import fish.payara.microprofile.openapi.api.visitor.ApiWalker;
 import fish.payara.microprofile.openapi.impl.config.OpenApiConfiguration;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.ExternalDocumentationImpl;
@@ -64,26 +63,17 @@ import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.AnnotationInfo;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import fish.payara.microprofile.openapi.impl.visitor.OpenApiWalker;
-import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import static java.util.Collections.singleton;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.logging.Level;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import static java.util.stream.Collectors.toSet;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -97,7 +87,6 @@ import org.eclipse.microprofile.openapi.models.media.MediaType;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.Style;
-import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.hk2.classmodel.reflect.AnnotatedElement;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 import org.glassfish.hk2.classmodel.reflect.ClassModel;
@@ -107,7 +96,6 @@ import org.glassfish.hk2.classmodel.reflect.FieldModel;
 import org.glassfish.hk2.classmodel.reflect.MethodModel;
 import org.glassfish.hk2.classmodel.reflect.Type;
 import org.glassfish.hk2.classmodel.reflect.Types;
-import org.glassfish.internal.data.ApplicationInfo;
 
 /**
  * A processor to parse the application for annotations, to add to the OpenAPI
@@ -1087,8 +1075,8 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
                     // Create the schema
                     if (context.isAllowedType(referenceClassType)) {
                         visitSchema(schemaAnnotation, referenceClass, context);
-                    } else {
-                        apiWalker.processAnnotations(singleton(referenceClassType), Schema.class, this::visitSchema);
+                    } else if(referenceClassType instanceof ClassModel) {
+                        apiWalker.processAnnotation((ClassModel)referenceClassType, this);
                     }
                 }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
@@ -40,32 +40,64 @@
 package fish.payara.microprofile.openapi.impl.visitor;
 
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
+import fish.payara.microprofile.openapi.impl.model.util.AnnotationInfo;
+import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import static java.util.logging.Level.WARNING;
+import java.util.logging.Logger;
+import static java.util.stream.Collectors.toSet;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.PATCH;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.glassfish.hk2.classmodel.reflect.AnnotatedElement;
+import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
+import org.glassfish.hk2.classmodel.reflect.ClassModel;
+import org.glassfish.hk2.classmodel.reflect.MethodModel;
 import org.glassfish.hk2.classmodel.reflect.Type;
 import org.glassfish.hk2.classmodel.reflect.Types;
 
 public class OpenApiContext implements ApiContext {
 
     private final Types allTypes;
-    private ClassLoader appClassLoader;
+    private final ClassLoader appClassLoader;
     private final OpenAPI api;
-    private final String path;
-    private final Operation operation;
     private final Set<Type> allowedTypes;
+    private final Map<String, Set<Type>> resourceMapping;
+    private String path;
+    private Operation operation;
+    private AnnotatedElement annotatedElement;
 
-    public OpenApiContext(Types allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader, OpenAPI api, String path, Operation operation) {
+    private static final Logger LOGGER = Logger.getLogger(OpenApiContext.class.getName());
+
+    public OpenApiContext(Types allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader, OpenAPI api) {
         this.allTypes = allTypes;
         this.allowedTypes = allowedTypes;
         this.api = api;
-        this.path = path;
-        this.operation = operation;
         this.appClassLoader = appClassLoader;
+        this.resourceMapping = generateResourceMapping();
     }
 
-    public OpenApiContext(Types allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader, OpenAPI api, String path) {
-        this(allTypes, allowedTypes, appClassLoader, api, path, null);
+    public OpenApiContext(OpenApiContext parentApiContext, AnnotatedElement annotatedElement) {
+        this.allTypes = parentApiContext.allTypes;
+        this.allowedTypes = parentApiContext.allowedTypes;
+        this.api = parentApiContext.api;
+        this.appClassLoader = parentApiContext.appClassLoader;
+        this.resourceMapping = parentApiContext.resourceMapping;
+        this.annotatedElement = annotatedElement;
     }
 
     @Override
@@ -75,14 +107,21 @@ public class OpenApiContext implements ApiContext {
 
     @Override
     public String getPath() {
+        if (path == null) {
+            path = getResourcePath(annotatedElement);
+        }
         return path;
     }
 
     @Override
     public Operation getWorkingOperation() {
+        if (operation == null && annotatedElement instanceof MethodModel) {
+            operation = getOperation((MethodModel) annotatedElement);
+        }
         return operation;
     }
 
+    @Override
     public boolean isAllowedType(Type type) {
         return allowedTypes.contains(type);
     }
@@ -100,5 +139,104 @@ public class OpenApiContext implements ApiContext {
     @Override
     public ClassLoader getApplicationClassLoader() {
         return appClassLoader;
+    }
+
+    /**
+     * Generates a map listing the location each resource class is mapped to.
+     */
+    private Map<String, Set<Type>> generateResourceMapping() {
+        Set<Type> classList = new HashSet<>();
+        Map<String, Set<Type>> mapping = new HashMap<>();
+        for (Type type : allowedTypes) {
+            if (type instanceof ClassModel) {
+                ClassModel classModel = (ClassModel) type;
+                if (classModel.getAnnotation(ApplicationPath.class.getName()) != null) {
+                    // Produce the mapping
+                    AnnotationModel annotation = classModel.getAnnotation(ApplicationPath.class.getName());
+                    String key = annotation.getValue("value", String.class);
+                    Set<Type> resourceClasses = new HashSet<>();
+                    mapping.put(key, resourceClasses);
+                    try {
+                        Class<?> clazz = appClassLoader.loadClass(classModel.getName());
+                        Application app = (Application) clazz.newInstance();
+                        // Add all classes contained in the application
+                        resourceClasses.addAll(app.getClasses()
+                                .stream()
+                                .map(Class::getName)
+                                .filter(name -> !name.startsWith("org.glassfish.jersey")) // Remove all Jersey providers
+                                .map(allTypes::getBy)
+                                .filter(Objects::nonNull)
+                                .collect(toSet()));
+                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+                        LOGGER.log(WARNING, "Unable to initialise application class.", ex);
+                    }
+                } else {
+                    classList.add(classModel);
+                }
+            }
+        }
+
+        // If there is one application and it's empty, add all classes
+        if (mapping.keySet().size() == 1) {
+            Set<Type> classes = mapping.values().iterator().next();
+            if (classes.isEmpty()) {
+                classes.addAll(classList);
+            }
+        }
+
+        // If there is no application, add all classes to the context root.
+        if (mapping.isEmpty()) {
+            mapping.put("/", classList);
+        }
+
+        return mapping;
+    }
+
+    private org.eclipse.microprofile.openapi.models.Operation getOperation(MethodModel method) {
+        String resourcePath = getResourcePath(method);
+        if (resourcePath != null) {
+            PathItem pathItem = api.getPaths().getPathItem(resourcePath);
+            if (pathItem != null) {
+                PathItem.HttpMethod httpMethod = ModelUtils.getHttpMethod(method);
+                return pathItem.getOperations().get(httpMethod);
+            }
+        }
+        return null;
+    }
+
+    private String getResourcePath(AnnotatedElement declaration) {
+        if (declaration instanceof MethodModel) {
+            return getResourcePath((MethodModel) declaration);
+        } else if (declaration instanceof ClassModel) {
+            return getResourcePath((ClassModel) declaration);
+        }
+        return null;
+    }
+
+    private String getResourcePath(ClassModel clazz) {
+        // If the class is a resource and contains a mapping
+        AnnotationInfo annotations = AnnotationInfo.valueOf(clazz);
+        if (annotations.isAnnotationPresent(Path.class)) {
+            for (Map.Entry<String, Set<Type>> entry : resourceMapping.entrySet()) {
+                if (entry.getValue() != null && entry.getValue().contains(clazz)) {
+                    return ModelUtils.normaliseUrl(entry.getKey() + "/" + annotations.getAnnotationValue(Path.class));
+                }
+            }
+        }
+        return null;
+    }
+
+    private String getResourcePath(MethodModel method) {
+        AnnotationInfo annotations = AnnotationInfo.valueOf(method.getDeclaringType());
+        if (annotations.isAnyAnnotationPresent(method,
+                GET.class, POST.class, PUT.class, DELETE.class, HEAD.class, OPTIONS.class, PATCH.class)) {
+            if (annotations.isAnnotationPresent(Path.class, method)) {
+                // If the method is a valid resource
+                return ModelUtils.normaliseUrl(getResourcePath(method.getDeclaringType()) + "/"
+                        + annotations.getAnnotationValue(Path.class, method));
+            }
+            return ModelUtils.normaliseUrl(getResourcePath(method.getDeclaringType()));
+        }
+        return null;
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -39,25 +39,17 @@
  */
 package fish.payara.microprofile.openapi.impl.visitor;
 
-import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor.VisitorFunction;
 import fish.payara.microprofile.openapi.api.visitor.ApiWalker;
 import fish.payara.microprofile.openapi.impl.model.util.AnnotationInfo;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.getOperation;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.getResourcePath;
 import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
-import static java.util.logging.Level.WARNING;
-import java.util.logging.Logger;
-import static java.util.stream.Collectors.toSet;
-import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.DELETE;
@@ -72,7 +64,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Application;
 import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -104,211 +95,161 @@ import org.glassfish.hk2.classmodel.reflect.Type;
 import org.glassfish.hk2.classmodel.reflect.Types;
 
 /**
- * A walker that visits each annotation and passes it to the visitor.
+ * A walker that visits each filtered class type & it's members, scans for
+ * OpenAPI annotations and passes it to the visitor.
  */
-public class OpenApiWalker implements ApiWalker {
+public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
 
-    private static final Logger LOGGER = Logger.getLogger(OpenApiWalker.class.getName());
-
-    private final OpenAPI api;
-    private final Types allTypes;
     private final Set<Type> allowedTypes;
-    private final Map<String, Set<Type>> resourceMapping;
-    private final ClassLoader appClassLoader;
+    private final OpenApiContext context;
+
+    private Map<Class<? extends Annotation>, VisitorFunction<AnnotationModel, E>> annotationVisitor;
+    private Map<Class<? extends Annotation>, Class<? extends Annotation>> annotationAlternatives;
 
     public OpenApiWalker(OpenAPI api, Types allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader) {
-        this.api = api;
-        this.allTypes = allTypes;
         this.allowedTypes = new TreeSet<>(Comparator.comparing(Type::getName, String::compareTo));
         this.allowedTypes.addAll(allowedTypes);
-        this.appClassLoader = appClassLoader;
-        this.resourceMapping = generateResourceMapping();
+        this.context = new OpenApiContext(allTypes, this.allowedTypes, appClassLoader, api);
     }
 
     @Override
     public void accept(ApiVisitor visitor) {
-        processAnnotations(allowedTypes, visitor);
-    }
-
-    public void processAnnotations(Set<Type> types, ApiVisitor visitor) {
-        // OpenAPI necessary annotations
-        processAnnotations(types, OpenAPIDefinition.class, visitor::visitOpenAPI);
-
-        // JAX-RS methods
-        processAnnotations(types, GET.class, visitor::visitGET);
-        processAnnotations(types, POST.class, visitor::visitPOST);
-        processAnnotations(types, PUT.class, visitor::visitPUT);
-        processAnnotations(types, DELETE.class, visitor::visitDELETE);
-        processAnnotations(types, HEAD.class, visitor::visitHEAD);
-        processAnnotations(types, OPTIONS.class, visitor::visitOPTIONS);
-        processAnnotations(types, PATCH.class, visitor::visitPATCH);
-
-        // JAX-RS parameters
-        processAnnotations(types, QueryParam.class, visitor::visitQueryParam);
-        processAnnotations(types, PathParam.class, visitor::visitPathParam);
-        processAnnotations(types, HeaderParam.class, visitor::visitHeaderParam);
-        processAnnotations(types, CookieParam.class, visitor::visitCookieParam);
-        processAnnotations(types, FormParam.class, visitor::visitFormParam);
-
-        // All other OpenAPI annotations
-        processAnnotations(types, Schema.class, visitor::visitSchema);
-        processAnnotations(types, Server.class, visitor::visitServer, Servers.class);
-        processAnnotations(types, Servers.class, visitor::visitServers, Server.class);
-        processAnnotations(types, Extensions.class, visitor::visitExtensions, Extension.class);
-        processAnnotations(types, Extension.class, visitor::visitExtension, Extensions.class);
-        processAnnotations(types, Operation.class, visitor::visitOperation);
-        processAnnotations(types, Callback.class, visitor::visitCallback, Callbacks.class);
-        processAnnotations(types, Callbacks.class, visitor::visitCallbacks, Callback.class);
-        processAnnotations(types, APIResponse.class, visitor::visitAPIResponse, APIResponses.class);
-        processAnnotations(types, APIResponses.class, visitor::visitAPIResponses, APIResponse.class);
-        processAnnotations(types, Parameters.class, visitor::visitParameters, Parameter.class);
-        processAnnotations(types, Parameter.class, visitor::visitParameter, Parameters.class);
-        processAnnotations(types, ExternalDocumentation.class, visitor::visitExternalDocumentation);
-        processAnnotations(types, Tag.class, visitor::visitTag, Tags.class);
-        processAnnotations(types, Tags.class, visitor::visitTags, Tag.class);
-        processAnnotations(types, SecurityScheme.class, visitor::visitSecurityScheme, SecuritySchemes.class);
-        processAnnotations(types, SecuritySchemes.class, visitor::visitSecuritySchemes, SecurityScheme.class);
-        processAnnotations(types, SecurityRequirement.class, visitor::visitSecurityRequirement, SecurityRequirements.class);
-        processAnnotations(types, SecurityRequirements.class, visitor::visitSecurityRequirements, SecurityRequirement.class);
-
-        // JAX-RS response types
-        processAnnotations(types, Produces.class, visitor::visitProduces);
-        processAnnotations(types, Consumes.class, visitor::visitConsumes);
-
-        // OpenAPI response types
-        processAnnotations(types, RequestBody.class, visitor::visitRequestBody);
-        //redo schema, now all others have been to ensure sub-schemas work
-        processAnnotations(types, Schema.class, visitor::visitSchema);
-    }
-
-    @SafeVarargs
-    public final <A extends Annotation, E extends AnnotatedElement> void processAnnotations(
-            Set<Type> types,
-            Class<A> annotationClass,
-            VisitorFunction<AnnotationModel, E> annotationFunction,
-            Class<? extends Annotation>... alternatives) {
-
-        for (Type type : types) {
+        for (Type type : allowedTypes) {
             if (type instanceof ClassModel) {
-                processAnnotation((ClassModel) type, annotationClass, annotationFunction, alternatives);
+                processAnnotation((ClassModel) type, visitor);
             }
         }
     }
 
-    @SafeVarargs
-    private final <A extends Annotation, E extends AnnotatedElement> void processAnnotation(
-            ClassModel annotatedClass, Class<A> annotationClass, VisitorFunction<AnnotationModel, E> annotationFunction,
-            Class<? extends Annotation>... alternatives) {
+    public final void processAnnotation(ClassModel annotatedClass, ApiVisitor visitor) {
         AnnotationInfo annotations = AnnotationInfo.valueOf(annotatedClass);
-        processAnnotation(annotatedClass, annotationClass, annotationFunction, annotations,
-                new OpenApiContext(allTypes, allowedTypes, appClassLoader, api, getResourcePath(annotatedClass, resourceMapping)), alternatives);
+        processAnnotation((E) annotatedClass, annotations, visitor, new OpenApiContext(context, annotatedClass));
+
+        for (final MethodModel method : annotatedClass.getMethods()) {
+            processAnnotation((E) method, annotations, visitor, new OpenApiContext(context, method));
+        }
 
         for (final FieldModel field : annotatedClass.getFields()) {
-            if (annotations.isAnnotationPresent(annotationClass, field)) {
-                if (annotationClass == HeaderParam.class
-                        || annotationClass == CookieParam.class
-                        || annotationClass == PathParam.class
-                        || annotationClass == QueryParam.class) {
-                    // NB. if fields are annotated as Param all methods have it
-                    for (MethodModel method : annotatedClass.getMethods()) {
-                        OpenApiContext context = new OpenApiContext(allTypes, allowedTypes, appClassLoader, api,
-                                getResourcePath(method, resourceMapping),
-                                getOperation(method, api, resourceMapping));
-                        if (context.getWorkingOperation() != null) {
-                            processAnnotation(field, annotationClass, annotationFunction, annotations, context,
-                                    alternatives);
-                        }
-                    }
-                } else {
-                    processAnnotation(field, annotationClass, annotationFunction, annotations,
-                            new OpenApiContext(allTypes, allowedTypes, appClassLoader, api, null), alternatives);
-                }
-            }
+            processAnnotation((E) field, annotations, visitor, new OpenApiContext(context, field));
         }
 
         for (final MethodModel method : annotatedClass.getMethods()) {
-            OpenApiContext context = new OpenApiContext(allTypes, allowedTypes, appClassLoader, api,
-                    getResourcePath(method, resourceMapping),
-                    getOperation(method, api, resourceMapping));
-            processAnnotation(method, annotationClass, annotationFunction, annotations, context, alternatives);
-
             for (org.glassfish.hk2.classmodel.reflect.Parameter parameter : method.getParameters()) {
-                processAnnotation(parameter, annotationClass, annotationFunction, annotations, context, alternatives);
+                processAnnotation((E) parameter, annotations, visitor, new OpenApiContext(context, method));
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    @SafeVarargs
-    private static <A extends Annotation, E extends AnnotatedElement> void processAnnotation(
-            AnnotatedElement element,
-            Class<A> annotationClass,
-            VisitorFunction<AnnotationModel, E> annotationFunction,
-            AnnotationInfo annotations,
-            ApiContext context,
-            Class<? extends Annotation>... alternatives
-    ) {
-        // If it's just the one annotation class
-        // Check the element
-        if (annotations.isAnnotationPresent(annotationClass, element)) {
-            annotationFunction.apply(annotations.getAnnotation(annotationClass, element), (E) element, context);
-        } else if (element instanceof MethodModel && annotations.isAnnotationPresent(annotationClass)
-                && !annotations.isAnyAnnotationPresent(element, alternatives)) {
-            // If the method isn't annotated, inherit the class annotation
-            if (context.getPath() != null) {
-                annotationFunction.apply(annotations.getAnnotation(annotationClass), (E) element, context);
-            }
-        }
-    }
+    private void processAnnotation(E element, AnnotationInfo annotations, ApiVisitor visitor, OpenApiContext context) {
 
-    /**
-     * Generates a map listing the location each resource class is mapped to.
-     */
-    private Map<String, Set<Type>> generateResourceMapping() {
-        Set<Type> classList = new HashSet<>();
-        Map<String, Set<Type>> mapping = new HashMap<>();
-        for (Type type : allowedTypes) {
-            if(type instanceof ClassModel) {
-                ClassModel classModel = (ClassModel) type;
-                if(classModel.getAnnotation(ApplicationPath.class.getName()) != null) {
-                    // Produce the mapping
-                    AnnotationModel annotation = classModel.getAnnotation(ApplicationPath.class.getName());
-                    String key = annotation.getValue("value", String.class);
-                    Set<Type> resourceClasses = new HashSet<>();
-                    mapping.put(key, resourceClasses);
-                    try {
-                        Class<?> clazz = appClassLoader.loadClass(classModel.getName());
-                        Application app = (Application) clazz.newInstance();
-                        // Add all classes contained in the application
-                        resourceClasses.addAll(app.getClasses()
-                                .stream()
-                                .map(Class::getName)
-                                .filter(name -> !name.startsWith("org.glassfish.jersey")) // Remove all Jersey providers
-                                .map(allTypes::getBy)
-                                .filter(Objects::nonNull)
-                                .collect(toSet()));
-                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-                        LOGGER.log(WARNING, "Unable to initialise application class.", ex);
+        for (Class<? extends Annotation> annotationClass : getAnnotationVisitor(visitor).keySet()) {
+            VisitorFunction<AnnotationModel, E> annotationFunction = getAnnotationVisitor(visitor).get(annotationClass);
+            Class<? extends Annotation> alternative = getAnnotationAlternatives().get(annotationClass);
+            // If it's just the one annotation class
+            // Check the element
+            if (annotations.isAnnotationPresent(annotationClass, element)) {
+                if (element instanceof FieldModel
+                        && (annotationClass == HeaderParam.class
+                        || annotationClass == CookieParam.class
+                        || annotationClass == PathParam.class
+                        || annotationClass == QueryParam.class)) {
+                    FieldModel field = (FieldModel) element;
+                    // NB. if fields are annotated as Param all methods have it
+                    for (MethodModel method : field.getDeclaringType().getMethods()) {
+                        OpenApiContext methodContext = new OpenApiContext(context, method);
+                        if (methodContext.getWorkingOperation() != null) {
+                            annotationFunction.apply(annotations.getAnnotation(annotationClass, element), element, methodContext);
+                        }
                     }
                 } else {
-                    classList.add(classModel);
+                    annotationFunction.apply(annotations.getAnnotation(annotationClass, element), element, context);
+                }
+            } else if (element instanceof MethodModel && annotations.isAnnotationPresent(annotationClass)
+                    && (alternative == null || !annotations.isAnnotationPresent(alternative, element))) {
+                // If the method isn't annotated, inherit the class annotation
+                if (context.getPath() != null) {
+                    annotationFunction.apply(annotations.getAnnotation(annotationClass), element, context);
                 }
             }
         }
-
-        // If there is one application and it's empty, add all classes
-        if (mapping.keySet().size() == 1) {
-            Set<Type> classes = mapping.values().iterator().next();
-            if (classes.isEmpty()) {
-                classes.addAll(classList);
-            }
-        }
-
-        // If there is no application, add all classes to the context root.
-        if (mapping.isEmpty()) {
-            mapping.put("/", classList);
-        }
-
-        return mapping;
     }
+
+    private Map<Class<? extends Annotation>, VisitorFunction<AnnotationModel, E>> getAnnotationVisitor(ApiVisitor visitor) {
+        if (annotationVisitor == null) {
+            annotationVisitor = new LinkedHashMap<>();
+
+            // OpenAPI necessary annotations
+            annotationVisitor.put(OpenAPIDefinition.class, visitor::visitOpenAPI);
+
+            // JAX-RS methods
+            annotationVisitor.put(GET.class, (annot, element, con) -> visitor.visitGET(annot, (MethodModel) element, con));
+            annotationVisitor.put(POST.class, (annot, element, con) -> visitor.visitPOST(annot, (MethodModel) element, con));
+            annotationVisitor.put(PUT.class, (annot, element, con) -> visitor.visitPUT(annot, (MethodModel) element, con));
+            annotationVisitor.put(DELETE.class, (annot, element, con) -> visitor.visitDELETE(annot, (MethodModel) element, con));
+            annotationVisitor.put(HEAD.class, (annot, element, con) -> visitor.visitHEAD(annot, (MethodModel) element, con));
+            annotationVisitor.put(OPTIONS.class, (annot, element, con) -> visitor.visitOPTIONS(annot, (MethodModel) element, con));
+            annotationVisitor.put(PATCH.class, (annot, element, con) -> visitor.visitPATCH(annot, (MethodModel) element, con));
+
+            // JAX-RS parameters
+            annotationVisitor.put(QueryParam.class, visitor::visitQueryParam);
+            annotationVisitor.put(PathParam.class, visitor::visitPathParam);
+            annotationVisitor.put(HeaderParam.class, visitor::visitHeaderParam);
+            annotationVisitor.put(CookieParam.class, visitor::visitCookieParam);
+            annotationVisitor.put(FormParam.class, visitor::visitFormParam);
+
+            // All other OpenAPI annotations
+            annotationVisitor.put(Schema.class, visitor::visitSchema);
+            annotationVisitor.put(Server.class, visitor::visitServer);
+            annotationVisitor.put(Servers.class, visitor::visitServers);
+            annotationVisitor.put(Extensions.class, visitor::visitExtensions);
+            annotationVisitor.put(Extension.class, visitor::visitExtension);
+            annotationVisitor.put(Operation.class, visitor::visitOperation);
+            annotationVisitor.put(Callback.class, visitor::visitCallback);
+            annotationVisitor.put(Callbacks.class, visitor::visitCallbacks);
+            annotationVisitor.put(APIResponse.class, visitor::visitAPIResponse);
+            annotationVisitor.put(APIResponses.class, visitor::visitAPIResponses);
+            annotationVisitor.put(Parameters.class, visitor::visitParameters);
+            annotationVisitor.put(Parameter.class, visitor::visitParameter);
+            annotationVisitor.put(ExternalDocumentation.class, visitor::visitExternalDocumentation);
+            annotationVisitor.put(Tag.class, visitor::visitTag);
+            annotationVisitor.put(Tags.class, visitor::visitTags);
+            annotationVisitor.put(SecurityScheme.class, visitor::visitSecurityScheme);
+            annotationVisitor.put(SecuritySchemes.class, visitor::visitSecuritySchemes);
+            annotationVisitor.put(SecurityRequirement.class, visitor::visitSecurityRequirement);
+            annotationVisitor.put(SecurityRequirements.class, visitor::visitSecurityRequirements);
+
+            // JAX-RS response
+            annotationVisitor.put(Produces.class, visitor::visitProduces);
+            annotationVisitor.put(Consumes.class, visitor::visitConsumes);
+
+            // OpenAPI response
+            annotationVisitor.put(RequestBody.class, visitor::visitRequestBody);
+        }
+        return annotationVisitor;
+    }
+
+    private Map<Class<? extends Annotation>, Class<? extends Annotation>> getAnnotationAlternatives() {
+        if (annotationAlternatives == null) {
+            annotationAlternatives = new HashMap<>();
+            annotationAlternatives.put(Server.class, Servers.class);
+            annotationAlternatives.put(Servers.class, Server.class);
+            annotationAlternatives.put(Extensions.class, Extension.class);
+            annotationAlternatives.put(Extension.class, Extensions.class);
+            annotationAlternatives.put(Callback.class, Callbacks.class);
+            annotationAlternatives.put(Callbacks.class, Callback.class);
+            annotationAlternatives.put(APIResponse.class, APIResponses.class);
+            annotationAlternatives.put(APIResponses.class, APIResponse.class);
+            annotationAlternatives.put(Parameters.class, Parameter.class);
+            annotationAlternatives.put(Parameter.class, Parameters.class);
+            annotationAlternatives.put(Tag.class, Tags.class);
+            annotationAlternatives.put(Tags.class, Tag.class);
+            annotationAlternatives.put(SecurityScheme.class, SecuritySchemes.class);
+            annotationAlternatives.put(SecuritySchemes.class, SecurityScheme.class);
+            annotationAlternatives.put(SecurityRequirement.class, SecurityRequirements.class);
+            annotationAlternatives.put(SecurityRequirements.class, SecurityRequirement.class);
+        }
+        return annotationAlternatives;
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>


## Description
This is a feature that includes refactoring of OpenAPI implementation by scanning OpenAPI metadata per class and support of the merging of multiple OpenAPI documents created via the deployment of more than one application.


## Testing
### Testing Performed
Unit test
MP OpenAPI TCK Runner
Manually tested with 2 WARs

### Testing Environment
Windows 10, JDK 11.0


### Important Info
Merging document from multiple application works well for list attributes but attribute like 'info' is overridden by the document of last deployed application.