### PR TITLE
FISH-509: Remove NamingException from PostConstruct method

### DIFF
--- a/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/JMXMonitoringService.java
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/src/main/java/fish/payara/jmx/monitoring/JMXMonitoringService.java
@@ -47,7 +47,6 @@ import fish.payara.jmx.monitoring.configuration.MonitoredAttribute;
 import fish.payara.jmx.monitoring.configuration.MonitoringServiceConfiguration;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import java.beans.PropertyVetoException;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -63,7 +62,6 @@ import javax.inject.Named;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.naming.NamingException;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.event.EventListener;
@@ -121,7 +119,7 @@ public class JMXMonitoringService implements EventListener {
     private ScheduledFuture<?> monitoringFuture;
 
     @PostConstruct
-    public void postConstruct() throws NamingException {
+    public void postConstruct() {
         events.register(this);
     }
 


### PR DESCRIPTION
## Description
Bug Fix related to a report during deployment that this method was not according to specifications.

## Testing


### Testing Performed
Smoke test
Activated JMX Monitoring service and verified entries appears in the server.log

### Testing Environment
Zulu 8.48.0.51-CA-macosx (build 1.8.0_262-b19) on Mac 10.14.6 with Maven 3.5.4


