### PR TITLE
FISH-35 Payara Micro system property payaramicro.logPropertiesFile and payaramicro.enableAccessLog do not work

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -2206,7 +2206,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
         
         String userLogPropertiesFileStr = getProperty("payaramicro.logPropertiesFile");
-        if (userLogPropertiesFileStr  != null && !userLogPropertiesFileStr.isEmpty()) {
+        if (userLogPropertiesFileStr  != null && !userLogPropertiesFileStr.trim().isEmpty()) {
              setLogPropertiesFile(new File(userLogPropertiesFileStr));
         }
 

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -2204,6 +2204,11 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         if (alternateHZConfigFileStr != null && !alternateHZConfigFileStr.isEmpty()) {
             alternateHZConfigFile = new File(alternateHZConfigFileStr);
         }
+        
+        String userLogPropertiesFileStr = getProperty("payaramicro.logPropertiesFile");
+        if (userLogPropertiesFileStr  != null && !userLogPropertiesFileStr.isEmpty()) {
+             setLogPropertiesFile(new File(userLogPropertiesFileStr));
+        }
 
         autoBindHttp = getBooleanProperty("payaramicro.autoBindHttp");
         autoBindRange = getIntegerProperty("payaramicro.autoBindRange", 5);
@@ -2213,7 +2218,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         logToFile = getBooleanProperty("payaramicro.logToFile");
         userLogFile = getProperty("payaramicro.userLogFile");
         enableAccessLog = getBooleanProperty("payaramicro.enableAccessLog");
-        enableAccessLogFormat = getBooleanProperty("payaramicro.logPropertiesFile");
+        enableAccessLogFormat = getBooleanProperty("payaramicro.enableAccessLogFormat");
         enableDynamicLogging = getBooleanProperty("payaramicro.enableDynamicLogging");
         enableHealthCheck = getBooleanProperty("payaramicro.enableHealthCheck");
         httpPort = getIntegerProperty("payaramicro.port", Integer.MIN_VALUE);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Is this a bug fix to where you could not set `payaramicro.logPropertiesFile` and `payaramicro.enableAccessLogFormat` system property

Fixes: https://github.com/payara/Payara/issues/4428

## Testing
### Testing Performed
Run the command below:
- java -Dpayaramicro.logPropertiesFile=logging.properties -jar payara-micro.jar

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
