### PR TITLE
FISH-45 Unable to resolve jackson-dataformat-xml due to wrong OSGI version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <jakarta.jws-api.version>1.1.1</jakarta.jws-api.version>
         <webservices.version>2.4.3.payara-p3</webservices.version>
         <woodstox.version>5.1.0</woodstox.version>
-        <stax2-api.version>4.1</stax2-api.version>
+        <stax2-api.version>4.2.1</stax2-api.version>
         <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>
         <jakarta.xml.rpc-api.version>1.1.4</jakarta.xml.rpc-api.version>
         <jakarta.resource-api.version>1.7.4</jakarta.resource-api.version>


### PR DESCRIPTION
## Description
Fixes https://github.com/payara/Payara/issues/4060 

## Testing

### Testing Performed
Tested with reproducer mentioned on the above issue.

### Testing Environment
Zulu JDK 1.8_222 on Elementary OS 0.4.1 Loki with Maven 3.5.4
