### PR TITLE
FISH-389 Add Transaction ID as Span Baggage Item

### DIFF
--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]" -->
+<!--"Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]" -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
 
@@ -246,6 +246,17 @@
             <groupId>fish.payara.api</groupId>
             <artifactId>payara-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
+            <artifactId>opentracing-adapter</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -89,7 +89,6 @@ import com.sun.enterprise.util.Utility;
 
 import fish.payara.cluster.DistributedLockType;
 import fish.payara.notification.requesttracing.RequestTraceSpanLog;
-import fish.payara.nucleus.requesttracing.RequestTracingService;
 
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
@@ -122,6 +121,10 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.UserTransaction;
 
+import fish.payara.nucleus.requesttracing.RequestTracingService;
+import fish.payara.opentracing.OpenTracingService;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.api.naming.GlassfishNamingManager;
@@ -235,7 +238,8 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected ContainerType containerType;
 
-    private final RequestTracingService requestTracing;
+    private final RequestTracingService requestTracingService;
+    private final OpenTracingService openTracingService;
 
     // constants for EJB(Local)Home/EJB(Local)Object methods,
     // used in authorizeRemoteMethod and authorizeLocalMethod
@@ -570,7 +574,8 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     {
         this.containerType = type;
         this.securityManager = sm;
-        this.requestTracing = Globals.getDefaultHabitat().getService(RequestTracingService.class);
+        this.requestTracingService = Globals.getDefaultHabitat().getService(RequestTracingService.class);
+        this.openTracingService = Globals.getDefaultHabitat().getService(OpenTracingService.class);
 
         try {
             this.loader = loader;
@@ -4159,11 +4164,8 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 callFlowInfo.getModuleName(),
                 callFlowInfo.getComponentName(),
                 method_sig);
-        if (requestTracing.isRequestTracingEnabled()) {
-            RequestTraceSpanLog spanLog = constructEjbMethodSpanLog(callFlowInfo, true);
-            requestTracing.addSpanLog(spanLog);
-        }
-        //callFlowAgent.ejbMethodStart(callFlowInfo);
+
+        addEjbMethodTraceLog(callFlowInfo, true);
     }
 
     final void onEjbMethodEnd(String method_sig, Throwable th) {
@@ -4173,10 +4175,34 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 callFlowInfo.getComponentName(),
                 th,
                 method_sig);
