### PR TITLE
FISH-767: reference ejb-opentracing.jar in manifest.mf of gf_client.jar.

### DIFF
--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -449,5 +449,13 @@
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
       </dependency>
 
+      <!-- Request tracing for remote eJB -->
+      <dependency>
+        <scope>runtime</scope>
+        <groupId>fish.payara.server.internal.ejb</groupId>
+        <artifactId>ejb-opentracing</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
## Description

The jar file handling the Request Tracing for Remote EJB jar is not referenced from the Manifest file of gf_client.jar file.

So when using gf_client.jar, the class OpenTracingIiopInterceptorFactory.class is missing and thus Request Tracing will not work. (no issue with embedded_all.jar)

## Testing

### Testing Performed
tested resulting gf_client.jazr

### Testing Environment
Zulu 8.48.0.51-CA-macosx (build 1.8.0_262-b19) on Mac 10.14.6 with Maven 3.5.4

