### PR TITLE
FISH-152 Mark Applications as Unavailable as soon as they are Disabled

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -633,13 +633,17 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             ApplicationInfo applicationInfo = (ApplicationInfo) event.hook();
             String appName = applicationInfo.getName();
             Applications applications = serviceLocator.getService(Applications.class);
+            String contextRoot = applications.getApplication(appName).getContextRoot();
 
-            StringBuilder stringBuilder = new StringBuilder();
-            // The final comma gets stripped out in suspendWebModule
-            getVirtualServers().forEach(virtualServer -> stringBuilder.append(virtualServer.getID()).append(","));
-            // Just provide all virtual hosts, it'll only suspend the app on those where it's deployed
-            suspendWebModule(applications.getApplication(appName).getContextRoot(), appName, stringBuilder.toString(),
-                    true);
+            // If no context root, nothing context to mark as unavailable
+            if (contextRoot != null) {
+                StringBuilder stringBuilder = new StringBuilder();
+                // The final comma gets stripped out in suspendWebModule
+                getVirtualServers().forEach(virtualServer -> stringBuilder.append(virtualServer.getID()).append(","));
+                // Just provide all virtual hosts, it'll only suspend the app on those where it's deployed
+                suspendWebModule(contextRoot, appName, stringBuilder.toString(),
+                        true);
+            }
         }
     }
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -635,7 +635,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             Applications applications = serviceLocator.getService(Applications.class);
             String contextRoot = applications.getApplication(appName).getContextRoot();
 
