### PR TITLE
FISH-99 FISH-298 Schemas are always picked up and used in OpenAPI

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
@@ -100,4 +100,16 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
@@ -100,16 +100,4 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -129,7 +129,7 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
                 }
                 return node;
             } catch (Exception e) {
-                LOGGER.warning("Failed to parse extension value: " + value);
+                LOGGER.log(Level.WARNING, "Failed to parse extension value: {0}", value);
                 return value;
             }
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -70,9 +70,12 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
     protected List<Tag> tags = new ArrayList<>();
     protected Paths paths = new PathsImpl();
     protected Components components = new ComponentsImpl();
+    
+    private ApiContext context;
 
     public static OpenAPI createInstance(AnnotationModel annotation, ApiContext context) {
-        OpenAPI from = new OpenAPIImpl();
+        OpenAPIImpl from = new OpenAPIImpl();
+        from.context = context;
         AnnotationModel info = annotation.getValue("info", AnnotationModel.class);
         if (info != null) {
             from.setInfo(InfoImpl.createInstance(info));
@@ -89,6 +92,10 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
             from.setComponents(ComponentsImpl.createInstance(components, context));
         }
         return from;
+    }
+    
+    public final ApiContext getContext() {
+        return context;
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -110,6 +110,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
 
     private Object additionalProperties;
     private Schema items;
+    @JsonIgnore
     private String implementation;
 
     public static Schema createInstance(AnnotationModel annotation, ApiContext context) {
@@ -828,6 +829,11 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
                 && ((SchemaImpl) from).getImplementation() != null
                 && context.getApi().getComponents().getSchemas() != null) {
             String implementationClass = ((SchemaImpl) from).getImplementation();
+            
+            if (to instanceof SchemaImpl) {
+                ((SchemaImpl) to).setImplementation(mergeProperty(((SchemaImpl)to).getImplementation(), ((SchemaImpl) from).getImplementation(), override));
+            }
+            
             if (!implementationClass.equals("java.lang.Void")) {
                 Type type = context.getType(implementationClass);
                 String schemaName = null;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -827,6 +827,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
         }
         if (from instanceof SchemaImpl
                 && ((SchemaImpl) from).getImplementation() != null
+                && context != null
                 && context.getApi().getComponents().getSchemas() != null) {
             String implementationClass = ((SchemaImpl) from).getImplementation();
             

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -44,7 +44,6 @@ import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.headers.HeaderImpl;
 import fish.payara.microprofile.openapi.impl.model.links.LinkImpl;
 import fish.payara.microprofile.openapi.impl.model.media.ContentImpl;
-import fish.payara.microprofile.openapi.impl.model.media.EncodingImpl;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.applyReference;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -43,7 +43,6 @@ package fish.payara.microprofile.openapi.impl.model.responses;
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleTreeMap;
 import java.util.Map;
-import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -131,7 +131,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     private OpenApiWalker apiWalker;
 
     /**
-     * @param types parsed application classes
+     * @param allTypes parsed application classes
      * @param allowedTypes filtered application classes for OpenAPI metadata
      * processing
      * @param appClassLoader the class loader for the application.
@@ -316,10 +316,16 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
                             && response.getContent().getMediaType(javax.ws.rs.core.MediaType.WILDCARD) != null) {
                         MediaType wildcardMedia = response.getContent().getMediaType(javax.ws.rs.core.MediaType.WILDCARD);
 
-                        // Copy the wildcard return type to the valid response types
+                        // Merge the wildcard return type with the valid response types
+                        //This keeps the specific details of a reponse type that has a schema
                         List<String> mediaTypes = produces.getValue("value", List.class);
                         for (String mediaType : mediaTypes) {
-                            response.getContent().addMediaType(getContentType(mediaType), wildcardMedia);
+                            MediaType held = response.getContent().getMediaType(getContentType(mediaType));
+                            if (held == null) {
+                                response.getContent().addMediaType(getContentType(mediaType), wildcardMedia);
+                            } else {
+                                MediaTypeImpl.merge(held, wildcardMedia, true);
+                            }
                         }
                         // If there is an @Produces, remove the wildcard
                         response.getContent().removeMediaType(javax.ws.rs.core.MediaType.WILDCARD);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -60,7 +60,6 @@ import fish.payara.microprofile.openapi.impl.model.security.SecurityRequirementI
 import fish.payara.microprofile.openapi.impl.model.security.SecuritySchemeImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
-import fish.payara.microprofile.openapi.impl.visitor.AnnotationInfo;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import fish.payara.microprofile.openapi.impl.visitor.OpenApiWalker;
 import java.lang.reflect.Method;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
@@ -41,17 +41,22 @@ package fish.payara.microprofile.openapi.impl.processor;
 
 import fish.payara.microprofile.openapi.api.processor.OASProcessor;
 import fish.payara.microprofile.openapi.impl.config.OpenApiConfiguration;
+import fish.payara.microprofile.openapi.impl.model.OpenAPIImpl;
 import fish.payara.microprofile.openapi.impl.model.PathItemImpl;
 import fish.payara.microprofile.openapi.impl.model.info.InfoImpl;
+import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.normaliseUrl;
 import java.net.URL;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 
 /**
  * A processor to apply any configuration options to the model, and fill any
@@ -147,5 +152,5 @@ public class BaseProcessor implements OASProcessor {
     private static void removeEmptyPaths(OpenAPI api) {
         PathItem emptyItem = new PathItemImpl();
         api.getPaths().entrySet().removeIf(entry -> emptyItem.equals(entry.getValue()));
-    }
+    }    
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
@@ -41,22 +41,17 @@ package fish.payara.microprofile.openapi.impl.processor;
 
 import fish.payara.microprofile.openapi.api.processor.OASProcessor;
 import fish.payara.microprofile.openapi.impl.config.OpenApiConfiguration;
-import fish.payara.microprofile.openapi.impl.model.OpenAPIImpl;
 import fish.payara.microprofile.openapi.impl.model.PathItemImpl;
 import fish.payara.microprofile.openapi.impl.model.info.InfoImpl;
-import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.normaliseUrl;
 import java.net.URL;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
-import org.eclipse.microprofile.openapi.models.media.Schema;
-import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 
 /**
  * A processor to apply any configuration options to the model, and fill any

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
@@ -147,5 +147,5 @@ public class BaseProcessor implements OASProcessor {
     private static void removeEmptyPaths(OpenAPI api) {
         PathItem emptyItem = new PathItemImpl();
         api.getPaths().entrySet().removeIf(entry -> emptyItem.equals(entry.getValue()));
-    }    
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -259,13 +259,15 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
         api.getPaths().getPathItems().forEach((String s, PathItem t) -> {
             t.getOperations().forEach((PathItem.HttpMethod u, org.eclipse.microprofile.openapi.models.Operation v) -> {
                 v.getResponses().getAPIResponses().forEach((String w, org.eclipse.microprofile.openapi.models.responses.APIResponse x) -> {
-                    x.getContent().getMediaTypes().forEach((y, z) -> {
-                        SchemaImpl.merge(z.getSchema(), z.getSchema(), true, context);
-                        if (z.getSchema() instanceof SchemaImpl) {
-                            SchemaImpl schema = (SchemaImpl) z.getSchema();
-                            schema.setImplementation(null);
-                        }
-                    });
+                    if (x.getContent() != null) {
+                        x.getContent().getMediaTypes().forEach((y, z) -> {
+                            SchemaImpl.merge(z.getSchema(), z.getSchema(), true, context);
+                            if (z.getSchema() instanceof SchemaImpl) {
+                                SchemaImpl schema = (SchemaImpl) z.getSchema();
+                                schema.setImplementation(null);
+                            }
+                        });
+                    }
                 });
             });
         });

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -42,6 +42,7 @@ package fish.payara.microprofile.openapi.impl.visitor;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor.VisitorFunction;
 import fish.payara.microprofile.openapi.api.visitor.ApiWalker;
+import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -85,6 +86,7 @@ import org.eclipse.microprofile.openapi.annotations.servers.Servers;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.tags.Tags;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
 import org.glassfish.hk2.classmodel.reflect.AnnotatedElement;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 import org.glassfish.hk2.classmodel.reflect.ClassModel;
@@ -118,6 +120,7 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
                 processAnnotation((ClassModel) type, visitor);
             }
         }
+        addSchemasToPaths();
     }
 
     public final void processAnnotation(ClassModel annotatedClass, ApiVisitor visitor) {
@@ -249,6 +252,24 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
             annotationAlternatives.put(SecurityRequirements.class, SecurityRequirement.class);
         }
         return annotationAlternatives;
+    }
+    
+    private void addSchemasToPaths() {
+        OpenAPI api = context.getApi();
+        api.getPaths().getPathItems().forEach((String s, PathItem t) -> {
+            t.getOperations().forEach((PathItem.HttpMethod u, org.eclipse.microprofile.openapi.models.Operation v) -> {
+                v.getResponses().getAPIResponses().forEach((String w, org.eclipse.microprofile.openapi.models.responses.APIResponse x) -> {
+                    x.getContent().getMediaTypes().forEach((y, z) -> {
+                        SchemaImpl.merge(z.getSchema(), z.getSchema(), true, context);
+                        if (z.getSchema() instanceof SchemaImpl) {
+                            SchemaImpl schema = (SchemaImpl) z.getSchema();
+                            schema.setImplementation(null);
+                        }
+                    });
+                });
+            });
+        });
+        
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/OpenApiApplicationTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/OpenApiApplicationTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -51,8 +51,8 @@ import org.junit.Test;
 
 public abstract class OpenApiApplicationTest {
 
-    private OpenAPI document;
-    private ObjectNode jsonDocument;
+    protected OpenAPI document;
+    protected ObjectNode jsonDocument;
 
     @Before
     public void createDocument() {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/ExternalSchemaWithProducesTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/ExternalSchemaWithProducesTest.java
@@ -1,0 +1,98 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *  
+ *  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *  
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.microprofile.openapi.test.app.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import fish.payara.microprofile.openapi.resource.rule.ApplicationProcessedDocument;
+import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
+import fish.payara.microprofile.openapi.test.app.TestApplication;
+import fish.payara.microprofile.openapi.test.app.application.schema.TeacherDTO;
+import fish.payara.microprofile.openapi.test.util.JsonUtils;
+import static fish.payara.microprofile.openapi.test.util.JsonUtils.toJson;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This test uses an {@link Produces} annotation on the REST method
+ * and also has the schema in another package.
+ * @author jonathan coustick
+ */
+@Path("/teachers")
+public class ExternalSchemaWithProducesTest extends OpenApiApplicationTest {
+    
+    @Before
+    @Override
+    public void createDocument() {
+        Class<?> filter = filterClass();
+        document = ApplicationProcessedDocument.createDocument(getClass(), TeacherDTO.class, TestApplication.class);
+        jsonDocument = toJson(document);
+    }
+    
+    @GET
+    @APIResponse(
+            description = "Get the Teacher information",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = TeacherDTO.class)
+            )
+    )
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getTeacher() {
+        return Response.ok().build();
+    }
+    
+    @Test
+    public void externalSchemaExampleIsRendere() {
+        JsonNode nameProperties = JsonUtils.path(getOpenAPIJson(), "components.schemas.Teacher.properties.name");
+        Assert.assertNotNull(nameProperties);
+        Assert.assertEquals("string", nameProperties.get("type").textValue());
+        Assert.assertEquals("the teacher name", nameProperties.get("description").textValue());
+        Assert.assertEquals("Trunchbull", nameProperties.get("example").textValue());
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/schema/TeacherDTO.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/schema/TeacherDTO.java
@@ -1,0 +1,64 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *  
+ *  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *  
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.microprofile.openapi.test.app.application.schema;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Data object, in a different package to the test.
+ * 
+ * Used in {@link fish.payara.microprofile.openapi.test.app.application.ExternalSchemaExampleTest ExternalSchemaExampleTest}.
+ * @author jonathan coustick
+ */
+@Schema(name = "Teacher", description = "POJO that represents a Teacher.")
+public class TeacherDTO {
+    
+    @Schema(name = "name", description = "the teacher name", example = "Trunchbull")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+}


### PR DESCRIPTION
## Description
This is a bug fix.

Fixes #4802


## Testing
### New tests
New test included in PR

### Testing Performed
* Tested using reproducers on Jira tickets
* Microprofile OpenAPI TCK

### Testing Environment
Zulu JDK 1.8_262 on Ubuntu 20.04 with Maven 3.6.3


## Notes for reviewers
Previously schemas may not have been referenced by APIResponse if the schema class was scanned later than the REST class, so this PR means the the APIWalker will go through the classes a second time to add in any references that didn't get linked the first time.