### PR TITLE
FISH-206 @RolesAllowed annotation in method prevents unauthenticated calls to other methods in remote EJB

### DIFF
--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/CSIV2TaggedComponentInfo.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/CSIV2TaggedComponentInfo.java
@@ -292,6 +292,9 @@ public final class CSIV2TaggedComponentInfo {
 
                 iorDescriptor.setRealmName(realmName);
 
+                // If the EJB contains some methods that don't require authentication, add a descriptor that
+                // doesn't require authentication so that lookup can be performed (access checks on protected
+                // methods should still happen later, this is simply to allow lookup)
                 for (MethodPermission methodPermission : ejbDescriptor.getMethodPermissionsFromDD().keySet()) {
                     if (methodPermission.isUnchecked()) {
                         EjbIORConfigurationDescriptor uncheckedDescriptor = new EjbIORConfigurationDescriptor();

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/CSIV2TaggedComponentInfo.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/CSIV2TaggedComponentInfo.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.iiop.security;
 
 import static com.sun.enterprise.deployment.EjbIORConfigurationDescriptor.NONE;

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/CSIV2TaggedComponentInfo.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/CSIV2TaggedComponentInfo.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sun.enterprise.deployment.MethodPermission;
 import org.glassfish.enterprise.iiop.api.GlassFishORBHelper;
 import org.glassfish.enterprise.iiop.impl.CSIv2Policy;
 import org.glassfish.internal.api.ORBLocator;
@@ -269,7 +270,6 @@ public final class CSIV2TaggedComponentInfo {
             iorDescriptor.setConfidentiality(SUPPORTED);
             iorDescriptor.setEstablishTrustInClient(SUPPORTED);
             iorDescriptors.add(iorDescriptor);
-            size = 1;
 
             // Check if method permissions are set on the descriptor.
             // If they are then enable username_password mechanism in as_context
@@ -291,6 +291,18 @@ public final class CSIV2TaggedComponentInfo {
                 }
 
                 iorDescriptor.setRealmName(realmName);
+
+                for (MethodPermission methodPermission : ejbDescriptor.getMethodPermissionsFromDD().keySet()) {
+                    if (methodPermission.isUnchecked()) {
+                        EjbIORConfigurationDescriptor uncheckedDescriptor = new EjbIORConfigurationDescriptor();
+                        uncheckedDescriptor.setIntegrity(SUPPORTED);
+                        uncheckedDescriptor.setConfidentiality(SUPPORTED);
+                        uncheckedDescriptor.setEstablishTrustInClient(SUPPORTED);
+                        uncheckedDescriptor.setRealmName(realmName);
+                        iorDescriptors.add(uncheckedDescriptor);
+                        break;
+                    }
+                }
             }
         }
 

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -229,6 +229,7 @@
             <modules>
                 <module>ejb-http-remoting</module>
                 <module>remote-ejb-tracing</module>
+                <module>rolesallowed-unprotected-methods</module>
             </modules>
             <dependencies>
                 <dependency>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <groupId>fish.payara.samples</groupId>
+        <version>5.23.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
+    <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
+    <name>Payara Samples - RolesAllowed Unprotected Methods</name>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>rolesallowed-unprotected-methods-common</module>
+        <module>rolesallowed-unprotected-methods-server</module>
+        <module>rolesallowed-unprotected-methods-client</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <type>pom</type>
+                <version>${project.version}</version>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
+</project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <artifactId>payara-samples-profiled-tests</artifactId>
         <groupId>fish.payara.samples</groupId>
-        <version>5.23.0-SNAPSHOT</version>
+        <version>5.2020.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <artifactId>payara-samples-profiled-tests</artifactId>
         <groupId>fish.payara.samples</groupId>
-        <version>5.2020.6-SNAPSHOT</version>
+        <version>5.2020.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
+        <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
+        <version>5.23.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rolesallowed-unprotected-methods-client</artifactId>
+    <name>Payara Samples - RolesAllowed Unprotected Methods: Client</name>
+
+    <properties>
+        <deployableName>rolesallowed-unprotected-methods-server</deployableName>
+        <payara.home></payara.home>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-${deployableName}</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <stripVersion>true</stripVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${deployableName}</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>deploy-${deployableName}</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>deploy ${project.build.directory}/dependency/${deployableName}.war</commandlineArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>undeploy-${deployableName}</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${payara.home}/glassfish/bin/asadmin</executable>
+                            <commandlineArgs>undeploy ${deployableName}</commandlineArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-embedded-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
+            <artifactId>rolesallowed-unprotected-methods-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
         <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
-        <version>5.2020.6-SNAPSHOT</version>
+        <version>5.2020.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
         <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
-        <version>5.23.0-SNAPSHOT</version>
+        <version>5.2020.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/RemoteEjbClientIT.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/RemoteEjbClientIT.java
@@ -56,7 +56,7 @@ import java.util.Properties;
 public class RemoteEjbClientIT {
 
     @Test
-    public void executeRemoteEjbPermitAllMethodWithoutAuthIT() {
+    public void executeHelloServiceBeanPermitAllMethodWithoutAuthIT() {
         Properties contextProperties = new Properties();
         contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterprise.naming.SerialInitContextFactory");
         contextProperties.setProperty("org.omg.CORBA.ORBInitialHost", "localhost");
@@ -75,7 +75,7 @@ public class RemoteEjbClientIT {
     }
 
     @Test
-    public void executeRemoteEjbRolesAllowedMethodWithoutAuthIT() {
+    public void executeHelloServiceBeanRolesAllowedMethodWithoutAuthIT() {
         Properties contextProperties = new Properties();
         contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterprise.naming.SerialInitContextFactory");
         contextProperties.setProperty("org.omg.CORBA.ORBInitialHost", "localhost");
@@ -95,6 +95,27 @@ public class RemoteEjbClientIT {
             }
         } catch (NamingException ne) {
             Assert.fail("Failed performing lookup:\n" + ne.getCause());
+        }
+    }
+
+    @Test
+    public void lookupProtectedHelloServiceBeanWithoutAuthIT() {
+        Properties contextProperties = new Properties();
+        contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterprise.naming.SerialInitContextFactory");
+        contextProperties.setProperty("org.omg.CORBA.ORBInitialHost", "localhost");
+        contextProperties.setProperty("org.omg.CORBA.ORBInitialPort", "3700");
+
+        try {
+            Context context = new InitialContext(contextProperties);
+
+            // Should fail
+            ProtectedHelloServiceRemote ejb = (ProtectedHelloServiceRemote) context.lookup(
+                    "java:global/rolesallowed-unprotected-methods-server/ProtectedHelloServiceBean!fish.payara.samples.rolesallowed.unprotected.methods.ProtectedHelloServiceRemote");
+            Assert.fail("Managed to access fully-secured EJB without being authenticated");
+        } catch (NamingException ne) {
+            Assert.assertTrue("Lookup seems to have failed for an unexpected reason. " +
+                            "Expected message to contain \"CORBA NO_PERMISSION\"",
+                    ne.toString().contains("CORBA NO_PERMISSION"));
         }
     }
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/RemoteEjbClientIT.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-client/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/RemoteEjbClientIT.java
@@ -1,0 +1,101 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rolesallowed.unprotected.methods;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ejb.EJBAccessException;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+/**
+ * Test that verifies the automatic propagation of baggage items across process boundaries when using Remote EJBs.
+ *
+ * @author Andrew Pielage <andrew.pielage@payara.fish>
+ */
+public class RemoteEjbClientIT {
+
+    @Test
+    public void executeRemoteEjbPermitAllMethodWithoutAuthIT() {
+        Properties contextProperties = new Properties();
+        contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterprise.naming.SerialInitContextFactory");
+        contextProperties.setProperty("org.omg.CORBA.ORBInitialHost", "localhost");
+        contextProperties.setProperty("org.omg.CORBA.ORBInitialPort", "3700");
+
+        try {
+            Context context = new InitialContext(contextProperties);
+            HelloServiceRemote ejb = (HelloServiceRemote) context.lookup(
+                    "java:global/rolesallowed-unprotected-methods-server/HelloServiceBean!fish.payara.samples.rolesallowed.unprotected.methods.HelloServiceRemote");
+
+            System.out.println(ejb.sayHello());
+            Assert.assertTrue(ejb.sayHello().equalsIgnoreCase("Hello Anonymous!"));
+        } catch (NamingException ne) {
+            Assert.fail("Failed performing lookup:\n" + ne.getCause());
+        }
+    }
+
+    @Test
+    public void executeRemoteEjbRolesAllowedMethodWithoutAuthIT() {
+        Properties contextProperties = new Properties();
+        contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterprise.naming.SerialInitContextFactory");
+        contextProperties.setProperty("org.omg.CORBA.ORBInitialHost", "localhost");
+        contextProperties.setProperty("org.omg.CORBA.ORBInitialPort", "3700");
+
+        try {
+            Context context = new InitialContext(contextProperties);
+            HelloServiceRemote ejb = (HelloServiceRemote) context.lookup(
+                    "java:global/rolesallowed-unprotected-methods-server/HelloServiceBean!fish.payara.samples.rolesallowed.unprotected.methods.HelloServiceRemote");
+
+            try {
+                // Should fail
+                System.out.println(ejb.secureSayHello());
+                Assert.fail("Managed to access secured method without being authenticated");
+            } catch (EJBAccessException ejbAccessException) {
+                System.out.println("Successfully prevented from accessing method without being authenticated");
+            }
+        } catch (NamingException ne) {
+            Assert.fail("Failed performing lookup:\n" + ne.getCause());
+        }
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
+        <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
+        <version>5.23.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rolesallowed-unprotected-methods-common</artifactId>
+    <name>Payara Samples - RolesAllowed Unprotected Methods: Common</name>
+    <description>Interfaces and common classes for the EJBs - split out so as to enforce client is as independent as possible</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
         <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
-        <version>5.23.0-SNAPSHOT</version>
+        <version>5.2020.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
         <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
-        <version>5.2020.6-SNAPSHOT</version>
+        <version>5.2020.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceLocal.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceLocal.java
@@ -1,0 +1,11 @@
+package fish.payara.samples.rolesallowed.unprotected.methods;
+
+import javax.ejb.Local;
+
+@Local
+public interface HelloServiceLocal {
+
+    String sayHello();
+
+    String secureSayHello();
+}

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceRemote.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceRemote.java
@@ -1,3 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
 package fish.payara.samples.rolesallowed.unprotected.methods;
 
 import javax.ejb.Remote;

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceRemote.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceRemote.java
@@ -1,0 +1,11 @@
+package fish.payara.samples.rolesallowed.unprotected.methods;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface HelloServiceRemote {
+
+    String sayHello();
+
+    String secureSayHello();
+}

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/ProtectedHelloServiceLocal.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/ProtectedHelloServiceLocal.java
@@ -43,9 +43,8 @@ package fish.payara.samples.rolesallowed.unprotected.methods;
 import javax.ejb.Local;
 
 @Local
-public interface HelloServiceLocal {
-
-    String sayHello();
+public interface ProtectedHelloServiceLocal {
 
     String secureSayHello();
+
 }

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/ProtectedHelloServiceRemote.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-common/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/ProtectedHelloServiceRemote.java
@@ -40,12 +40,11 @@
 
 package fish.payara.samples.rolesallowed.unprotected.methods;
 
-import javax.ejb.Local;
+import javax.ejb.Remote;
 
-@Local
-public interface HelloServiceLocal {
-
-    String sayHello();
+@Remote
+public interface ProtectedHelloServiceRemote {
 
     String secureSayHello();
+
 }

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
@@ -71,4 +71,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
+        <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
+        <version>5.23.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rolesallowed-unprotected-methods-server</artifactId>
+    <name>Payara Samples - RolesAllowed Unprotected Methods: Server</name>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <!-- Make sure all dependencies are marked as optional so nothing is transitively pulled into the client test -->
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
+            <artifactId>rolesallowed-unprotected-methods-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
         <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
-        <version>5.2020.6-SNAPSHOT</version>
+        <version>5.2020.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.samples.rolesallowed-unprotected-methods</groupId>
         <artifactId>rolesallowed-unprotected-methods-parent</artifactId>
-        <version>5.23.0-SNAPSHOT</version>
+        <version>5.2020.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceBean.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServiceBean.java
@@ -1,0 +1,68 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.rolesallowed.unprotected.methods;
+
+import javax.annotation.Resource;
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+@Stateless
+@DeclareRoles("user")
+public class HelloServiceBean implements HelloServiceLocal, HelloServiceRemote {
+
+    @Resource
+    private SessionContext sc;
+
+    @PermitAll
+    @Override
+    public String sayHello() {
+        return "Hello " + sc.getCallerPrincipal().getName() + "!";
+    }
+
+    @RolesAllowed("user")
+    @Override
+    public String secureSayHello() {
+        return "Hello " + sc.getCallerPrincipal().getName() + "!";
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServlet.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServlet.java
@@ -1,0 +1,48 @@
+package fish.payara.samples.rolesallowed.unprotected.methods;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.ejb.EJB;
+import javax.ejb.EJBAccessException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/sayhello")
+public class HelloServlet extends HttpServlet {
+
+    @EJB
+    private HelloServiceLocal helloServiceBean;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        sayHello(response);
+    }
+
+    private void sayHello(HttpServletResponse response) throws IOException {
+        response.setContentType("text/html;charset=UTF-8");
+
+        try (PrintWriter out = response.getWriter()) {
+            out.println("<html>");
+            out.println("<head>");
+            out.println("<title>Hello Servlet</title>");
+            out.println("</head>");
+            out.println("<body>");
+            out.println("<h1>" + helloServiceBean.sayHello() + "</h1>");
+
+            try {
+                // Should fail!
+                out.println("<h1>" + helloServiceBean.secureSayHello() + "</h1>");
+            } catch (EJBAccessException ejbAccessException) {
+                out.println("<h1>Managed to get access!</h1>");
+            }
+
+            out.println("</body>");
+            out.println("</html>");
+            out.println();
+        }
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServlet.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServlet.java
@@ -1,3 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
 package fish.payara.samples.rolesallowed.unprotected.methods;
 
 import java.io.IOException;
@@ -36,7 +76,7 @@ public class HelloServlet extends HttpServlet {
                 // Should fail!
                 out.println("<h1>" + helloServiceBean.secureSayHello() + "</h1>");
             } catch (EJBAccessException ejbAccessException) {
-                out.println("<h1>Managed to get access!</h1>");
+                out.println("<h1>Didn't get access to secure method!</h1>");
             }
 
             out.println("</body>");

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/ProtectedHelloServiceBean.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/main/java/fish/payara/samples/rolesallowed/unprotected/methods/ProtectedHelloServiceBean.java
@@ -40,12 +40,22 @@
 
 package fish.payara.samples.rolesallowed.unprotected.methods;
 
-import javax.ejb.Local;
+import javax.annotation.Resource;
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
 
-@Local
-public interface HelloServiceLocal {
+@Stateless
+@DeclareRoles("user")
+public class ProtectedHelloServiceBean implements ProtectedHelloServiceLocal, ProtectedHelloServiceRemote {
 
-    String sayHello();
+    @Resource
+    private SessionContext sc;
 
-    String secureSayHello();
+    @RolesAllowed("user")
+    @Override
+    public String secureSayHello() {
+        return "Hello " + sc.getCallerPrincipal().getName() + "!";
+    }
 }

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServletIT.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServletIT.java
@@ -1,3 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
 package fish.payara.samples.rolesallowed.unprotected.methods;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -33,7 +73,7 @@ public class HelloServletIT {
         Response response = ClientBuilder.newClient().target(url + "/" + "sayhello").request().get();
         String responseString = response.readEntity(String.class);
         Assert.assertTrue(responseString.contains("Hello ANONYMOUS"));
-        Assert.assertTrue(!responseString.contains("Managed to get access!"));
+        Assert.assertTrue(responseString.contains("Didn't get access to secure method!"));
     }
 
 }

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServletIT.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/HelloServletIT.java
@@ -1,0 +1,39 @@
+package fish.payara.samples.rolesallowed.unprotected.methods;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import java.net.URL;
+
+/**
+ * @author Andrew Pielage <andrew.pielage@payara.fish>
+ */
+@RunWith(Arquillian.class)
+public class HelloServletIT {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "rolesallowed-unprotected-methods.war")
+                .addPackage("fish.payara.samples.rolesallowed.unprotected.methods");
+    }
+
+    @Test
+    public void invokeServletIT() {
+        Response response = ClientBuilder.newClient().target(url + "/" + "sayhello").request().get();
+        String responseString = response.readEntity(String.class);
+        Assert.assertTrue(responseString.contains("Hello ANONYMOUS"));
+        Assert.assertTrue(!responseString.contains("Managed to get access!"));
+    }
+
+}


### PR DESCRIPTION
## Description
Without authorisation being passed, an EJB client would fail to perform a lookup on an EJB if it had a @RolesAllowed annotation if no IOR descriptor and no authentication were provided - it would default to requiring authentication to perform a lookup if any checked method permissions were detected. If the EJB had methods annotated with PermitAll however, this would prevent you from accessing these methods without providing authentication since you could not perform the initial context lookup.

## Important Info
This should ideally be run through the JakartaEE TCK before being merged, due to the security implication of me cracking the door open slightly. 

### Dependant PRs
None

### Blockers
None

## Testing
Added some new tests and ran some small bits of the Jakarta TCK and Java EE7 Samples.

### New tests
Added a new sample to payara-samples, which only runs if using the `payara-server-remote` profile.

It runs the following checks:
* EJB can be injected into a servlet without authentication (working as it did before these changes).
  * Method annotated with `PermitAll` can be accessed (working as it did before these changes).
  * Method annotated with `RolesAllowed` can **not** be accessed (working as it did before these changes).
* Standalone Java client can perform lookup on EJB annotated with a mix of `RolesAllowed` and `PermitAll` annotations
  * Method annotated with `PermitAll` can be accessed
  * Method annotated with `RolesAllowed` can **not** be accessed
* Standalone Java client can **not** perform lookup on an EJB annotated _only_ with `RolesAllowed`.

## Documentation
N/A

## Notes for Reviewers
I can't find the CSIv2 spec so I don't know if this default behaviour of locking the door for lookups if a single checked method is detected is expected.
