### PR TITLE
FISH-37 URL in DataSourceDefinition overrides serverName

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/DataSourceDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/DataSourceDefinitionDescriptor.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2020] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.deployment;
 
@@ -164,7 +164,12 @@ public class DataSourceDefinitionDescriptor extends ResourceDescriptor {
 
     public void setServerName(String serverName) {
         this.serverName = serverName;
-        setServerNameSet(true);
+        if (serverName == null) {
+            setServerNameSet(false);
+        } else {
+            setServerNameSet(true);
+        }
+        
     }
 
     public String getUser() {

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016-2020] [Payara Foundation and/or affiliates]
 
 package org.glassfish.jdbcruntime.deployment.annotation.handlers;
 
@@ -368,8 +368,8 @@ public class DataSourceDefinitionHandler extends AbstractResourceHandler {
 
     }
 
-
-    private DataSourceDefinitionDescriptor createDescriptor(DataSourceDefinition defn) {
+    //Not private as accessed by tests
+    DataSourceDefinitionDescriptor createDescriptor(DataSourceDefinition defn) {
 
         DataSourceDefinitionDescriptor desc = new DataSourceDefinitionDescriptor();
         desc.setMetadataSource(MetadataSource.ANNOTATION);
@@ -394,11 +394,12 @@ public class DataSourceDefinitionHandler extends AbstractResourceHandler {
             desc.setDatabaseName(defn.databaseName());
         }
 
-        if ((desc.getPortNumber() != -1 && desc.getDatabaseName() != null && desc.getServerName() != null)) {
+        if (desc.getPortNumber() != -1 && desc.getDatabaseName() != null && desc.getServerName() != null) {
             //standard properties are set, ignore URL
         } else {
             if (defn.url() != null && !defn.url().equals("")) {
                 desc.setUrl(defn.url());
+                desc.setServerName(null); //To prevent serverName overriding the URL, always use the URL if the standard properties are not set
             }
         }
 

--- a/appserver/jdbc/jdbc-runtime/src/test/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionTest.java
+++ b/appserver/jdbc/jdbc-runtime/src/test/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionTest.java
@@ -1,0 +1,163 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.jdbcruntime.deployment.annotation.handlers;
+
+import com.sun.enterprise.deployment.DataSourceDefinitionDescriptor;
+import java.lang.annotation.Annotation;
+import javax.annotation.sql.DataSourceDefinition;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for DataSourceDefinition processing in DataSourceDefinitionHandler
+ * @author jonathan coustick
+ */
+public class DataSourceDefinitionTest {
+ 
+    /**
+     * Test to ensure that if the URL has been set, it will override the default serverName of localhost
+     * and cause that to be set to null.
+     */
+    @Test
+    public void testServerAndURL() {
+        DataSourceDefinitionHandler handler = new DataSourceDefinitionHandler();
+        DataSourceDefinition definition = new DataSourceDefinition() {
+            @Override
+            public String name() {
+                return null;
+            }
+
+            @Override
+            public String className() {
+                return null;
+            }
+
+            @Override
+            public String description() {
+                return null;
+            }
+
+            @Override
+            public String url() {
+                return "jdbc://foo/bar";
+            }
+
+            @Override
+            public String user() {
+                return null;
+            }
+
+            @Override
+            public String password() {
+                return null;
+            }
+
+            @Override
+            public String databaseName() {
+                return null;
+            }
+
+            @Override
+            public int portNumber() {
+                return -1;
+            }
+
+            @Override
+            public String serverName() {
+                return "localhost";
+            }
+
+            @Override
+            public int isolationLevel() {
+                return -1;
+            }
+
+            @Override
+            public boolean transactional() {
+                return false;
+            }
+
+            @Override
+            public int initialPoolSize() {
+                return -1;
+            }
+
+            @Override
+            public int maxPoolSize() {
+                return -1;
+            }
+
+            @Override
+            public int minPoolSize() {
+                return -1;
+            }
+
+            @Override
+            public int maxIdleTime() {
+                return -1;
+            }
+
+            @Override
+            public int maxStatements() {
+                return -1;
+            }
+
+            @Override
+            public String[] properties() {
+                return null;
+            }
+
+            @Override
+            public int loginTimeout() {
+                return -1;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return DataSourceDefinition.class;
+            }
+        };
+        DataSourceDefinitionDescriptor descriptor = handler.createDescriptor(definition);
+        Assert.assertNull(descriptor.getServerName());
+        
+    }
+            
+            
+}

--- a/appserver/jdbc/jdbc-runtime/src/test/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionTest.java
+++ b/appserver/jdbc/jdbc-runtime/src/test/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionTest.java
@@ -58,8 +58,42 @@ public class DataSourceDefinitionTest {
     @Test
     public void testServerAndURL() {
         DataSourceDefinitionHandler handler = new DataSourceDefinitionHandler();
-        DataSourceDefinition definition = new DataSourceDefinition() {
+        
+        //Check url overrides serverName and sets it to null
+        DataSourceDefinition definition = new DataSourceDefinitionImpl() {
             @Override
+            public String url() {
+                return "http://database:5432/demo";
+            }
+
+            @Override
+            public String serverName() {
+                return "localhost";
+            }
+            
+        };
+        DataSourceDefinitionDescriptor descriptor = handler.createDescriptor(definition);
+        Assert.assertNull(descriptor.getServerName());
+        
+        
+        //Check if url is not set then serverName is left as-is
+        definition = new DataSourceDefinitionImpl() {
+            @Override
+            public String url() {
+                return null;
+            }
+
+            @Override
+            public String serverName() {
+                return "localhost";
+            }
+        };
+        descriptor = handler.createDescriptor(definition);
+        Assert.assertEquals("localhost", descriptor.getServerName());
+    }
+    
+    abstract class DataSourceDefinitionImpl implements DataSourceDefinition {
+        @Override
             public String name() {
                 return null;
             }
@@ -72,11 +106,6 @@ public class DataSourceDefinitionTest {
             @Override
             public String description() {
                 return null;
-            }
-
-            @Override
-            public String url() {
-                return "jdbc://foo/bar";
             }
 
             @Override
@@ -97,11 +126,6 @@ public class DataSourceDefinitionTest {
             @Override
             public int portNumber() {
                 return -1;
-            }
-
-            @Override
-            public String serverName() {
-                return "localhost";
             }
 
             @Override
@@ -153,10 +177,6 @@ public class DataSourceDefinitionTest {
             public Class<? extends Annotation> annotationType() {
                 return DataSourceDefinition.class;
             }
-        };
-        DataSourceDefinitionDescriptor descriptor = handler.createDescriptor(definition);
-        Assert.assertNull(descriptor.getServerName());
-        
     }
             
             


### PR DESCRIPTION
## Description
This is a bug fix.

If URL has been set it should override the serverName, causing that to be set to null
to prevent that being using when the DataSource is initialised

Fixes #4385

## Important Info

## Testing
### New tests
New test added in PR, DataSource Definition Tests

### Testing Performed
* Written test
* Debugging Payara and checking the value of serverName is set to null and unused
* Docker test in original issue

### Testing Environment
Zulu JDK 1.8_262 on Ubuntu 20.04 with Maven 3.6.3

