### PR TITLE
FISH-277 Better Monitoring Console Integration into the Admin Console

### DIFF
--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -38,6 +38,7 @@
       </security-provider>
     </authorization-service>
   </security-configurations>
+  <monitoring-console-configuration enabled="true"></monitoring-console-configuration>
   <system-applications />
   <resources>
     <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
@@ -51,6 +52,7 @@
   </resources>
   <servers>
     <server name="%%%SERVER_ID%%%" config-ref="%%%CONFIG_MODEL_NAME%%%">
+      <application-ref ref="__monitoringconsole" virtual-servers="server"></application-ref>
       <resource-ref ref="jdbc/__TimerPool" />
       <resource-ref ref="jdbc/__default" />
     </server>
@@ -254,6 +256,9 @@
         <thread-pool max-thread-pool-size="250" name="thread-pool-1"></thread-pool>
         <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
       </thread-pools>
+      <monitoring-service>
+        <module-monitoring-levels http-service="HIGH" web-container="HIGH"></module-monitoring-levels>
+      </monitoring-service>      
       <system-property name="fish.payara.classloading.delegate" value="false" />
       <system-property name="jersey.config.client.readTimeout" value="300000" />
       <system-property name="jersey.config.client.connectTimeout" value="300000" />
@@ -476,6 +481,9 @@
         <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
       </thread-pools>
       <group-management-service />
+      <monitoring-service>
+        <module-monitoring-levels http-service="HIGH" web-container="HIGH"></module-monitoring-levels>
+      </monitoring-service>
       <!--%%%DEFAULT_TOKENS_HERE%%%-->
       <system-property name="ASADMIN_LISTENER_PORT" value="24848" />
       <system-property name="HTTP_LISTENER_PORT" value="28080" />
@@ -497,4 +505,18 @@
     <secure-admin-principal dn="%%%ADMIN_CERT_DN%%%"></secure-admin-principal>
     <secure-admin-principal dn="%%%INSTANCE_CERT_DN%%%"></secure-admin-principal>
   </secure-admin>
