### PR TITLE
FISH-141 Support Additional Fields with LogRecord when using JsonLogFormatter

### DIFF
--- a/appserver/tests/payara-samples/samples/logging/pom.xml
+++ b/appserver/tests/payara-samples/samples/logging/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>5.2020.5-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>logging</artifactId>
+    <name>Payara Samples - Logging</name>
+    <packaging>war</packaging>
+
+    <properties>
+        <payara.home></payara.home>
+        <payara.domain.dir>${payara.home}/glassfish/domains</payara.domain.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
+        <!-- Need servlet api too - platform api doesn't include String bundles -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admin</groupId>
+            <artifactId>config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>internal-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>simple-glassfish-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>payara-server-managed</id>
+            <properties>
+                <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/appserver/tests/payara-samples/samples/logging/src/main/java/fish/payara/samples/logging/LogRecordMapParameterServlet.java
+++ b/appserver/tests/payara-samples/samples/logging/src/main/java/fish/payara/samples/logging/LogRecordMapParameterServlet.java
@@ -1,0 +1,72 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.logging;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Basic servlet that creates a log record with
+ * @author Rudy De Busscher
+ */
+@WebServlet("/LogRecordMapParameter")
+public class LogRecordMapParameterServlet extends HttpServlet {
+
+    public static String correlationIdKey = "Correlation-Id";
+    public static String correlationIdValue = "1234-5678";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getOutputStream().print("Hello World");
+
+        LogRecord lr = new LogRecord(Level.INFO, "some message");
+        lr.setParameters(new Object[]{Collections.singletonMap(correlationIdKey, correlationIdValue/*Correlation.getId()*/)});
+        Logger.getLogger(LogRecordMapParameterServlet.class.getName()).log(lr);
+
+    }
+}

--- a/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
+++ b/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
@@ -1,0 +1,192 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.logging;
+
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.CliCommands;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.ServerOperations;
+import fish.payara.samples.SincePayara;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(PayaraArquillianTestRunner.class)
+@SincePayara("5.2020.5")
+@NotMicroCompatible
+public class JsonLogFormatIT {
+
+    @ArquillianResource
+    private URL baseUrl;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return PayaraTestShrinkWrap.getWebArchive()
+                .addClass(LogRecordMapParameterServlet.class)
+                .addClass(JsonLogFormatIT.class);
+    }
+
+    @Test
+    public void mapParameterLoggedIT() throws Exception {
+        ArrayList<String> command = new ArrayList<>();
+        ArrayList<String> output = new ArrayList<>();
+        command.add("list-log-attributes");
+        CliCommands.payaraGlassFish(command, output);
+
+        boolean foundFile = false;
+        boolean foundConsole = false;
+        String originalFileHandlerFormatter = "";
+        String originalConsoleHandlerFormatter = "";
+        for (String keyValue : output) {
+            if (keyValue.startsWith("com.sun.enterprise.server.logging.GFFileHandler.formatter")) {
+                originalFileHandlerFormatter = keyValue.substring(
+                        keyValue.indexOf("\t<") + 2, keyValue.length() - 1);
+                foundFile = true;
+                continue;
+            }
+            if (keyValue.startsWith("java.util.logging.ConsoleHandler.formatter")) {
+                originalConsoleHandlerFormatter = keyValue.substring(
+                        keyValue.indexOf("\t<") + 2, keyValue.length() - 1);
+                foundConsole = true;
+                continue;
+            }
+            if (foundFile && foundConsole) {
+                break;
+            }
+        }
+
+        // Will return null if file could not be determined.
+        File logFile = getLogFile();
+        if (logFile == null) {
+            fail("Could not determine or read log file.");
+        }
+
+        try {
+            // Set log settings to JSON
+            command.clear();
+            output.clear();
+            command.add("set-log-attributes");
+            command.add("java.util.logging.ConsoleHandler.formatter='fish.payara.enterprise.server.logging.JSONLogFormatter'"
+                    + ":com.sun.enterprise.server.logging.GFFileHandler.formatter="
+                    + "'fish.payara.enterprise.server.logging.JSONLogFormatter'");
+            CliCommands.payaraGlassFish(command, output);
+            assertEquals("Command set-log-attributes executed successfully.", output.get(output.size() - 1));
+
+            // Invoke page
+            try (WebClient client = new WebClient()) {
+                TextPage page = client.getPage(baseUrl + "LogRecordMapParameter");
+                System.out.println(page.getContent());
+            }
+
+            // Check log
+            boolean foundMapContents = false;
+            try (Scanner scanner = new Scanner(new FileInputStream(logFile))) {
+                while (scanner.hasNext()) {
+                    String line = scanner.nextLine();
+                    if (line.contains("\"" + LogRecordMapParameterServlet.correlationIdKey
+                            + "\":\"" + LogRecordMapParameterServlet.correlationIdValue + "\"")) {
+                        foundMapContents = true;
+                        break;
+                    }
+                }
+            }
+            Assert.assertTrue(foundMapContents);
+        } finally {
+            command.clear();
+            output.clear();
+            command.add("set-log-attributes");
+            command.add("java.util.logging.ConsoleHandler.formatter=" + originalConsoleHandlerFormatter
+                    + ":com.sun.enterprise.server.logging.GFFileHandler.formatter=" + originalFileHandlerFormatter);
+            CliCommands.payaraGlassFish(command, output);
+        }
+    }
+
+    private File getLogFile() {
+        // Get domain name
+        String domain = System.getProperty("payara.domain.name");
+        if (domain == null) {
+            domain = ServerOperations.getPayaraDomainFromServer();
+            Logger.getLogger(JsonLogFormatIT.class.getName()).log(Level.INFO,
+                    "Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
+        }
+
+        // Get the domain dir
+        String domainsdir = System.getProperty("payara.domain.dir");
+        if (domainsdir == null) {
+            // Try getting default from payara.home and glassfishRemote_gfHome
+            String installRoot = System.getProperty("payara.home");
+            if (installRoot == null) {
+                installRoot = System.getProperty("glassfishRemote_gfHome");
+                if (installRoot == null) {
+                    return null;
+                }
+            }
+
+            domainsdir = installRoot + File.separator + "glassfish" + File.separator + "domains";
+            Logger.getLogger(JsonLogFormatIT.class.getName()).log(Level.INFO,
+                    "Using default domains dir \"" + domainsdir + "\". If this is not correct use -Dpayara.domain.dir and -Dpayara.domain.name to override.");
+        }
+
+        File logFile = new File(domainsdir + File.separator + domain + File.separator + "logs"
+                + File.separator + "server.log");
+
+        if (logFile.exists() && logFile.canRead()) {
+            return logFile;
+        }
+        return null;
+    }
+}

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -36,6 +36,7 @@
         <module>rolesPermitted</module>
         <module>realm-identity-stores</module>
         <module>jakartaee-namespace-transformer</module>
