### PR TITLE
QACI-377 Added TLS 1 to 1.3 support test

### DIFF
--- a/appserver/tests/payara-samples/samples/http/pom.xml
+++ b/appserver/tests/payara-samples/samples/http/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>5.2020.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>http</artifactId>
+    <name>Payara Samples - Payara - Http</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>common-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/http/src/test/java/fish/payara/samples/TLSSupportTest.java
+++ b/appserver/tests/payara-samples/samples/http/src/test/java/fish/payara/samples/TLSSupportTest.java
@@ -1,0 +1,77 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples;
+
+import com.sun.enterprise.util.JDK;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *
+ * @author Alan Roth
+ */
+public class TLSSupportTest {
+    private final List<String> SUPPORTED_SSL_PROTOCOLS = Arrays.asList("TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3");
+
+    @Before
+    public void before() {
+        Assume.assumeTrue(JDK.isTls13Supported() || JDK.isOpenJSSEFlagRequired());
+    }
+
+    @Test
+    public void when_socket_ssl_protocols_returned_expect_supported_tls_versions() throws IOException {
+        SocketFactory factory = SSLSocketFactory.getDefault();
+        SSLSocket socket = (SSLSocket) factory.createSocket();
+        socket.setEnabledProtocols(SUPPORTED_SSL_PROTOCOLS.stream().toArray(String[]::new));
+        List<String> sslProtocols = Arrays.asList(socket.getSSLParameters().getProtocols());
+
+        Assert.assertEquals(SUPPORTED_SSL_PROTOCOLS, sslProtocols);
+        Assert.assertTrue(Arrays.asList(socket.getSupportedProtocols()).contains("TLSv1.3"));
+    }
+}

--- a/appserver/tests/payara-samples/samples/http/src/test/java/fish/payara/samples/TLSSupportTest.java
+++ b/appserver/tests/payara-samples/samples/http/src/test/java/fish/payara/samples/TLSSupportTest.java
@@ -49,6 +49,7 @@ import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,7 +62,9 @@ public class TLSSupportTest {
 
     @Before
     public void before() {
-        Assume.assumeTrue(JDK.isTls13Supported() || JDK.isOpenJSSEFlagRequired());
+        List<String> jvmOptions = ManagementFactory.getRuntimeMXBean().getInputArguments();
+        boolean openJSSEOption = jvmOptions.contains("-XX:+UseOpenJSSE");
+        Assume.assumeTrue(JDK.isTls13Supported() || openJSSEOption && JDK.isOpenJSSEFlagRequired());
     }
 
     @Test

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -36,6 +36,7 @@
         <module>rolesPermitted</module>
         <module>realm-identity-stores</module>
         <module>jakartaee-namespace-transformer</module>
+        <module>http</module>
         <module>logging</module>
         <module>ejb-http-remoting</module>
         <module>remote-ejb-tracing</module>


### PR DESCRIPTION
## Description
A simple test to confirm TLS support by checking available protocols for newly created sockets, for TLS versions 1 to 1.3.

## Important Info
### Blockers
This test fails, as TLSv1.3 is not listed as a  'supported' protocol for sockets, this has been confirmed as a genuine failure. Spawned FISH-462.
~~Couldn't test on JDK11 due to QACI-451.~~


## Testing

### Testing Performed
Samples remote and managed on JDK8

### Testing Environment

JDK zulu 1.8.0_265 Remote & Managed, 5.2020.5-SNAPSHOT
JDK zulu 1.8.0_262 Remote & Managed, 5.2020.5-SNAPSHOT
JDK zulu 1.8.0_152 (Skipped test, as expected), 5.2020.5-SNAPSHOT


## Notes for Reviewers
The test will be skipped if TLSv1.3 is not supported for the JDK version it is being run on.

I timeboxed this test to push it out with this test case, but I was writing another test case which can be seen in AlanRoth/QACI-377-extra branch, however encountered a problem with establishing a handshake with the server closing too soon.