+
+<applications>
+  <application context-root="/monitoring-console" object-type="user" name="__monitoringconsole" directory-deployed="true" location="${com.sun.aas.installRootURI}/lib/install/applications/__monitoringconsole/">
+    <property name="archiveType" value="war"></property>
+    <property name="cdiDevModeEnabled" value="false"></property>
+    <property name="appLocation" value="${com.sun.aas.installRootURI}/lib/install/applications/__monitoringconsole/"></property>
+    <property name="defaultAppName" value="__monitoringconsole"></property>
+    <module name="__monitoringconsole">
+      <engine sniffer="cdi"></engine>
+      <engine sniffer="security"></engine>
+      <engine sniffer="web"></engine>
+    </module>
+  </application>
+</applications>
 </domain>

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/ApplicationHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/ApplicationHandlers.java
@@ -93,7 +93,7 @@ public class ApplicationHandlers {
         Applications applications = Globals.getDefaultBaseServiceLocator().getService(Applications.class);
         String appName = (String) handlerCtx.getInputValue("appName");
         Application app = applications.getApplication(appName);
-        handlerCtx.setOutputValue(NAME_RESULT, app.getContextRoot());
+        handlerCtx.setOutputValue(NAME_RESULT, app == null ? null : app.getContextRoot());
     }
 
     /**

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/ApplicationHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/ApplicationHandlers.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 /**
  *
  * @author anilam
@@ -46,6 +46,8 @@ package org.glassfish.admingui.common.handlers;
 
 import com.sun.jsftemplating.annotation.HandlerInput;
 import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.enterprise.config.serverbeans.Application;
+import com.sun.enterprise.config.serverbeans.Applications;
 import com.sun.jsftemplating.annotation.Handler;
 import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
 import java.net.URLEncoder;
@@ -56,6 +58,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
+
 import java.util.Map;
 import java.util.Iterator;
 import java.util.Collection;
@@ -70,6 +73,7 @@ import org.glassfish.admingui.common.util.GuiUtil;
 import org.glassfish.admingui.common.util.DeployUtil;
 import org.glassfish.admingui.common.util.RestUtil;
 import org.glassfish.admingui.common.util.TargetUtil;
+import org.glassfish.internal.api.Globals;
 import org.glassfish.admingui.common.util.AppUtil;
 
 
@@ -80,6 +84,17 @@ public class ApplicationHandlers {
     private static final String NAME_CONFIG_NAME = "configName";
     private static final String NAME_RESULT = "result";
 
+    @Handler(id = "py.getContextRoot",
+            input = {
+                @HandlerInput(name = "appName", type = String.class, required = true)},
+            output = {
+                @HandlerOutput(name = NAME_RESULT, type = String.class)})
+    public static void getContextRoot(HandlerContext handlerCtx) {
+        Applications applications = Globals.getDefaultBaseServiceLocator().getService(Applications.class);
+        String appName = (String) handlerCtx.getInputValue("appName");
+        Application app = applications.getApplication(appName);
+        handlerCtx.setOutputValue(NAME_RESULT, app.getContextRoot());
+    }
 
     /**
      *	<p> This handler returns the list of applications for populating the table.
@@ -293,17 +308,17 @@ public class ApplicationHandlers {
 
     @Handler(id = "gf.appScopedResourcesExist",
         input = {
-            @HandlerInput(name = "appName", type = String.class, required = true), 
+            @HandlerInput(name = "appName", type = String.class, required = true),
             @HandlerInput(name = "moduleList", type = List.class, required = true)
             },
         output = {
             @HandlerOutput(name = "appScopedResExists", type = java.lang.Boolean.class)})
     public static void appScopedResourcesExist(HandlerContext handlerCtx) {
-        String appName = (String) handlerCtx.getInputValue("appName"); 
+        String appName = (String) handlerCtx.getInputValue("appName");
         try {
-            List<String> moduleList = 
+            List<String> moduleList =
                     (List<String>) handlerCtx.getInputValue("moduleList");
-            handlerCtx.setOutputValue("appScopedResExists", 
+            handlerCtx.setOutputValue("appScopedResExists",
                     AppUtil.doesAppContainsResources(appName, moduleList));
         } catch (NullPointerException e) {
             handlerCtx.setOutputValue("appScopedResExists", false);
@@ -446,7 +461,7 @@ public class ApplicationHandlers {
         output = {
             @HandlerOutput(name = NAME_CONFIG_NAME, type = String.class)})
     public static void getConfigName(HandlerContext handlerCtx) {
-        handlerCtx.setOutputValue(NAME_CONFIG_NAME, 
+        handlerCtx.setOutputValue(NAME_CONFIG_NAME,
                 TargetUtil.getConfigName((String) handlerCtx.getInputValue("target")));
     }
 
@@ -617,7 +632,7 @@ public class ApplicationHandlers {
                 attrs = RestUtil.getAttributesMap(endpoint);
             } else {
                 endpoint = prefix+"/deployment-groups/deployment-group/" + oneTarget + "/application-ref/" + appName;
-                attrs = RestUtil.getAttributesMap(endpoint);                
+                attrs = RestUtil.getAttributesMap(endpoint);
             }
             oneRow.put("name", appName);
             oneRow.put("selected", false);
@@ -758,7 +773,7 @@ public class ApplicationHandlers {
         List<Map<String, String>> list = new ArrayList<>();
 
         while (it.hasNext()) {
-            url = it.next(); 
+            url = it.next();
             String target = "";
             int i = url.indexOf("@@@");
             if (i >= 0) {
@@ -817,7 +832,7 @@ public class ApplicationHandlers {
         }
         return ctxRoot;
     }
-    
+
 
 
 /********************/
