### PR TITLE
Revert Unstable on Expired Certs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,11 +27,7 @@ pipeline {
                     echo "Payara pom version is ${pom.version}"
                     echo "Build number is ${payaraBuildNumber}"
                     echo "Domain name is ${DOMAIN_NAME}"
-
-                    echo '*#*#*#*#*#*#*#*#*#*#*#*#  Certificates Expiring Soon  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-                    sh """keytool -list -v -keystore '${pwd()}/nucleus/admin/template/src/main/resources/config/cacerts.jks' -storepass 'changeit' | grep -E 'Valid from:.*`date +'%b' --date='+1 month'`.*`date +'%Y'`|`date +'%b'`.*`date +'%Y'`"""
-                    echo '*#*#*#*#*#*#*#*#*#*#*#*#  Certificates Expiring Soon  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-                }
+              }
             }
         }
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 def pom
 def DOMAIN_NAME
 def payaraBuildNumber
-def rc
 pipeline {
     agent any
     options {
@@ -30,10 +29,7 @@ pipeline {
                     echo "Domain name is ${DOMAIN_NAME}"
 
                     echo '*#*#*#*#*#*#*#*#*#*#*#*#  Certificates Expiring Soon  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-                    rc = sh(returnStatus: true, script: "keytool -list -v -keystore \'${pwd()}/nucleus/admin/template/src/main/resources/config/cacerts.jks\' -storepass \'changeit\' | grep -E \"Valid from:.*`date +'%b' --date='+1 month'`.*`date +'%Y'`|`date +'%b'`.*`date +'%Y'`\"")
-                    if(rc != 1) {
-                        currentBuild.result = 'UNSTABLE'
-                    }
+                    sh """keytool -list -v -keystore '${pwd()}/nucleus/admin/template/src/main/resources/config/cacerts.jks' -storepass 'changeit' | grep -E 'Valid from:.*`date +'%b' --date='+1 month'`.*`date +'%Y'`|`date +'%b'`.*`date +'%Y'`"""
                     echo '*#*#*#*#*#*#*#*#*#*#*#*#  Certificates Expiring Soon  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                 }
             }


### PR DESCRIPTION
We now have a feature in the build to renew expired certs when the product is being built which makes this stage redundant and will only cause issues with PR testing - thus I am reverting it