### PR TITLE
FISH-240 Fix Classpath Exceptions in Samples

### DIFF
--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/pom.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/pom.xml
@@ -72,6 +72,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
             <scope>provided</scope>

--- a/appserver/tests/payara-samples/samples/jaxws-security/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-security/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
JDK11 seemed to throw random classpath related exceptions in a couple of projects. These dependencies seem to fix the problems.