@@ -892,7 +907,7 @@ public class ApplicationHandlers {
                     for (String hostName : hostNames) {
                         if (localHostName != null && hostName.equalsIgnoreCase("localhost"))
                             hostName = localHostName;
-//                            URLs.add("[" + target + "]  - " + protocol + "://" + hostName + ":" + resolvedPort + "[ " + one + " " + configName 
+//                            URLs.add("[" + target + "]  - " + protocol + "://" + hostName + ":" + resolvedPort + "[ " + one + " " + configName
 //                                    + " " + listener + " " + target + " ]");
                         URLs.add(target + "@@@" + protocol + "://" + hostName + ":" + resolvedPort);
                     }

--- a/appserver/admingui/common/src/main/resources/commonTask.jsf
+++ b/appserver/admingui/common/src/main/resources/commonTask.jsf
@@ -67,6 +67,10 @@
   <event>
     <!beforeCreate
     py.getContextRoot(appName="__monitoringconsole" result="#{pageSession.contextRoot}");
+    setAttribute(key="showMonitoringLink" value="true" );
+    if($pageSession{contextRoot}=#{null}) {
+	    setAttribute(key="showMonitoringLink" value="false" );
+    }    
     getTargetURLList(AppID="__monitoringconsole", contextRoot="#{pageSession.contextRoot}",  URLList="#{pageSession.monitoringConsoleURLs}");
     />
   </event>
@@ -129,7 +133,7 @@
         </sun:commonTasksGroup>
 
           <sun:commonTasksGroup id="monitoring" title="$resource{i18n.commonTasks.group.Monitoring}" >
-            <sun:commonTask
+            <sun:commonTask rendered="#{showMonitoringLink}"
               text="$resource{i18n.commonTasks.task.monitoring}"
               toolTip="$resource{i18n.commonTasks.task.monitoring.toolTip}"
               onClick="javascript:var win=window.open('#{pageSession.monitoringConsoleURLs[0].url}','_blank');if (win) {win.focus();}; return false;">

--- a/appserver/admingui/common/src/main/resources/commonTask.jsf
+++ b/appserver/admingui/common/src/main/resources/commonTask.jsf
@@ -45,6 +45,7 @@
 <!initPage
     setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings")
     setResourceBundle(key="help_common" bundle="org.glassfish.common.admingui.Helplinks");
+    
 />
 <!composition template="/templates/default.layout" guiTitle="$resource{i18n.commonTasks.title}"
       <!-- GLASSFISH-20207 guiOnLoad="if (frameOnload) {frameOnload();};"  -->
@@ -62,6 +63,14 @@
 </f:verbatim>
 </define>
 <!define name="content">
+
+  <event>
+    <!beforeCreate
+    py.getContextRoot(appName="__monitoringconsole" result="#{pageSession.contextRoot}");
+    getTargetURLList(AppID="__monitoringconsole", contextRoot="#{pageSession.contextRoot}",  URLList="#{pageSession.monitoringConsoleURLs}");
+    />
+  </event>
+    
     "<div style="height:100%; background-color:#B6C6D6; #{pageSession.contentCSS}">
       <sun:form id="form">
         <sun:commonTasksSection id="commonTasksSection" helpText="$resource{i18n.commonTasks.help}"  title="$resource{i18n.commonTasks.title}" columns="$int{2}" style="visibility: #{commonTaskVisibility}">
@@ -119,7 +128,12 @@
             </sun:commonTask>
         </sun:commonTasksGroup>
 
-          <sun:commonTasksGroup id="monitoring"  title="$resource{i18n.commonTasks.group.Monitoring}" >
+          <sun:commonTasksGroup id="monitoring" title="$resource{i18n.commonTasks.group.Monitoring}" >
+            <sun:commonTask
+              text="$resource{i18n.commonTasks.task.monitoring}"
+              toolTip="$resource{i18n.commonTasks.task.monitoring.toolTip}"
+              onClick="javascript:var win=window.open('#{pageSession.monitoringConsoleURLs[0].url}','_blank');if (win) {win.focus();}; return false;">
+            </sun:commonTask>
               <sun:commonTask
                 text="$resource{i18nc.tree.monitorData}"
                 toolTip="$resource{i18nc.tree.monitorData}"

--- a/appserver/admingui/common/src/main/resources/monitor/monitoringInfo.jsf
+++ b/appserver/admingui/common/src/main/resources/monitor/monitoringInfo.jsf
@@ -51,6 +51,10 @@
   <event>
     <!beforeCreate
     py.getContextRoot(appName="__monitoringconsole" result="#{pageSession.contextRoot}");
+    setAttribute(key="showMonitoringLink" value="true" );
+    if($pageSession{contextRoot}=#{null}) {
+	    setAttribute(key="showMonitoringLink" value="false" );
+    }
     getTargetURLList(AppID="__monitoringconsole", contextRoot="#{pageSession.contextRoot}",  URLList="#{pageSession.monitoringConsoleURLs}");
     />
   </event>
@@ -60,8 +64,8 @@
     <sun:title id="propertyContentPage" title="$resource{i18n.commonTasks.group.Monitoring}"
                helpText="$resource{common.monitoringInfo.pageHelp}" />
 
-    <sun:propertySheet requiredFields="false">
-        <sun:propertySheetSection>
+    <sun:propertySheet>
+        <sun:propertySheetSection rendered="#{showMonitoringLink}">
             <sun:property label="$resource{common.monitoringInfo.monitoringConsoleLinkLabel}">
                 <sun:hyperlink text="$resource{i18n.commonTasks.task.monitoring}" onClick="javascript:var win=window.open('#{pageSession.monitoringConsoleURLs[0].url}','_blank');if (win) {win.focus();}; return false;" />
             </sun:property>

--- a/appserver/admingui/common/src/main/resources/monitor/monitoringInfo.jsf
+++ b/appserver/admingui/common/src/main/resources/monitor/monitoringInfo.jsf
@@ -48,11 +48,26 @@
 
 <!composition template="/templates/default.layout"  guiTitle="$resource{common.monitoring.Title}" >
 <!define name="content">
+  <event>
+    <!beforeCreate
+    py.getContextRoot(appName="__monitoringconsole" result="#{pageSession.contextRoot}");
+    getTargetURLList(AppID="__monitoringconsole", contextRoot="#{pageSession.contextRoot}",  URLList="#{pageSession.monitoringConsoleURLs}");
+    />
+  </event>
+
 <sun:form id="propertyForm">
 #include "/common/shared/alertMsg_1.inc"
     <sun:title id="propertyContentPage" title="$resource{i18n.commonTasks.group.Monitoring}"
                helpText="$resource{common.monitoringInfo.pageHelp}" />
-    "<br />
+
+    <sun:propertySheet requiredFields="false">
+        <sun:propertySheetSection>
+            <sun:property label="$resource{common.monitoringInfo.monitoringConsoleLinkLabel}">
+                <sun:hyperlink text="$resource{i18n.commonTasks.task.monitoring}" onClick="javascript:var win=window.open('#{pageSession.monitoringConsoleURLs[0].url}','_blank');if (win) {win.focus();}; return false;" />
+            </sun:property>
+        </sun:propertySheetSection>
+    </sun:propertySheet>
+    
 #include "/common/shared/monitorHandlers.inc"
     <sun:table id="monitorInstancesTable" title="$resource{i18n.commonTasks.group.Monitoring}">
         <sun:tableRowGroup id="rowGroup1" data={"$pageSession{listOfRows}"} sourceVar="td">

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -661,6 +661,7 @@ monitoring.monMbeansHelp=Deploy all MBeans needed for monitoring
 monitoring.monDtrace=DTrace Monitoring:
 monitoring.monDtraceHelp=Enable or disable DTrace Monitoring
 monitoringInfo.pageHelp=View and manage the monitoring information for Payara Server instances.
+monitoringInfo.monitoringConsoleLinkLabel=Real-time monitoring
 
 #monitoring Service page, Module  name
 monitoring.module.Jvm=Jvm

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -661,7 +661,7 @@ monitoring.monMbeansHelp=Deploy all MBeans needed for monitoring
 monitoring.monDtrace=DTrace Monitoring:
 monitoring.monDtraceHelp=Enable or disable DTrace Monitoring
 monitoringInfo.pageHelp=View and manage the monitoring information for Payara Server instances.
-monitoringInfo.monitoringConsoleLinkLabel=Real-time monitoring
+monitoringInfo.monitoringConsoleLinkLabel=Real-time Monitoring:
 
 #monitoring Service page, Module  name
 monitoring.module.Jvm=Jvm

--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -415,6 +415,9 @@ commonTasks.task.monitor.infoTitle=View Monitoring Data
 commonTasks.task.monitor.infoLinkText=More on Monitoring Data
 commonTasks.task.monitor.toolTip=View Monitoring Data
 
+commonTasks.task.monitoring=Open Monitoring Console
+commonTasks.task.monitoring.toolTip=Open Monitoring Console to view live monitoring data
+
 commonTasks.task.configMonitor=Configure Monitoring
 commonTasks.task.configMonitor.infoText=Configure monitoring
 commonTasks.task.configMonitor.infoTitle=Configure Montoring


### PR DESCRIPTION
### Summary
This PR adds a couple of small connections to better integrate monitoring console into the admin GUI.

Now by default the monitoring for _Web_ and _HTTP_ is set to _HIGH_ and the monitoring console application is deployed on default **for the `production` domain**
These changes occur in the `domain.xml` template.

In the admin GUI links to the monitoring console are added to the _Common Tasks_ page as well as the _Monitoring Data_ home page. 
The URL is resolved from the application name in two steps: 

* First resolve the application `contextRoot` by application name (new handler method added), 
* secondly use application name and the resolved  `contextRoot` to URLs (HTTP and HTTPS) and use the HTTP one

The links do not show if MC is not deployed.

### Testing 
#### Testing Performed
* Start server `production` domain `asadmin stop-domain production` and open admin GUI
* click _Open Monitoring Console_ button on Common Tasks page and check that a working MC opens in new tab
* navigate to _Monitoring Data_, click the _Open Monitoring Console_ link and check that a working MC opens in new tab
* check that on the start page of MC all widgets show data (HTTP and Web Monitoring need to be enabled for that)
* create another instance, start it, check MC is not deployed on that instance
* use `asadmin set-monitoring-console-configuration --enabled=false` to disable MC, check the links are no longer shown
* use `asadmin set-monitoring-console-configuration --enabled=true` to enable MC, check the links are shown again
* Start server `domain1` domain, check that the links to MC do not show

### Documentation
https://github.com/payara/Payara-Community-Documentation/pull/56