### PR TITLE
FISH-59 Payara Micro --enableRequestTracing argument not accepting values 

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -91,7 +91,7 @@ public enum RUNTIME_OPTION {
     accessloginterval(true),
     accesslogsuffix(true),
     accesslogprefix(true),
-    enablerequesttracing(false),
+    enablerequesttracing(true, new RequestTracingValidator(), true),
     requesttracingthresholdunit(true),
     requesttracingthresholdvalue(true),
     enablerequesttracingadaptivesampling(false),
@@ -114,13 +114,22 @@ public enum RUNTIME_OPTION {
     contextroot(true),
     warmup(false);
 
-    private RUNTIME_OPTION(boolean hasValue) {
+    RUNTIME_OPTION(boolean hasValue) {
         this(hasValue, new Validator());
     }
 
-    private RUNTIME_OPTION(boolean hasValue, Validator validator) {
+    RUNTIME_OPTION(boolean hasValue, boolean optionalValue) {
+        this(hasValue, new Validator(), optionalValue);
+    }
+
+    RUNTIME_OPTION(boolean hasValue, Validator validator) {
+        this(hasValue, validator, false);
+    }
+
+    RUNTIME_OPTION(boolean hasValue, Validator validator, boolean optionalValue) {
         this.value = hasValue;
         this.validator = validator;
+        this.optional = optionalValue;
     }
 
     boolean validate(String optionValue) throws ValidationException {
@@ -130,9 +139,17 @@ public enum RUNTIME_OPTION {
     boolean hasFollowingValue() {
         return value;
     }
+
+    boolean followingValueIsOptional() {
+        return optional;
+    }
+
     private final Validator validator;
     
     // Indicates the runtime option requires a value
     private final boolean value;
+
+    // Indicates the runtime option is optional
+    private final boolean optional;
 
 }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RequestTracingValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RequestTracingValidator.java
@@ -66,8 +66,6 @@ public class RequestTracingValidator extends Validator {
                 throw new ValidationException(MessageFormat.format(
                         RuntimeOptions.commandlogstrings.getString("requestTracingIncorrect"), optionValue));
             }
-
-            return true;
         }
 
         return true;

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RequestTracingValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RequestTracingValidator.java
@@ -1,0 +1,75 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.micro.cmd.options;
+
+import java.text.MessageFormat;
+
+public class RequestTracingValidator extends Validator {
+
+    @Override
+    boolean validate(String optionValue) throws ValidationException {
+        if (optionValue != null) {
+            String[] requestTracingValues = optionValue.split("(?<=\\d)(?=\\D)|(?=\\d)(?<=\\D)");
+            // If valid, there should be no more than 2 entries
+            if (requestTracingValues.length <= 2) {
+                // If the first entry is a number, the second entry should be a String
+                if (requestTracingValues[0].matches("\\d+") &&
+                        (requestTracingValues.length == 2 && !requestTracingValues[1].matches("\\D+"))) {
+                    // If there is a second entry, and it's not a String
+                    throw new ValidationException(MessageFormat.format(
+                            RuntimeOptions.commandlogstrings.getString("requestTracingIncorrect"), optionValue));
+                }
+
+                // If the first entry is a String, there shouldn't be a second entry
+                if (requestTracingValues[0].matches("\\D+") && (requestTracingValues.length == 2)) {
+                    throw new ValidationException(MessageFormat.format(
+                            RuntimeOptions.commandlogstrings.getString("requestTracingIncorrect"), optionValue));
+                }
+            } else {
+                throw new ValidationException(MessageFormat.format(
+                        RuntimeOptions.commandlogstrings.getString("requestTracingIncorrect"), optionValue));
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+}

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -94,13 +94,22 @@ public class RuntimeOptions {
                     RUNTIME_OPTION option = RUNTIME_OPTION.valueOf(arg.substring(2).toLowerCase());
                     String value = null;
                     if (option.hasFollowingValue()) {
-                        // there is a second value
-                        value = args[i+1];
-                        i++;
-                        if (value.startsWith("--")) {
-                            throw new IndexOutOfBoundsException();
+                        if (!option.followingValueIsOptional()) {
+                            // there is a second value
+                            value = args[i+1];
+                            i++;
+                            if (value.startsWith("--")) {
+                                throw new IndexOutOfBoundsException();
+                            }
+                            option.validate(value);
+                        } else {
+                            // If we're not at the end, and the next arg isn't a command option, validate it
+                             if (i + 1 != args.length && !args[i + 1].startsWith("--")) {
+                                 value = args[i+1];
+                                 i++;
+                                 option.validate(value);
+                             }
                         }
-                        option.validate(value);
                     }
                     List<String> values = options.get(option);
                     if (values == null) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1293,18 +1293,11 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                                     if (requestTracing.length == 2 && requestTracing[1].matches("\\D+")) {
                                         requestTracingThresholdUnit = parseTimeUnit(requestTracing[1],
                                                 "request tracing threshold unit").name();
-                                    } // If there is a second entry, and it's not a String
-                                    else if (requestTracing.length == 2 && !requestTracing[1].matches("\\D+")) {
-                                        throw new IllegalArgumentException();
                                     }
                                 } // If the first entry is a String
                                 else if (requestTracing[0].matches("\\D+")) {
                                     requestTracingThresholdUnit = parseTimeUnit(requestTracing[0],
                                             "request tracing threshold unit").name();
-                                    // There shouldn't be a second entry
-                                    if (requestTracing.length == 2) {
-                                        throw new IllegalArgumentException();
-                                    }
                                 }
                             } else {
                                 throw new IllegalArgumentException();

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/resources/commandlogstrings.properties
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/resources/commandlogstrings.properties
@@ -1,7 +1,7 @@
 #
  # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  #
- # Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ # Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
  #
  # The contents of this file are subject to the terms of either the GNU
  # General Public License Version 2 only ("GPL") or the Common Development
@@ -52,3 +52,4 @@ notValidPort={0} is not a valid port number it must be > 1 and < 65535
 integerIncorrect={0} must be a valid integer
 integerRangeIncorrect={0} must be a valid integer > {1} and < {2}
 valueIsNotAllowed={0} must be one of {1}
+requestTracingIncorrect={0} is not a valid request tracing option

--- a/appserver/extras/payara-micro/payara-micro-core/src/test/java/fish/payara/micro/cmd/options/RequestTracingValidatorTest.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/test/java/fish/payara/micro/cmd/options/RequestTracingValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.micro.cmd.options;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class RequestTracingValidatorTest {
+
+
+    @Test
+    public void test_no_following_option_no_following_value() {
+        try {
+            new RuntimeOptions(new String[]{"--enableRequestTracing"});
+        } catch (ValidationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_following_option_no_following_value() {
+        try {
+            new RuntimeOptions(new String[]{"--enableRequestTracing", "--noCluster"});
+        } catch (ValidationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_following_option_following_value() {
+        try {
+            new RuntimeOptions(new String[]{"--enableRequestTracing", "3MINUTES", "--noCluster"});
+        } catch (ValidationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_no_following_option_following_value() {
+        try {
+            new RuntimeOptions(new String[]{"--enableRequestTracing", "8H"});
+        } catch (ValidationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
This is a bug fix.

The `--enableRequestTracing` command line option for Payara Micro originally accepted configuration values so that you didn't have to specify the `--requesttracingthresholdunit` and `--requesttracingthresholdvalue` options separately. At some point extra validation was added to the command line arguments, which broke this.

I've added a new runtime option type of "optional followup value", since the configuration options are, well, optional. 
I've also moved some of the validation into a proper valdiator.

## Testing
### New tests
New unit (kind of) test added to Payara Micro Boot module to check that options can be set (doesn't validate the option itself - just that you **can** add configuration values)

### Testing Performed
```
java -jar payara-micro.jar --enableRequestTracing --noCluster
java -jar payara-micro.jar --enableRequestTracing 2MINUTES --noCluster
java -jar payara-micro.jar --enableRequestTracing 3s
java -jar payara-micro.jar --enableRequestTracing 1
java -jar payara-micro.jar --enableRequestTracing 2 --noCluster
java -jar payara-micro.jar --enableRequestTracing
```
Checking the log output each time to a) ensure micro actually started b) the request tracing configuration was configured as desired.

### Testing Environment
Windows 10, JDK 8u262

## Documentation
Not required
