### PR TITLE
QACI-464 FISH-775 CmpRosterTest fails due to DirWatcher race dondition w/filesystem

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
- // Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+ // Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.loader;
 
@@ -120,7 +120,7 @@ public class ASURLClassLoader extends CurrentBeforeParentClassLoader
     */
     private volatile String doneSnapshot;
 
-    private boolean mostLoadInThisStackFrame;
+    private boolean mustLoadInThisStackFrame;
 
     /** streams opened by this loader */
     private final List<SentinelInputStream> streams = new CopyOnWriteArrayList<>();
@@ -382,8 +382,8 @@ public class ASURLClassLoader extends CurrentBeforeParentClassLoader
     }
 
     private AutoCloseable mustLoad() {
-        mostLoadInThisStackFrame = true;
-        return () -> mostLoadInThisStackFrame = false;
+        mustLoadInThisStackFrame = true;
+        return () -> mustLoadInThisStackFrame = false;
     }
 
     /**
@@ -983,7 +983,7 @@ public class ASURLClassLoader extends CurrentBeforeParentClassLoader
         }
 
         boolean hasItem(String item, ASURLClassLoader classLoader) {
-            return classLoader.mostLoadInThisStackFrame || presenceCheck.test(item);
+            return classLoader.mustLoadInThisStackFrame || presenceCheck.test(item);
         }
 
           /**


### PR DESCRIPTION
added ASURLClassLoader.mustLoadFrom() to indicate that DirWatcher should be disregarded due to race conditions

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
There is an inherent race condition between OS delivering filesystem changes to DirWatcher,
when classes are loaded right after the class files are created.
Ignore DirWatcher when classes are necessary for app to work

## Testing
Fixes QuickLook stability
MacOS exposes this really well because it's a polling version of DirWatcher instead of pushing events