### PR TITLE
FISH-392 Fix Trace getting started when Request Tracing is Disabled

### DIFF
--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
@@ -71,12 +71,8 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
     public OpenTracingIiopServerInterceptor(OpenTracingService openTracingService) {
         this.openTracingService = openTracingService;
 
-        if (openTracingService == null) {
-            return;
-        }
-        this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);
-        if (tracer == null) {
-            return;
+        if (openTracingService != null && openTracingService.isEnabled()) {
+            this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);
         }
     }
 
@@ -100,7 +96,7 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
 
         OpenTracingIiopTextMap openTracingIiopTextMap = null;
         try (ByteArrayInputStream bis = new ByteArrayInputStream(serviceContext.context_data);
-                ObjectInput in = new OpenTracingIiopObjectInputStream(bis)) {
+             ObjectInput in = new OpenTracingIiopObjectInputStream(bis)) {
             openTracingIiopTextMap = (OpenTracingIiopTextMap) in.readObject();
         } catch (IOException | ClassNotFoundException exception) {
             throw new ForwardRequest(exception.getMessage(), serverRequestInfo);
@@ -150,6 +146,9 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
     private boolean tracerAvailable() {
         if (tracer == null) {
             if (openTracingService == null) {
+                return false;
+            }
+            if (!openTracingService.isEnabled()) {
                 return false;
             }
             this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);

--- a/appserver/tests/payara-samples/samples/remote-ejb-tracing/remote-ejb-tracing-client/pom.xml
+++ b/appserver/tests/payara-samples/samples/remote-ejb-tracing/remote-ejb-tracing-client/pom.xml
@@ -99,6 +99,17 @@
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>enable-requesttracing</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>set-requesttracing-configuration --enabled true --dynamic true</commandlineArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>deploy-${deployableName}</id>
                         <phase>pre-integration-test</phase>
                         <goals>
@@ -118,6 +129,17 @@
                         <configuration>
                             <executable>${payara.home}/glassfish/bin/asadmin</executable>
                             <commandlineArgs>undeploy ${deployableName}</commandlineArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>disable-requesttracing</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>set-requesttracing-configuration --enabled false --dynamic true</commandlineArgs>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Description
Bug fix.
OpenTracingIiopServerInterceptor starts a trace even if request tracing is disabled - this is inconsistent with the behaviour of opentracing and request tracing everywhere else.

## Testing
Ran the remote-ejb-tracing sample. Before it didn't enable request tracing and would still pass against a clean domain - with the changes in this PR it should fail against a clean domain so I've added extra setup and teardown steps to the test.