### PR TITLE
Use Maven Properties for GF Properties file

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/branding/glassfish-version.properties
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/branding/glassfish-version.properties
@@ -1,9 +1,9 @@
 product_name=@@@PRODUCT@@@
 brief_product_name=@@@PRODUCT@@@
 abbrev_product_name=@@@PRODUCT@@@
-major_version=5
-minor_version=2020
-update_version=4-SNAPSHOT
+major_version=@@@MAJOR_VERSION@@@
+minor_version=@@@MINOR_VERSION@@@
+update_version=@@@UPDATE_VERSION@@@
 build_id=@@@BUILD_NUMBER@@@
 version_prefix=
 version_suffix=#badassmicrofish

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -134,6 +134,9 @@
         </delete>
 	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@PRODUCT@@@" value="${product.name}"/>
 	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@BUILD_NUMBER@@@" value="${build.number}"/>
+	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@MAJOR_VERSION@@@" value="${major_version}"/>
+	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@MINOR_VERSION@@@" value="${minor_version}"/>
+	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@UPDATE_VERSION@@@" value="${update_version}"/>
      </target>
      
     <target name="addSchemas" >


### PR DESCRIPTION
## Description
Just a small update, makes use of maven properties in the ant build for the glassfish-version.properties file so as to remove some extra margin for error in the release process

## Testing
### Testing Performed
Build and run locally to show correct version number on server startup, additionally looked manually in the file after building and values are correct