### PR TITLE
FISH-90 Fix incorrect classpath in wscompile script

### DIFF
--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
@@ -64,7 +64,7 @@ checkEndorsedAvailable
 
 if [ $? -lt 9 ]
 then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
@@ -61,7 +61,7 @@ set JAVA=java
 CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
-    %JAVA% %WSCOMPILE_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
+    %JAVA% %WSCOMPILE_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
 ) else (
-    %JAVA% %WSCOMPILE_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
+    %JAVA% %WSCOMPILE_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
 )


### PR DESCRIPTION
## Description
This is a bug fix.
The wscompile script hadn't been adapted to use the new jakarta jar.
I've also removed a classpath entry which doesn't seem to exist? (aixporting).

## Testing
Ran wscompile script and **didn't** get a lovely CNF exception.

### Testing Environment
Windows 10, JDK 8u262 & JDK 11.0.8
