### PR TITLE
FISH-747 Azure config source configuration on Admin console fails

### DIFF
--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/configAPI/azureConfigSourceConfiguration.jsf
@@ -136,7 +136,7 @@
                     label="$resource{i18n_microprofile.config.azure.configuration.privateKeyFileLabel}"  
                     helpText="$resource{i18n_microprofile.config.azure.configuration.privateKeyFileHelpText}">
             <sun:textField id="privateKeyFileField" columns="$int{75}" maxLength="255" 
-                        text="#{pageSession.valueMap['privateKeyPath']}" styleClass="required"  
+                        text="#{pageSession.valueMap['privateKeyFile']}" styleClass="required"  
                         required="#{true}"/>
         </sun:property>
     </sun:propertySheetSection>

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/GetAzureSecretsConfigSourceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/admin/GetAzureSecretsConfigSourceConfigurationCommand.java
@@ -75,7 +75,7 @@ public class GetAzureSecretsConfigSourceConfigurationCommand extends BaseGetConf
             config.put("Tenant ID", configuration.getTenantId());
             config.put("Client ID", configuration.getClientId());
             config.put("Key VaultName", configuration.getKeyVaultName());
-            config.put("Private Key Path", configuration.getPrivateKeyFilePath());
+            config.put("Private Key File", configuration.getPrivateKeyFilePath());
             config.put("Thumbprint", configuration.getThumbprint());
         }
         return config;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This PR fixes an issue where you could not use the admin console to configure Azure config source configuration.
