### PR TITLE
FISH-867 Fix Servlet TCK Failures (Revert of FISH-779 and FISH-766)

### DIFF
--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -878,7 +878,7 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
         try {
             if (certs != null) {
                 // Certificate credential used to authenticate
-                WebAndEjbToJaasBridge.doX500Login(createSubjectWithCerts(certs), realmName, moduleID);
+                WebAndEjbToJaasBridge.doX500Login(createSubjectWithCerts(certs), moduleID);
             } else if (digestParams != null) {
                 // Digest credential used to authenticate
                 WebAndEjbToJaasBridge.login(new DigestCredentials(realmName, username, digestParams));

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
@@ -56,6 +56,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -471,11 +472,17 @@ public class GlassFishSingleSignOn extends SingleSignOn
         // SSO entries. However, this should be addressed separately.
 
         try {
-            this.cache.forEach((ssoId, sso) -> {
-                if (sso.isEmpty() && sso.getLastAccessTime() < tooOld) {
-                    removals.add(ssoId);
+            synchronized (cache) {
+
+                Iterator<String> it = cache.keySet().iterator();
+                while (it.hasNext()) {
+                    String key = it.next();
+                    SingleSignOnEntry sso = (SingleSignOnEntry) cache.get(key);
+                    if (sso.isEmpty() && sso.getLastAccessTime() < tooOld) {
+                        removals.add(key);
+                    }
                 }
-            });
+            }
 
             int removalCount = removals.size();
             // S1AS8 6155481 START


### PR DESCRIPTION
3 Servlet failures were caused by an 'unauthorized' error. This PR makes the following changes:

- Partially revert FISH-766. The community contribution is still present, but the changed functionality introduced by https://github.com/payara/Payara/pull/4479/commits/b298f292cd383ea3aab7ad244f0d4ce649a6a4e9#r456932973 is broken, so has been removed.
- Totally revert https://github.com/payara/Payara/pull/4610. The issue will need reopening and readdressing, but in a way that still passes the TCK. Unfortunately, this community contribution will not be present in the release notes as it's been reverted.