-        //callFlowAgent.ejbMethodEnd(callFlowInfo);
-        if (requestTracing.isRequestTracingEnabled()) {
-            RequestTraceSpanLog spanLog = constructEjbMethodSpanLog(callFlowInfo, false);
-            requestTracing.addSpanLog(spanLog);
+        addEjbMethodTraceLog(callFlowInfo, false);
+    }
+
+    private void addEjbMethodTraceLog(CallFlowInfo info, boolean callEnter) {
+        if (openTracingService.isEnabled()) {
+            Tracer tracer = openTracingService.getTracer(openTracingService.getApplicationName(invocationManager));
+            RequestTraceSpanLog spanLog = constructEjbMethodSpanLog(info, callEnter);
+
+            if (tracer != null) {
+                Span span = tracer.activeSpan();
+
+                if (span != null) {
+                    span.log(spanLog.getTimeMillis(), spanLog.getLogEntries());
+
+                    // Add transaction ID as baggage item
+                    if (info.getTransactionId() != null) {
+                        span.setBaggageItem("TX-ID", info.getTransactionId());
+                    }
+                } else {
+                    // Traces started in the pre-OpenTracing style won't have an active span, so just attempt to add as
+                    // is to thread local trace if there is one
+                    requestTracingService.addSpanLog(spanLog);
+                }
+            } else {
+                // If we couldn't get a tracer here, it's because we couldn't get a name from the invocation manager.
+                // In such a case, just try to add the span log to the currently active thread local request trace
+                requestTracingService.addSpanLog(spanLog);
+            }
         }
     }
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -4188,11 +4188,6 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                 if (span != null) {
                     span.log(spanLog.getTimeMillis(), spanLog.getLogEntries());
-
-                    // Add transaction ID as baggage item
-                    if (info.getTransactionId() != null) {
-                        span.setBaggageItem("TX-ID", info.getTransactionId());
-                    }
                 } else {
                     // Traces started in the pre-OpenTracing style won't have an active span, so just attempt to add as
                     // is to thread local trace if there is one

--- a/appserver/tests/payara-samples/samples/remote-ejb-tracing/remote-ejb-tracing-client/src/test/java/fish/payara/samples/remote/ejb/tracing/RemoteEjbClientIT.java
+++ b/appserver/tests/payara-samples/samples/remote-ejb-tracing/remote-ejb-tracing-client/src/test/java/fish/payara/samples/remote/ejb/tracing/RemoteEjbClientIT.java
@@ -76,7 +76,7 @@ public class RemoteEjbClientIT {
                 span.setBaggageItem("Wibbles", "Wobbles");
                 String baggageItems = ejb.annotatedMethod();
                 Assert.assertTrue("Baggage items didn't match, received: " + baggageItems,
-                        baggageItems.equals("\nWibbles : Wobbles\n"));
+                        baggageItems.contains("\nWibbles : Wobbles\n"));
 
                 span.setBaggageItem("Nibbles", "Nobbles");
                 baggageItems = ejb.nonAnnotatedMethod();

--- a/appserver/transaction/jta/pom.xml
+++ b/appserver/transaction/jta/pom.xml
@@ -141,8 +141,14 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-modules</groupId>
-            <artifactId>requesttracing-core</artifactId>
+            <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
+++ b/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates.]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.transaction;
 
@@ -59,6 +59,9 @@ import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.logging.LogDomains;
 import fish.payara.notification.requesttracing.RequestTraceSpanLog;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
+import fish.payara.opentracing.OpenTracingService;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationException;
@@ -111,6 +114,8 @@ public class JavaEETransactionManagerSimplified
     @Inject private ServiceLocator habitat;
 
     @Inject protected InvocationManager invMgr;
+
+    @Inject private Provider<OpenTracingService> openTracingServiceProvider;
 
     @Inject private Provider<RequestTracingService> requestTracing;
 
@@ -196,6 +201,16 @@ public class JavaEETransactionManagerSimplified
     public void postConstruct() {
         initDelegates();
         initProperties();
+    }
+
+    private OpenTracingService getOpenTracing() {
+        OpenTracingService openTracingService = openTracingServiceProvider.get();
+        if (openTracingService == null) {
+            _logger.log(Level.INFO, "Error retrieving OpenTracing "
+                    + "service during initialisation of "
+                    + "JavaEETransactionManagerSimplified - NullPointerException");
+        }
+        return openTracingService;
     }
 
     private RequestTracingService getRequestTracing() {
@@ -662,11 +677,12 @@ public class JavaEETransactionManagerSimplified
 
         setCurrentTransaction(tx);
 
-        if (requestTracing != null && getRequestTracing().isRequestTracingEnabled()) {
-            RequestTraceSpanLog spanLog = constructJTABeginSpanLog(tx);
-            getRequestTracing().addSpanLog(spanLog);
+        if (openTracingServiceProvider != null) {
+            OpenTracingService openTracingService = getOpenTracing();
+            if (openTracingService != null && openTracingService.isEnabled()) {
+                addJtaEventTraceLog(constructJTABeginSpanLog(tx), tx, openTracingService);
+            }
         }
-
         return tx;
     }
 
@@ -954,9 +970,11 @@ public class JavaEETransactionManagerSimplified
                 }
             }
 
