### PR TITLE
FISH-664 MP OpenTracing 2.0-RC2 Upgrade

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpan.java
+++ b/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpan.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.notification.requesttracing;
 
+import io.opentracing.tag.Tag;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -63,7 +64,7 @@ public class RequestTraceSpan implements Serializable, Comparable<RequestTraceSp
     private Instant endTime;
     private long spanDuration;
     private EventType eventType;
-    private final Map<String, String> spanTags;
+    private final Map<Object, String> spanTags;
     private final List<RequestTraceSpanLog> spanLogs;
     private String eventName;
     private final List<SpanReference> spanReferences;
@@ -177,11 +178,26 @@ public class RequestTraceSpan implements Serializable, Comparable<RequestTraceSp
         }
     }
     
-    public String getSpanTag(String tag) {
+    /**
+     * Adds more information about a span
+     *
+     * @param tag
+     * @param value
+     */
+    public void addSpanTag(Tag tag, String value) {
+        if (value != null) {
+            // Escape any quotes
+            spanTags.put(tag, value.replaceAll("\"", "\\\\\""));
+        } else {
+            spanTags.put(tag, value);
+        }
+    }
+    
+    public String getSpanTag(Object tag) {
         return spanTags.get(tag);
     }
     
-    public Map<String, String> getSpanTags() {
+    public Map<Object, String> getSpanTags() {
         return spanTags;
     }
     
@@ -245,7 +261,7 @@ public class RequestTraceSpan implements Serializable, Comparable<RequestTraceSp
         
         if (spanTags != null && !spanTags.isEmpty()) {
             result.append(",\"spanTags\":[");
-            for (Entry<String, String> entry : spanTags.entrySet()) {
+            for (Entry<Object, String> entry : spanTags.entrySet()) {
                 result.append("{\"").append(entry.getKey()).append("\": \"").append(entry.getValue()).append("\"},");
             }
             result.deleteCharAt(result.length() - 1);

--- a/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpanContext.java
+++ b/api/payara-api/src/main/java/fish/payara/notification/requesttracing/RequestTraceSpanContext.java
@@ -98,6 +98,16 @@ public class RequestTraceSpanContext implements Serializable, io.opentracing.Spa
         this.traceId = traceId;
     }
 
+    @Override
+    public String toTraceId() {
+        return traceId.toString();
+    }
+
+    @Override
+    public String toSpanId() {
+        return spanId.toString();
+    }
+
     public void addBaggageItem(String name, String value) {
         if (value != null) {
             // Escape any quotes

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -266,7 +266,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
 
         builder.withTag("Thread Name", Thread.currentThread().getName());
 
-        builder.startActive(true);
+        tracer.activateSpan(builder.start());
     }
 
     @Override

--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
@@ -57,6 +57,7 @@ import java.io.ObjectInput;
 
 import static fish.payara.ejb.opentracing.OpenTracingIiopInterceptorFactory.OPENTRACING_IIOP_ID;
 import static fish.payara.opentracing.OpenTracingService.PAYARA_CORBA_RMI_TRACER_NAME;
+import fish.payara.opentracing.ScopeManager;
 
 /**
  * IIOP Server Interceptor for propagating OpenTracing SpanContext to Payara Server.
@@ -113,7 +114,7 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
         }
 
         // Start the span and mark it as active
-        spanBuilder.startActive(true).span();
+        tracer.activateSpan(spanBuilder.start());
     }
 
     @Override
@@ -139,7 +140,11 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
 
         // Make sure active scope is closed - this is an entry point to the server so the currently active span
         // **should** be the one started in receive_request
-        try (Scope activeScope = tracer.scopeManager().active()) {
+        tracer.scopeManager().activeSpan().finish();
+        if (tracer.scopeManager() instanceof ScopeManager) {
+            ScopeManager manager = (ScopeManager) tracer.scopeManager();
+            try (Scope activeScope = manager.activeScope()) {
+            }
         }
     }
 

--- a/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/runtime/MonitoringConsoleRuntimeImpl.java
+++ b/appserver/monitoring-console/core/src/main/java/fish/payara/monitoring/runtime/MonitoringConsoleRuntimeImpl.java
@@ -101,6 +101,7 @@ import fish.payara.notification.requesttracing.RequestTraceSpan;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import fish.payara.nucleus.hazelcast.HazelcastCore;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
+import io.opentracing.tag.Tag;
 
 /**
  * This implementation of the {@link MonitoringConsoleRuntime} connects the Payara independent parts of the monitoring
@@ -355,8 +356,12 @@ public class MonitoringConsoleRuntimeImpl
                         .addField("endTime", span.getTraceEndTime().toEpochMilli())
                         .addField("duration", span.getSpanDuration())
                         .addChild("tags");
-                    for (Entry<String, String> tag : span.getSpanTags().entrySet()) {
-                        tags.addField(tag.getKey(), tag.getValue());
+                    for (Entry<Object, String> tag : span.getSpanTags().entrySet()) {
+                        if (tag.getKey() instanceof Tag) {
+                            tags.addField(((Tag)tag.getKey()).getKey(), tag.getValue());
+                        } else {
+                            tags.addField(tag.getKey().toString(), tag.getValue());
+                        }
                     }
                 }
                 matches.add(data);

--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/cdi/TracedInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/cdi/TracedInterceptor.java
@@ -139,7 +139,7 @@ public class TracedInterceptor implements Serializable {
         Span parentSpan = tracer.activeSpan();
 
         final Span span = tracer.buildSpan(operationName).start();
-        try (Scope scope = tracer.scopeManager().activate(span, true)) {
+        try (Scope scope = tracer.scopeManager().activate(span)) {
             try {
                 return invocationContext.proceed();
             } catch (final Exception ex) {
@@ -151,6 +151,8 @@ public class TracedInterceptor implements Serializable {
                 span.log(errorInfoMap);
                 throw ex;
             }
+        } finally {
+            span.finish();
         }
     }
 

--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/OpenTracingRequestEventListener.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/jaxrs/OpenTracingRequestEventListener.java
@@ -43,6 +43,7 @@ import fish.payara.microprofile.opentracing.cdi.OpenTracingCdiUtils;
 import fish.payara.opentracing.OpenTracingService;
 
 import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -137,9 +138,9 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
                 return;
             }
 
-            final Scope activeScope = openTracing.getTracer(this.applicationName).scopeManager().active();
-            if (activeScope == null) {
-                LOG.finest(() -> "Could not find any active scope, nothing to do.");
+            final Span activeSpan = openTracing.getTracer(this.applicationName).scopeManager().activeSpan();
+            if (activeSpan == null) {
+                LOG.finest(() -> "Could not find any active span, nothing to do.");
                 return;
             }
 
@@ -180,7 +181,8 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
             spanBuilder.asChildOf(spanContext);
         }
         // Start the span and continue on to the targeted method
-        spanBuilder.startActive(true);
+        Scope scope = tracer.activateSpan(spanBuilder.start());
+        requestContext.setProperty(Scope.class.getName(), scope);//tracer.activeSpan();
         LOG.fine(() -> "Request tracing enabled for request=" + requestContext.getRequest() + " to application="
             + this.applicationName + " on uri=" + toString(requestContext.getUriInfo()));
 
@@ -189,8 +191,7 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
 
     private void onException(final RequestEvent event) {
         LOG.fine(() -> "onException(event=" + event.getType() + ")");
-        final Scope activeScope = getAlreadyActiveScope();
-        final Span activeSpan = activeScope.span();
+        final Span activeSpan = getAlreadyActiveSpan();
         activeSpan.setTag(Tags.ERROR.getKey(), true);
         activeSpan.setTag(Tags.HTTP_STATUS.getKey(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         activeSpan.log(Collections.singletonMap(Fields.EVENT, "error"));
@@ -206,9 +207,8 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
         LOG.fine(() -> "Response context: status code=" + statusInfo.getStatusCode() //
             + ", hasEntity=" + response.hasEntity());
 
-        final Scope activeScope = getAlreadyActiveScope();
+        final Span activeSpan = getAlreadyActiveSpan();
         LOG.finest("Setting the HTTP response status etc. to the active span...");
-        final Span activeSpan = activeScope.span();
         activeSpan.setTag(Tags.HTTP_STATUS.getKey(), statusInfo.getStatusCode());
 
         // If the response status is an error, add error information to the span
@@ -227,12 +227,19 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
 
     private void finish(final RequestEvent event) {
         LOG.fine(() -> "finish(event=" + event.getType() + ")");
-        final Scope activeScope = openTracing.getTracer(this.applicationName).scopeManager().active();
-        if (activeScope == null) {
-            LOG.finest("Active scope is null, nothing to do.");
+        ScopeManager scopeManager = openTracing.getTracer(this.applicationName).scopeManager();
+        final Span activeSpan = scopeManager.activeSpan();
+        if (activeSpan == null) {
+            LOG.finest("Active span is null, nothing to do.");
             return;
         }
-        activeScope.close();
+        scopeManager.activeSpan().finish();
+        Object scopeObj = event.getContainerRequest().getProperty(Scope.class.getName());
+        if(scopeObj !=null && scopeObj instanceof Scope){
+            try(Scope scope = (Scope)scopeObj) {
+                event.getContainerRequest().removeProperty(Scope.class.getName());
+            }
+        }
         LOG.finest("Finished.");
     }
 
@@ -326,12 +333,12 @@ public class OpenTracingRequestEventListener implements RequestEventListener {
         return OpenTracingCdiUtils.getConfigOverrideValue(Traced.class, "value", resourceInfo, Boolean.class);
     }
 
-    private Scope getAlreadyActiveScope() {
-        final Scope activeScope = openTracing.getTracer(this.applicationName).scopeManager().active();
-        if (activeScope == null) {
-            throw new IllegalStateException("Active scope is null, something closed it.");
+    private Span getAlreadyActiveSpan() {
+        final Span activeSpan = openTracing.getTracer(this.applicationName).scopeManager().activeSpan();
+        if (activeSpan == null) {
+            throw new IllegalStateException("Active span is null, something closed it.");
         }
-        return activeScope;
+        return activeSpan;
     }
 
     /**

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingScope.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingScope.java
@@ -67,17 +67,14 @@ import io.opentracing.Span;
  */
 public class OpenTracingScope implements io.opentracing.Scope {
 
-    private Span currentSpan;
-    private boolean finishOnClose;
+    private final Span currentSpan;
+    private final OpenTracingScope previouslyActiveScope;
+    private final ScopeManager scopeManager;
 
-    private OpenTracingScope previouslyActiveScope;
-    private ScopeManager scopeManager;
-
-    OpenTracingScope(ScopeManager scopeManager, Span spanToActivate, boolean finishOnClose) {
+    OpenTracingScope(ScopeManager scopeManager, Span spanToActivate) {
         this.scopeManager = scopeManager;
         this.currentSpan = spanToActivate;
-        this.finishOnClose = finishOnClose;
-        previouslyActiveScope = (OpenTracingScope) scopeManager.active();
+        previouslyActiveScope = (OpenTracingScope) scopeManager.activeScope();
         scopeManager.activeScope.set(this);
     }
 
@@ -88,15 +85,10 @@ public class OpenTracingScope implements io.opentracing.Scope {
             return;
         }
 
-        if (finishOnClose) {
-            currentSpan.finish();
-        }
-
         scopeManager.activeScope.set(previouslyActiveScope);
     }
 
-    @Override
-    public Span span() {
+    Span span() {
         return currentSpan;
     }
 }

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/ScopeManager.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/ScopeManager.java
@@ -62,7 +62,7 @@ import io.opentracing.Span;
 
 /**
  * Manages OpenTracing Spans and Scopes
- * 
+ *
  * @author jonathan coustick
  * @since 5.183
  * @see io.opentracing.ScopeManager
@@ -72,13 +72,21 @@ public class ScopeManager implements io.opentracing.ScopeManager {
     ThreadLocal<OpenTracingScope> activeScope = new ThreadLocal<>();
 
     @Override
-    public Scope activate(Span span, boolean autoClose) {
-        return new OpenTracingScope(this, span, autoClose);
+    public Scope activate(Span span) {
+        return new OpenTracingScope(this, span);
+    }
+
+    public OpenTracingScope activeScope() {
+        return activeScope.get();
     }
 
     @Override
-    public Scope active() {
-        return activeScope.get();
+    public Span activeSpan() {
+        OpenTracingScope scope = activeScope();
+        if (scope != null) {
+            return scope.span();
+        }
+        return null;
     }
-    
+
 }

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/span/Span.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/span/Span.java
@@ -43,6 +43,7 @@ import fish.payara.notification.requesttracing.RequestTraceSpan;
 import fish.payara.notification.requesttracing.RequestTraceSpanLog;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
 import io.opentracing.SpanContext;
+import io.opentracing.tag.Tag;
 
 import java.time.Instant;
 import java.util.Map;
@@ -106,6 +107,13 @@ public class Span extends RequestTraceSpan implements io.opentracing.Span {
     public io.opentracing.Span setTag(String tagName, Number tagValue) {
         // Pass through to the Request Tracing Service
         addSpanTag(tagName, String.valueOf(tagValue));
+        return this;
+    }
+
+    @Override
+    public <T> io.opentracing.Span setTag(Tag<T> tag, T tagValue) {
+        // Pass through to the Request Tracing Service
+        addSpanTag(tag, String.valueOf(tagValue));
         return this;
     }
 

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/tracer/Tracer.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/tracer/Tracer.java
@@ -44,13 +44,15 @@ import fish.payara.notification.requesttracing.RequestTraceSpan;
 import fish.payara.notification.requesttracing.RequestTraceSpan.SpanContextRelationshipType;
 import fish.payara.notification.requesttracing.RequestTraceSpanContext;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
+import fish.payara.opentracing.OpenTracingScope;
+import fish.payara.opentracing.ScopeManager;
 
 import io.opentracing.Scope;
-import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
+import io.opentracing.tag.Tag;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -84,11 +86,11 @@ import org.glassfish.internal.api.Globals;
 public class Tracer implements io.opentracing.Tracer {
 
     private final String applicationName;
-    private final ScopeManager scopeManager;
-    
+    private final io.opentracing.ScopeManager scopeManager;
+
     private static final String TRACEID_KEY = "traceid";
     private static final String SPANID_KEY = "spanid";
-    
+
     /**
      * Constructor that registers this Tracer to an application.
      *
@@ -99,7 +101,7 @@ public class Tracer implements io.opentracing.Tracer {
         scopeManager = new fish.payara.opentracing.ScopeManager();
     }
 
-    public Tracer(String applicationName, ScopeManager scopeManager) {
+    public Tracer(String applicationName, io.opentracing.ScopeManager scopeManager) {
         this.applicationName = applicationName;
         this.scopeManager = scopeManager;
     }
@@ -113,22 +115,22 @@ public class Tracer implements io.opentracing.Tracer {
     public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
         RequestTraceSpanContext payaraSpanContext = (RequestTraceSpanContext) spanContext;
         Iterable<Map.Entry<String, String>> baggageItems = payaraSpanContext.baggageItems();
-        
+
         if (carrier instanceof TextMap) {
             TextMap map = (TextMap) carrier;
-            
-            if (format.equals(Format.Builtin.HTTP_HEADERS)) {          
+
+            if (format.equals(Format.Builtin.HTTP_HEADERS)) {
                 for (Map.Entry<String, String> baggage : baggageItems) {
                     map.put(encodeURLString(baggage.getKey()), encodeURLString(baggage.getValue()));
                 }
-                
+
                 map.put(TRACEID_KEY, encodeURLString(payaraSpanContext.getTraceId().toString()));
                 map.put(SPANID_KEY, encodeURLString(payaraSpanContext.getSpanId().toString()));
             } else if (format.equals(Format.Builtin.TEXT_MAP)) {
                 for (Map.Entry<String, String> baggage : baggageItems) {
                     map.put(baggage.getKey(), baggage.getValue());
                 }
-                
+
                 map.put(TRACEID_KEY, payaraSpanContext.getTraceId().toString());
                 map.put(SPANID_KEY, payaraSpanContext.getSpanId().toString());
             } else {
@@ -146,8 +148,8 @@ public class Tracer implements io.opentracing.Tracer {
                 } catch (IOException ex) {
                     Logger.getLogger(Tracer.class.getName()).log(Level.WARNING, null, ex);
                     throw new UncheckedIOException(ex);
-                }                
-                
+                }
+
             } else {
                 throw new InvalidCarrierFormatException(format, carrier);
             }
@@ -159,12 +161,12 @@ public class Tracer implements io.opentracing.Tracer {
     @Override
     public <C> SpanContext extract(Format<C> format, C carrier) {
         boolean traceIDRecieved = false;
-        
+
         if (carrier instanceof TextMap) {
             TextMap map = (TextMap) carrier;
-            Map<String,String> baggageItems = new HashMap<>();
+            Map<String, String> baggageItems = new HashMap<>();
             Iterator<Map.Entry<String, String>> allEntries = map.iterator();
-            
+
             UUID traceId = null;
             UUID spanId = null;
 
@@ -184,8 +186,8 @@ public class Tracer implements io.opentracing.Tracer {
                             break;
                     }
                 }
-            
-            } else if (format.equals(Format.Builtin.TEXT_MAP)){
+
+            } else if (format.equals(Format.Builtin.TEXT_MAP)) {
                 while (allEntries.hasNext()) {
                     Entry<String, String> entry = allEntries.next();
                     switch (entry.getKey()) {
@@ -205,16 +207,16 @@ public class Tracer implements io.opentracing.Tracer {
                 throw new InvalidCarrierFormatException(format, carrier);
             }
             if (traceIDRecieved) {
-                if (spanId == null){
+                if (spanId == null) {
                     throw new IllegalArgumentException("No SpanId recieved");
                 }
                 return new RequestTraceSpanContext(traceId, spanId, baggageItems);
             } else {
                 return null; //Did not recieve a SpanContext
             }
-        } else if (carrier instanceof ByteBuffer){
+        } else if (carrier instanceof ByteBuffer) {
             ByteBuffer buffer = (ByteBuffer) carrier;
-            if (format.equals(Format.Builtin.BINARY)){
+            if (format.equals(Format.Builtin.BINARY)) {
                 try {
                     ByteArrayInputStream inputStream = new ByteArrayInputStream(buffer.array());
                     ObjectInputStream objectStream = new ObjectInputStream(inputStream);
@@ -232,19 +234,15 @@ public class Tracer implements io.opentracing.Tracer {
     }
 
     @Override
-    public ScopeManager scopeManager() {
+    public io.opentracing.ScopeManager scopeManager() {
         return scopeManager;
     }
 
     @Override
     public Span activeSpan() {
-        Scope activeScope = scopeManager().active();
-        if (activeScope != null) {
-            return activeScope.span();
-        }
-        return null;
+        return scopeManager().activeSpan();
     }
-    
+
     private String decodeURLString(String toDecode) {
         try {
             return URLDecoder.decode(toDecode, StandardCharsets.UTF_8.displayName());
@@ -252,12 +250,24 @@ public class Tracer implements io.opentracing.Tracer {
             throw new IllegalArgumentException(ex);
         }
     }
-    
+
     private String encodeURLString(String toEncode) {
         try {
             return URLEncoder.encode(toEncode, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException ex) {
             throw new IllegalArgumentException(ex);
+        }
+    }
+
+    @Override
+    public Scope activateSpan(Span span) {
+        return scopeManager.activate(span);
+    }
+
+    @Override
+    public void close() {
+        if (scopeManager instanceof ScopeManager) {
+            ((ScopeManager) scopeManager).activeScope().close();
         }
     }
 
@@ -336,45 +346,24 @@ public class Tracer implements io.opentracing.Tracer {
         }
 
         @Override
+        public <T> SpanBuilder withTag(Tag<T> key, T value) {
+            span.setTag(key, value);
+            return this;
+        }
+
+        @Override
         public SpanBuilder withStartTimestamp(long microseconds) {
             microsecondsStartTime = microseconds;
             return this;
         }
 
         @Override
-        public Scope startActive(boolean bln) {
-            Scope origin = scopeManager().active();
-            if (origin != null) {
-                Span parent = origin.span();
-                asChildOf(parent);
-            }
-            origin = scopeManager.activate(span, bln);
-            
-            if (requestTracing != null && !requestTracing.isTraceInProgress()) {
-                if (span.getSpanReferences().isEmpty()) {
-                    span.setEventType(EventType.TRACE_START);
-                } else {
-                    span.setEventType(EventType.PROPAGATED_TRACE);
-                    
-                    // Assume the first parent reference found has the correct traceId - would it ever not be?
-                    span.setTraceId(span.getSpanReferences().get(0).getReferenceSpanContext().getTraceId());
-                }
-                
-                requestTracing.startTrace(span);
-            }
-            
-            return origin;
-            
-        }
-
-        @Override
-        public Span startManual() {
+        public Span start() {
             // If we shouldn't ignore the currently active span, set it as this span's parent
             if (!ignoreActiveSpan) {
                 fish.payara.opentracing.span.Span activeSpan = (fish.payara.opentracing.span.Span) activeSpan();
-
                 if (activeSpan != null) {
-                    span.addSpanReference(activeSpan.getSpanContext(), SpanContextRelationshipType.ChildOf);
+                    asChildOf(activeSpan);
                 }
             }
 
@@ -390,22 +379,16 @@ public class Tracer implements io.opentracing.Tracer {
                     span.setEventType(EventType.TRACE_START);
                 } else {
                     span.setEventType(EventType.PROPAGATED_TRACE);
-                    
+
                     // Assume the first parent reference found has the correct traceId - would it ever not be?
                     span.setTraceId(span.getSpanReferences().get(0).getReferenceSpanContext().getTraceId());
                 }
-                
+
                 requestTracing.startTrace(span);
-            } 
-            
+            }
+
             return span;
         }
-
-        @Override
-        public Span start() {
-            return startManual();
-        }
-
     }
 
 }

--- a/nucleus/payara-modules/requesttracing-core/pom.xml
+++ b/nucleus/payara-modules/requesttracing-core/pom.xml
@@ -144,8 +144,6 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>${opentracing.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTracingService.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTracingService.java
@@ -105,6 +105,7 @@ import fish.payara.nucleus.requesttracing.sampling.AdaptiveSampleFilter;
 import fish.payara.nucleus.requesttracing.sampling.SampleFilter;
 import fish.payara.nucleus.requesttracing.store.RequestTraceStoreFactory;
 import fish.payara.nucleus.requesttracing.store.RequestTraceStoreInterface;
+import io.opentracing.tag.Tag;
 
 /**
  * Main service class that provides methods used by interceptors for tracing
@@ -653,8 +654,12 @@ public class RequestTracingService implements EventListener, ConfigListener, Mon
                 attrs.add(String.valueOf(annotationSpan.getStartInstant().toEpochMilli()));
                 attrs.add("End");
                 attrs.add(String.valueOf(annotationSpan.getTraceEndTime().toEpochMilli()));
-                for (Entry<String, String> tag : annotationSpan.getSpanTags().entrySet()) {
-                    attrs.add(tag.getKey());
+                for (Entry<Object, String> tag : annotationSpan.getSpanTags().entrySet()) {
+                    if (tag.getKey() instanceof Tag) {
+                        attrs.add(((Tag) tag.getKey()).getKey());
+                    } else {
+                        attrs.add(tag.getKey().toString());
+                    }
                     attrs.add(tag.getValue());
                 }
                 tracingCollector.group(group)

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <jbi.version>1.0</jbi.version>
         <jakarta-platform.version>8.0.0</jakarta-platform.version>
         <microprofile-release.version>3.3</microprofile-release.version>
-        <microprofile-opentracing.version>1.3.1</microprofile-opentracing.version>
+        <microprofile-opentracing.version>2.0-RC2</microprofile-opentracing.version>
         <microprofile-config.version>1.4</microprofile-config.version>
         <microprofile-fault-tolerance.version>2.1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.2-RC2</microprofile-jwt-auth.version>
@@ -203,7 +203,7 @@
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
         <payara-arquillian-container.version>2.3</payara-arquillian-container.version>
-        <opentracing.version>0.31.0</opentracing.version>
+        <opentracing.version>0.33.0</opentracing.version>
         <h2db.version>1.4.196</h2db.version>
         <websocket-api.version>1.1.2</websocket-api.version>
         <concurrent-api.version>1.1.2</concurrent-api.version>


### PR DESCRIPTION
## Description
This is a feature PR to upgrade the MicroProfile OpenTracing 2.0 and OpenTraing API 0.33.

OpenTraing API 0.33 includes breaking changes and deprecated methods are removed:
  - `ScopeManager.active()`
  - `ScopeManager.activate(Span, boolean)`
  - `Scope.span()`
  - `SpanBuilder.startActive()`
  - `Tracer.startManual()`

## Testing
### Testing Performed
OpenTracing TCK 2.0-RC2

## Depends on
https://github.com/payara/patched-src-microprofile-opentracing/pull/1
https://github.com/payara/MicroProfile-TCK-Runners/pull/128
https://github.com/payara/Payara_PatchedProjects/pull/347