### PR TITLE
QACI-451 Compile jaxws-tracing on jdk11

### DIFF
--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -1,5 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright Payara Services Limited -->
+<!--
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-		<version>${nimbus-jose-jwt.version}</version>
+                <version>${nimbus-jose-jwt.version}</version>
             </dependency>
             <!-- Used to automatically configure microprofile rest client in tests -->
             <dependency>

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
@@ -16,7 +16,16 @@
             <groupId>fish.payara.samples</groupId>
             <artifactId>test-utils</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>fish.payara.api</groupId>
             <artifactId>payara-api</artifactId>

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/TraceMonitor.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/TraceMonitor.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/TraceMonitor.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/TraceMonitor.java
@@ -52,31 +52,28 @@ import fish.payara.notification.requesttracing.RequestTracingNotificationData;
 
 @ApplicationScoped
 public class TraceMonitor {
-    
+
     private boolean observerCalled;
-    
+
     private static final Logger logger = Logger.getLogger(TraceMonitor.class.getName());
 
     public void observe(@Observes @Inbound EventbusMessage event) {
-        
+        logger.info("CDI notifier: " + event.getMessage());
         if (event.getData() instanceof RequestTracingNotificationData) {
             RequestTracingNotificationData notificationData = (RequestTracingNotificationData) event.getData();
-            
+
             List<RequestTraceSpan> spans = notificationData.getRequestTrace().getTraceSpans();
-            
-            for (int i = 0; i < spans.size(); i++) {
-                if ("customOperation".equals(spans.get(i).getEventName())) {
+
+            for (RequestTraceSpan span : spans) {
+                if ("customOperation".equals(span.getEventName())) {
                     observerCalled = true;
                 }
             }
-           
         }
-        
-        logger.info("CDI notifier: " + event.getMessage());
     }
-    
+
     public boolean isObserverCalled() {
         return observerCalled;
     }
-    
+
 }

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointImplementation.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointImplementation.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointImplementation.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/ejb/JAXWSEndPointImplementation.java
@@ -39,6 +39,9 @@
  */
 package fish.payara.samples.jaxws.endpoint.ejb;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.ejb.Stateless;
 import javax.jws.WebService;
 
@@ -48,10 +51,12 @@ import org.eclipse.microprofile.opentracing.Traced;
 @Stateless
 @WebService(endpointInterface = "fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointInterface")
 public class JAXWSEndPointImplementation implements JAXWSEndPointInterface {
+    private static final Logger LOG = Logger.getLogger(JAXWSEndPointImplementation.class.getName());
 
     @Override
     @Traced(operationName = "customOperation")
     public String sayHi(String name) {
+        LOG.log(Level.INFO, "sayHi(name={0})", name);
         return "Hi " + name;
     }
 

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/servlet/JAXWSEndPointImplementation.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/servlet/JAXWSEndPointImplementation.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/servlet/JAXWSEndPointImplementation.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/main/java/fish/payara/samples/jaxws/endpoint/servlet/JAXWSEndPointImplementation.java
@@ -39,6 +39,9 @@
  */
 package fish.payara.samples.jaxws.endpoint.servlet;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.jws.WebService;
 
 import org.eclipse.microprofile.opentracing.Traced;
@@ -47,10 +50,12 @@ import org.eclipse.microprofile.opentracing.Traced;
     endpointInterface = "fish.payara.samples.jaxws.endpoint.servlet.JAXWSEndPointInterface",
     serviceName = "JAXWSEndPointImplementationService")
 public class JAXWSEndPointImplementation implements JAXWSEndPointInterface {
+    private static final Logger LOG = Logger.getLogger(JAXWSEndPointImplementation.class.getName());
 
     @Override
     @Traced(operationName = "customOperation")
     public String sayHi(String name) {
+        LOG.log(Level.INFO, "sayHi(name={0})", name);
         return "Hi " + name;
     }
 

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/JAXWSEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/JAXWSEndpointTest.java
@@ -1,3 +1,42 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
 package fish.payara.samples.jaxws.test;
 
 import fish.payara.samples.PayaraTestShrinkWrap;

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/JAXWSEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/JAXWSEndpointTest.java
@@ -1,26 +1,36 @@
 package fish.payara.samples.jaxws.test;
 
-import static fish.payara.samples.CliCommands.payaraGlassFish;
+import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.jaxws.endpoint.TraceMonitor;
 
 import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.inject.Inject;
 import javax.xml.ws.Service;
 
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
-import fish.payara.samples.PayaraTestShrinkWrap;
-import fish.payara.samples.jaxws.endpoint.TraceMonitor;
+import static fish.payara.samples.CliCommands.payaraGlassFish;
 
 public abstract class JAXWSEndpointTest {
+    private static final Logger LOG = Logger.getLogger(JAXWSEndpointTest.class.getName());
 
     protected Service jaxwsEndPointService;
 
     @Inject
     private TraceMonitor traceMonitor;
+
+    @Rule
+    public TestName name = new TestName();
 
     @ArquillianResource
     protected URL url;
@@ -54,6 +64,16 @@ public abstract class JAXWSEndpointTest {
             "--enabled=true",
             "--hazelcastEnabled=true"
         );
+    }
+
+    @Before
+    public void logStart() {
+        LOG.log(Level.INFO, "Test method {0} started.", name.getMethodName());
+    }
+
+    @After
+    public void logEnd() {
+        LOG.log(Level.INFO, "Test method {0} finished.", name.getMethodName());
     }
 
     @AfterClass

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/JAXWSEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/JAXWSEndpointTest.java
@@ -1,4 +1,4 @@
-package fish.payara.samples.jaxws.endpoint;
+package fish.payara.samples.jaxws.test;
 
 import static fish.payara.samples.CliCommands.payaraGlassFish;
 
@@ -13,11 +13,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.jaxws.endpoint.TraceMonitor;
 
 public abstract class JAXWSEndpointTest {
 
     protected Service jaxwsEndPointService;
-    
+
     @Inject
     private TraceMonitor traceMonitor;
 
@@ -27,7 +28,8 @@ public abstract class JAXWSEndpointTest {
     public static WebArchive createBaseDeployment() {
         return PayaraTestShrinkWrap
                 .getWebArchive()
-                .addPackage(JAXWSEndpointTest.class.getPackage());
+                .addPackage(TraceMonitor.class.getPackage())
+                .addClass(JAXWSEndpointTest.class);
     }
 
     public boolean isTraceMonitorTriggered() {
@@ -35,7 +37,7 @@ public abstract class JAXWSEndpointTest {
     }
 
     @BeforeClass
-    public static void enableRequesttracing() {
+    public static void enableRequesttracing() throws Exception {
         payaraGlassFish(
             "set-requesttracing-configuration",
             "--thresholdValue=25",
@@ -44,7 +46,7 @@ public abstract class JAXWSEndpointTest {
             "--thresholdUnit=MICROSECONDS",
             "--dynamic=true"
         );
-        
+
         payaraGlassFish(
             "notification-cdieventbus-configure",
             "--loopBack=true",
@@ -53,7 +55,7 @@ public abstract class JAXWSEndpointTest {
             "--hazelcastEnabled=true"
         );
     }
-    
+
     @AfterClass
     public static void disableRequestTracing() {
         payaraGlassFish(

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/ejb/EJBEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/ejb/EJBEndpointTest.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/ejb/EJBEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/ejb/EJBEndpointTest.java
@@ -37,14 +37,15 @@
  *    only if the new code is made subject to such option by the copyright
  *    holder.
  */
-package fish.payara.samples.jaxws.endpoint.servlet;
+package fish.payara.samples.jaxws.test.ejb;
 
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.SincePayara;
 import fish.payara.samples.Unstable;
-import fish.payara.samples.jaxws.endpoint.JAXWSEndpointTest;
-
+import fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointImplementation;
+import fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointInterface;
+import fish.payara.samples.jaxws.test.JAXWSEndpointTest;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -53,57 +54,55 @@ import javax.xml.ws.Service;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.shrinkwrap.api.ArchivePaths;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
+/**
+ * @author Arjan Tijms
+ */
 @RunWith(PayaraArquillianTestRunner.class)
 @NotMicroCompatible("JAX-WS is not supported on Micro")
-@FixMethodOrder(NAME_ASCENDING)
 @SincePayara("5.193")
 @Category(Unstable.class)
-// Due to bug in grizzly fails on JDK8u232 and newer
-public class ServletEndpointTest extends JAXWSEndpointTest {
+public class EJBEndpointTest extends JAXWSEndpointTest {
+
+    private Service jaxwsEndPointService;
 
     @Deployment
     public static WebArchive createDeployment() {
         return createBaseDeployment()
-                .addPackage(ServletEndpointTest.class.getPackage())
-                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
+            .addPackage(JAXWSEndPointImplementation.class.getPackage())
+            .addClasses(EJBEndpointTest.class);
     }
-
-    private Service jaxwsEndPointService;
 
     @Before
     public void setupClass() throws MalformedURLException {
+        URL rootUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), "");
+
         jaxwsEndPointService = Service.create(
             // The WSDL file used to create this service is fetched from the application we deployed
             // above using the createDeployment() method.
-
-            new URL(url, "JAXWSEndPointImplementationService?wsdl"),
-            new QName("http://servlet.endpoint.jaxws.samples.payara.fish/", "JAXWSEndPointImplementationService"));
+            new URL(rootUrl, "JAXWSEndPointImplementationService/JAXWSEndPointImplementation?wsdl"),
+            new QName("http://ejb.endpoint.jaxws.samples.payara.fish/", "JAXWSEndPointImplementationService"));
     }
 
     @Test
     @RunAsClient
-    public void test1RequestFromClient() throws MalformedURLException {
+    public void test1RequestFromClient() throws Exception {
         assertEquals("Hi Payara!", jaxwsEndPointService
                 .getPort(JAXWSEndPointInterface.class)
                 .sayHi("Payara!"));
     }
 
-    @Test
     // Runs on Server
-    public void test2ServerCheck() throws MalformedURLException {
+    @Test
+    public void test2ServerCheck() throws Exception {
         assertTrue(isTraceMonitorTriggered());
     }
 

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/ejb/EJBEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/ejb/EJBEndpointTest.java
@@ -56,9 +56,11 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -67,6 +69,7 @@ import static org.junit.Assert.assertTrue;
  * @author Arjan Tijms
  */
 @RunWith(PayaraArquillianTestRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @NotMicroCompatible("JAX-WS is not supported on Micro")
 @SincePayara("5.193")
 @Category(Unstable.class)
@@ -103,7 +106,7 @@ public class EJBEndpointTest extends JAXWSEndpointTest {
     // Runs on Server
     @Test
     public void test2ServerCheck() throws Exception {
-        assertTrue(isTraceMonitorTriggered());
+        assertTrue("TraceMonitor wasn't triggered!", isTraceMonitorTriggered());
     }
 
 }

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/servlet/ServletEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/servlet/ServletEndpointTest.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/servlet/ServletEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/servlet/ServletEndpointTest.java
@@ -59,14 +59,17 @@ import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
 @RunWith(PayaraArquillianTestRunner.class)
+@FixMethodOrder(NAME_ASCENDING)
 @NotMicroCompatible("JAX-WS is not supported on Micro")
 @SincePayara("5.193")
 @Category(Unstable.class)
@@ -81,6 +84,7 @@ public class ServletEndpointTest extends JAXWSEndpointTest {
     }
 
     private Service jaxwsEndPointService;
+
 
     @Before
     public void setupClass() throws MalformedURLException {
@@ -103,6 +107,6 @@ public class ServletEndpointTest extends JAXWSEndpointTest {
     // Runs on Server
     @Test
     public void test2ServerCheck() throws MalformedURLException {
-        assertTrue(isTraceMonitorTriggered());
+        assertTrue("TraceMonitor wasn't triggered!", isTraceMonitorTriggered());
     }
 }

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/servlet/ServletEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/servlet/ServletEndpointTest.java
@@ -37,13 +37,15 @@
  *    only if the new code is made subject to such option by the copyright
  *    holder.
  */
-package fish.payara.samples.jaxws.endpoint.ejb;
+package fish.payara.samples.jaxws.test.servlet;
 
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.SincePayara;
 import fish.payara.samples.Unstable;
-import fish.payara.samples.jaxws.endpoint.JAXWSEndpointTest;
+import fish.payara.samples.jaxws.endpoint.servlet.JAXWSEndPointImplementation;
+import fish.payara.samples.jaxws.endpoint.servlet.JAXWSEndPointInterface;
+import fish.payara.samples.jaxws.test.JAXWSEndpointTest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -53,44 +55,41 @@ import javax.xml.ws.Service;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
-/**
- * @author Arjan Tijms
- */
 @RunWith(PayaraArquillianTestRunner.class)
 @NotMicroCompatible("JAX-WS is not supported on Micro")
-@FixMethodOrder(NAME_ASCENDING)
 @SincePayara("5.193")
 @Category(Unstable.class)
-// fails from unknown reasons
-public class EJBEndpointTest extends JAXWSEndpointTest {
-
-    private Service jaxwsEndPointService;
+public class ServletEndpointTest extends JAXWSEndpointTest {
 
     @Deployment
     public static WebArchive createDeployment() {
-        return createBaseDeployment().addPackage(EJBEndpointTest.class.getPackage());
+        return createBaseDeployment()
+                .addPackage(JAXWSEndPointImplementation.class.getPackage())
+                .addClass(ServletEndpointTest.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
     }
+
+    private Service jaxwsEndPointService;
 
     @Before
     public void setupClass() throws MalformedURLException {
-        URL rootUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), "");
-
         jaxwsEndPointService = Service.create(
             // The WSDL file used to create this service is fetched from the application we deployed
             // above using the createDeployment() method.
-            new URL(rootUrl, "JAXWSEndPointImplementationService/JAXWSEndPointImplementation?wsdl"),
-            new QName("http://ejb.endpoint.jaxws.samples.payara.fish/", "JAXWSEndPointImplementationService"));
+
+            new URL(url, "JAXWSEndPointImplementationService?wsdl"),
+            new QName("http://servlet.endpoint.jaxws.samples.payara.fish/", "JAXWSEndPointImplementationService"));
     }
 
     @Test
@@ -101,10 +100,9 @@ public class EJBEndpointTest extends JAXWSEndpointTest {
                 .sayHi("Payara!"));
     }
 
-    @Test
     // Runs on Server
+    @Test
     public void test2ServerCheck() throws MalformedURLException {
         assertTrue(isTraceMonitorTriggered());
     }
-
 }

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestShrinkWrap.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestShrinkWrap.java
@@ -1,3 +1,43 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
 package fish.payara.samples;
 
 import org.jboss.shrinkwrap.api.Archive;

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestShrinkWrap.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/PayaraTestShrinkWrap.java
@@ -9,7 +9,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 /**
  * Utility class used to generate shrinkwrap archives that will be safe to run
  * on the server side by including all potentially required dependent classes.
- * 
+ *
  * @author Matt Gill
  */
 public final class PayaraTestShrinkWrap {
@@ -27,10 +27,9 @@ public final class PayaraTestShrinkWrap {
 
     private static <T extends Archive<T> & ClassContainer<T>> T getArchive(Class<T> archiveType) {
         return ShrinkWrap.create(archiveType)
-                .addClass(PayaraArquillianTestRunner.class)
-                .addClass(PayaraTestRunnerDelegate.class)
-                .addClass(SincePayara.class)
-                .addClass(NotMicroCompatible.class)
-                .addClass(PayaraVersion.class);
+                .addClasses(PayaraArquillianTestRunner.class, PayaraTestRunnerDelegate.class, PayaraVersion.class)
+                .addClasses(SincePayara.class, NotMicroCompatible.class)
+                .addClasses(Unstable.class)
+            ;
     }
 }


### PR DESCRIPTION
## Description

The module depended on JDK support for JAX-WS. There were also other issues:

- missing separation between test and war packages
- Unstable wasn't inside the war package which caused errors on JDK8 on server side (JDK11 has fix for this)
- **the test still fails now, but the result is same on JDK8 and JDK11**

## Testing

### Testing Performed
With both JDK11 and JDK8:
```
rm -rf ./target; mvn clean install -pl :payara-samples,:jaxws-tracing -Ppayara-samples,payara-server-managed,unstable -fae
```
With JDK8 only:
```
rm -rf ./target; mvn clean install -pl :payara-samples -Ppayara-samples,payara-server-managed -fae -amd
rm -rf ./target; mvn clean install -pl :payara-samples,:jaxws-tracing -Ppayara-samples,payara-server-managed,unstable -fae -amd
asadmin start-domain; mvn clean install -pl :payara-samples,:jaxws-tracing -Ppayara-samples,payara-server-remote,unstable -fae

```
### Testing Environment
```

mvn -version
Apache Maven 3.6.2 (40f52333136460af0dc0d7232c0dc0bcf0d9e117; 2019-08-27T17:06:16+02:00)
Maven home: /home/dmatej/work/apache-maven-3.6.2
Java version: 1.8.0_265, vendor: AdoptOpenJDK, runtime: /usr/lib/jvm/jdk8u265-b01/jre
Default locale: cs_CZ, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-47-generic", arch: "amd64", family: "unix"
```