-            if (requestTracing != null && tx != null && getRequestTracing().isRequestTracingEnabled()) {
-                RequestTraceSpanLog spanLog = constructJTAEndSpanLog(tx);
-                getRequestTracing().addSpanLog(spanLog);
+            if (openTracingServiceProvider != null) {
+                OpenTracingService openTracingService = getOpenTracing();
+                if (openTracingService != null && openTracingService.isEnabled()) {
+                    addJtaEventTraceLog(constructJTAEndSpanLog(tx), tx, openTracingService);
+                }
             }
         } finally {
             setCurrentTransaction(null); // clear current thread's tx
@@ -992,9 +1010,11 @@ public class JavaEETransactionManagerSimplified
                 }
             }
 
-            if (requestTracing != null && tx != null && getRequestTracing().isRequestTracingEnabled()) {
-                RequestTraceSpanLog spanLog = constructJTAEndSpanLog(tx);
-                getRequestTracing().addSpanLog(spanLog);
+            if (openTracingServiceProvider != null) {
+                OpenTracingService openTracingService = getOpenTracing();
+                if (openTracingService != null && openTracingService.isEnabled()) {
+                    addJtaEventTraceLog(constructJTAEndSpanLog(tx), tx, openTracingService);
+                }
             }
         } finally {
             setCurrentTransaction(null); // clear current thread's tx
@@ -1714,6 +1734,28 @@ public class JavaEETransactionManagerSimplified
         }
 
         return tx;
+    }
+
+    private void addJtaEventTraceLog(RequestTraceSpanLog spanLog, JavaEETransaction tx,
+            OpenTracingService openTracingService) {
+        Tracer tracer = openTracingService.getTracer(openTracingService.getApplicationName(invMgr));
+
+        if (tracer != null) {
+            Span span = tracer.activeSpan();
+
+            if (span != null) {
+                span.log(spanLog.getTimeMillis(), spanLog.getLogEntries());
+
+                // Add transaction ID as baggage item
+                if (tx != null && tx.getClass().equals(JavaEETransactionImpl.class)) {
+                    span.setBaggageItem("TX-ID", ((JavaEETransactionImpl) tx).getTransactionId());
+                }
+            }
+        } else {
+            // If we couldn't get a tracer here, it's because we couldn't get a name from the invocation manager.
+            // In such a case, just try to add the span log to the currently active thread local request trace
+            getRequestTracing().addSpanLog(spanLog);
+        }
     }
 
     private RequestTraceSpanLog constructJTABeginSpanLog(JavaEETransactionImpl transaction) {

--- a/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
+++ b/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
@@ -1747,8 +1747,12 @@ public class JavaEETransactionManagerSimplified
                 span.log(spanLog.getTimeMillis(), spanLog.getLogEntries());
 
                 // Add transaction ID as baggage item
-                if (tx != null && tx.getClass().equals(JavaEETransactionImpl.class)) {
-                    span.setBaggageItem("TX-ID", ((JavaEETransactionImpl) tx).getTransactionId());
+                if (tx != null) {
+                    if (tx.getClass().equals(JavaEETransactionImpl.class)) {
+                        span.setBaggageItem("TX-ID", ((JavaEETransactionImpl) tx).getTransactionId());
+                    } else {
+                        span.setBaggageItem("TransactionInfo", tx.toString());
+                    }
                 }
             }
         } else {

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -113,6 +113,10 @@ public class OpenTracingService implements EventListener {
      * @return The Tracer instance for the given application
      */
     public synchronized Tracer getTracer(String applicationName) {
+        if (applicationName == null) {
+            return null;
+        }
+
         // Get the tracer if there is one
         Tracer tracer = tracers.get(applicationName);
 


### PR DESCRIPTION
## Description
Improvement.

Adds the transaction ID as a baggage item to the active span.
To accomodate this, the old-style request tracing was changed to be in the OpenTracing style.
The old style of attaching the log details to the currently active thread local trace is still present however for cases where we can't determine the tracer or active span.

## Testing
### New tests
New test added to existing `remote-ejb-tracing` sample, checking that a transaction ID has been added as a baggage item.

## Documentation
Pending...
