### PR TITLE
FISH-339  Create Azure Secrets Cloud Config Source

### DIFF
--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/fish/payara/admingui/microprofile/Strings.properties
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/fish/payara/admingui/microprofile/Strings.properties
@@ -148,7 +148,7 @@ config.gcp.configuration.tokenKeyFileLabel=Token Key File
 config.gcp.configuration.tokenKeyFileHelpText=The path to the JSON key file which a service account uses to authenticate with GCP Secrets. This file will be copied to the config/ directory.
 
 config.azure.configuration.enabledLabel=Enabled
-config.azure.configuration.enabledHelpText=Enable the config source, which fetches data from GCP Secrets Manager
+config.azure.configuration.enabledHelpText=Enable the config source, which fetches data from Azure Key Vault
 config.azure.configuration.dynamicLabel=Dynamic
 config.azure.configuration.dynamicHelpText=Configure the config source dynamically, which will not require a restart
 config.azure.configuration.tenantIdLabel=Tenant ID

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/fish/payara/admingui/microprofile/Strings.properties
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/fish/payara/admingui/microprofile/Strings.properties
@@ -49,6 +49,7 @@ microprofile.configuration.configOrdinalTab=Ordinal
 microprofile.configuration.configPropertyTab=Property
 microprofile.configuration.configSecretsDirectoryTab=Directory
 microprofile.configuration.gcpSecretsConfigSourceTab=GCP Secrets
+microprofile.configuration.azureSecretsConfigSourceTab=Azure Secrets
 microprofile.configuration.jdbcConfigSourceTab=JDBC
 
 microprofile.specs.configuration.config.pageTitle=Config API
@@ -110,6 +111,8 @@ microprofile.specs.configuration.config.secretsDirectory.pageTitle=Secrets Direc
 microprofile.specs.configuration.config.secretsDirectory.pageTitleHelpText=Sets the directory to be used for the directory config source.
 microprofile.specs.configuration.config.gcpSecretsConfigSource.pageTitle=GCP Secrets Config Source
 microprofile.specs.configuration.config.gcpSecretsConfigSource.pageTitleHelpText=Configuration options for the config source which fetches data from GCP Secrets Manager.
+microprofile.specs.configuration.config.azureSecretsConfigSource.pageTitle=Azure Secrets Config Source
+microprofile.specs.configuration.config.azureSecretsConfigSource.pageTitleHelpText=Configuration options for the config source which fetches secrets from Azure Key Vault.
 microprofile.specs.configuration.config.jdbcConfigSource.pageTitle=JDBC
 microprofile.specs.configuration.config.jdbcConfigSource.pageTitleHelpText=Configuration options to set the properties required by JDBC config source to read the values from the configured database.
 
@@ -143,6 +146,21 @@ config.gcp.configuration.projectNameLabel=Project Name
 config.gcp.configuration.projectNameHelpText=The name of the GCP project to fetch secrets from
 config.gcp.configuration.tokenKeyFileLabel=Token Key File
 config.gcp.configuration.tokenKeyFileHelpText=The path to the JSON key file which a service account uses to authenticate with GCP Secrets. This file will be copied to the config/ directory.
+
+config.azure.configuration.enabledLabel=Enabled
+config.azure.configuration.enabledHelpText=Enable the config source, which fetches data from GCP Secrets Manager
+config.azure.configuration.dynamicLabel=Dynamic
+config.azure.configuration.dynamicHelpText=Configure the config source dynamically, which will not require a restart
+config.azure.configuration.tenantIdLabel=Tenant ID
+config.azure.configuration.tenantIdHelpText=Tenant ID of your Azure Active Directory application
+config.azure.configuration.clientIdLabel=Client ID
+config.azure.configuration.clientIdHelpText=The Client (Application) ID of your Azure Active Directory application
+config.azure.configuration.keyVaultNameLabel=Key Vault Name
+config.azure.configuration.keyVaultNameHelpText=Name of the Azure Key Vault to fetch secrets from
+config.azure.configuration.thumbprintLabel=Thumbprint
+config.azure.configuration.thumbprintHelpText=The thumbprint of the certificate (certificate hash) that is tied to your Azure Active Directory application
+config.azure.configuration.privateKeyFileLabel=Private Key File
+config.azure.configuration.privateKeyFileHelpText=The path to the Private key file which will be used for certificate-based authentication to request access token. This file will be copied to the config/ directory.
 
 config.jdbcConfigSource.configuration.jndiName=JNDI Name
 config.jdbcConfigSource.configuration.jndiNameHelp=JDNI name of the JDBC resource

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/microprofileConfigAPITabs.inc
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/microprofileConfigAPITabs.inc
@@ -80,4 +80,12 @@
           gf.redirect(page="#{request.contextPath}/microprofile/microprofile/specs/configAPI/gcpConfigSourceConfiguration.jsf?configName=#{configName}");
           />
     </sun:tab>
