### PR TITLE
FISH-393: asadmin command list-rest-endpoints doesn't list PATCH methods.

### DIFF
--- a/appserver/payara-appserver-modules/payara-rest-endpoints/src/main/java/fish/payara/appserver/rest/endpoints/RestEndpointModel.java
+++ b/appserver/payara-appserver-modules/payara-rest-endpoints/src/main/java/fish/payara/appserver/rest/endpoints/RestEndpointModel.java
@@ -49,6 +49,7 @@ import javax.ws.rs.HttpMethod;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
 
 /**
@@ -153,6 +154,10 @@ public class RestEndpointModel {
         OPTIONS options = element.getAnnotation(OPTIONS.class);
         if (options != null) {
             return HttpMethod.OPTIONS;
+        }
+        PATCH patch = element.getAnnotation(PATCH.class);
+        if (patch != null) {
+            return HttpMethod.PATCH;
         }
         return null;
     }


### PR DESCRIPTION

## Description
Bugfix. list-rest-endpoints command doesn't list REST endpoints tagged with @PATCH.

## Testing

### Testing Performed
Ran the reproducer for the issue.


### Testing Environment
Oracle 1.8.0_181 on Mac 10.14.6 with Maven 3.5.4

