### PR TITLE
#4953 package jaxws opentracing to embedded Payara

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -43,7 +43,7 @@
 <!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fish.payara.extras</groupId>
@@ -104,7 +104,7 @@
                             <tasks>
                                 <ant dir="." antfile="../build.xml" target="create.distribution">
                                     <property name="finaljar"
-                                              value="${project.build.directory}/payara-embedded-all.jar"/>
+                                      value="${project.build.directory}/payara-embedded-all.jar"/>
                                     <property name="bundlename" value="fish.payara.extras.embedded.all"/>
                                     <property name="install.dir.name" value="${install.dir.name}"/>
                                 </ant>
@@ -378,6 +378,13 @@
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>jmx-monitoring-package</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>opentracing-jaxws-package</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>


### PR DESCRIPTION
- JaxwsContainerRequestTracing is now discovered by ServiceLocator

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Fixes packaging of embedded Payara. Any deployed webservice could not handle requests, because at least one implementation of opentracing is required.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual run of integration tests with embedded Payara.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
