### PR TITLE
MP JWT uses long datatype for exp and iat verification to prevent overflow in 2038

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JwtTokenParser.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JwtTokenParser.java
@@ -191,9 +191,9 @@ public class JwtTokenParser {
      * @return if the JWT has expired
      */
     private boolean checkNotExpired(Map<String, JsonValue> presentedClaims) {
-        final int currentTime = (int) (System.currentTimeMillis() / 1000);
-        final int expiredTime = ((JsonNumber) presentedClaims.get(exp.name())).intValue();
-        final int issueTime = ((JsonNumber) presentedClaims.get(iat.name())).intValue();
+        final long currentTime = System.currentTimeMillis() / 1000;
+        final long expiredTime = ((JsonNumber) presentedClaims.get(exp.name())).longValue();
+        final long issueTime = ((JsonNumber) presentedClaims.get(iat.name())).longValue();
 
         return currentTime < expiredTime && issueTime < expiredTime;
     }


### PR DESCRIPTION
## Description
This PR addresses a bug I found while working on a MP JWT feature. The JWT claims `iat` and `exp` are stored as `int` for verification. Both claims hold a timestamp as the number of seconds since epoch. The code is susceptible to the year 2038 integer overflow problem; aka, the epochalypse. Values after January 19, 2038 3:14:07 GMT will cause an integer overflow. This can cause valid tokens to be treated as expired.

This will eventually cause a security problem once we reach 2038/01/19. Any tokens that expired before 2038/01/19 can be accepted once again. This happens because the current time overflows and becomes negative but all `exp` claims before this day will not overflow and will remain positive. It will appear as though the old tokens have not expired yet.

This PR changes the expiry check to use `long` instead. That buys us a little over 290 billion years... but if we're still worried about a `long` overflow, I can update the PR to use `BitInteger` 🙂 .

There's not a GitHub or Jira issue to tie this to but I can file one if needed.

## Testing
### New tests
I'm a bit new to how testing works in this repository. I'd be happy to write tests with a little direction on where they best belong. This module does not have unit tests yet so I assume that's happening some where else?

### Testing Performed
I manually tested these changes with expired tokens, valid tokens before 2038, and valid tokens after 2038.

### Testing Environment
```
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Java version: 1.8.0_275, vendor: AdoptOpenJDK, runtime: C:\Program Files\Java\jdk-8u275\jre
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```