### PR TITLE
FISH-731 Update Hibernate validator to 6.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
         <jax-rs-api.impl.version>2.1.6</jax-rs-api.impl.version>
         <jersey.version>2.30.payara-p3</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
-        <hibernate.validator.version>6.1.2.Final</hibernate.validator.version>
-        <hibernate.validator-cdi.version>6.1.2.Final</hibernate.validator-cdi.version>
+        <hibernate.validator.version>6.1.5.Final</hibernate.validator.version>
+        <hibernate.validator-cdi.version>6.1.5.Final</hibernate.validator-cdi.version>
         <jakarta.el.version>3.0.3.payara-p2</jakarta.el.version>
         <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>


### PR DESCRIPTION
Fixes CVE-2020-10693

Signed-off-by: Andrew Pielage <andrew.pielage@payara.fish>