### PR TITLE
FISH-396 _JAVA_OPTIONS prevents Payara Server determining Java version for JVM options

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.launcher;
 
@@ -912,13 +912,12 @@ public abstract class GFLauncher {
             Process p = r.exec(javaExePath + " -version");
             p.waitFor();
             try (BufferedReader b = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
-                String line = b.readLine();
-                if (line == null) {
-                    return Optional.empty();
-                }
-                Matcher m = JAVA_VERSION_PATTERN.matcher(line);
-                if (m.matches()) {
-                    return Optional.ofNullable(JDK.getVersion(m.group(1)));
+                String line;
+                while ((line = b.readLine()) != null) {
+                    Matcher m = JAVA_VERSION_PATTERN.matcher(line);
+                    if (m.matches()) {
+                        return Optional.ofNullable(JDK.getVersion(m.group(1)));
+                    }
                 }
             }
             return Optional.empty();


### PR DESCRIPTION
## Description
This is a bug fix.

When `_JAVA_OPTIONS` environment variable is set it makes executions of `java ...` print out out the options before the usual output.
This breaks the `java -version` check done during launcher bootstrap since it expects it to be on the first line. This fix simply makes it check all lines.

## Important Info

### Dependant PRs 
None

### Blockers 
Nil

## Testing
### New tests
Keiner - messing with env variables is iffy in a _build_ test

### Testing Performed
Set environment variable
Start server with debug enabled
Stepped through to check if skips incorrect java options line and reads the correct "version" line: https://github.com/payara/Payara-Enterprise/compare/payara-server-4.1.2.191.maintenance...Pandrex247:FISH-396?expand=1#diff-7fd7ed9c30a3768cece34b929651acb8R919
Checked that full list of java options are present.

### Testing Environment
OpenSUSE Leap 15.2, 8u252
OpenSUSE Leap 15.2, 11.0.8
Windows 10, 8u265
Windows 10, 11.0.8

## Notes for Reviewers
Nope