### PR TITLE
FISH-89 Address possible NPE during request tracing startup

### DIFF
--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/domain/execoptions/RequestTracingExecutionOptions.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/domain/execoptions/RequestTracingExecutionOptions.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -46,6 +46,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
  * Configuration class that holds the dynamic configuration of the Request
  * Tracing service.
@@ -54,26 +57,29 @@ import java.util.concurrent.TimeUnit;
  */
 public class RequestTracingExecutionOptions {
 
-    private Boolean enabled;
+    // Default values taken from RequestTracingServiceConfiguration
+    private Boolean enabled = false;
     
-    private Double sampleRate;
-    private Boolean adaptiveSamplingEnabled;
-    private Integer adaptiveSamplingTargetCount;
-    private Integer adaptiveSamplingTimeValue;
-    private TimeUnit adaptiveSamplingTimeUnit;
+    private Double sampleRate = 1.0;
+    private Boolean adaptiveSamplingEnabled = false;
+    private Integer adaptiveSamplingTargetCount = 6;
+    private Integer adaptiveSamplingTimeValue = 1;
+    private TimeUnit adaptiveSamplingTimeUnit = MINUTES;
     
-    private Boolean applicationsOnlyEnabled;
-    private Long thresholdValue;
-    private TimeUnit thresholdUnit;
-    private Boolean sampleRateFirstEnabled;
+    private Boolean applicationsOnlyEnabled = true;
+    private Long thresholdValue = 30L;
+    private TimeUnit thresholdUnit = SECONDS;
+    private Boolean sampleRateFirstEnabled = true;
     
-    private Integer traceStoreSize;
-    private Long traceStoreTimeout;
-    private Boolean reservoirSamplingEnabled;
+    private Integer traceStoreSize = 20;
+    // Default timeout value **NOT** taken from RequestTracingServiceConfiguration, but from TimeUtil.setStoreTimeLimit
+    private Long traceStoreTimeout = 0L;
+    private Boolean reservoirSamplingEnabled = false;
     
-    private Boolean historicTraceStoreEnabled;
-    private Integer historicTraceStoreSize;
-    private Long historicTraceStoreTimeout;
+    private Boolean historicTraceStoreEnabled = false;
+    private Integer historicTraceStoreSize = 20;
+    // Default timeout value **NOT** taken from RequestTracingServiceConfiguration, but from TimeUtil.setStoreTimeLimit
+    private Long historicTraceStoreTimeout = 0L;
 
     private final Map<NotifierType, NotifierExecutionOptions> notifierExecutionOptionsList = new HashMap<>();
 


### PR DESCRIPTION
## Description
This is a bug fix.

During the startup of the server with request tracing enabled, it was possible for an NPE to be thrown due to a check of `shouldStartTrace`. This simply enforces that the execution options have default values for everything rather than relying on the `bootstrapRequestTracing` method.

## Testing
Not really feasible due to race condition nature and lack of reproducer.
I cannae see how this could break anything though (famous last words) - what could go wrong?
