### PR TITLE
FISH-356 All Payara Health Checks Define Green State

### DIFF
--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HoggingThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/preliminary/HoggingThreadsHealthCheck.java
@@ -67,7 +67,7 @@ import static fish.payara.nucleus.notification.TimeHelper.prettyPrintDuration;
 
 /**
  * A "hogging thread" is a thread that uses most of the CPU during the measured period.
- * 
+ *
  * @author mertcaliskan (initial version)
  * @author Jan Bernitt (consumer based and monitoring)
  */
@@ -106,7 +106,7 @@ public class HoggingThreadsHealthCheck
          */
         long startOfExceedingThresholdTimestamp;
         /**
-         * Number of times in a row the check has identified the thread as "hogging" 
+         * Number of times in a row the check has identified the thread as "hogging"
          */
         int identifiedAsHoggingCount;
         /**
@@ -130,8 +130,8 @@ public class HoggingThreadsHealthCheck
     @Override
     public HealthCheckHoggingThreadsExecutionOptions constructOptions(HoggingThreadsChecker checker) {
         return new HealthCheckHoggingThreadsExecutionOptions(Boolean.valueOf(checker.getEnabled()),
-                Long.parseLong(checker.getTime()), asTimeUnit(checker.getUnit()), 
-                Long.parseLong(checker.getThresholdPercentage()), 
+                Long.parseLong(checker.getTime()), asTimeUnit(checker.getUnit()),
+                Long.parseLong(checker.getThresholdPercentage()),
                 Integer.parseInt(checker.getRetryCount()));
     }
 
@@ -148,7 +148,7 @@ public class HoggingThreadsHealthCheck
                     " not support getting CPU times"));
             return result;
         }
-        acceptHoggingThreads(checkRecordsByThreadId, 
+        acceptHoggingThreads(checkRecordsByThreadId,
                 (percentage, threshold, totalTimeHogging, initialMethod, info) ->
                     result.add(new HealthCheckResultEntry(HealthCheckResultStatus.CRITICAL,
                             "Thread with <id-name>: " + info.getThreadId() + "-" + info.getThreadName() +
@@ -166,7 +166,7 @@ public class HoggingThreadsHealthCheck
         }
         AtomicInteger hoggingThreadCount = new AtomicInteger(0);
         AtomicLong hoggingThreadMaxDuration = new AtomicLong(0L);
-        acceptHoggingThreads(colletionRecordsByThreadId, 
+        acceptHoggingThreads(colletionRecordsByThreadId,
                 (percentage, threshold, totalTimeHogging, initialMethod, info) -> {
                     String thread = info.getThreadName();
                     if (thread == null || thread.isEmpty()) {
@@ -192,6 +192,7 @@ public class HoggingThreadsHealthCheck
             return;
         }
         collector.watch("ns:health HoggingThreadCount", "Hogging Threads", "count")
+            .green(-1, 1, false, null, null, false)
             .amber(0, -2, false, null, null, false)
             .red(1, -2, false, null, null, false);
     }
@@ -207,7 +208,7 @@ public class HoggingThreadsHealthCheck
                 final long cpuTimeInNanos = bean.getThreadCpuTime(threadId);
                 if (cpuTimeInNanos == -1)
                     continue;
-                long cpuTime = TimeUnit.NANOSECONDS.toMillis(cpuTimeInNanos); 
+                long cpuTime = TimeUnit.NANOSECONDS.toMillis(cpuTimeInNanos);
                 // from here all times are in millis
                 ThreadCpuTimeRecord record = recordsById.get(threadId);
                 if (record == null) {

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -134,8 +134,10 @@ public class StuckThreadsHealthCheck extends
         if (options == null || !options.isEnabled()) {
             return;
         }
+        long thresholdInMillis = getThresholdInMillis();
         collector.watch("ns:health StuckThreadDuration", "Stuck Threads", "ms")
-            .red(getThresholdInMillis(), -30000L, false, null, null, false);
+            .red(thresholdInMillis, -30000L, false, null, null, false)
+            .green(-thresholdInMillis, 1, false, null, null, false);
     }
 
     private static String composeStateText(ThreadInfo info) {
@@ -148,7 +150,7 @@ public class StuckThreadsHealthCheck extends
 
     private static String composeActionText(Thread.State state) {
         switch(state) {
-        case BLOCKED: 
+        case BLOCKED:
             return "Blocked on ";
         case WAITING:
         case TIMED_WAITING:


### PR DESCRIPTION
### Summary
This is a tiny improvement that makes sure all of the Payara Health Checks define a Green state.

### Testing
Start server, enable Payara health checks, open MC and navigate to RAG/Traffic Light Status page.
Check that both hogging and stuck threads are shown as green instead of white.