### PR TITLE
Revert "FISH-31 Upgrade Grizzly to 2.4.4.payara-p3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
-        <grizzly.version>2.4.4.payara-p3</grizzly.version>
+        <grizzly.version>2.4.4.payara-p2</grizzly.version>
         <jax-rs-api.impl.version>2.1.6</jax-rs-api.impl.version>
         <jersey.version>2.30.payara-p2</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>


### PR DESCRIPTION
This reverts commit 2a0b89bc068ceb6ce93330ee0f822f5afadabdb8.

The reverted commit breaks a websocket TCK test. QACI-406 will endeavour to fix this test without rolling back functionality.