### PR TITLE
FISH-474 display vendor if specified in jvm-options

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/InstanceHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/InstanceHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 
 /*
  * InstanceHandler.java
@@ -160,7 +160,7 @@ public class InstanceHandler {
             //place for user to fix the jvm options.
             String deleteProfileEndpoint = (String) handlerCtx.getInputValue("deleteProfileEndpoint");
             if (!GuiUtil.isEmpty(deleteProfileEndpoint)){
-                Map attrMap = new HashMap();
+                Map<String, Object> attrMap = new HashMap<>();
                 attrMap.put(TARGET, (String) handlerCtx.getInputValue(TARGET));
                 RestUtil.restRequest(deleteProfileEndpoint, attrMap, "DELETE", handlerCtx, false, false);
             }
@@ -168,7 +168,7 @@ public class InstanceHandler {
             //If the origList is not empty,  we want to restore it. Since POST remove all options first and then add it back. As a
             //result, all previous existing option is gone.
             List<Map<String, Object>> origList = (List<Map<String, Object>>) handlerCtx.getInputValue("origList");
-            Map<String, Object> payload1 = new HashMap<String, Object>();
+            Map<String, Object> payload1 = new HashMap<>();
             if (endpoint.contains(PROFILER)) {
                 payload1.put(PROFILER, "true");
             }
@@ -186,13 +186,13 @@ public class InstanceHandler {
             String jvmOptionUnescaped = new JvmOption((String) oneRow.get(JVM_OPTION),
                     (String) oneRow.get(MIN_VERSION), (String) oneRow.get(MAX_VERSION)).toString();
             String jvmOptionEscape = UtilHandlers.escapePropertyValue(jvmOptionUnescaped);         //refer to GLASSFISH-19069
-            ArrayList kv = getKeyValuePair(jvmOptionEscape);
-            payload.put((String)kv.get(0), kv.get(1));
+            ArrayList<String> kv = getKeyValuePair(jvmOptionEscape);
+            payload.put(kv.get(0), kv.get(1));
         }
     }
 
-    public static ArrayList getKeyValuePair(String str) {
-        ArrayList list = new ArrayList(2);
+    public static ArrayList<String> getKeyValuePair(String str) {
+        ArrayList<String> list = new ArrayList<>(2);
         int index = str.indexOf('=');
         String key = "";
         String value = "";

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admin.rest.resources;
 
@@ -74,6 +74,8 @@ import org.glassfish.api.ActionReport;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Function;
 import org.glassfish.admin.rest.utils.ResourceUtil;
 import org.glassfish.admin.rest.utils.Util;
 import org.jvnet.hk2.config.Dom;
@@ -98,6 +100,7 @@ public abstract class CollectionLeafResource extends AbstractResource {
     
     private static final String MIN_VERSION = "minVersion";
     private static final String MAX_VERISON = "maxVersion";
+    private static final String VENDOR = "vendor";
     private static final String JVM_OPTION = "jvmOption";
 
     /** Creates a new instance of xxxResource */
@@ -259,8 +262,13 @@ public abstract class CollectionLeafResource extends AbstractResource {
     }
     
     private Map<String, String> optionToMap(JvmOption option){
-        Map<String, String> baseMap = new HashMap<>();
-        baseMap.put(MIN_VERSION, option.minVersion.map(JDK.Version::toString).orElse(""));
+        Map<String, String> baseMap = new HashMap<>();        
+        if (option.vendor.isPresent()) {
+            baseMap.put(MIN_VERSION, option.vendor.get() + "-" + option.minVersion.map(JDK.Version::toString).orElse(""));
+        } else {
+            baseMap.put(MIN_VERSION, option.minVersion.map(JDK.Version::toString).orElse(""));
+        }
+        
         baseMap.put(MAX_VERISON, option.maxVersion.map(JDK.Version::toString).orElse(""));
         baseMap.put(JVM_OPTION, option.option);
         

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/xml/MiniXmlParser.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/xml/MiniXmlParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.universal.xml;
 
@@ -288,8 +288,14 @@ public class MiniXmlParser {
 
         public JvmOption(String option, String minVersion, String maxVersion) {
             this.option = option;
-            this.vendor = Optional.empty();
-            this.minVersion = Optional.ofNullable(JDK.getVersion(minVersion));
+            if (minVersion != null && minVersion.contains("-")) {
+                String[] parts = minVersion.split("-");
+                this.vendor = Optional.ofNullable(parts[0]);
+                this.minVersion = Optional.ofNullable(JDK.getVersion(parts[1]));
+            } else {
+                this.vendor = Optional.empty();
+                this.minVersion = Optional.ofNullable(JDK.getVersion(minVersion));
+            }
             this.maxVersion = Optional.ofNullable(JDK.getVersion(maxVersion));
         }
 
@@ -324,7 +330,8 @@ public class MiniXmlParser {
             if (!minVersion.isPresent() && !maxVersion.isPresent()) {
                 return option;
             }
-            return String.format("[%s|%s]%s", minVersion.isPresent() ? minVersion.get() : "", maxVersion.isPresent() ? maxVersion.get() : "", option);
+            return String.format("[%s%s|%s]%s", vendor.isPresent() ? vendor.get() + "-" : "" ,minVersion.isPresent() ? minVersion.get() : "",
+                    maxVersion.isPresent() ? maxVersion.get() : "", option);
         }
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/ListJvmOptions.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/ListJvmOptions.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.admin.commands;
 
@@ -129,6 +129,9 @@ public final class ListJvmOptions implements AdminCommand, AdminCommandSecurity.
                 }
                 option.minVersion.ifPresent(minVersion -> {
                     sb.append("min(");
+                    option.vendor.ifPresent(vendor -> {
+                        sb.append(vendor).append("-");
+                    });
                     sb.append(minVersion);
                     sb.append(")");
                 });


### PR DESCRIPTION
## Description
This is a bug fix.

This applies both in the admin console and asadmin command.
Also allows for saving of JVM options with vendor info.

## Testing

### Testing Performed
Run the `list-jvm-options` asadmin command and see that the vendor is listed
Go the the jvm options and add and edit a jvm option that has a vendor as part of the minimum JDK version.

### Testing Environment
Zulu JDK 1.8_262 on Ubuntu 20.04 with Maven 3.6.3

## Documentation

## Notes for Reviewers
