### PR TITLE
FISH-154 Support log-jdbc-calls in asadmin and xml

### DIFF
--- a/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara-resources_1_6.dtd
+++ b/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara-resources_1_6.dtd
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright [2018-2020] Payara Foundation and/or affiliates -->
 
 <!--  
   A resources instance document referring to this DTD should have a DOCTYPE as follows:
@@ -417,7 +417,11 @@
         used in a method, which avoids enlistment of connections that 
         are not used in a transaction. This also prevents unnecessary 
         enlistment of connections cached in the calling components.   
-        Default value is false.                                       
+        Default value is false.
+    log-jdbc-calls
+        Log all SQL calls made through a JDBC connection pool, with 
+        the time taken to execute the call also recorded and logged to
+        the server at the FINE level. Default value is false.
     match-connections                                                          
         To switch on/off connection matching for the pool. It can be  
         set to false if the administrator knows that the connections  
@@ -568,6 +572,7 @@
     statement-timeout-in-seconds CDATA "-1"
     lazy-connection-enlistment %boolean; "false"
     lazy-connection-association %boolean; "false"
+    log-jdbc-calls %boolean; "false"
     associate-with-thread %boolean; "false"
     match-connections %boolean; "false"
     max-connection-usage-count CDATA "0"

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright (c) 2020 Payara Foundation and/or affiliates
 
 package org.glassfish.jdbc.admin.cli;
 
