### PR TITLE
[QACI-94] - ignore cmp roster test

### DIFF
--- a/appserver/tests/quicklook/ejb/cmp/src/test/CmpRosterTestNG.java
+++ b/appserver/tests/quicklook/ejb/cmp/src/test/CmpRosterTestNG.java
@@ -67,8 +67,7 @@ public class CmpRosterTestNG {
      *Each method can act as one test within one test suite
      */
 
-	@Ignore
-    @Test(groups ={ "pulse"} ) // test method
+    @Test(groups ={ "pulse"}, enabled = false ) // test method
     public void test() throws Exception{
         
         try{

--- a/appserver/tests/quicklook/ejb/cmp/src/test/CmpRosterTestNG.java
+++ b/appserver/tests/quicklook/ejb/cmp/src/test/CmpRosterTestNG.java
@@ -67,7 +67,7 @@ public class CmpRosterTestNG {
      *Each method can act as one test within one test suite
      */
 
-
+	@Ignore
     @Test(groups ={ "pulse"} ) // test method
     public void test() throws Exception{
         


### PR DESCRIPTION
Temporary removal of CMP Roster Test for Nightly Stability