### PR TITLE
FISH-392 Trace gets started even when RequestTracing is disabled

### DIFF
--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
@@ -149,7 +149,7 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
 
     private boolean tracerAvailable() {
         if (tracer == null) {
-            if (openTracingService == null) {
+            if (openTracingService == null || !openTracingService.isEnabled()) {
                 return false;
             }
             this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);

--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
@@ -71,7 +71,7 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
     public OpenTracingIiopServerInterceptor(OpenTracingService openTracingService) {
         this.openTracingService = openTracingService;
 
-        if (openTracingService != null || openTracingService.isEnabled()) {
+        if (openTracingService != null && openTracingService.isEnabled()) {
             this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);
         }
     }
@@ -145,7 +145,10 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
 
     private boolean tracerAvailable() {
         if (tracer == null) {
-            if (openTracingService == null || !openTracingService.isEnabled()) {
+            if (openTracingService == null) {
+                return false;
+            }
+            if (!openTracingService.isEnabled()) {
                 return false;
             }
             this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);

--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
@@ -71,12 +71,8 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
     public OpenTracingIiopServerInterceptor(OpenTracingService openTracingService) {
         this.openTracingService = openTracingService;
 
-        if (openTracingService == null) {
-            return;
-        }
-        this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);
-        if (tracer == null) {
-            return;
+        if (openTracingService != null || openTracingService.isEnabled()) {
+            this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);
         }
     }
 


### PR DESCRIPTION
## Description
Bug fix.
OpenTracingIiopServerInterceptor starts a trace even if request tracing is disabled - this is inconsistent with the behaviour of opentracing and request tracing everywhere else.