+    <sun:tab id="microProfileConfigAzureSecretsConfigSourceTab" immediate="$boolean{true}" 
+             text="$resource{i18n_microprofile.microprofile.configuration.azureSecretsConfigSourceTab}" 
+             toolTip="$resource{i18n_microprofile.microprofile.configuration.azureSecretsConfigSourceTab} Tab" >
+        <!command
+          setSessionAttribute(key="microprofileConfigTabs" value="microProfileConfigAzureSecretsConfigSourceTab");
+          gf.redirect(page="#{request.contextPath}/microprofile/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf?configName=#{configName}");
+          />
+    </sun:tab>
 </sun:tabSet>

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf
@@ -59,7 +59,7 @@
                 value="#{requestScope.resp.data.extraProperties.configSourceConfiguration}");
         mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.configName}");
         
-        setPageSessionAttribute(key="convertToFalseList", value={"enabled", "noisy"});
+        setPageSessionAttribute(key="convertToFalseList", value={"enabled"});
         
         if (#{pageSession.valueMap['enabled']}=true) {
             setPageSessionAttribute(key="enabledSelected", value="true");
@@ -81,9 +81,11 @@
                         onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) 
                         submitAndDisable(this, '$resource{i18n.button.Processing}'); return false;" >
                 <!command
+                    mapPut(map="#{pageSession.valueMap}" key="enabled" value="#{pageSession.enabledSelected}");
+                    mapPut(map="#{pageSession.valueMap}" key="dynamic" value="#{pageSession.dynamic}");
                     prepareSuccessfulMsg();
