### PR TITLE
FISH-405 FISH-604 Revert for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <json.bind-api.version>1.0.2</json.bind-api.version>
         <yasson.version>1.0.6</yasson.version>
         <jakarta-persistence-api.version>2.2.3</jakarta-persistence-api.version>
-        <eclipselink.version>2.7.7.payara-p1</eclipselink.version>
+        <eclipselink.version>2.7.7.payara-p2</eclipselink.version>
         <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
         <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
         <jakarta.inject.version>1.0</jakarta.inject.version>


### PR DESCRIPTION
Title.
Use EclipseLink 2.7.7 without the fix for FISH-405