### PR TITLE
QACI-249 Revert "Exclude ServerLogTest"

### DIFF
--- a/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/ServerLogTest.java
+++ b/appserver/tests/payara-samples/samples/rest-management/src/test/java/fish/payara/samples/rest/management/ServerLogTest.java
@@ -44,12 +44,10 @@ import static org.junit.Assert.assertFalse;
 import java.util.Scanner;
 
 import org.junit.Test;
-import org.junit.Ignore;
 
 /**
  * Tests to run against the server log
  */
-@Ignore
 public class ServerLogTest extends RestManagementTest {
 
     /**


### PR DESCRIPTION
The warnings that failed ServerLogTest should be solved with FISH-31, which has been now merged.

Testing with this PR