+        <module>logging</module>
     </modules>
 
     <dependencyManagement>
@@ -127,6 +128,21 @@
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${session.executionRootDirectory}/target/${payara.directory.name}</GLASSFISH_HOME>
+                            </environmentVariables>
+                            <!-- This needs tuning -->
+                            <systemPropertyVariables>
+                                <glassfishRemote_gfHome>${session.executionRootDirectory}/target/${payara.directory.name}</glassfishRemote_gfHome>
+                                <javaEEServer>payara-remote</javaEEServer>
+                                <payara.domain.name>${payara.domain.name}</payara.domain.name>
+                                <arquillian.launch>payara</arquillian.launch>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -187,6 +203,14 @@
                             </environmentVariables>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <MICRO_JAR>${session.executionRootDirectory}/target/payara-micro-${payara.version}.jar</MICRO_JAR>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -217,6 +241,15 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <javaEEServer>payara-remote</javaEEServer>
+                                <payara.domain.name>${payara.domain.name}</payara.domain.name>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
                                 <javaEEServer>payara-remote</javaEEServer>

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
@@ -379,6 +379,30 @@ public class JSONLogFormatter extends Formatter implements LogEventBroadcaster {
                         .append(eventObject.toString()), level);
             }
 
+            Object[] parameters = record.getParameters();
+            if (parameters != null) {
+                for (Object parameter : parameters) {
+                    if (parameter instanceof Map) {
+                        for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) parameter).entrySet()) {
+                            // there are implementations that allow <null> keys...
+                            String key;
+                            if (entry.getKey() != null) {
+                                key = entry.getKey().toString();
+                            } else {
+                                key = "null";
+                            }
+
+                            // also handle <null> values...
+                            if (entry.getValue() != null) {
+                                eventObject.add(key, entry.getValue().toString());
+                            } else {
+                                eventObject.add(key, "null");
+                            }
+                        }
+                    }
+                }
+            }
+
             String logMessage = record.getMessage();
 
             if (null == logMessage || logMessage.trim().equals("")) {

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
@@ -37,7 +37,6 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
- // Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 package fish.payara.enterprise.server.logging;
 
 import com.sun.common.util.logging.GFLogRecord;


### PR DESCRIPTION
## Description
Feature.

Parameters added to a log record as a map will now be logged out.

Also adds some default maven-failsafe -plugin settings because I'm tired of copy-pasting them.

## Important Info
### Blockers
None.

## Testing
### New tests
New sample added.

### Testing Performed
Ran sample test.

Also tested manually by deploying servlet in sample, changing log formatting to JSON, and hitting servlet.

### Testing Environment
Windows 10, JDK 8u265

## Documentation
Pending...

## Notes for Reviewers
None.