-                    gf.restRequest(endpoint="#{pageSession.MICROPROFILE_CONFIG_URL}/set-azure-config-source-configuration" 
-                    method="POST" attrs="#{pageSession.valueMap}");
+                    gf.updateEntity(endpoint="#{pageSession.MICROPROFILE_CONFIG_URL}/set-azure-config-source-configuration" 
+                         attrs="#{pageSession.valueMap}" convertToFalse="#{pageSession.convertToFalseList}");
                     /> 
             </sun:button>
         </sun:panelGroup>

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf
@@ -1,0 +1,144 @@
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
+
+<!initPage
+    setResourceBundle(key="i18n_microprofile" bundle="fish.payara.admingui.microprofile.Strings");
+/>
+<!composition template="/templates/default.layout"  
+    guiTitle="$resource{i18n_microprofile.microprofile.specs.configuration.config.azureSecretsConfigSource.pageTitle}">
+
+<!define name="content">
+
+<event>
+    <!beforeCreate
+        setSessionAttribute(key="microprofileConfigTabs" value="microProfileConfigAzureSecretsConfigSourceTab");
+        getRequestValue(key="configName" value="#{pageSession.configName}");
+        setPageSessionAttribute(key="MICROPROFILE_CONFIG_URL", 
+                value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/microprofile-config");
+        gf.restRequest(endpoint="#{pageSession.MICROPROFILE_CONFIG_URL}/get-azure-config-source-configuration?target=#{pageSession.configName}"  
+                method="GET" result="#{requestScope.resp}");
+        
+        setPageSessionAttribute(key="valueMap", 
+                value="#{requestScope.resp.data.extraProperties.configSourceConfiguration}");
+        mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.configName}");
+        
+        setPageSessionAttribute(key="convertToFalseList", value={"enabled", "noisy"});
+        
+        if (#{pageSession.valueMap['enabled']}=true) {
+            setPageSessionAttribute(key="enabledSelected", value="true");
+        }
+        setPageSessionAttribute(key="dynamic", value="true");
+        />
+</event>
+    
+    
+<sun:form id="propertyForm">
+#include "/common/shared/alertMsg_1.inc"
+#include "/microprofile/microprofile/microprofileConfigTabs.inc"
+#include "/microprofile/microprofile/microprofileConfigAPITabs.inc"
+    <sun:title id="propertyContentPage" title="$resource{i18n_microprofile.microprofile.specs.configuration.config.azureSecretsConfigSource.pageTitle}" 
+               helpText="$resource{i18n_microprofile.microprofile.specs.configuration.config.azureSecretsConfigSource.pageTitleHelpText}" >
+        <!facet pageButtonsTop>
+        <sun:panelGroup id="topButtons">
+            <sun:button id="saveButton"  text="$resource{i18n.button.Save}"
+                        onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) 
+                        submitAndDisable(this, '$resource{i18n.button.Processing}'); return false;" >
+                <!command
+                    prepareSuccessfulMsg();
+                    gf.restRequest(endpoint="#{pageSession.MICROPROFILE_CONFIG_URL}/set-azure-config-source-configuration" 
+                    method="POST" attrs="#{pageSession.valueMap}");
+                    /> 
+            </sun:button>
+        </sun:panelGroup>
+    </facet>
+    </sun:title>
+<sun:propertySheet id="propertySheet">
+#include "/common/shared/configNameSection.inc"
+  <sun:propertySheetSection id="azureSecretsConfigSourceProps">
+        <sun:property id="enabledProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.enabledLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.enabledHelpText}">
+            <sun:checkbox id="enabledProp" selected="#{pageSession.enabledSelected}" selectedValue="true" />
+        </sun:property>
+        <sun:property id="dynamic" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.dynamicLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.dynamicHelpText}">
+            <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
+        </sun:property>
+        <sun:property id="keyVaultName" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.keyVaultNameLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.keyVaultNameHelpText}">
+            <sun:textField id="keyVaultNameField" columns="$int{75}" maxLength="255" 
+                        text="#{pageSession.valueMap['keyVaultname']}" styleClass="required"  
+                        required="#{true}"/>
+        </sun:property>
+        <sun:property id="tenantID" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.tenantIdLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.tenantIdHelpText}">
+            <sun:textField id="tenantIDField" columns="$int{75}" maxLength="255" 
+                        text="#{pageSession.valueMap['tenantId']}" styleClass="required"  
+                        required="#{true}"/>
+        </sun:property>
+        <sun:property id="clientID" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.clientIdLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.clientIdHelpText}">
+            <sun:textField id="clientIDField" columns="$int{75}" maxLength="255" 
+                        text="#{pageSession.valueMap['clientId']}" styleClass="required"  
+                        required="#{true}"/>
+        </sun:property>
+        <sun:property id="thumbprint" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.thumbprintLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.thumbprintHelpText}">
+            <sun:textField id="thumbprintField" columns="$int{75}" maxLength="255" 
+                        text="#{pageSession.valueMap['thumbprint']}" styleClass="required"  
+                        required="#{true}"/>
+        </sun:property>
+        <sun:property id="privateKeyFile" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                    label="$resource{i18n_microprofile.config.azure.configuration.privateKeyFileLabel}"  
+                    helpText="$resource{i18n_microprofile.config.azure.configuration.privateKeyFileHelpText}">
+            <sun:textField id="privateKeyFileField" columns="$int{75}" maxLength="255" 
+                        text="#{pageSession.valueMap['privateKeyPath']}" styleClass="required"  
+                        required="#{true}"/>
+        </sun:property>
+    </sun:propertySheetSection>
+   </sun:propertySheet>
+  </sun:form>
+ </define>
+</composition>

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/gcpConfigSourceConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/gcpConfigSourceConfiguration.jsf
@@ -113,7 +113,7 @@
                     label="$resource{i18n_microprofile.config.gcp.configuration.tokenKeyFileLabel}"  
                     helpText="$resource{i18n_microprofile.config.gcp.configuration.tokenKeyFileHelpText}">
             <sun:textField id="tokenKeyFileField" columns="$int{75}" maxLength="255" 
