### PR TITLE
FISH-82 Command Line option --warmup results in an Exception when Payara Micro instance stops when Request Tracing is activated

### DIFF
--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/store/RequestTraceStoreFactory.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/store/RequestTraceStoreFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -44,12 +44,12 @@ import fish.payara.nucleus.requesttracing.store.strategy.LongestTraceStorageStra
 import fish.payara.nucleus.requesttracing.store.strategy.ReservoirTraceStorageStrategy;
 import fish.payara.nucleus.requesttracing.store.strategy.TraceStorageStrategy;
 import fish.payara.nucleus.store.ClusteredStore;
+import org.glassfish.api.event.Events;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.internal.api.Globals;
 
 import java.util.Map;
 import java.util.UUID;
-
-import org.glassfish.api.event.Events;
-import org.glassfish.internal.api.Globals;
 
 /**
  * A factory for generating a
@@ -87,7 +87,12 @@ public class RequestTraceStoreFactory {
         }
 
         // Get a clustered store if possible
-        ClusteredStore clusteredStore = Globals.getDefaultHabitat().getService(ClusteredStore.class);
+        ClusteredStore clusteredStore = null;
+        ServiceHandle<ClusteredStore> serviceHandle = Globals.getDefaultHabitat().getServiceHandle(ClusteredStore.class);
+        if (serviceHandle != null && serviceHandle.isActive()) {
+            clusteredStore = serviceHandle.getService();
+        }
+
         if (clusteredStore != null && clusteredStore.isEnabled()) {
             Map<UUID, RequestTrace> store = (Map) clusteredStore.getMap(storeName);
             return new ClusteredRequestTraceStore(store, strategy);


### PR DESCRIPTION
## Description
This is a bug fix.

Adds a check to the RequestTraceStoreFactory for whether the ClusteredStore service is actually active.

## Testing

`java -jar payara-micro.jar --enableRequestTracing --warmup --rootdir startup`
You should see no errors about ClusteredStore being started at _RunLevel_ 9 rather than 10.

### Testing Environment
Windows 10, Zulu JDK 8u262
