### PR TITLE
QACI-592 Fixed build consistency when using QuickBuild

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -10,15 +10,6 @@
     <packaging>pom</packaging>
     <name>Payara Docker Images</name>
 
-    <modules>
-        <module>basic</module>
-        <module>server-full</module>
-        <module>server-web</module>
-        <module>server-node</module>
-        <module>micro</module>
-        <module>tests</module>
-    </modules>
-
     <properties>
         <payara.version>${project.version}</payara.version>
         <docker.noCache>true</docker.noCache>
@@ -58,6 +49,35 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>DefaultBuild</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>basic</module>
+                <module>server-full</module>
+                <module>server-web</module>
+                <module>server-node</module>
+                <module>micro</module>
+                <module>tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>QuickBuild</id>
+            <activation>
+                <property>
+                    <name>QuickBuild</name>
+                </property>
+            </activation>
+            <modules>
+                <module>basic</module>
+                <module>server-full</module>
+                <module>server-node</module>
+                <module>micro</module>
+                <module>tests</module>
+            </modules>
+        </profile>
         <profile>
             <id>generate-docker-images-only-if-dockerfile-exists</id>
             <activation>

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -19,12 +19,6 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.extras</groupId>
-            <artifactId>server-web-docker-image</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.extras</groupId>
             <artifactId>server-node-docker-image</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -100,4 +94,44 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+         <profile>
+            <id>DefaultBuild</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.extras</groupId>
+                    <artifactId>server-web-docker-image</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>QuickBuild</id>
+            <activation>
+                <property>
+                    <name>QuickBuild</name>
+                </property>
+            </activation>
+            <build>
+
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <excludes>
+                                    <exclude>**/PayaraServerWebTest.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Testing

### Testing Performed
Delete Payara artifacts.
```
rm -rf ~/.m2/repository/fish
docker image rm payara/server-web:5.2020.8-SNAPSHOT-jdk11
docker image rm payara/server-web:5.2020.8-SNAPSHOT
```
Build all artifacts (but don't run Payara Samples)
- to my surprise it passed even with TC8
```
mvn clean install -PQuickBuild,BuildExtras,BuildDockerImages -amd -TC8; # time: 5:53
```
Without "Extras" and payara-web
```
rm -rf ~/.m2/repository/fish/payara/distributions/payara-web* # to be sure that it compiles even without it
mvn clean install -PQuickBuild,BuildDockerImages -amd -TC8; # time: 4:21
```
Build zip files and docker images
-  TC8 - :eyes: Wow!
```
mvn clean install -pl :extras,:docker-images -PQuickBuild,BuildExtras,BuildDockerImages -amd # time: 6:37
mvn clean install -pl :extras,:docker-images -PQuickBuild,BuildExtras,BuildDockerImages -amd -TC8 # time: 3:57
```
Build payara-web and docker images
```
rm -rf ~/.m2/repository/fish/payara/distributions/payara-web*
mvn clean install -pl :payara-web # time: 0:23
mvn clean install -pl :docker-images -PBuildDockerImages -amd # time: 2:30
```

The issue was introduced in commits under CUSTCOM-130