-                        text="#{pageSession.valueMap['tokenKeyFile']}" styleClass="required"  
+                        text="#{pageSession.valueMap['jsonKeyFile']}" styleClass="required"  
                         required="#{true}"/>
         </sun:property>
     </sun:propertySheetSection>

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSource.java
@@ -1,0 +1,321 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.util.Base64;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import fish.payara.microprofile.config.extensions.azure.model.Secret;
+import fish.payara.microprofile.config.extensions.azure.model.SecretHolder;
+import fish.payara.microprofile.config.extensions.azure.model.SecretsResponse;
+import fish.payara.nucleus.microprofile.config.source.extension.ConfiguredExtensionConfigSource;
+import fish.payara.security.oauth2.OAuth2Client;
+import java.io.File;
+import java.nio.file.Files;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.DatatypeConverter;
+import org.glassfish.api.admin.ServerEnvironment;
+import org.jvnet.hk2.annotations.Service;
+
+@Service(name = "azure-secrets-config-source")
+public class AzureSecretsConfigSource extends ConfiguredExtensionConfigSource<AzureSecretsConfigSourceConfiguration> {
+
+    private static final Logger LOGGER = Logger.getLogger(AzureSecretsConfigSource.class.getName());
+
+    private OAuth2Client authClient;
+    private Client client = ClientBuilder.newClient();
+    private static final String AUTH_URL = "https://login.microsoftonline.com/%s/oauth2/v2.0/token";
+    private static final String SCOPE_URL = "https://vault.azure.net/.default";
+    private static final String SECRETS_ENDPOINT = "https://%s.vault.azure.net/secrets";
+    private static final String API_VERSION = "?api-version=7.1";
+
+    @Inject
+    private ServerEnvironment env;
+
+    @Override
+    public void bootstrap() {
+        StringBuilder contentBuilder = new StringBuilder();
+        try {
+            final File tokenFile = getPrivateKeyFile();
+            if (tokenFile == null) {
+                LOGGER.warning("Couldn't find private key file, make sure it's configured.");
+            } else {
+                try (Stream<String> stream = Files.lines(tokenFile.toPath())) {
+                    stream.forEach(s -> contentBuilder.append(s));
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.log(Level.WARNING, "Couldn't find or read the private key file, make sure it exists.", ex);
+        }
+
+        Map<String, String> data = new HashMap<>();
+        String tenantId = configuration.getTenantId();
+        String clientId = configuration.getClientId();
+        if (tenantId == null || clientId == null) {
+            LOGGER.warning("An error occurred while authenticating Azure to get a token, makes sure Azure Config Source has been configured with correct  configuration options.");
+        } else {
+            data.put("grant_type", "client_credentials");
+            data.put("client_id", clientId);
+            data.put("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+            data.put("scope", SCOPE_URL);
+
+            try {
+                final SignedJWT jwt = buildJwt(clientId, String.format(AUTH_URL, tenantId), configuration.getThumbprint());
+                jwt.sign(new RSASSASigner(parsePrivateKey(contentBuilder.toString())));
+                data.put("client_assertion", jwt.serialize());
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException | JOSEException e) {
+                LOGGER.log(Level.WARNING, "An error occurred while signing the Azure auth token", e);
+            }
+            this.authClient = new OAuth2Client(String.format(AUTH_URL, tenantId), data);
+        }
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, String> results = new HashMap<>();
+
+        final String accessToken = authenticate();
+
+        if (accessToken == null) {
+            return results;
+        }
+
+        final WebTarget secretsTarget = client
+                .target(String.format(SECRETS_ENDPOINT, configuration.getKeyVaultName()) + API_VERSION);
+
+        final Response secretsResponse = secretsTarget
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .get();
+
+        if (secretsResponse.getStatus() != 200) {
+            return results;
+        }
+
+        final List<Secret> secrets = secretsResponse
+                .readEntity(SecretsResponse.class)
+                .getValue();
+
+        for (Secret secret : secrets) {
+            final String secretName = secret.getId().replace(String.format(SECRETS_ENDPOINT, configuration.getKeyVaultName()) + "/", "");
+            results.put(secretName, getValue(secretName));
+        }
+        return results;
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        final String accessToken = authenticate();
+        if (accessToken == null) {
+            return null;
+        }
+
+        final WebTarget secretTarget = client
+                .target(String.format(SECRETS_ENDPOINT, configuration.getKeyVaultName()) + "/" + propertyName + API_VERSION);
+
+        final Response secretResponse = secretTarget
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .get();
+
+        final int status = secretResponse.getStatus();
+        if (status != 200) {
+            if (status != 400) {
+                LOGGER.log(Level.WARNING, "Failed to get Azure secret. {0}", secretResponse.readEntity(String.class));
+            }
+            return null;
+        }
+
+        final String value = secretResponse
+                .readEntity(Secret.class)
+                .getValue();
+
+        return value;
+    }
+
+    @Override
+    public boolean setValue(String secretName, String secretValue) {
+        final String accessToken = authenticate();
+
+        if (accessToken == null) {
+            return false;
+        }
+
+        final WebTarget setSecretTarget = client
+                .target(String.format(SECRETS_ENDPOINT, configuration.getKeyVaultName()) + "/" + secretName + API_VERSION);
+
+        final Response setSecretResponse = setSecretTarget
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .put(Entity.entity(new SecretHolder(secretValue), MediaType.APPLICATION_JSON));
+
+        if (setSecretResponse.getStatus() == 200) {
+            return true;
+        }
+        LOGGER.log(Level.WARNING, "Failed to set Azure secret. {0}", setSecretResponse.readEntity(String.class));
+        return false;
+    }
+
+    @Override
+    public boolean deleteValue(String secretName) {
+        final String accessToken = authenticate();
+
+        if (accessToken == null) {
+            return false;
+        }
+
+        final WebTarget secretTarget = client
+                .target(String.format(SECRETS_ENDPOINT, configuration.getKeyVaultName()) + "/" + secretName + API_VERSION);
+
+        final Response secretResponse = secretTarget
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .delete();
+
+        if (secretResponse.getStatus() == 200) {
+            return true;
+        }
+        LOGGER.log(Level.WARNING, "Failed to delete Azure secret. {0}", secretResponse.readEntity(String.class));
+        return false;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return super.getOrdinal(); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public String getName() {
+        return "azure";
+    }
+
+    private File getPrivateKeyFile() {
+        final String fileName = configuration.getPrivateKeyFilePath();
+        if (fileName != null) {
+            return env.getConfigDirPath().toPath().resolve(configuration.getPrivateKeyFilePath()).toFile();
+        }
+        return null;
+    }
+
+    private static SignedJWT buildJwt(final String issuer, final String audience, final String thumbprint) {
+        Instant now = Instant.now();
+        Instant expiry = now.plus(1, ChronoUnit.MINUTES);
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject(issuer)
+                .audience(audience)
+                .expirationTime(Date.from(expiry))
+                .issueTime(Date.from(now))
+                .issuer(issuer)
+                .build();
+
+        byte[] bytes = DatatypeConverter.parseHexBinary(thumbprint);
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(JOSEObjectType.JWT)
+                .x509CertThumbprint(Base64URL.encode(bytes))
+                .build();
+
+        return new SignedJWT(header, claims);
+    }
+
+    private static PrivateKey parsePrivateKey(String privateKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        String privateKeyContent = privateKey
+                .replaceAll("\\n", "")
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "");
+
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+
+        PKCS8EncodedKeySpec keySpecPKCS8 = new PKCS8EncodedKeySpec(new Base64(privateKeyContent).decode());
+        return kf.generatePrivate(keySpecPKCS8);
+    }
+
+    private String authenticate() {
+        if (authClient == null) {
+            LOGGER.log(Level.WARNING, "Couldn't authenticate with Azure. Check your configuration options are correct.");
+        } else {
+            final Response response = authClient.authenticate();
+            final int status = response.getStatus();
+            if (status == 200) {
+                JsonObject data = response.readEntity(JsonObject.class);
+                Integer expirySeconds = data.getInt("expires_in");
+                authClient.expire(Duration.ofSeconds(expirySeconds));
+                return data.getString("access_token");
+            } else if (status == 400) {
+                LOGGER.log(Level.WARNING, "Couldn't authenticate with Azure. Check your configuration options are correct.");
+            }
+        }
+        return null;
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSource.java
@@ -250,11 +250,6 @@ public class AzureSecretsConfigSource extends ConfiguredExtensionConfigSource<Az
     }
 
     @Override
-    public int getOrdinal() {
-        return super.getOrdinal(); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
     public String getName() {
         return "azure";
     }

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSourceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSourceConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure;
+
+import fish.payara.nucleus.microprofile.config.spi.ConfigSourceConfiguration;
+import org.jvnet.hk2.config.Attribute;
+import org.jvnet.hk2.config.Configured;
+
+@Configured(name = "azure-secrets-config-source-configuration")
+public interface AzureSecretsConfigSourceConfiguration extends ConfigSourceConfiguration {
+
+    @Attribute(required = true)
+    String getTenantId();
+    void setTenantId(String tenabtId);
+    
+    @Attribute(required = true)
+    String getClientId();
+    void setClientId(String clientId);
+    
+    @Attribute(required = true)
+    String getKeyVaultName();
+    void setKeyVaultName(String keyVaultName);
+    
+    @Attribute(required = true)
+    String getPrivateKeyFilePath();
+    void setPrivateKeyFilePath(String path);
+    
+    @Attribute(required = true)
+    String getThumbprint();
+    void setThumbprint(String thumbprint);
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/GetAzureSecretsConfigSourceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/GetAzureSecretsConfigSourceConfigurationCommand.java
@@ -1,0 +1,83 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure.admin;
+
+import fish.payara.microprofile.config.extensions.azure.AzureSecretsConfigSourceConfiguration;
+import java.util.Map;
+
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+
+import fish.payara.nucleus.microprofile.config.source.extension.BaseGetConfigSourceConfigurationCommand;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
+
+@Service(name = "get-azure-config-source-configuration")
+@PerLookup
+@CommandLock(CommandLock.LockType.NONE)
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
+@TargetType(value = {CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CLUSTERED_INSTANCE, CommandTarget.CONFIG})
+@RestEndpoints({
+    @RestEndpoint(configBean = MicroprofileConfigConfiguration.class,
+            opType = RestEndpoint.OpType.GET,
+            path = "get-azure-config-source-configuration",
+            description = "List Azure Secrets Config Source Configuration")
+})
+public class GetAzureSecretsConfigSourceConfigurationCommand extends BaseGetConfigSourceConfigurationCommand<AzureSecretsConfigSourceConfiguration> {
+
+    @Override
+    protected Map<String, Object> getConfigSourceConfiguration(AzureSecretsConfigSourceConfiguration configuration) {
+        Map<String, Object> config = super.getConfigSourceConfiguration(configuration);
+        if (configuration != null) {
+            config.put("Tenant ID", configuration.getTenantId());
+            config.put("Client ID", configuration.getClientId());
+            config.put("Key VaultName", configuration.getKeyVaultName());
+            config.put("Private Key Path", configuration.getPrivateKeyFilePath());
+            config.put("Thumbprint", configuration.getThumbprint());
+        }
+        return config;
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/SetAzureSecretsConfigSourceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/SetAzureSecretsConfigSourceConfigurationCommand.java
@@ -84,16 +84,16 @@ public class SetAzureSecretsConfigSourceConfigurationCommand extends BaseSetConf
 
     private static final Logger LOGGER = Logger.getLogger(SetAzureSecretsConfigSourceConfigurationCommand.class.getPackage().getName());
 
-    @Param(optional = true, name = "tenant-id")
+    @Param(optional = true, name = "tenant-id", alias = "tenantId")
     protected String tenantId;
 
-    @Param(optional = true, name = "client-id")
+    @Param(optional = true, name = "client-id", alias = "clientId")
     protected String clientId;
 
-    @Param(optional = true, name = "key-vault-name ")
+    @Param(optional = true, name = "key-vault-name", alias = "keyVaultname")
     protected String keyVaultName;
 
-    @Param(optional = true, name = "private-key-file")
+    @Param(optional = true, name = "private-key-file", alias = "privateKeyPath")
     private File privateKeyFile;
 
     @Param(optional = true)

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/SetAzureSecretsConfigSourceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/SetAzureSecretsConfigSourceConfigurationCommand.java
@@ -1,0 +1,141 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure.admin;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+
+import com.sun.enterprise.util.StringUtils;
+import fish.payara.microprofile.config.extensions.azure.AzureSecretsConfigSourceConfiguration;
+
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+
+import fish.payara.nucleus.microprofile.config.source.extension.BaseSetConfigSourceConfigurationCommand;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
+
+@Service(name = "set-azure-config-source-configuration")
+@PerLookup
+@CommandLock(CommandLock.LockType.NONE)
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
+@TargetType(value = {CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CLUSTERED_INSTANCE, CommandTarget.CONFIG})
+@RestEndpoints({
+    @RestEndpoint(configBean = MicroprofileConfigConfiguration.class,
+            opType = RestEndpoint.OpType.POST,
+            path = "set-azure-config-source-configuration",
+            description = "Configures Azure Secrets Config Source")
+})
+public class SetAzureSecretsConfigSourceConfigurationCommand extends BaseSetConfigSourceConfigurationCommand<AzureSecretsConfigSourceConfiguration> {
+
+    private static final Logger LOGGER = Logger.getLogger(SetAzureSecretsConfigSourceConfigurationCommand.class.getPackage().getName());
+
+    @Param(optional = true, name = "tenant-id")
+    protected String tenantId;
+
+    @Param(optional = true, name = "client-id")
+    protected String clientId;
+
+    @Param(optional = true, name = "key-vault-name ")
+    protected String keyVaultName;
+
+    @Param(optional = true, name = "private-key-file")
+    private File privateKeyFile;
+
+    @Param(optional = true)
+    private String thumbprint;
+
+    @Inject
+    private ServerEnvironment env;
+
+    @Override
+    protected void applyValues(AzureSecretsConfigSourceConfiguration configuration) throws PropertyVetoException {
+        super.applyValues(configuration);
+        if (StringUtils.ok(tenantId)) {
+            configuration.setTenantId(tenantId);
+        }
+
+        if (StringUtils.ok(clientId)) {
+            configuration.setClientId(clientId);
+        }
+
+        if (StringUtils.ok(keyVaultName)) {
+            configuration.setKeyVaultName(keyVaultName);
+        }
+
+        if (StringUtils.ok(thumbprint)) {
+            configuration.setThumbprint(thumbprint);
+        }
+
+        if (privateKeyFile != null) {
+            if (!privateKeyFile.exists() || !privateKeyFile.isFile()) {
+                throw new PropertyVetoException("Private Key file not found", new PropertyChangeEvent(configuration, "privateKeyFile", null, privateKeyFile));
+            }
+            try {
+                Path configDirPath = env.getConfigDirPath().toPath();
+                Path output = Files.copy(privateKeyFile.toPath(), configDirPath.resolve(privateKeyFile.getName()),
+                        StandardCopyOption.REPLACE_EXISTING);
+                configuration.setPrivateKeyFilePath(configDirPath.relativize(output).toString());
+                LOGGER.info("File copied to " + output);
+            } catch (IOException e) {
+                final String message = "Unable to find or access target file";
+                LOGGER.log(Level.WARNING, message, e);
+                throw new PropertyVetoException(message, new PropertyChangeEvent(configuration, "privateKeyFile", null, privateKeyFile));
+            }
+        }
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/Attributes.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/Attributes.java
@@ -1,0 +1,84 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure.model;
+
+public class Attributes {
+
+    private Boolean enabled;
+    private Long created;
+    private Long updated;
+    private String recoveryLevel;
+
+    public Attributes() {
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public Long getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(Long updated) {
+        this.updated = updated;
+    }
+
+    public String getRecoveryLevel() {
+        return recoveryLevel;
+    }
+
+    public void setRecoveryLevel(String recoveryLevel) {
+        this.recoveryLevel = recoveryLevel;
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/Secret.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/Secret.java
@@ -1,0 +1,75 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure.model;
+
+public class Secret {
+
+    private String id;
+    private String value;
+    private Attributes attributes;
+
+    public Secret() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Attributes getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Attributes attributes) {
+        this.attributes = attributes;
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/SecretHolder.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/SecretHolder.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.config.extensions.azure.model;
+
+public class SecretHolder {
+
+    private String value;
+
+    public SecretHolder() {
+    }
+
+    public SecretHolder(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/SecretsResponse.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/SecretsResponse.java
@@ -1,17 +1,46 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
  */
 package fish.payara.microprofile.config.extensions.azure.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-/**
- *
- * @author SusanRai
- */
 public class SecretsResponse {
 
     public SecretsResponse() {

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/SecretsResponse.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/model/SecretsResponse.java
@@ -1,0 +1,29 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.microprofile.config.extensions.azure.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ *
+ * @author SusanRai
+ */
+public class SecretsResponse {
+
+    public SecretsResponse() {
+    }
+
+    private List<Secret> value;
+
+    public List<Secret> getValue() {
+        return value;
+    }
+
+    public void setValue(List<Secret> value) {
+        this.value = value;
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/gcp/GetGCPSecretsConfigSourceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/gcp/GetGCPSecretsConfigSourceConfigurationCommand.java
@@ -72,7 +72,7 @@ public class GetGCPSecretsConfigSourceConfigurationCommand extends BaseGetConfig
         Map<String, Object> config = super.getConfigSourceConfiguration(configuration);
         if (configuration != null) {
             config.put("Project Name", configuration.getProjectName());
-            config.put("Token File Path", configuration.getTokenFilePath());
+            config.put("Json Key File", configuration.getTokenFilePath());
         }
         return config;
     }

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/gcp/SetGCPSecretsConfigSourceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/gcp/SetGCPSecretsConfigSourceConfigurationCommand.java
@@ -83,8 +83,8 @@ public class SetGCPSecretsConfigSourceConfigurationCommand extends BaseSetConfig
 
     private static final Logger LOGGER = Logger.getLogger(SetGCPSecretsConfigSourceConfigurationCommand.class.getPackage().getName());
 
-    @Param(optional = true)
-    protected String project;
+    @Param(optional = true, alias = "project-name")
+    protected String projectName;
 
     @Param(optional = true, alias = "json-key-file")
     private File jsonKeyFile;
@@ -95,8 +95,8 @@ public class SetGCPSecretsConfigSourceConfigurationCommand extends BaseSetConfig
     @Override
     protected void applyValues(GCPSecretsConfigSourceConfiguration configuration) throws PropertyVetoException {
         super.applyValues(configuration);
-        if (StringUtils.ok(project)) {
-            configuration.setProjectName(project);
+        if (StringUtils.ok(projectName)) {
+            configuration.setProjectName(projectName);
         }
         if (jsonKeyFile != null) {
             if (!jsonKeyFile.exists() || !jsonKeyFile.isFile()) {


### PR DESCRIPTION
## Description
This is a feature, that allows you to fetch secrets from Azure Key Vault to be used as a config source for Payara.

## Documentation
TODO

## Notes for Reviewers
Currently Azure supports two options for authentication to get an access code: password-based authentication and certidifcate-based authentication. I have decided to use the latter as it is the recommended way and it also means the user doesn't have to provide their password. 
