### PR TITLE
FISH-407 List of enabled application targets is not always correct

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -1805,6 +1805,31 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                                 }
                             }
                         }
+                        
+                        DeploymentGroup deploymentGroup = dmn.getDeploymentGroupNamed(target);
+                        if (deploymentGroup != null) {
+                            // update the application-ref from Deployment Group
+                            for (ApplicationRef appRef
+                                    : deploymentGroup.getApplicationRef()) {
+                                if (appRef.getRef().equals(appName)) {
+                                    ConfigBeanProxy appRef_w = t.enroll(appRef);
+                                    ((ApplicationRef) appRef_w).setEnabled(String.valueOf(enabled));
+                                    break;
+                                }
+                            }
+
+                            // update the application-ref from Deployment Group instances
+                            for (Server svr : deploymentGroup.getInstances()) {
+                                for (ApplicationRef appRef
+                                        : svr.getApplicationRef()) {
+                                    if (appRef.getRef().equals(appName)) {
+                                        ConfigBeanProxy appRef_w = t.enroll(appRef);
+                                        ((ApplicationRef) appRef_w).setEnabled(String.valueOf(enabled));
+                                        break;
+                                    }
+                                }
+                            }
+                        }
                     }
              }
              return Boolean.TRUE;

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016-2020] [Payara Foundation]
 
 package org.glassfish.deployment.admin;
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -385,7 +385,7 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
 
             // SHOULD CHECK THAT WE ARE THE CORRECT TARGET BEFORE DISABLING 
             String serverName = server.getName();
-            if (serverName.equals(target) || isTargetCluster() || isTargetDeploymentGroup()) {
+            if (serverName.equals(target) || isTargetCluster() || isTargetDeploymentGroup() || isTargetInstanceInDeploymentGroup()) {
                 // wait until all applications are loaded. Otherwise we get "Application not registered"
                 startupProvider.get();
                 ApplicationInfo appInfo = deployment.get(appName);
@@ -437,13 +437,22 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
     }
 
     private boolean isTargetDeploymentGroup() {
-        List<DeploymentGroup> deploymentGroups = server.getDeploymentGroup();
-            for (DeploymentGroup deploymentGroup : deploymentGroups) {
-                if (deploymentGroup.getName().equals(target)) {
+        if (domain.getDeploymentGroupNamed(target) != null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isTargetInstanceInDeploymentGroup() {
+        for (DeploymentGroup deploymentGroup : domain.getDeploymentGroups().getDeploymentGroup()) {
+
+            for (Server instance : deploymentGroup.getInstances()) {
+                if (instance.getName().equals(target)) {
                     return true;
                 }
             }
-        
+        }
         return false;
     }
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/EnableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/EnableCommand.java
@@ -56,6 +56,7 @@ import org.glassfish.config.support.CommandTarget;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.config.serverbeans.*;
 import com.sun.enterprise.admin.util.ClusterOperationUtil;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import java.util.Collection;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
@@ -255,21 +256,24 @@ public class EnableCommand extends StateCommandParameters implements AdminComman
             }
         }
 
-        try {
-            Application app = applications.getApplication(name()); 
-            ApplicationRef appRef = domain.getApplicationRefInServer(server.getName(), name());
-            
+        try {              
             // update enabled so anything that triggers an action during startup can see the 
             // application is enabled.
             try {
                 deployment.updateAppEnabledAttributeInDomainXML(name(), target, true);
             } catch(TransactionFailure e) {
-                    logger.log(Level.WARNING, "failed to set enable attribute for " + name(), e);
+                logger.log(Level.WARNING, "failed to set enable attribute for " + name(), e);
             }
-
-            DeploymentContext dc = deployment.enable(target, app, appRef, report, logger);
-            suppInfo.setDeploymentContext((ExtendedDeploymentContext)dc);
-
+            
+            // SHOULD CHECK THAT WE ARE THE CORRECT TARGET BEFORE ENABLING 
+            String serverName = server.getName();
+            if (serverName.equals(target) || isTargetCluster() || isTargetDeploymentGroup()) {
+                ApplicationRef appRef = domain.getApplicationRefInTarget(name(), target);
+                Application app = applications.getApplication(name()); 
+                DeploymentContext deploymentContext = deployment.enable(target, app, appRef, report, logger);
+                suppInfo.setDeploymentContext((ExtendedDeploymentContext) deploymentContext);
+            }
+            
             if (report.getActionExitCode().equals(ActionReport.ExitCode.FAILURE)) {
                 // update the domain.xml
                 try {
@@ -285,6 +289,28 @@ public class EnableCommand extends StateCommandParameters implements AdminComman
         } 
     }        
 
+     private boolean isTargetCluster() {
+        Cluster cluster = server.getCluster();
+        if (cluster != null) {
+            if (cluster.getName().equals(target)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    private boolean isTargetDeploymentGroup() {
+        List<DeploymentGroup> deploymentGroups = server.getDeploymentGroup();
+            for (DeploymentGroup deploymentGroup : deploymentGroups) {
+                if (deploymentGroup.getName().equals(target)) {
+                    return true;
+                }
+            }
+        
+        return false;
+    }
+    
     public String getTarget(ParameterMap parameters) {
         return DeploymentCommandUtils.getTarget(parameters, OpsParams.Origin.load, deployment);
     }

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/EnableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/EnableCommand.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2020] [Payara Foundation]
+
 package org.glassfish.deployment.admin;
 
 import com.sun.enterprise.deploy.shared.ArchiveFactory;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
When using the Maven cargo plugin to deploy an application on a deployment group, it is listed as not being enabled, when going to the endpoint of an instance in the deployment group show it is.

## Notes for Reviewers
Detail information on the reproducer is available on [FISH-87](https://payara.atlassian.net/browse/FISH-87). 