@@ -177,6 +178,9 @@ public class CreateJdbcConnectionPool implements AdminCommand {
     @Param(name = "wrapJdbcObjects",  optional=true, defaultValue="true")
     Boolean wrapjdbcobjects;
     
+    @Param(name="logjdbccalls", optional = true, defaultValue="false")
+    Boolean logJdbcCalls;
+    
     @Param(name="description", optional=true)
     String description;
     
@@ -201,10 +205,11 @@ public class CreateJdbcConnectionPool implements AdminCommand {
      *
      * @param context information
      */
+    @Override
     public void execute(AdminCommandContext context) {
         final ActionReport report = context.getActionReport();
        
-        HashMap attrList = new HashMap();
+        HashMap<String, String> attrList = new HashMap<>();
         attrList.put(ResourceConstants.CONNECTION_POOL_NAME, jdbc_connection_pool_id);
         attrList.put(ResourceConstants.DATASOURCE_CLASS, datasourceclassname);
         attrList.put(ServerTags.DESCRIPTION, description);
@@ -243,6 +248,7 @@ public class CreateJdbcConnectionPool implements AdminCommand {
         attrList.put(ResourceConstants.POOLING, pooling.toString());
         attrList.put(ResourceConstants.VALIDATION_CLASSNAME, validationclassname);
         attrList.put(ResourceConstants.WRAP_JDBC_OBJECTS, wrapjdbcobjects.toString());
+        attrList.put(ResourceConstants.LOG_JDBC_CALLS, logJdbcCalls.toString());
         
         ResourceStatus rs;
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2020] Payara Foundation and/or affiliates
 
 package org.glassfish.jdbc.admin.cli;
 
@@ -110,6 +111,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
     private String pooling = Boolean.TRUE.toString();
     private String validationclassname = null;
     private String wrapJDBCObjects = Boolean.TRUE.toString();
+    private String logJDBCCalls = Boolean.FALSE.toString();
 
     private String description = null;
     private String jdbcconnectionpoolid = null;
@@ -117,10 +119,12 @@ public class JDBCConnectionPoolManager implements ResourceManager {
     public JDBCConnectionPoolManager() {
     }
 
+    @Override
     public String getResourceType() {
         return ServerTags.JDBC_CONNECTION_POOL;
     }
 
+    @Override
     public ResourceStatus create(Resources resources, HashMap attributes, final Properties properties,
                                  String target) throws Exception {
         setAttributes(attributes);
@@ -132,7 +136,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
 
         try {
             ConfigSupport.apply(new SingleConfigCode<Resources>() {
-
+                @Override
                 public Object run(Resources param) throws PropertyVetoException, TransactionFailure {
                     return createResource(param, properties);
                 }
@@ -261,6 +265,9 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         if(ping != null){
             newResource.setPing(ping);
         }
+        if (logJDBCCalls != null) {
+            newResource.setLogJdbcCalls(logJDBCCalls);
+        }
         if (driverclassname != null) {
             newResource.setDriverClassname(driverclassname);
         }
@@ -317,6 +324,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         statementcachesize = (String) attrList.get(STATEMENT_CACHE_SIZE);
         validationclassname = (String) attrList.get(VALIDATION_CLASSNAME);
         initsql = (String) attrList.get(INIT_SQL);
+        logJDBCCalls = (String) attrList.get(LOG_JDBC_CALLS);
         
         // Can't be set to null as the default value is now the SilentSqlTraceListener class, which requires statement 
         // wrapping to be enabled
@@ -434,6 +442,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         }
     }
 
+    @Override
     public Resource createConfigBean(Resources resources, HashMap attributes, Properties properties, boolean validate)
             throws Exception {
         setAttributes(attributes);

--- a/appserver/jdbc/admin/src/main/manpages/org/glassfish/jdbc/admin/cli/create-jdbc-connection-pool.1
+++ b/appserver/jdbc/admin/src/main/manpages/org/glassfish/jdbc/admin/cli/create-jdbc-connection-pool.1
@@ -35,6 +35,7 @@ SYNOPSIS
            [--associatewiththread={false|true}]
            [--driverclassname=jdbcdriverclassname]
            [--matchconnections={false|true}]
+           [--logjdbccalls={false|true}]
            [--maxconnectionusagecount=maxconnectionusagecount]
            [--ping={false|true}]
            [--pooling={false|true}]
@@ -343,6 +344,17 @@ OPTIONS
            true
                A connection should be matched by the resource adaptor.
 
+       --logjdbccalls
+           Specifies whether all SQL calls made through a JDBC connection pool
+           are traced.
+
+           false
+               JDBC calls are not all logged (default)
+
+           true
+               Each call into the connection pool is timed and logged
+               to the server log at FINE level.
+
        --maxconnectionusagecount
            Specifies the maximum number of times that a connection can be
            reused. When this limit is reached, the connection is closed. By
@@ -540,4 +552,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Java EE 8               18 Dec 2019         create-jdbc-connection-pool(1)
+Jakarta EE 8               16 Sep 2020         create-jdbc-connection-pool(1)

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/JdbcConnectionPoolDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation]
+// Portions Copyright [2016-2020] [Payara Foundation and/or affiliates]
 
 package org.glassfish.jdbc.deployer;
 
@@ -298,7 +298,7 @@ public class JdbcConnectionPoolDeployer implements ResourceDeployer {
             JdbcConnectionPool adminPool,
             ConnectorConnectionPool conConnPool, ConnectorDescriptor connDesc) {
 
-        ArrayList propList = new ArrayList();
+        ArrayList<ConnectorConfigProperty> propList = new ArrayList<>();
 
         if (adminPool.getResType() != null) {
             if (ConnectorConstants.JAVA_SQL_DRIVER.equals(adminPool.getResType())) {

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2020] Payara Foundation and/or affiliates
  */
 
 package org.glassfish.resources.admin.cli;
@@ -260,4 +260,6 @@ public final class ResourceConstants {
     public static final String TASK_QUEUE_CAPACITY = "task-queue-capacity";
 
     public static final String SYSTEM_ALL_REQ = "system-all-req";
+    
+    public static final String LOG_JDBC_CALLS = "log-jdbc-calls";
 }

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2020] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.resources.admin.cli;
 
 import com.sun.enterprise.util.SystemPropertyConstants;
@@ -750,6 +751,7 @@ public class ResourcesXMLParser implements EntityResolver
                 attributes.getNamedItem(STATEMENT_TIMEOUT_IN_SECONDS);
         Node lazyConnectionEnlistmentNode =
                 attributes.getNamedItem(LAZY_CONNECTION_ENLISTMENT);
+        Node logJdbcCalls = attributes.getNamedItem(LOG_JDBC_CALLS);
         Node lazyConnectionAssociationNode =
                 attributes.getNamedItem(LAZY_CONNECTION_ASSOCIATION);
         Node associateWithThreadNode =
@@ -882,6 +884,9 @@ public class ResourcesXMLParser implements EntityResolver
         if (lazyConnectionAssociationNode != null) {
            jdbcConnPool.setAttribute(LAZY_CONNECTION_ASSOCIATION,
                                         lazyConnectionAssociationNode.getNodeValue());
+        }
+        if (logJdbcCalls != null) {
+            jdbcConnPool.setAttribute(LOG_JDBC_CALLS, logJdbcCalls.getNodeValue());
         }
         if (associateWithThreadNode != null) {
            jdbcConnPool.setAttribute(ASSOCIATE_WITH_THREAD,


### PR DESCRIPTION
## Description
This is a feature. It adds the options for log-jdbc-calls to the asadmin command `create-jdbc-connection-pool` and as an attribute to the `jdbc-connection-pool` element in `resources.xml`.

## Testing

### Testing Performed
Tested with the resources.xml file
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 4 Resource Definitions//EN" "file:///home/jcoustick/NetBeansProjects/Payara/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara-resources_1_6.dtd">
<resources>
    <jdbc-connection-pool name="TestPool"
                          res-type="javax.sql.DataSource"
                          datasource-classname="org.h2.jdbcx.JdbcDataSource" log-jdbc-calls="true">
        <property name="user" value="sa"/>
        <property name="password" value=""/>
        <property name="url" value="jdbc:h2:mem:hibernateExample"/>
    </jdbc-connection-pool>
</resources>
```
This was added to Payara with `asadmin> add-resources ~/resources.xml`. Then went to the admin console Resources -> JDBC -> JDBC Connection Pools -> TestPool -> Advanced and the Log JDBC Calls checkbox was ticked.

Tested the asadmin command by running the command 
`asadmin create-jdbc-connection-pool --datasourceclassname org.h2.jdbcx.JdbcDataSource --restype javax.sql.XADataSource --logjdbccalls=true testpool`
Then went to the admin console Resources -> JDBC -> JDBC Connection Pools -> testpool -> Advanced and the Log JDBC Calls checkbox was ticked.


### Testing Environment
Zulu JDK 1.8_262 on Ubuntu 20.04 with Maven 3.6.3

## Documentation
<!-- Link documentation if a PR exists -->