### PR TITLE
FISH-732: Define toString() of MBeanMetaData and XmlTag to have meaningful messages in server.log

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
@@ -47,10 +47,11 @@ import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SUB_ATTRI
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import java.util.Optional;
 import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -271,5 +272,21 @@ public class MBeanMetadata implements Metadata {
                 Objects.equals(unit, thatUnit) &&
                 Objects.equals(this.getTypeRaw(), that.getTypeRaw()) &&
                 Objects.equals(reusable, that.isReusable());
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", MBeanMetadata.class.getSimpleName() + "[", "]")
+                .add("mBean='" + mBean + "'")
+                .add("dynamic=" + dynamic)
+                .add("name='" + name + "'")
+                .add("displayName='" + displayName + "'")
+                .add("description='" + description + "'")
+                .add("unit='" + unit + "'")
+                .add("type='" + type + "'")
+                .add("reusable=" + reusable)
+                .add("valid=" + valid)
+                .add("tags=" + tags)
+                .toString();
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/XmlTag.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/XmlTag.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -46,6 +46,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.StringJoiner;
 
 /**
  * Tag of name/value pair, used for XML unmarshalling
@@ -83,4 +84,12 @@ public class XmlTag {
         public void setValue(String value) {
             this.value = value;
         }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", XmlTag.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("value='" + value + "'")
+                .toString();
     }
+}


### PR DESCRIPTION
## Description
When duplicate name is used in metrics.xml file, the message in the server.log was not very meaningful as it just indicated memory pointers.

## Testing

### Testing Performed
Ran reproducer.

### Testing Environment
Zulu 8.48.0.51-CA-macosx (build 1.8.0_262-b19) on Mac 10.14.6 with Maven 3.5.4

