### PR TITLE
FISH-315 Fix Micro Domain.xml Error

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -102,7 +102,7 @@ Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
             </log-service>
             <monitoring-service-configuration amx="false" enabled="false" log-frequency="30">
                 <notifier>log-notifier</notifier>
-                <eventbus-notifier></eventbus-notifier>
+                <notifier>eventbus-notifier</notifier>
             </monitoring-service-configuration>
             <microprofile-metrics-configuration></microprofile-metrics-configuration>
             <security-service activate-default-principal-to-role-mapping="true" jacc="simple">


### PR DESCRIPTION
The notifier update missed an old eventbus notifier tag in the micro domain.xml, which has now been updated to the new syntax.

This caused an error in the Payara Micro logs:

~~~
[2020-09-23T11:32:49.808+0000] [] [SEVERE] [] [] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1600860769808] [levelValue: 1000] [[
  Ignoring unrecognized element eventbus-notifier at Line number = 105
Column number = 36
System Id = null
Public Id = null
Location Uri= null
CharacterOffset = 7338
]]
~~~