### PR TITLE
Fix Cert Management Versions

### DIFF
--- a/appserver/extras/certificate-management/certificate-management-admin/pom.xml
+++ b/appserver/extras/certificate-management/certificate-management-admin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.extras.certificate-management</groupId>
         <artifactId>certificate-management-parent</artifactId>
-        <version>5.2020.3-SNAPSHOT</version>
+        <version>5.2020.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/extras/certificate-management/certificate-management-cli/pom.xml
+++ b/appserver/extras/certificate-management/certificate-management-cli/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.extras.certificate-management</groupId>
         <artifactId>certificate-management-parent</artifactId>
-        <version>5.2020.3-SNAPSHOT</version>
+        <version>5.2020.4-SNAPSHOT</version>
     </parent>
     <artifactId>certificate-management-cli</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/extras/certificate-management/certificate-management-common/pom.xml
+++ b/appserver/extras/certificate-management/certificate-management-common/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.extras.certificate-management</groupId>
         <artifactId>certificate-management-parent</artifactId>
-        <version>5.2020.3-SNAPSHOT</version>
+        <version>5.2020.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/extras/certificate-management/certificate-management-console-plugin/pom.xml
+++ b/appserver/extras/certificate-management/certificate-management-console-plugin/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.extras.certificate-management</groupId>
         <artifactId>certificate-management-parent</artifactId>
-        <version>5.2020.3-SNAPSHOT</version>
+        <version>5.2020.4-SNAPSHOT</version>
     </parent>
     <artifactId>certificate-management-console-plugin</artifactId>
     <packaging>glassfish-jar</packaging>


### PR DESCRIPTION
## Description
Cert Management was missed from the version increment, leading to failures when building with the `-PBuildExtras` profile.