### PR TITLE
FISH-289 Create JDK11 Docker images

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -24,8 +24,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.java.tag>8u232</docker.java.tag>
-        <docker.java.image>${docker.java.repository}:${docker.java.tag}</docker.java.image>
+        <docker.jdk8.tag>8u232</docker.jdk8.tag>
+        <docker.jdk11.tag>11.0.7</docker.jdk11.tag>
 
         <docker.payara.domainName>production</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>
@@ -67,6 +67,34 @@
             </activation>
             <build>
                 <plugins>
+                    <!-- Required until https://github.com/fabric8io/docker-maven-plugin/issues/859 is resolved -->
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>filter-dockerfiles</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk8">
+                                            <filterset>
+                                                <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk8.tag}"/>
+                                            </filterset>
+                                        </copy>
+                                        <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk11">
+                                            <filterset>
+                                                <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk11.tag}"/>
+                                                <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk11"/>
+                                            </filterset>
+                                        </copy>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
@@ -91,7 +119,25 @@
                                         </tags>
                                         <cleanup>none</cleanup>
                                         <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>Dockerfile</dockerFile>
+                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk8</dockerFile>
+                                        <assembly>
+                                            <mode>tar</mode>
+                                            <descriptor>assembly.xml</descriptor>
+                                            <tarLongFileMode>gnu</tarLongFileMode>
+                                        </assembly>
+                                    </build>
+                                </image>
+                                <image>
+                                    <name>${docker.payara.repository}</name>
+                                    <build>
+                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                        <filter>@</filter>
+                                        <tags>
+                                            <tag>${docker.payara.tag}-jdk11</tag>
+                                        </tags>
+                                        <cleanup>none</cleanup>
+                                        <noCache>${docker.noCache}</noCache>
+                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
                                         <assembly>
                                             <mode>tar</mode>
                                             <descriptor>assembly.xml</descriptor>


### PR DESCRIPTION
The JDK11 Docker images are currently built in a separate Maven lifecycle with a manual system property override. This change causes the Docker Maven plugin to generate a '-jdk11' version of each Docker image in the same lifecycle.