### PR TITLE
FISH-315 Camel Case Testing

### DIFF
--- a/nucleus/common/internal-api/src/main/java/fish/payara/internal/notification/NotifierUtils.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/internal/notification/NotifierUtils.java
@@ -42,7 +42,6 @@ package fish.payara.internal.notification;
 import java.lang.reflect.ParameterizedType;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
@@ -92,6 +91,7 @@ public final class NotifierUtils {
      * @param notifierClass the notifier of the class
      * @return the class used to configure the configured notifier
      */
+    @SuppressWarnings("unchecked")
     public static <C extends PayaraNotifierConfiguration> Class<C> getConfigurationClass(Class<?> notifierClass) {
         final ParameterizedType genericSuperclass = (ParameterizedType) notifierClass.getGenericSuperclass();
         return (Class<C>) genericSuperclass.getActualTypeArguments()[0];
@@ -106,15 +106,17 @@ public final class NotifierUtils {
         }
 
         String result = "";
-        // Make sure the string has no leading or trailing whitespace
-        string = string.trim();
+        // Make sure the string has no leading or trailing whitespace or symbols
+        string = string.trim()
+            .replaceAll("^[^a-zA-Z0-9]", "")
+            .replaceAll("[^a-zA-Z0-9]$", "");
 
         // Count through each other character
         for (int i = 0; i < string.length(); i++) {
             char ch = string.charAt(i);
 
             // If a space is found, ignore and convert the next letter to 
-            if (Character.isWhitespace(ch)) {
+            if (Character.isWhitespace(ch) || (!Character.isAlphabetic(ch) && !Character.isDigit(ch))) {
                 result += Character.toUpperCase(string.charAt(++i));
             } else {
                 result += Character.toLowerCase(ch);

--- a/nucleus/common/internal-api/src/main/java/fish/payara/internal/notification/NotifierUtils.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/internal/notification/NotifierUtils.java
@@ -101,15 +101,20 @@ public final class NotifierUtils {
      * @return a camel cased string representing the result
      */
     public static String convertToCamelCase(String string) {
-        if (string == null || string.isEmpty()) {
-            return string;
+        if (string == null) {
+            return null;
         }
 
-        String result = "";
         // Make sure the string has no leading or trailing whitespace or symbols
         string = string.trim()
             .replaceAll("^[^a-zA-Z0-9]+", "")
             .replaceAll("[^a-zA-Z0-9]+$", "");
+
+        if (string.isEmpty()) {
+            return string;
+        }
+
+        String result = "";
 
         // Track if a space or other character that requires an upper case character is encountered
         boolean upperCaseNextCharacter = false;

--- a/nucleus/common/internal-api/src/main/java/fish/payara/internal/notification/NotifierUtils.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/internal/notification/NotifierUtils.java
@@ -108,16 +108,23 @@ public final class NotifierUtils {
         String result = "";
         // Make sure the string has no leading or trailing whitespace or symbols
         string = string.trim()
-            .replaceAll("^[^a-zA-Z0-9]", "")
-            .replaceAll("[^a-zA-Z0-9]$", "");
+            .replaceAll("^[^a-zA-Z0-9]+", "")
+            .replaceAll("[^a-zA-Z0-9]+$", "");
+
+        // Track if a space or other character that requires an upper case character is encountered
+        boolean upperCaseNextCharacter = false;
 
         // Count through each other character
         for (int i = 0; i < string.length(); i++) {
             char ch = string.charAt(i);
 
-            // If a space is found, ignore and convert the next letter to 
+            // If a space is found, ignore and convert the next letter to upper case
             if (Character.isWhitespace(ch) || (!Character.isAlphabetic(ch) && !Character.isDigit(ch))) {
-                result += Character.toUpperCase(string.charAt(++i));
+                upperCaseNextCharacter = true;
+                continue;
+            } else if (upperCaseNextCharacter) {
+                upperCaseNextCharacter = false;
+                result += Character.toUpperCase(ch);
             } else {
                 result += Character.toLowerCase(ch);
             }

--- a/nucleus/common/internal-api/src/test/java/fish/payara/internal/notification/CamelCaseConversionTest.java
+++ b/nucleus/common/internal-api/src/test/java/fish/payara/internal/notification/CamelCaseConversionTest.java
@@ -53,6 +53,11 @@ public class CamelCaseConversionTest {
     }
 
     @Test
+    public void if_non_alphanumeric_string_expect_empty() {
+        assertEquals("", convertToCamelCase("!\"£$%|^&*():;[]{}'@#~/?\\|"));
+    }
+
+    @Test
     public void if_lower_case_expect_same() {
         assertEquals("accountid", convertToCamelCase("accountid"));
     }

--- a/nucleus/common/internal-api/src/test/java/fish/payara/internal/notification/CamelCaseConversionTest.java
+++ b/nucleus/common/internal-api/src/test/java/fish/payara/internal/notification/CamelCaseConversionTest.java
@@ -1,0 +1,106 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.internal.notification;
+
+import static fish.payara.internal.notification.NotifierUtils.convertToCamelCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CamelCaseConversionTest {
+
+    @Test
+    public void if_empty_expect_same() {
+        assertEquals(null, convertToCamelCase(null));
+        assertEquals("", convertToCamelCase(""));
+    }
+
+    @Test
+    public void if_lower_case_expect_same() {
+        assertEquals("accountid", convertToCamelCase("accountid"));
+    }
+
+    @Test
+    public void if_upper_case_expect_lower_case() {
+        assertEquals("accountid", convertToCamelCase("ACCOUNTID"));
+    }
+
+    @Test
+    public void if_numbers_expect_same() {
+        assertEquals("a123", convertToCamelCase("a123"));
+        assertEquals("a123b", convertToCamelCase("a123b"));
+        assertEquals("123", convertToCamelCase("123"));
+    }
+
+    @Test
+    public void if_leading_symbols_expect_removed() {
+        assertEquals("abc", convertToCamelCase("_abc"));
+        assertEquals("abc", convertToCamelCase("&abc"));
+        assertEquals("abc", convertToCamelCase("-abc"));
+    }
+
+    @Test
+    public void if_trailing_symbols_expect_removed() {
+        assertEquals("abc", convertToCamelCase("abc_"));
+        assertEquals("abc", convertToCamelCase("abc&"));
+        assertEquals("abc", convertToCamelCase("abc-"));
+    }
+
+    @Test
+    public void if_internal_symbols_expect_next_character_capitalised() {
+        assertEquals("aBc", convertToCamelCase("a_bc"));
+        assertEquals("aBc", convertToCamelCase("a-bc"));
+    }
+
+    @Test
+    public void if_surrounding_whitespace_expect_removed() {
+        assertEquals("abc", convertToCamelCase("abc "));
+        assertEquals("abc", convertToCamelCase("abc  "));
+        assertEquals("abc", convertToCamelCase(" abc"));
+        assertEquals("abc", convertToCamelCase("  abc"));
+    }
+
+    @Test
+    public void if_internal_whitespace_expect_next_character_capitalised() {
+        assertEquals("aBc", convertToCamelCase("a bc"));
+        assertEquals("abC", convertToCamelCase("ab c"));
+    }
+
+}

--- a/nucleus/common/internal-api/src/test/java/fish/payara/internal/notification/CamelCaseConversionTest.java
+++ b/nucleus/common/internal-api/src/test/java/fish/payara/internal/notification/CamelCaseConversionTest.java
@@ -70,37 +70,29 @@ public class CamelCaseConversionTest {
     }
 
     @Test
-    public void if_leading_symbols_expect_removed() {
-        assertEquals("abc", convertToCamelCase("_abc"));
-        assertEquals("abc", convertToCamelCase("&abc"));
-        assertEquals("abc", convertToCamelCase("-abc"));
-    }
-
-    @Test
-    public void if_trailing_symbols_expect_removed() {
-        assertEquals("abc", convertToCamelCase("abc_"));
-        assertEquals("abc", convertToCamelCase("abc&"));
-        assertEquals("abc", convertToCamelCase("abc-"));
-    }
-
-    @Test
-    public void if_internal_symbols_expect_next_character_capitalised() {
-        assertEquals("aBc", convertToCamelCase("a_bc"));
-        assertEquals("aBc", convertToCamelCase("a-bc"));
-    }
-
-    @Test
-    public void if_surrounding_whitespace_expect_removed() {
-        assertEquals("abc", convertToCamelCase("abc "));
-        assertEquals("abc", convertToCamelCase("abc  "));
+    public void if_leading_non_alphanumeric_characters_expect_removed() {
         assertEquals("abc", convertToCamelCase(" abc"));
         assertEquals("abc", convertToCamelCase("  abc"));
+        assertEquals("abc", convertToCamelCase("-abc"));
+        assertEquals("abc", convertToCamelCase("_-abc"));
+        assertEquals("abc", convertToCamelCase(" -abc"));
     }
 
     @Test
-    public void if_internal_whitespace_expect_next_character_capitalised() {
+    public void if_trailing_non_alphanumeric_characters_expect_removed() {
+        assertEquals("abc", convertToCamelCase("abc "));
+        assertEquals("abc", convertToCamelCase("abc  "));
+        assertEquals("abc", convertToCamelCase("abc-"));
+        assertEquals("abc", convertToCamelCase("abc-_"));
+        assertEquals("abc", convertToCamelCase("abc- "));
+    }
+
+    @Test
+    public void if_internal_non_alphanumeric_characters_expect_next_character_capitalised() {
+        assertEquals("aBc", convertToCamelCase("a_bc"));
+        assertEquals("aBc", convertToCamelCase("a-_bc"));
         assertEquals("aBc", convertToCamelCase("a bc"));
-        assertEquals("abC", convertToCamelCase("ab c"));
+        assertEquals("aBc", convertToCamelCase("a  bc"));
     }
 
 }


### PR DESCRIPTION
Added testing for the camel casing function to make sure that notifier properties are calculated correctly the majority of the time. This is to ensure that notifier implementations don't see any unexpected results.

This PR wasn't necessary, but in implementing new notifiers I was getting anxiety at the sight of this method