### PR TITLE
FISH-25 Fix SOAP Web Service Tester not working correctly on JDK 11

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -264,6 +264,7 @@
                 <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
                 <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+                <jvm-options>[9|]-Djava.class.path=${com.sun.aas.installRoot}/modules/glassfish.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.jws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.rpc-api.jar${path.separator}${com.sun.aas.installRoot}/modules/webservices-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jaxb-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.ws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.activation-api.jar</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />
@@ -486,6 +487,7 @@
                 <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
                 <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+                <jvm-options>[9|]-Djava.class.path=${com.sun.aas.installRoot}/modules/glassfish.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.jws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.rpc-api.jar${path.separator}${com.sun.aas.installRoot}/modules/webservices-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jaxb-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.ws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.activation-api.jar</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -214,6 +214,7 @@
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[9|]-Djava.class.path=${com.sun.aas.installRoot}/modules/glassfish.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.jws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.rpc-api.jar${path.separator}${com.sun.aas.installRoot}/modules/webservices-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jaxb-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.ws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.activation-api.jar</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />
@@ -419,6 +420,7 @@
         <jvm-options>[|8]-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>[|8]-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+        <jvm-options>[9|]-Djava.class.path=${com.sun.aas.installRoot}/modules/glassfish.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.jws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.rpc-api.jar${path.separator}${com.sun.aas.installRoot}/modules/webservices-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jaxb-osgi.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.xml.ws-api.jar${path.separator}${com.sun.aas.installRoot}/modules/jakarta.activation-api.jar</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
@@ -62,7 +62,7 @@ checkEndorsedAvailable
 
 if [ $? -lt 9 ]
 then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
@@ -60,7 +60,7 @@ set JAVA=java
 CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
-    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
 ) else (
-    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
 )

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
@@ -64,7 +64,7 @@ checkEndorsedAvailable
 
 if [ $? -lt 9 ]
 then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
@@ -61,7 +61,7 @@ set JAVA=java
 CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
-    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
 ) else (
-    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
 )

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
@@ -61,7 +61,7 @@ checkEndorsedAvailable
 
 if [ $? -lt 9 ]
 then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsGen "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsGen "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsGen "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsGen "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
@@ -60,7 +60,7 @@ set JAVA=java
 CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
-    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*
 ) else (
-    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.xml.ws-api.jar" com.sun.tools.ws.WsGen %*
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.xml.ws-api.jar" com.sun.tools.ws.WsGen %*
 )

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -61,7 +61,7 @@ checkEndorsedAvailable
 
 if [ $? -lt 9 ]
 then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsImport "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsImport "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -63,5 +63,5 @@ if [ $? -lt 9 ]
 then 
     exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar" com.sun.tools.ws.WsImport "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.ws-api.jar:$AS_INSTALL_LIB/jakarta.jws-api.jar" com.sun.tools.ws.WsImport "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
@@ -61,7 +61,7 @@ set JAVA=java
 CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
-    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*
 ) else (
-    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.xml.ws-api.jar" com.sun.tools.ws.WsImport %*
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.xml.ws-api.jar;%~dp0..\modules\jakarta.jws-api.jar" com.sun.tools.ws.WsImport %*
 )

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
@@ -61,7 +61,7 @@ checkEndorsedAvailable
 
 if [ $? -lt 9 ]
 then 
-    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
 else
-    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/javax.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
+    exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
 fi

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
@@ -60,7 +60,7 @@ set JAVA=java
 CALL %~dp0jdkcheck.bat
 
 if %ENDORSED_AVAILABLE%==true (
-    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
+    %JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
 ) else (
-    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\javax.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
+    %JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
 )


### PR DESCRIPTION
## Description
Bug fix.

Fixes the incorrect file in the webservices scripts, and adds the Jakarta JWS API Jar to the import script too as it seems to need it.
The tester servlet doesn't use these scripts however, and instead uses the Java APIs directly. To fix this, I've had to add classpath entries as a system property as it appears to not use the already loaded classes and instead gets the classpath specified during bootstrap (by default `${installRoot}/glassfish/modules/glassfish.jar` which is just the bootstrap jar).

Related to https://github.com/payara/Payara/pull/4837
Fixes https://github.com/payara/Payara/issues/4350

## Testing
Using https://github.com/rlfnb/JaxWSPoC, deploying, and hitting endpoint: http://localhost:8080/StupidWebService/StupidWebService?Tester

Should successfully import and not spew out a load of CNF exceptions.

I also checked from the command line with the following command:
`.\payara5\glassfish\bin\wsimport.bat -d .\testy\ -keep http://localhost:8080/StupidWebService/StupidWebService?WSDL -Xendorsed -target 2.1 -extension`

I've checked using embedded-all and it seemed happy (aside from an unrelated missing _allows access_) to import when I poked the tester endpoint so don't need to change the embedded domain.xml.
```
    public static void main(String[] args) {
        try {
            GlassFishRuntime runtime = GlassFishRuntime.bootstrap();
            GlassFishProperties glassfishProperties = new GlassFishProperties();
            GlassFish glassfish = runtime.newGlassFish(glassfishProperties);
            glassfish.start();
            glassfish.getDeployer().deploy(new File("C:\\Users\\pandr\\Downloads\\JaxRSPoC-1.0-SNAPSHOT.war"));
        } catch (GlassFishException ex) {
            Logger.getLogger(Main.class.getName()).log(Level.SEVERE, null, ex);
        }
    }
```

### Testing Environment
Windows 10, JDK 8u262 and 11.0.8

## Notes for Reviewers
Would appreciate a Linux test to check the classpath xml :)

I think this is also potentially a shakey solution, so an additional pair of eyes looking through Metro would be appreciated but I didn't see a nice point to hook in without a refactor (it very much seemed intentional that it specifically used the classpath system property).

The entry point into Metro is https://github.com/payara/Payara/blob/master/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/monitoring/WebServiceTesterServlet.java#L421
