### PR TITLE
FISH-278 Update Docker Java Versions to 8u252

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -24,7 +24,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.java.tag>8u232</docker.java.tag>
+        <docker.java.tag>8u252</docker.java.tag>
         <docker.java.image>${docker.java.repository}:${docker.java.tag}</docker.java.image>
 
         <docker.payara.domainName>production</docker.payara.domainName>


### PR DESCRIPTION
Now that HTTP/2 support has been extended to 8u252, the Dockerfiles can
be updated to use this Java version.