### PR TITLE
FISH-873 TransactionScopedCDIUtil Context Util - can now be run without a context

### DIFF
--- a/appserver/web/gf-web-connector/osgi.bundle
+++ b/appserver/web/gf-web-connector/osgi.bundle
@@ -37,10 +37,10 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2020] [Payara Foundation and/or its affiliates]
 
 -exportcontents: org.glassfish.web.sniffer; \
 		 org.glassfish.web.config.serverbeans; \
          org.glassfish.web.plugin.common; \
-         fish.payara.appserver.context;
+         fish.payara.appserver.context; \
 		 version=${project.osgi.version}

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionScopedCDIUtil.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionScopedCDIUtil.java
@@ -219,7 +219,8 @@ public class TransactionScopedCDIUtil {
             catch(MultiException e) {
                 log(e.getMessage());
             }
-            this.ctxUtil = ctxUtil.map(JavaEEContextUtil::currentInvocation);
+            this.ctxUtil = ctxUtil.map(ctx -> ctx.getInvocationComponentId() != null ?
+                    ctx.currentInvocation() : ctx.empty());
         }
 
         private void setInjectionTarget(InjectionTarget<Object> injectionTarget) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Now checking for no-invocation context run during testing
Not sure if this affects real-world applications, but I think it may
Fixes test issue with #5010 

## Important Info
### Blockers
None

## Testing
Was caused by the following throwing WARNINGS, but not errors, thus not failing the build
```
testcase name="testafterBeanDiscovery" classname="org.glassfish.cdi.transaction.TransactionScopedContextExtensionTest" time="0.538">
<error message="No Current Invocation present" type="java.lang.IllegalStateException">java.lang.IllegalStateException: No Current Invocation present at org.glassfish.cdi.transaction.TransactionScopedContextExtensionTest.testafterBeanDiscovery(TransactionScopedContextExtensionTest.java:76) </error>
<system-err>
```

### Testing Performed
tests now pass without warning

### Testing Environment
jdk 8, mac

## Documentation
None

## Notes for Reviewers
Relates to FISH-790
