### PR TITLE
FISH-863 Fix MP Sniffer RAR Issue

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/activation/ConfigSniffer.java
+++ b/appserver/payara-appserver-modules/microprofile/config/src/main/java/fish/payara/microprofile/config/activation/ConfigSniffer.java
@@ -58,6 +58,18 @@ public class ConfigSniffer extends MicroProfileSniffer {
     }
 
     @Override
+    public String[] getIncompatibleSnifferTypes() {
+        // This sniffer is always active, so don't throw errors for any other sniffers
+        return new String[0];
+    }
+
+    @Override
+    public boolean isUserVisible() {
+        // Always active, so don't clutter the user with this information
+        return false;
+    }
+
+    @Override
     public Class<? extends Annotation>[] getAnnotationTypes() {
         return null;
     }

--- a/appserver/payara-appserver-modules/microprofile/microprofile-connector/src/main/java/fish/payara/microprofile/connector/MicroProfileSniffer.java
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-connector/src/main/java/fish/payara/microprofile/connector/MicroProfileSniffer.java
@@ -133,7 +133,7 @@ public abstract class MicroProfileSniffer implements Sniffer {
     }
 
     @Override
-    public final String[] getIncompatibleSnifferTypes() {
+    public String[] getIncompatibleSnifferTypes() {
         final String[] types = new String[1];
         types[0] = "connector";
         return types;
@@ -145,7 +145,7 @@ public abstract class MicroProfileSniffer implements Sniffer {
     }
 
     @Override
-    public final boolean isUserVisible() {
+    public boolean isUserVisible() {
         return true;
     }
 


### PR DESCRIPTION
Connectors failed as the MP Config Sniffer always activated and was incompatible with connector modules. Now the Config Sniffer is hidden from the user and compatible with every module.

Signed-off-by: Matthew Gill <matthew.gill@live.co.uk>

Is this the correct branch?