### PR TITLE
FISH-314 Enable TLS 1.3 on JDK 8u262

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -263,7 +263,7 @@
                 <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
                 <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
                 <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-                <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+                <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />
@@ -485,7 +485,7 @@
                 <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
                 <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
                 <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-                <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+                <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -258,7 +258,7 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />
@@ -476,7 +476,7 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -213,7 +213,7 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />
@@ -418,7 +418,7 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -236,7 +236,7 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />
@@ -435,7 +435,7 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2020] Payara Foundation and/or affiliates
 
 /*
  * UtilHandlers.java
@@ -1164,28 +1164,12 @@ public class UtilHandlers {
         return builder.toString();
     }
 
-    @Handler(id = "py.getJavaVendor",
+    @Handler(id = "py.isTls13Supported",
             output = {
-                @HandlerOutput(name = "javaVendor", type = String.class)}
+                @HandlerOutput(name = "result", type = Boolean.class)}
     )
-    public static void getJavaVendor(HandlerContext handlerCtx) {
-        handlerCtx.setOutputValue("javaVendor", JDK.getVendor());
-    }
-
-    @Handler(id = "py.getJdkMajorVersion",
-            output = {
-                @HandlerOutput(name = "jdkMajorVersion", type = Integer.class)}
-    )
-    public static void getJdkMajorVersion(HandlerContext handlerCtx) {
-        handlerCtx.setOutputValue("jdkMajorVersion", JDK.getMajor());
-    }
-
-    @Handler(id = "py.getJdkUpdateVersion",
-            output = {
-                @HandlerOutput(name = "jdkUpdateVersion", type = Integer.class)}
-    )
-    public static void getJdkUpdateVersion(HandlerContext handlerCtx) {
-        handlerCtx.setOutputValue("jdkUpdateVersion", JDK.getUpdate());
+    public static void isTls13Supported(HandlerContext handlerCtx) {
+        handlerCtx.setOutputValue("result", JDK.isTls13Supported() || JDK.isOpenJSSEFlagRequired());
     }
 
     private static final String PATH_SEPARATOR = "${path.separator}";

--- a/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
@@ -39,7 +39,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2019] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright [2018-2020] Payara Foundation and/or affiliates -->
 
 <!-- sslAttrs.inc -->
 
@@ -61,23 +61,8 @@
                 OtherCiphersList="#{requestScope.availableOther}"
                 EccCiphersList="#{requestScope.availableEcc}")
 
-        py.getJdkMajorVersion(jdkMajorVersion="#{requestScope.jdkMajorVersion}");
-        setPageSessionAttribute(key="showTLS13Prop", value="#{true}");
-        
-        if (#{requestScope.jdkMajorVersion}<$int{9}){
-            setPageSessionAttribute(key="showTLS13Prop", value="#{false}");
-            py.getJavaVendor(javaVendor="#{requestScope.javaVendor}");
-            setPageSessionAttribute(key="isVendorAzul", value="#{requestScope.javaVendor.contains('Azul')}");
-
-            if (#{pageSession.isVendorAzul}){
-                py.getJdkUpdateVersion(jdkUpdateVersion="#{requestScope.jdkUpdateVersion}");
-
-                if (#{requestScope.jdkUpdateVersion}>$int{221}){
-                    setPageSessionAttribute(key="showTLS13Prop", value="#{true}");
-                }
-
-            }
-        }
+        py.isTls13Supported(result="#{requestScope.isTls13Supported}");
+        setPageSessionAttribute(key="showTLS13Prop", value="#{requestScope.isTls13Supported}");
     />
      <!afterCreate
         getClientId(component="$this{component}" clientId=>$page{sheetId});

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -24,7 +24,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk8.tag>8u252</docker.jdk8.tag>
+        <docker.jdk8.tag>8u262</docker.jdk8.tag>
         <docker.jdk11.tag>11.0.7</docker.jdk11.tag>
 
         <docker.payara.domainName>production</docker.payara.domainName>

--- a/appserver/extras/embedded/all/src/main/resources/config/domain.xml
+++ b/appserver/extras/embedded/all/src/main/resources/config/domain.xml
@@ -246,7 +246,7 @@
                 <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
                 <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
                 <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-                <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+                <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
             </java-config>
             <network-config>
                 <protocols>

--- a/appserver/extras/embedded/web/src/main/resources/config/domain.xml
+++ b/appserver/extras/embedded/web/src/main/resources/config/domain.xml
@@ -239,7 +239,7 @@
                 <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
                 <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
                 <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-                <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+                <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
             </java-config>
             <network-config>
                 <protocols>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
@@ -205,7 +205,7 @@
         <jvm-options>[1.8.0u121|1.8.0u160]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.7.jar</jvm-options>
         <jvm-options>[1.8.0u161|1.8.0u190]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.jar</jvm-options>
         <jvm-options>[1.8.0u191|1.8.0u500]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
-        <jvm-options>[Azul-1.8.0u222|1.8.0u500]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
       </java-config>
       <network-config>
         <protocols>

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -38,24 +38,9 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.util;
-
-import com.sun.enterprise.util.JDK;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.Base64;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.glassfish.grizzly.config.dom.Ssl.TLS1;
@@ -63,16 +48,31 @@ import static org.glassfish.grizzly.config.dom.Ssl.TLS11;
 import static org.glassfish.grizzly.config.dom.Ssl.TLS12;
 import static org.glassfish.grizzly.config.dom.Ssl.TLS13;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+import com.sun.enterprise.util.JDK;
+
 
 public final class HttpConnectorAddress {
+
     static final String HTTP_CONNECTOR = "http";
     static final String HTTPS_CONNECTOR = "https";
     public static final String  AUTHORIZATION_KEY     = "Authorization";
     private static final String AUTHORIZATION_TYPE = "Basic ";
     private static final String DEFAULT_PROTOCOL = TLS12;
-    private static final String ZULU_JDK_VENDOR = "Azul";
-    private static final int MINIMUM_MAJOR_VERSION = 9;
-    private static final int MINIMUM_UPDATE_VERSION = 222;
 
     private String host;
     private int    port;
@@ -207,9 +207,8 @@ public final class HttpConnectorAddress {
                                         break;
 
                         case TLS13: protocol = TLS13;
-                                        if (JDK.getMajor() < MINIMUM_MAJOR_VERSION) {
-                                            if (JDK.getVendor().contains(ZULU_JDK_VENDOR) && 
-                                                    JDK.getUpdate() >= MINIMUM_UPDATE_VERSION) {
+                                        if (!JDK.isTls13Supported()) {
+                                            if (JDK.isOpenJSSEFlagRequired()) {
                                                 protocol = TLS13;
                                             } else {
                                                 protocol = DEFAULT_PROTOCOL;

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.util;
 
@@ -52,6 +52,28 @@ import java.util.Optional;
  * @author bnevins
  */
 public final class JDK {
+
+    private static final int TLS13_MINIMUM_MINOR_VERSION = 8;
+    private static final int TLS13_MINIMUM_UPDATE_VERSION = 261;
+
+    private static final String OPENJSSE_VENDOR = "Azul";
+    private static final int OPENJSSE_MINIMUM_UPDATE_VERSION = 222;
+    private static final int OPENJSSE_MAXIMUM_UPDATE_VERSION = 252;
+
+    public static boolean isTls13Supported() {
+        return getMinor() >= TLS13_MINIMUM_MINOR_VERSION
+            && getUpdate() >= TLS13_MINIMUM_UPDATE_VERSION;
+    }
+
+    public static boolean isOpenJSSEFlagRequired() {
+        final String vendor = getVendor();
+        final int updateVersion = getUpdate();
+        return vendor != null
+            && vendor.contains(OPENJSSE_VENDOR)
+            && updateVersion >= OPENJSSE_MINIMUM_UPDATE_VERSION
+            && updateVersion <= OPENJSSE_MAXIMUM_UPDATE_VERSION;
+    }
+
     /**
      * See if the current JDK is legal for running GlassFish
      * @return true if the JDK is >= 1.6.0


### PR DESCRIPTION
The -XX:+OpenJSSE flag is disabled for Zulu versions above 8u262 (as they now have native TLS 1.3 support).

TLS 1.3 option is now visible for 8u262+ as well.

Docker Zulu versions have been updated to avoid problems with TLS 1.3.