-            // If no context root, nothing context to mark as unavailable
+            // If no context root, no context to mark as unavailable
             if (contextRoot != null) {
                 StringBuilder stringBuilder = new StringBuilder();
                 // The final comma gets stripped out in suspendWebModule

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -633,7 +633,16 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             ApplicationInfo applicationInfo = (ApplicationInfo) event.hook();
             String appName = applicationInfo.getName();
             Applications applications = serviceLocator.getService(Applications.class);
-            String contextRoot = applications.getApplication(appName).getContextRoot();
+            if (applications == null) {
+                return;
+            }
+
+            com.sun.enterprise.config.serverbeans.Application application = applications.getApplication(appName);
+            if (application == null) {
+                return;
+            }
+
+            String contextRoot = application.getContextRoot();
 
             // If no context root, no context to mark as unavailable
             if (contextRoot != null) {

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.deployment;
 
@@ -162,6 +162,11 @@ public interface Deployment {
      * and decide whether to abort undeployment
      */
     public final EventTypes<DeploymentContext> UNDEPLOYMENT_VALIDATION = EventTypes.create("Undeployment_Validation", DeploymentContext.class);
+
+    // This event is thrown before the STOP deployment phase, specifically from the disable asadmin command
+    // It is used to mark the context unavailable before stopping the application and its engines, in cases where
+    // implementing the ApplicationLifecycleInterceptor interface will cause a circular dependency
+    EventTypes<ApplicationInfo> DISABLE_START = EventTypes.create("Disable_Start", ApplicationInfo.class);
 
 
     public interface DeploymentContextBuilder {

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
@@ -163,9 +163,11 @@ public interface Deployment {
      */
     public final EventTypes<DeploymentContext> UNDEPLOYMENT_VALIDATION = EventTypes.create("Undeployment_Validation", DeploymentContext.class);
 
-    // This event is thrown before the STOP deployment phase, specifically from the disable asadmin command
-    // It is used to mark the context unavailable before stopping the application and its engines, in cases where
-    // implementing the ApplicationLifecycleInterceptor interface will cause a circular dependency
+    /**
+     * This event is thrown before the STOP deployment phase, notably from the disable and undeploy asadmin commands.
+     * It is used to mark the context unavailable before stopping the application and its engines, in cases where
+     * implementing the ApplicationLifecycleInterceptor interface will cause a circular dependency
+     */
     EventTypes<ApplicationInfo> DISABLE_START = EventTypes.create("Disable_Start", ApplicationInfo.class);
 
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -59,6 +59,7 @@ import org.glassfish.api.deployment.UndeployCommandParameters;
 import org.glassfish.api.admin.ExecuteOn;
 import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.api.admin.ParameterMap;
+import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.Events;
 import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.internal.deployment.ExtendedDeploymentContext;
@@ -389,7 +390,7 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
                 // wait until all applications are loaded. Otherwise we get "Application not registered"
                 startupProvider.get();
                 ApplicationInfo appInfo = deployment.get(appName);
-
+                events.send(new EventListener.Event<>(Deployment.DISABLE_START, appInfo), true);
                 final DeploymentContext basicDC = deployment.disable(this, app, appInfo, report, logger);
                 suppInfo.setDeploymentContext((ExtendedDeploymentContext)basicDC);  
             }

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DisableCommand.java
@@ -393,6 +393,12 @@ public class DisableCommand extends UndeployCommandParameters implements AdminCo
                 events.send(new EventListener.Event<>(Deployment.DISABLE_START, appInfo), true);
                 final DeploymentContext basicDC = deployment.disable(this, app, appInfo, report, logger);
                 suppInfo.setDeploymentContext((ExtendedDeploymentContext)basicDC);  
+            } else if (env.isDas() && DeploymentUtils.isDomainTarget(target)
+                    && domain.getApplicationRefInTarget(appName, DeploymentUtils.DAS_TARGET_NAME) != null) {
+                // We still want to send the Disable_Start event for the DAS, even if the target is "domain"
+                startupProvider.get();
+                ApplicationInfo appInfo = deployment.get(appName);
+                events.send(new EventListener.Event<>(Deployment.DISABLE_START, appInfo), true);
             }
 
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
@@ -378,7 +378,7 @@ public class UndeployCommand extends UndeployCommandParameters implements AdminC
                 ActionReport subReport = report.addSubActionsReport();
 
                 // Disable the application first - note that even though the DAS may come under the target of "domain"
-                // it won't be disabled
+                // it won't be disabled by the disable command itself, but rather by an application config listener
                 CommandRunner.CommandInvocation inv = commandRunner.getCommandInvocation("disable", subReport, context.getSubject());
                 try {
                     final ParameterMapExtractor extractor = new ParameterMapExtractor(this);

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
@@ -44,6 +44,7 @@ package org.glassfish.deployment.admin;
 import com.sun.enterprise.admin.util.JarFileUtils;
 import com.sun.enterprise.config.serverbeans.*;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+import org.glassfish.api.event.EventListener;
 import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.data.ApplicationRegistry;
 import org.glassfish.internal.deployment.Deployment;
@@ -73,20 +74,15 @@ import org.jvnet.hk2.config.TransactionFailure;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.jar.JarFile;
+
 import org.glassfish.api.admin.AccessRequired;
 import org.glassfish.api.admin.AdminCommand;
 import org.glassfish.api.admin.AdminCommandContext;
@@ -376,11 +372,14 @@ public class UndeployCommand extends UndeployCommandParameters implements AdminC
                 return;
             }
 
-            // disable the application first for non-DAS target
+            // Undeploy the application first for non-DAS targets - note that if the target is "domain" this check will
+            // pass despite the DAS potentially being a valid target
             if (env.isDas() && !DeploymentUtils.isDASTarget(target)) {
                 ActionReport subReport = report.addSubActionsReport();
-                CommandRunner.CommandInvocation inv = commandRunner.getCommandInvocation("disable", subReport, context.getSubject());
 
+                // Disable the application first - note that even though the DAS may come under the target of "domain"
+                // it won't be disabled
+                CommandRunner.CommandInvocation inv = commandRunner.getCommandInvocation("disable", subReport, context.getSubject());
                 try {
                     final ParameterMapExtractor extractor = new ParameterMapExtractor(this);
                     final ParameterMap parameters = extractor.extract(Collections.EMPTY_LIST);
@@ -419,6 +418,15 @@ public class UndeployCommand extends UndeployCommandParameters implements AdminC
             generatedArtifacts.record(deploymentContext);
 
             if (info!=null) {
+                /**
+                 * Send the disable start event for the DAS. Even though the disable command itself doesn't get called
+                 * against the DAS, the unload lifecycle method is still executed (calling the
+                 * ApplicationLifecycleListeners for the STOP event), so fire the alternative event here.
+                 */
+                if (env.isDas() && (DeploymentUtils.isDASTarget(target) || DeploymentUtils.isDomainTarget(target))) {
+                    events.send(new EventListener.Event<>(Deployment.DISABLE_START, info), true);
+                }
+
                 deployment.undeploy(appName, deploymentContext);
             }
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
@@ -423,7 +423,8 @@ public class UndeployCommand extends UndeployCommandParameters implements AdminC
                  * against the DAS, the unload lifecycle method is still executed (calling the
                  * ApplicationLifecycleListeners for the STOP event), so fire the alternative event here.
                  */
-                if (env.isDas() && (DeploymentUtils.isDASTarget(target) || DeploymentUtils.isDomainTarget(target))) {
+                if (env.isDas() && (DeploymentUtils.isDASTarget(target) || DeploymentUtils.isDomainTarget(target))
+                        && domain.getApplicationRefInTarget(appName, DeploymentUtils.DAS_TARGET_NAME) != null) {
                     events.send(new EventListener.Event<>(Deployment.DISABLE_START, info), true);
                 }
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
@@ -420,11 +420,11 @@ public class UndeployCommand extends UndeployCommandParameters implements AdminC
             if (info!=null) {
                 /**
                  * Send the disable start event for the DAS. Even though the disable command itself doesn't get called
-                 * against the DAS, the unload lifecycle method is still executed (calling the
-                 * ApplicationLifecycleListeners for the STOP event), so fire the alternative event here.
+                 * against the DAS when the target is specifically set to "server", the unload lifecycle method is still
+                 * executed (calling the ApplicationLifecycleListeners for the STOP event), so fire the alternative
+                 * event here.
                  */
-                if (env.isDas() && (DeploymentUtils.isDASTarget(target) || DeploymentUtils.isDomainTarget(target))
-                        && domain.getApplicationRefInTarget(appName, DeploymentUtils.DAS_TARGET_NAME) != null) {
+                if (env.isDas() && (DeploymentUtils.isDASTarget(target))) {
                     events.send(new EventListener.Event<>(Deployment.DISABLE_START, info), true);
                 }
 


### PR DESCRIPTION

## Description
Improvement.

It was possible to get errors if an application endpoint was accessed during disable/undeployment. This improvement should help to alleviate these by marking the context for an application as unavailable (returning an 503 error when accessed) during the disable process while it is being unloaded and cleared away.

## Important Info
There is possibly a race condition present here due to processing the new _Disable_Start_ event asynchronously, but from all investigations and testing it's not possible for anything bad to happen. If the web container disables the context first, that's the goal we're aiming for and everything is bon. If the app engine and its modules are torn down before the context can be disabled (this _should_ be slower), then it either does nothing or simply logs a message at level "fine" because the application is already gone (meaning the context we wanted to mark as unavailable is too).

## Testing
### New tests
None due to the sensitive timing nature of this.

### Testing Performed
The general format I used for testing was to spin up a number of terminal windows that constantly poked a deployed application's endpoint, and checking the output and server logs as I disabled or undeployed the app. In Powershell, I used this (adjusting port and endpoint as required):

```
while ($true) { 
   curl http://localhost:8080/endpoint/
}
```

I've tested the following scenarios:

* Wars:
  * Deploying the venerable clusterjsp application to the DAS, and undeploying (target set to _server_ & _domain_)
  * Deploying the clusterjsp application to an instance, and undeploying
  * Deploying the clusterjsp application to the DAS and an instance, and undeploying from both
  * Deploying the clusterjsp application to the DAS and an instance, and undeploying from one
  * Deploying the clusterjsp application to the DAS, and disabling (target set to _server_ & _domain_)
  * Deploying the clusterjsp application to an instance, and disabling
  * Deploying the clusterjsp application to the DAS and an instance, and disabling on both
  * Deploying the clusterjsp application to the DAS and an instance, and disabling on one
  * Deploying the clusterjsp application to the DAS, and disabling
* EJBs:
  * Deploying an EJB with no endpoint to the DAS and an instance, and undeploying from both
* Ears:
  * Deploying the Ear attached to FISH-242 to the DAS (after cherry-picking the associated fix so it actually deploys), and undeploying from both
  * Deploying the Ear attached to FISH-242 to the DAS (after cherry-picking the associated fix so it actually deploys), and disabling on both


### Testing Environment
Windows 10, Zulu JDK 8

## Documentation
N/A
