### PR TITLE
FISH-55 Creating Java Mail Session targetted to Deployment Group fails

### DIFF
--- a/appserver/resources/javamail/javamail-connector/src/main/java/org/glassfish/resources/javamail/admin/cli/CreateJavaMailResource.java
+++ b/appserver/resources/javamail/javamail-connector/src/main/java/org/glassfish/resources/javamail/admin/cli/CreateJavaMailResource.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2020] Payara Foundation and/or its affiliates
  */
 
 package org.glassfish.resources.javamail.admin.cli;
@@ -67,7 +67,8 @@ import java.util.logging.Logger;
  * Create Java Mail Resource
  *
  */
-@TargetType(value={CommandTarget.DAS,CommandTarget.DOMAIN, CommandTarget.CLUSTER, CommandTarget.STANDALONE_INSTANCE })
+@TargetType(value={CommandTarget.DAS,CommandTarget.DOMAIN, CommandTarget.CLUSTER, CommandTarget.STANDALONE_INSTANCE,
+        CommandTarget.DEPLOYMENT_GROUP})
 @RestEndpoints({
         @RestEndpoint(configBean=Resources.class,
                 opType=RestEndpoint.OpType.POST,

--- a/appserver/tests/payara-samples/samples/asadmin/pom.xml
+++ b/appserver/tests/payara-samples/samples/asadmin/pom.xml
@@ -25,8 +25,8 @@
     the GPL Version 2 license, then the option applies only if the new code is
     made subject to such option by the copyright holder. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -41,8 +41,8 @@
 
     <dependencies>
         <dependency>
-          <groupId>fish.payara.server.internal.admin</groupId>
-          <artifactId>config-api</artifactId>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>config-api</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/CreateJavaMailResourceTest.java
+++ b/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/CreateJavaMailResourceTest.java
@@ -1,0 +1,99 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.asadmin;
+
+import fish.payara.samples.NotMicroCompatible;
+import org.glassfish.embeddable.CommandResult;
+import org.junit.Test;
+
+@NotMicroCompatible("This asadmin command is not supported on Micro")
+public class CreateJavaMailResourceTest extends AsadminTest {
+
+    @Test
+    public void testJavaMailDeploymentGroupRef() {
+        boolean dgCreated = false;
+        boolean javaMailResourceCreated = false;
+        boolean resourceRefCreated = false;
+
+        try {
+            CommandResult result = asadmin("create-deployment-group", "create-javamail-resource-test-dg");
+            assertSuccess(result);
+            dgCreated = true;
+
+            result = asadmin("create-javamail-resource",
+                    "--debug=false",
+                    "--storeProtocol=imap",
+                    "--auth=false",
+                    "--transportProtocol=smtp",
+                    "--host=localhost",
+                    "--storeProtocolClass=com.sun.mail.imap.IMAPStore",
+                    "--from=ratatosk@payara.fish",
+                    "--transportProtocolClass=com.sun.mail.smtp.SMTPTransport",
+                    "--enabled=true",
+                    "--target=domain",
+                    "--mailhost=localhost",
+                    "--mailuser=ratatosk",
+                    "mail/create-javamail-resource-test");
+            assertSuccess(result);
+            javaMailResourceCreated = true;
+
+            result = asadmin("create-resource-ref",
+                    "--enabled=true",
+                    "--target=create-javamail-resource-test-dg",
+                    "mail/create-javamail-resource-test");
+            assertSuccess(result);
+            resourceRefCreated = true;
+        } finally {
+            if (resourceRefCreated) {
+                asadmin("delete-resource-ref",
+                        "--target=create-javamail-resource-test-dg",
+                        "mail/create-javamail-resource-test");
+            }
+
+            if (javaMailResourceCreated) {
+                asadmin("delete-javamail-resource", "mail/create-javamail-resource-test");
+            }
+
+            if (dgCreated) {
+                asadmin("delete-deployment-group", "create-javamail-resource-test-dg");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Bug fix.

When using the "New JavaMail session" screen on the Web administration console, the user is allowed to choose a Deployment Group. When saving however, the follow error appears on the screen:

```
Resource <name> has Invalid target to create resource-ref on <dg-name>.
```

This was caused by the create-javamail-resource command itself not allowing a target type of deployment group.

## Important Info
### Blockers
None.

## Testing
### New tests
New asadmin test added, which creates a deployment group and a javamail resource, before attempting to assign a resource ref between them.

### Testing Performed
Essentially the steps taken in the added test.

### Testing Environment
Windows, Zulu JDK 8u265

## Documentation
N/A

## Notes for Reviewers
Brownie point for whomever spots the mythological reference without using Google/Wikipedia 🐿
