### PR TITLE
FISH-405 Use upgrade & patched eclipselink version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <json.bind-api.version>1.0.2</json.bind-api.version>
         <yasson.version>1.0.6</yasson.version>
         <jakarta-persistence-api.version>2.2.3</jakarta-persistence-api.version>
-        <eclipselink.version>2.7.6.payara-p1</eclipselink.version>
+        <eclipselink.version>2.7.7.payara-p1</eclipselink.version>
         <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
         <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
         <jakarta.inject.version>1.0</jakarta.inject.version>


### PR DESCRIPTION
## Description
This is a bug fix. This fixes the issue around JPA left join on embeddable types.

## Important Info
### Blockers
Patched Project PR: payara/Payara_PatchedProjects#336


## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
Ran the reproducer in the Jira, before request fails and exception thrown, afterwards it works fine.

### Testing Environment
Zulu JDK 1.8_262 on Ubuntu 20.04 with Maven 3.6.3


## Notes for Reviewers
Eclipselink code changes in https://github.com/payara/patched-src-eclipselink/commit/98f2160602ad3f6909eb4d650414f22225826765
This PR includes upgrade Eclipselink from 2.7.6 to 2.7.7
