### PR TITLE
FISH-388 Fix NPE when printing out active span

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpan.java
+++ b/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpan.java
@@ -42,6 +42,7 @@ package fish.payara.notification.requesttracing;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -234,9 +235,13 @@ public class RequestTraceSpan implements Serializable, Comparable<RequestTraceSp
         
         result.append("\"startTime\":\"").append(startTime.atZone(ZoneId.systemDefault()).toString())
                 .append("\",");
-        result.append("\"endTime\":\"").append(endTime.atZone(ZoneId.systemDefault()).toString())
-                .append("\",");
-        result.append("\"traceDuration\":\"").append(spanDuration).append("\"");
+        if (endTime != null) {
+            result.append("\"endTime\":\"").append(endTime.atZone(ZoneId.systemDefault()).toString())
+                    .append("\",");
+            result.append("\"traceDuration\":\"").append(spanDuration).append("\"");
+        } else {
+            result.append("\"traceDuration\":\"").append(startTime.until(Instant.now(), ChronoUnit.NANOS)).append("\"");
+        }
         
         if (spanTags != null && !spanTags.isEmpty()) {
             result.append(",\"spanTags\":[");


### PR DESCRIPTION
## Description
This is a bug fix.

Currently if you try to use the _toString_ method on an active span (as in a span that hasn't actually finished yet) you get a NPE due to it not having an end time. This fixes this by simply not attempting to print this detail.

It also calculates a trace duration.

## Testing
Tested using Rudy's app.
You can also see this by evaluating an active span during debugging.
