### PR TITLE
Failed to deploy RAR connectors in current Payara Micro

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/microprofile-connector/src/main/java/fish/payara/microprofile/connector/MicroProfileSniffer.java
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-connector/src/main/java/fish/payara/microprofile/connector/MicroProfileSniffer.java
@@ -50,16 +50,26 @@ import org.glassfish.api.container.Sniffer;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.api.deployment.archive.ReadableArchive;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.web.sniffer.WarType;
 import org.jvnet.hk2.annotations.Contract;
+
+import javax.inject.Inject;
 
 @Contract
 public abstract class MicroProfileSniffer implements Sniffer {
 
     private static final Logger LOGGER = Logger.getLogger(MicroProfileSniffer.class.getName());
+    
+    @Inject ServiceLocator habitat;
 
     @Override
     public boolean handles(DeploymentContext context) {
+        ArchiveType archiveType = habitat.getService(ArchiveType.class, context.getArchiveHandler().getArchiveType());
+        if (archiveType != null && !supportsArchiveType(archiveType)) {
+            return false;
+        }
+
         final ReadableArchive archive = context.getSource();
 
         final String archivePath = archive.getURI().getPath();


### PR DESCRIPTION
## Description
When deploy any rar we get the `java.lang.IllegalArgumentException: Sniffers with type [config] and type [connector] should not claim the archive at the same time.`

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
Run Payara Micro, e.g. `java -jar payara-micro.jar --deploy activemq-rar-5.16.0.rar`

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
**OS**: Windows 10 Pro
**JDK**: Zulu JDK 1.8.0_265

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
