### PR TITLE
FISH-198 Fix for IllegalArgument when deploying using curl to endpoint with upload flag

### DIFF
--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2020] Payara Foundation and/or affiliates
 
 package org.glassfish.admin.payload;
 
@@ -50,7 +50,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -190,7 +189,7 @@ public abstract class PayloadFilesManager {
          * Creates a new PayloadFilesManager for dealing with permanent files that
          * will be anchored at the specified target directory.
          * @param targetDir directory under which the payload's files should be stored
-         * @param report result report to which extraction results will be appened
+         * @param report result report to which extraction results will be appended
          * @param logger logger to receive messages
          */
         public Perm(final File targetDir, final ActionReport report, final Logger logger) {

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2020] Payara Foundation and/or affiliates
 
 package org.glassfish.admin.payload;
 
@@ -284,14 +284,29 @@ class ZipPayloadImpl extends PayloadImpl {
 
                 @Override
                 public Payload.Part next() {
+                    byte[] extraBytes = nextEntry.getExtra();
+                    if (extraBytes == null) {
+                        Properties extractProperties = new Properties();
+                        extractProperties.put("data-request-type", "file-xfer");
+                        extractProperties.put("data-request-name", nextEntry.getName());
+                        final Payload.Part part = new ZipPayloadImpl.Part(
+                            nextEntry.getName(), 
+                            null,
+                            extractProperties,
+                            Inbound.this);
+                        isNextEntryPrefetched = false;
+                        return part;
+                    } else {
                     final Extra extra = new Extra(nextEntry.getExtra());
-                    final Payload.Part part = new ZipPayloadImpl.Part(
+                        final Payload.Part part = new ZipPayloadImpl.Part(
                             nextEntry.getName(), 
                             extra.getContentType(),
                             extra.getProperties(),
                             Inbound.this);
-                    isNextEntryPrefetched = false;
-                    return part;
+                        isNextEntryPrefetched = false;
+                        return part;
+                    }
+                    
                 }
 
                 @Override
@@ -332,7 +347,7 @@ class ZipPayloadImpl extends PayloadImpl {
      * the Part.
      * <p>
      * The "normal" properties and the content type are exposed separately to
-     * the rest of the ipmlementation but we use a single Properties dump to
+     * the rest of the implementation but we use a single Properties dump to
      * represent both.  So before exposing the Properties object we remove
      * the content-type entry.
      */

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
@@ -69,6 +69,7 @@ import javax.inject.Named;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
+import org.glassfish.admin.payload.PayloadFilesManager;
 import org.glassfish.admin.payload.PayloadImpl;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.AdminCommand;
@@ -113,6 +114,8 @@ import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.uuid.UuidGenerator;
 import com.sun.enterprise.util.uuid.UuidGeneratorImpl;
 import com.sun.enterprise.v3.admin.adapter.AdminEndpointDecider;
+import java.io.File;
+import static org.glassfish.admin.payload.PayloadFilesManager.strings;
 
 /**
  * Listen to admin commands...
@@ -202,14 +205,14 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
     /**
      * Call the service method, and notify all listeners
      *
-     * @exception Exception if an error happens during handling of
+     * @exception RuntimeException if an error happens during handling of
      *   the request. Common errors are:
      *   <ul><li>IOException if an input/output error occurs and we are
      *   processing an included servlet (otherwise it is swallowed and
-     *   handled by the top level error handler mechanism)
+     *   handled by the top level error handler mechanism)</li>
      *       <li>ServletException if a servlet throws an exception and
      *  we are processing an included servlet (otherwise it is swallowed
-     *  and handled by the top level error handler mechanism)
+     *  and handled by the top level error handler mechanism)</li>
      *  </ul>
      *  Tomcat should be able to handle and log any other exception ( including
      *  runtime exceptions )
@@ -528,8 +531,9 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
 
         try {
             
-            //If the upload option is present, this needs converting to a path
-            if (parameters.containsKey("upload")) {
+            //If the upload option is present and false, this needs converting to a path
+            String uploadValue = parameters.getOne("upload");
+            if ("false".equalsIgnoreCase(uploadValue)) {
                 
                 Buffer contentBuffer = req.getInputBuffer().getBuffer();
                 int capacity = contentBuffer.capacity();
@@ -540,6 +544,7 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
                 
                 parameters.add("path", new String(path)); //path as passed in
                 parameters.remove("upload"); //remove to prevent exception as this is not a param in the command class
+                
             }
             
             
@@ -547,6 +552,23 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
                 .newInstance(req.getContentType(), req.getInputStream());
             if (aalogger.isLoggable(Level.FINE)) {
                 aalogger.log(Level.FINE, "***** AdminAdapter {0}  *****", req.getMethod());
+            }
+            
+            //This is seperated from the false test as the inboundPayload is required to be set whether
+            //or not the upload flag is set.
+            if ("true".equalsIgnoreCase(uploadValue)) {
+                //This is a file that needs to be extracted
+                File extractLocation = new File(domain.getApplicationRoot() + File.separator + "upload-" + inboundPayload.hashCode() + File.separator);
+                if (!extractLocation.mkdirs()) {
+                    aalogger.log(Level.WARNING, strings.getLocalString(
+                        "payload.mkdirsFailed",
+                        "Attempt to create directories for {0} failed; no further information is available. Continuing.",
+                        extractLocation.getAbsolutePath()));
+                }
+                PayloadFilesManager.Perm permFileManager = new PayloadFilesManager.Perm(extractLocation, null, aalogger);
+                permFileManager.processParts(inboundPayload);
+                parameters.add("path", extractLocation.toString());
+                parameters.remove("upload");
             }
             
             AdminCommand adminCommand = commandRunner.getCommand(scope, command, report, aalogger);


### PR DESCRIPTION
## Description
This is a bug fix

## Important Info

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
Using curl command `curl --location --request POST 'http://127.0.0.1:4848/__asadmin/deploy?name=mavenproject22&contextroot=/mavenproject22&upload=false&type=war&target=server&force=true' \
--header 'Content-Type: application/zip' \
--data-binary '~/hello-world.war'` and checking for success.
Using curl command `curl --location --request POST 'http://127.0.0.1:4848/__asadmin/deploy?name=mavenproject22&contextroot=/mavenproject22&upload=true&type=war&target=server&force=true' \
--header 'Content-Type: application/zip' \
--data-binary @hello-world.war` and checking for success.
Also deployed using asadmin command and via admin console to check that nothing else has broken.

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 20.04 with Maven 3.6.3

## Notes for reviewers

Behaviour now matches documentation, upload=false results in the path being sent, the path
must be correct on the receiving computer for deployment. upload=true means that a file is
being sent and it will be uploaded to the remote computer.
