### PR TITLE
QACI-454 QACI-595 more reliable samples

### DIFF
--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -287,7 +287,6 @@
                         <systemPropertyVariables>
                             <isUsingMicroProfile>${micro.isActive}</isUsingMicroProfile>
                         </systemPropertyVariables>
-                        <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -291,11 +291,14 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M5</version>
                     <configuration>
                         <!-- don't run tests in parallel -->
                         <forkCount>1</forkCount>
                         <reuseForks>true</reuseForks>
+                        <systemPropertyVariables>
+                            <isUsingMicroProfile>${micro.isActive}</isUsingMicroProfile>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/appserver/tests/payara-samples/samples-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/samples-programmatic/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>samples-micro-programmatic</artifactId>
-
     <name>Payara Samples - Micro Programmatic</name>
 
     <dependencies>

--- a/appserver/tests/payara-samples/samples/asadmin/pom.xml
+++ b/appserver/tests/payara-samples/samples/asadmin/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/AsadminTest.java
+++ b/appserver/tests/payara-samples/samples/asadmin/src/test/java/fish/payara/samples/asadmin/AsadminTest.java
@@ -66,6 +66,7 @@ import org.jvnet.hk2.config.UnsatisfiedDependencyException;
 
 import fish.payara.samples.PayaraArquillianTestRunner;
 import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.ServerOperations;
 
 @RunWith(PayaraArquillianTestRunner.class)
 public abstract class AsadminTest {
@@ -77,7 +78,7 @@ public abstract class AsadminTest {
     @Deployment
     public static Archive<?> deploy() {
         return PayaraTestShrinkWrap.getJavaArchive()
-                .addClasses(AsadminTest.class);
+                .addClasses(AsadminTest.class, ServerOperations.class);
     }
 
     @Before

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/pom.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-ejb/pom.xml
@@ -83,6 +83,10 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
         </dependency>

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/pom.xml
@@ -32,7 +32,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/appserver/tests/payara-samples/samples/datagrid-encryption/pom.xml
+++ b/appserver/tests/payara-samples/samples/datagrid-encryption/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/payara-samples/samples/datagrid-encryption/sfsb-passivation/src/test/java/fish/payara/samples/datagridencryption/sfsb/SfsbEncryptionTest.java
+++ b/appserver/tests/payara-samples/samples/datagrid-encryption/sfsb-passivation/src/test/java/fish/payara/samples/datagridencryption/sfsb/SfsbEncryptionTest.java
@@ -40,6 +40,14 @@
 package fish.payara.samples.datagridencryption.sfsb;
 
 import fish.payara.samples.ServerOperations;
+
+import java.net.URL;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -50,12 +58,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-import java.net.URL;
 
 /**
  * @author Andrew Pielage <andrew.pielage@payara.fish>
@@ -69,17 +71,22 @@ public class SfsbEncryptionTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "sfsb-passivation.war")
-                .addPackage("fish.payara.samples.datagridencryption.sfsb");
+                .addPackage("fish.payara.samples.datagridencryption.sfsb")
+                .addClass(ServerOperations.class);
     }
 
     @BeforeClass
     public static void enableSecurity() {
-        ServerOperations.enableDataGridEncryption();
+        if (ServerOperations.isServer()) {
+            ServerOperations.enableDataGridEncryption();
+        }
     }
 
     @AfterClass
     public static void resetSecurity() {
-        ServerOperations.disableDataGridEncryption();
+        if (ServerOperations.isServer()) {
+            ServerOperations.disableDataGridEncryption();
+        }
     }
 
     @Test

--- a/appserver/tests/payara-samples/samples/dynamic-roles/pom.xml
+++ b/appserver/tests/payara-samples/samples/dynamic-roles/pom.xml
@@ -57,7 +57,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.valid4j</groupId>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/client/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/client/pom.xml
@@ -169,7 +169,6 @@
                             <value>${servlet.port}</value>
                         </property>
                     </systemProperties>
-                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
         </plugins>

--- a/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-invoker-secure-endpoint/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
 
         <dependency>

--- a/appserver/tests/payara-samples/samples/formauth/pom.xml
+++ b/appserver/tests/payara-samples/samples/formauth/pom.xml
@@ -42,7 +42,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/pom.xml
@@ -49,7 +49,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/appserver/tests/payara-samples/samples/jakartaee-namespace-transformer/pom.xml
+++ b/appserver/tests/payara-samples/samples/jakartaee-namespace-transformer/pom.xml
@@ -65,7 +65,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
          <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/pom.xml
@@ -28,7 +28,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/src/test/java/fish/payara/samples/jaxrs/rolesallowed/servlet/JAXRSRolesAllowedEETest.java
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed-servlet/src/test/java/fish/payara/samples/jaxrs/rolesallowed/servlet/JAXRSRolesAllowedEETest.java
@@ -39,7 +39,9 @@ public class JAXRSRolesAllowedEETest {
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
-        ServerOperations.addUserToContainerIdentityStore("test", "a");
+        if (ServerOperations.isServer()) {
+            ServerOperations.addUserToContainerIdentityStore("test", "a");
+        }
 
         WebArchive archive =
             create(WebArchive.class)

--- a/appserver/tests/payara-samples/samples/jaxrs-rolesallowed/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxrs-rolesallowed/pom.xml
@@ -33,7 +33,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/jaxws-security/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-security/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
 
         <dependency>

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/pom.xml
@@ -53,7 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.jws</groupId>

--- a/appserver/tests/payara-samples/samples/logging/pom.xml
+++ b/appserver/tests/payara-samples/samples/logging/pom.xml
@@ -62,7 +62,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/pom.xml
@@ -42,7 +42,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/src/test/java/fish/payara/samples/microprofile/endpoint/insecure/MicroprofileInsecureEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/insecure/src/test/java/fish/payara/samples/microprofile/endpoint/insecure/MicroprofileInsecureEndpointTest.java
@@ -63,10 +63,10 @@ import org.junit.runner.RunWith;
 import static java.util.Arrays.asList;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Gaurav Gupta
@@ -81,23 +81,26 @@ public class MicroprofileInsecureEndpointTest {
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
-
         return create(WebArchive.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @BeforeClass
     public static void enableSecurity() {
-        CliCommands.payaraGlassFish(asList("set-metrics-configuration", "--endpoint", "mpmetrics"));
-        CliCommands.payaraGlassFish(asList("set-microprofile-healthcheck-configuration", "--endpoint", "mphealth"));
-        ServerOperations.restartContainer();
+        if (ServerOperations.isServer()) {
+            CliCommands.payaraGlassFish(asList("set-metrics-configuration", "--endpoint", "mpmetrics"));
+            CliCommands.payaraGlassFish(asList("set-microprofile-healthcheck-configuration", "--endpoint", "mphealth"));
+            ServerOperations.restartContainer();
+        }
     }
 
     @AfterClass
     public static void resetSecurity() {
-        CliCommands.payaraGlassFish(asList("set-metrics-configuration", "--endpoint", "metrics"));
-        CliCommands.payaraGlassFish(asList("set-microprofile-healthcheck-configuration", "--endpoint", "health"));
-        ServerOperations.restartContainer();
+        if (ServerOperations.isServer()) {
+            CliCommands.payaraGlassFish(asList("set-metrics-configuration", "--endpoint", "metrics"));
+            CliCommands.payaraGlassFish(asList("set-microprofile-healthcheck-configuration", "--endpoint", "health"));
+            ServerOperations.restartContainer();
+        }
     }
 
     @Before

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/pom.xml
@@ -42,8 +42,8 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
-        </dependency>
+            <artifactId>samples-test-utils</artifactId>
+       </dependency>
        <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/src/test/java/fish/payara/samples/microprofile/endpoint/secure/MicroprofileSecureEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/src/test/java/fish/payara/samples/microprofile/endpoint/secure/MicroprofileSecureEndpointTest.java
@@ -138,13 +138,11 @@ public class MicroprofileSecureEndpointTest {
 
         try {
             webClient.getPage(base + "../metrics");
+            fail("/metrics could be accessed without proper security credentials");
         } catch (FailingHttpStatusCodeException e) {
             assertNotNull(e);
             assertEquals(SC_UNAUTHORIZED, e.getStatusCode());
-            return;
         }
-
-        fail("/metrics could be accessed without proper security credentials");
     }
 
     @Test
@@ -153,13 +151,12 @@ public class MicroprofileSecureEndpointTest {
 
         try {
             webClient.getPage(base + "../health");
+            fail("/health could be accessed without proper security credentials");
         } catch (FailingHttpStatusCodeException e) {
             assertNotNull(e);
             assertEquals(SC_UNAUTHORIZED, e.getStatusCode());
             return;
         }
-
-        fail("/health could be accessed without proper security credentials");
     }
 
     @Test
@@ -168,13 +165,11 @@ public class MicroprofileSecureEndpointTest {
 
         try {
             webClient.getPage(base + "../openapi");
+            fail("/openapi could be accessed without proper security credentials");
         } catch (FailingHttpStatusCodeException e) {
             assertNotNull(e);
             assertEquals(SC_UNAUTHORIZED, e.getStatusCode());
-            return;
         }
-
-        fail("/openapi could be accessed without proper security credentials");
     }
 
 }

--- a/appserver/tests/payara-samples/samples/microprofile-healthcheck/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-healthcheck/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/oauth2/pom.xml
+++ b/appserver/tests/payara-samples/samples/oauth2/pom.xml
@@ -53,7 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
 
         <dependency>

--- a/appserver/tests/payara-samples/samples/openid/pom.xml
+++ b/appserver/tests/payara-samples/samples/openid/pom.xml
@@ -58,7 +58,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>

--- a/appserver/tests/payara-samples/samples/payara-expression-config-properties/pom.xml
+++ b/appserver/tests/payara-samples/samples/payara-expression-config-properties/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -90,6 +90,26 @@
             <build>
                 <plugins>
                     <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>delete-server</id>
+                                <inherited>false</inherited>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <phase>clean</phase>
+                                <configuration>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${session.executionRootDirectory}/target</directory>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -44,7 +44,7 @@
         <dependencies>
             <dependency>
                 <groupId>fish.payara.samples</groupId>
-                <artifactId>test-utils</artifactId>
+                <artifactId>samples-test-utils</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -124,7 +124,7 @@
                             <!-- This needs tuning -->
                             <systemPropertyVariables>
                                 <glassfishRemote_gfHome>${session.executionRootDirectory}/target/${payara.directory.name}</glassfishRemote_gfHome>
-                                <javaEEServer>payara-remote</javaEEServer>
+                                <javaEEServer>payara-managed</javaEEServer>
                                 <payara.domain.name>${payara.domain.name}</payara.domain.name>
                                 <arquillian.launch>payara</arquillian.launch>
                             </systemPropertyVariables>
@@ -139,7 +139,7 @@
                             <!-- This needs tuning -->
                             <systemPropertyVariables>
                                 <glassfishRemote_gfHome>${session.executionRootDirectory}/target/${payara.directory.name}</glassfishRemote_gfHome>
-                                <javaEEServer>payara-remote</javaEEServer>
+                                <javaEEServer>payara-managed</javaEEServer>
                                 <payara.domain.name>${payara.domain.name}</payara.domain.name>
                                 <arquillian.launch>payara</arquillian.launch>
                             </systemPropertyVariables>

--- a/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
+++ b/appserver/tests/payara-samples/samples/realm-identity-stores/pom.xml
@@ -84,7 +84,7 @@ made subject to such option by the copyright holder. -->
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>

--- a/appserver/tests/payara-samples/samples/rest-management/pom.xml
+++ b/appserver/tests/payara-samples/samples/rest-management/pom.xml
@@ -54,7 +54,7 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/rolesPermitted/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesPermitted/pom.xml
@@ -45,7 +45,7 @@
 
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/rolesallowed-unprotected-methods-server/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.samples</groupId>
-            <artifactId>test-utils</artifactId>
+            <artifactId>samples-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/test-utils/pom.xml
+++ b/appserver/tests/payara-samples/test-utils/pom.xml
@@ -9,7 +9,7 @@
         <version>5.2020.8-SNAPSHOT</version>
     </parent>
 
-    <artifactId>test-utils</artifactId>
+    <artifactId>samples-test-utils</artifactId>
     <name>Payara Samples - test-utils</name>
 
     <dependencies>

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/SecurityUtils.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/SecurityUtils.java
@@ -1,0 +1,138 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.samples;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.logging.Logger;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.omnifaces.utils.security.Certificates;
+import static java.math.BigInteger.ONE;
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.DAYS;
+
+/**
+ * Provides functionalitites of {@link ServerOperations} depending on external optional utilities.
+ *
+ * @author David Matejcek
+ */
+class SecurityUtils {
+    private static final Logger logger = Logger.getLogger(SecurityUtils.class.getName());
+    private static final BouncyCastleProvider PROVIDER = new BouncyCastleProvider();
+
+    static {
+        Security.addProvider(PROVIDER);
+    }
+
+    static X509Certificate createSelfSignedCertificate(KeyPair keys) {
+        try {
+            return new JcaX509CertificateConverter()
+                    .setProvider(PROVIDER)
+                    .getCertificate(
+                            new X509v3CertificateBuilder(
+                                    new X500Name("CN=lfoo, OU=bar, O=kaz, L=zak, ST=lak, C=UK"),
+                                    ONE,
+                                    Date.from(now()),
+                                    Date.from(now().plus(1, DAYS)),
+                                    new X500Name("CN=lfoo, OU=bar, O=kaz, L=zak, ST=lak, C=UK"),
+                                    SubjectPublicKeyInfo.getInstance(keys.getPublic().getEncoded()))
+                                    .build(
+                                            new JcaContentSignerBuilder("SHA256WithRSA")
+                                                    .setProvider(PROVIDER)
+                                                    .build(keys.getPrivate())));
+        } catch (CertificateException | OperatorCreationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    static URL getHostFromCertificate(X509Certificate[] serverCertificateChain, URL existingURL) {
+        try {
+            URL httpsUrl = new URL(
+                    existingURL.getProtocol(),
+                    Certificates.getHostFromCertificate(serverCertificateChain),
+                    existingURL.getPort(),
+                    existingURL.getFile()
+            );
+
+            logger.info("Changing base URL from " + existingURL + " into " + httpsUrl + "\n");
+            return httpsUrl;
+
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Failure creating HTTPS URL", e);
+        }
+    }
+
+
+    static KeyPair generateRandomRSAKeys() {
+        return Certificates.generateRandomRSAKeys();
+    }
+
+    public static String createTempJKSKeyStore(PrivateKey privateKey, X509Certificate clientCertificate) {
+        return Certificates.createTempJKSKeyStore(privateKey, clientCertificate);
+    }
+
+    public static String createTempJKSTrustStore(X509Certificate[] serverCertificateChain) {
+        return Certificates.createTempJKSTrustStore(serverCertificateChain);
+    }
+
+    /**
+     * @return never null, but can be an empty array
+     */
+    public static X509Certificate[] getCertificateChainFromServer(String host, int port) {
+        final X509Certificate[] chain = Certificates.getCertificateChainFromServer(host, port);
+        if (chain == null) {
+            return new X509Certificate[0];
+        }
+        return chain;
+    }
+}

--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/ServerOperations.java
@@ -1,16 +1,8 @@
 package fish.payara.samples;
 
-import static java.math.BigInteger.ONE;
 import static java.nio.file.Files.copy;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static java.time.Instant.now;
-import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.logging.Level.FINEST;
-import static org.omnifaces.utils.Lang.isEmpty;
-import static org.omnifaces.utils.security.Certificates.createTempJKSKeyStore;
-import static org.omnifaces.utils.security.Certificates.createTempJKSTrustStore;
-import static org.omnifaces.utils.security.Certificates.generateRandomRSAKeys;
-import static org.omnifaces.utils.security.Certificates.getCertificateChainFromServer;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,15 +18,11 @@ import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
-import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.gargoylesoftware.htmlunit.WebClient;
@@ -42,29 +30,44 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.impl.Jdk14Logger;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.OperatorCreationException;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.omnifaces.utils.security.Certificates;
+
+import static fish.payara.samples.SecurityUtils.getCertificateChainFromServer;
+import static fish.payara.samples.SecurityUtils.getHostFromCertificate;
+
 
 /**
  * Various high level Java EE 7 samples specific operations to execute against
  * the various servers used for running the samples
- * 
- * @author arjan
  *
+ * @author arjan
  */
 public class ServerOperations {
-    
+
     private static final Logger logger = Logger.getLogger(ServerOperations.class.getName());
-    
+    private static final String ERR_MESSAGE_UNSUPPORTED
+        = "Not supported. Probably you used wrong Maven profile to run the test.";
+    private static final String SYSTEM_PROPERTY_SERVER = "javaEEServer";
+
+    public static boolean isMicro() {
+        return System.getenv("MICRO_JAR") != null;
+    }
+
+    public static boolean isServer() {
+        return isManagedServer() || isRemoteServer();
+    }
+
+    public static boolean isManagedServer() {
+        return "payara-managed".equals(System.getProperty(SYSTEM_PROPERTY_SERVER));
+    }
+
+    public static boolean isRemoteServer() {
+        return "payara-remote".equals(System.getProperty(SYSTEM_PROPERTY_SERVER));
+    }
+
     public static void addUserToContainerIdentityStore(String username, String groups) {
         addUserToContainerIdentityStore("file", username, groups);
     }
+
     /**
      * Add the default test user and credentials to the identity store of
      * supported containers
@@ -74,202 +77,155 @@ public class ServerOperations {
         // TODO: abstract adding container managed users to utility class
         // TODO: consider PR for sending CLI commands to Arquillian
 
-        String javaEEServer = System.getProperty("javaEEServer");
-
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-
-            System.out.println("Adding user for " + javaEEServer);
-
-            List<String> cmd = new ArrayList<>();
-
-            cmd.add("create-file-user");
-            cmd.add("--groups");
-            cmd.add(groups);
-            cmd.add("--authrealmname");
-            cmd.add(authRealm);
-            cmd.add("--passwordfile");
-            cmd.add(Paths.get("").toAbsolutePath() + "/src/test/resources/password.txt");
-
-            cmd.add(username);
-
-            CliCommands.payaraGlassFish(cmd);
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
+        List<String> cmd = new ArrayList<>();
+        cmd.add("create-file-user");
+        cmd.add("--groups");
+        cmd.add(groups);
+        cmd.add("--authrealmname");
+        cmd.add(authRealm);
+        cmd.add("--passwordfile");
+        cmd.add(Paths.get("").toAbsolutePath() + "/src/test/resources/password.txt");
 
-        // TODO: support other servers than Payara and GlassFish
+        cmd.add(username);
 
-        // WildFly ./bin/add-user.sh -a -u u1 -p p1 -g g1
+        CliCommands.payaraGlassFish(cmd);
     }
 
     /**
-     * Add the default test user and credentials to the identity store of 
+     * Add the default test user and credentials to the identity store of
      * supported containers
      */
     public static void addUsersToContainerIdentityStore() {
         addUsersToContainerIdentityStore("u1", "g1", "file");
     }
-        
+
     public static void addUsersToContainerIdentityStore(String username, String group, String fileAuthRealmName) {
 
         // TODO: abstract adding container managed users to utility class
         // TODO: consider PR for sending CLI commands to Arquillian
-        
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            System.out.println("Adding user for " + javaEEServer);
-            
-            List<String> cmd = new ArrayList<>();
-            
-            cmd.add("create-file-user");
-            cmd.add("--groups");
-            cmd.add(group);
-            cmd.add("--passwordfile");
-            cmd.add(Paths.get("").toAbsolutePath() + "/src/test/resources/password.txt");
-            cmd.add("--authrealmname");
-            cmd.add(fileAuthRealmName);
-            
-            cmd.add(username);
-            
-            CliCommands.payaraGlassFish(cmd);
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
-        
-        // TODO: support other servers than Payara and GlassFish
-        
-        // WildFly ./bin/add-user.sh -a -u u1 -p p1 -g g1
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add("create-file-user");
+        cmd.add("--groups");
+        cmd.add(group);
+        cmd.add("--passwordfile");
+        cmd.add(Paths.get("").toAbsolutePath() + "/src/test/resources/password.txt");
+        cmd.add("--authrealmname");
+        cmd.add(fileAuthRealmName);
+
+        cmd.add(username);
+
+        CliCommands.payaraGlassFish(cmd);
     }
-    
+
     public static void addMavenJarsToContainerLibFolder(String pathToPomFile, String mavenCoordinates) {
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            String gfHome = System.getProperty("glassfishRemote_gfHome");
-            if (gfHome == null) {
-                logger.info("glassfishRemote_gfHome not specified");
-                return;
-            }
-            
-            Path gfHomePath = Paths.get(gfHome);
-            if (!gfHomePath.toFile().exists()) {
-                logger.severe("glassfishRemote_gfHome at " + gfHome + " does not exists");
-                return;
-            }
-            
-            if (!gfHomePath.toFile().isDirectory()) {
-                logger.severe("glassfishRemote_gfHome at " + gfHome + " is not a directory");
-                return;
-            }
-                        
-            String domain = System.getProperty("payara.domain.name");
-            if (domain == null) {
-                domain = getPayaraDomainFromServer();
-                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
-            }
-            
-            Path libsPath = gfHomePath.resolve("glassfish/lib");
-            
-            if (!libsPath.toFile().exists()) {
-                logger.severe("The container lib folder at " + libsPath.toAbsolutePath() + " does not exists");
-                logger.severe("Is the domain \"" + domain + "\" correct?");
-                return;
-            }
-            
-            logger.info("*** Adding jars to lib folder " + libsPath.toAbsolutePath());
-            
-            File[] jars = Libraries.resolveMavenCoordinatesToFiles(pathToPomFile, mavenCoordinates);
-            
-            for (File jar : jars) {
-                logger.info("*** Copying  " + jar.toPath());
-                try {
-                    copy(jar.toPath(), libsPath.resolve(jar.getName()), REPLACE_EXISTING);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
+        }
+        String gfHome = System.getProperty("glassfishRemote_gfHome");
+        if (gfHome == null) {
+            logger.info("glassfishRemote_gfHome not specified");
+            return;
+        }
+
+        Path gfHomePath = Paths.get(gfHome);
+        if (!gfHomePath.toFile().exists()) {
+            logger.severe("glassfishRemote_gfHome at " + gfHome + " does not exists");
+            return;
+        }
+
+        if (!gfHomePath.toFile().isDirectory()) {
+            logger.severe("glassfishRemote_gfHome at " + gfHome + " is not a directory");
+            return;
+        }
+
+        String domain = System.getProperty("payara.domain.name");
+        if (domain == null) {
+            domain = getPayaraDomainFromServer();
+            logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
+        }
+
+        Path libsPath = gfHomePath.resolve("glassfish/lib");
+
+        if (!libsPath.toFile().exists()) {
+            logger.severe("The container lib folder at " + libsPath.toAbsolutePath() + " does not exists");
+            logger.severe("Is the domain \"" + domain + "\" correct?");
+            return;
+        }
+
+        logger.info("*** Adding jars to lib folder " + libsPath.toAbsolutePath());
+
+        File[] jars = Libraries.resolveMavenCoordinatesToFiles(pathToPomFile, mavenCoordinates);
+
+        for (File jar : jars) {
+            logger.info("*** Copying  " + jar.toPath());
+            final Path resolved = libsPath.resolve(jar.getName());
+            try {
+                copy(jar.toPath(), resolved, REPLACE_EXISTING);
+            } catch (IOException e) {
+                throw new IllegalStateException("Cannot copy "+ jar.toPath() + " to " + resolved);
             }
         }
-        
-        
     }
-    
+
     public static void addCertificateToContainerTrustStore(Certificate clientCertificate) {
-        
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            String gfHome = System.getProperty("glassfishRemote_gfHome");
-            if (gfHome == null) {
-                logger.info("glassfishRemote_gfHome not specified");
-                return;
-            }
-            
-            Path gfHomePath = Paths.get(gfHome);
-            if (!gfHomePath.toFile().exists()) {
-                logger.severe("glassfishRemote_gfHome at " + gfHome + " does not exists");
-                return;
-            }
-            
-            if (!gfHomePath.toFile().isDirectory()) {
-                logger.severe("glassfishRemote_gfHome at " + gfHome + " is not a directory");
-                return;
-            }
-                        
-            String domain = System.getProperty("payara.domain.name", "domain1");
-            if (domain != null) {
-                domain = getPayaraDomainFromServer();
-                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
-            }
-            
-            Path cacertsPath = gfHomePath.resolve("glassfish/domains/" + domain + "/config/cacerts.jks");
-            
-            if (!cacertsPath.toFile().exists()) {
-                logger.severe("The container trust store at " + cacertsPath.toAbsolutePath() + " does not exists");
-                logger.severe("Is the domain \"" + domain + "\" correct?");
-                return;
-            }
-            
-            logger.info("*** Adding certificate to container trust store: " + cacertsPath.toAbsolutePath());
-        
-            KeyStore keyStore = null;
-            try (InputStream in = new FileInputStream(cacertsPath.toAbsolutePath().toFile())) {
-                keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-                keyStore.load(in, "changeit".toCharArray());
-                
-                keyStore.setCertificateEntry("arquillianClientTestCert", clientCertificate);
-                
-                keyStore.store(new FileOutputStream(cacertsPath.toAbsolutePath().toFile()), "changeit".toCharArray());
-            } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
-                throw new IllegalStateException(e);
-            }
-            
-            restartContainer(domain);
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
-        
+        String gfHome = System.getProperty("glassfishRemote_gfHome");
+        if (gfHome == null) {
+            logger.info("glassfishRemote_gfHome not specified");
+            return;
+        }
+
+        Path gfHomePath = Paths.get(gfHome);
+        if (!gfHomePath.toFile().exists()) {
+            logger.severe("glassfishRemote_gfHome at " + gfHome + " does not exists");
+            return;
+        }
+
+        if (!gfHomePath.toFile().isDirectory()) {
+            logger.severe("glassfishRemote_gfHome at " + gfHome + " is not a directory");
+            return;
+        }
+
+        String domain = System.getProperty("payara.domain.name", "domain1");
+        if (domain != null) {
+            domain = getPayaraDomainFromServer();
+            logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara.domain.name to override.");
+        }
+
+        Path cacertsPath = gfHomePath.resolve("glassfish/domains/" + domain + "/config/cacerts.jks");
+
+        if (!cacertsPath.toFile().exists()) {
+            logger.severe("The container trust store at " + cacertsPath.toAbsolutePath() + " does not exists");
+            logger.severe("Is the domain \"" + domain + "\" correct?");
+            return;
+        }
+
+        logger.info("*** Adding certificate to container trust store: " + cacertsPath.toAbsolutePath());
+
+        KeyStore keyStore = null;
+        try (InputStream in = new FileInputStream(cacertsPath.toAbsolutePath().toFile())) {
+            keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(in, "changeit".toCharArray());
+
+            keyStore.setCertificateEntry("arquillianClientTestCert", clientCertificate);
+
+            keyStore.store(new FileOutputStream(cacertsPath.toAbsolutePath().toFile()), "changeit".toCharArray());
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        restartContainer(domain);
+
     }
 
     /**
@@ -280,7 +236,7 @@ public class ServerOperations {
      * an embedded profile
      * <p>
      * TODO: add support for servers with secure admin enabled
-     * 
+     *
      * @param url the url to transform
      * @return the transformed URL, or null if the running server isn't using an
      *         admin listener.
@@ -289,17 +245,14 @@ public class ServerOperations {
         try {
             return switchPort(url, 4848, "http");
         } catch (MalformedURLException e) {
-            System.out.println("Failure creating admin URL");
-            e.printStackTrace();
-            logger.log(Level.SEVERE, "Failure creating admin URL", e);
-            return null;
+            throw new IllegalArgumentException("Failure creating admin URL", e);
         }
     }
-    
+
     /**
      * Switch the provided URL to use the secure port if the running server supports
      * it.
-     * 
+     *
      * @param url the url to transform
      * @return the transformed URL, or null if the running server isn't using a
      *         secure listener.
@@ -308,21 +261,18 @@ public class ServerOperations {
         if ("https".equals(url.getProtocol())) {
             return url;
         }
-        
+
         try {
             return switchPort(url, 8181, "https");
         } catch (MalformedURLException e) {
-            System.out.println("Failure creating HTTPS URL");
-            e.printStackTrace();
-            logger.log(Level.SEVERE, "Failure creating HTTPS URL", e);
-            return null;
+            throw new IllegalArgumentException("Failure creating HTTPS URL", e);
         }
     }
 
     /**
      * If the Payara Server being tested supports the provided port, switch the
      * given URL to use that port.
-     * 
+     *
      * @param url      the URL to transform
      * @param port     the target port
      * @param protocol the target protocol to use
@@ -330,280 +280,137 @@ public class ServerOperations {
      * @throws MalformedURLException if the target URL is invalid
      */
     private static URL switchPort(URL url, int port, String protocol) throws MalformedURLException {
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            URL result = new URL(
-                protocol,
-                url.getHost(),
-                port,
-                url.getFile()
-            );
-            
-            System.out.println("Changing base URL from " + url + " into " + result);
-            
-            return result;
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
-        
-        return null;
+        URL result = new URL(
+            protocol,
+            url.getHost(),
+            port,
+            url.getFile()
+        );
+
+        logger.info("Changing base URL from " + url + " into " + result);
+        return result;
     }
-    
+
     public static String getPayaraDomainFromServer() {
-        System.out.println("Getting Payara domain from server");
-        
+        logger.info("Getting Payara domain from server");
         List<String> output = new ArrayList<>();
         List<String> cmd = new ArrayList<>();
-        
+
         cmd.add("list-domains");
-        
+
         CliCommands.payaraGlassFish(cmd, output);
-        
+
         String domain = null;
         for (String line : output) {
             if (line.contains(" not running")) {
                 continue;
             }
-            
+
             if (line.contains(" running")) {
                 domain = line.substring(0, line.lastIndexOf(" running"));
                 break;
             }
         }
-        
+
         return domain;
     }
-    
+
     public static void addContainerSystemProperty(String key, String value) {
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            System.out.println("Adding system property");
-            
-            List<String> cmd = new ArrayList<>();
-            
-            cmd.add("create-jvm-options");
-            cmd.add("-D" + key + "=\"" + value + "\"");
-            
-            CliCommands.payaraGlassFish(cmd);
-            
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
+        logger.info("Adding system property");
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add("create-jvm-options");
+        cmd.add("-D" + key + "=\"" + value + "\"");
+
+        CliCommands.payaraGlassFish(cmd);
     }
-    
+
     public static void restartContainer() {
         restartContainer(null);
     }
-    
+
     public static void restartContainer(String domain) {
         // Arquillian connectors can stop/start already, but not on demand by code
-        
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            System.out.println("Restarting domain");
-            
-            List<String> cmd = new ArrayList<>();
-            
-            cmd.add("restart-domain");
-            
-            String restartDomain = domain;
-            if (restartDomain == null) {
-                restartDomain = System.getProperty("payara.domain.name");
-            }
-            
-            if (restartDomain == null) {
-                restartDomain = getPayaraDomainFromServer();
-            }
-            
-            cmd.add(restartDomain);
-            
-            CliCommands.payaraGlassFish(cmd);
-            
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
+        }
+        logger.info("Restarting domain");
+
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add("restart-domain");
+
+        String restartDomain = domain;
+        if (restartDomain == null) {
+            restartDomain = System.getProperty("payara.domain.name");
+        }
+
+        if (restartDomain == null) {
+            restartDomain = getPayaraDomainFromServer();
+        }
+
+        cmd.add(restartDomain);
+
+        CliCommands.payaraGlassFish(cmd);
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
     }
-    
-    public static void restartContainerDebug() {
-        // Arquillian connectors can stop/start already, but not on demand by code
-        
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            System.out.println("Stopping domain");
-            
-            List<String> cmd = new ArrayList<>();
-            
-            cmd.add("stop-domain");
-            
-            CliCommands.payaraGlassFish(cmd);
-            
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            
-            System.out.println("Starting domain");
-            
-            cmd = new ArrayList<>();
-            
-            cmd.add("start-domain");
-            
-            CliCommands.payaraGlassFish(cmd);
-            
-            System.out.println("Command returned");
-            
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            
-            System.out.println("After sleep");
-        }
-    }
-    
+
+
     public static void setupContainerJDBCIDigestIdentityStore() {
-        
-        String javaEEServer = System.getProperty("javaEEServer");
-        
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-            
-            System.out.println("Setting up container JDBC identity store for " + javaEEServer);
-            
-            List<String> cmd = new ArrayList<>();
-            
-            cmd.add("create-auth-realm");
-            cmd.add("--classname");
-            cmd.add("com.sun.enterprise.security.auth.realm.jdbc.JDBCRealm");
-            cmd.add("--property");
-            cmd.add(
-                "jaas-context=jdbcDigestRealm:" + 
-                "encoding=HASHED:" + 
-                "password-column=password:" + 
-                "datasource-jndi=java\\:comp/DefaultDataSource:" + 
-                "group-table=grouptable:"+ 
-                "charset=UTF-8:" + 
-                "user-table=usertable:" + 
-                "group-name-column=groupname:" + 
-                "digest-algorithm=None:" + 
-                "user-name-column=username");
-            
-            cmd.add("eesamplesdigestrealm");
-            
-            CliCommands.payaraGlassFish(cmd);
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
-        
-        // TODO: support other servers than Payara and GlassFish
-        
-        // WildFly ./bin/add-user.sh -a -u u1 -p p1 -g g1
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add("create-auth-realm");
+        cmd.add("--classname");
+        cmd.add("com.sun.enterprise.security.auth.realm.jdbc.JDBCRealm");
+        cmd.add("--property");
+        cmd.add(
+            "jaas-context=jdbcDigestRealm:" +
+            "encoding=HASHED:" +
+            "password-column=password:" +
+            "datasource-jndi=java\\:comp/DefaultDataSource:" +
+            "group-table=grouptable:"+
+            "charset=UTF-8:" +
+            "user-table=usertable:" +
+            "group-name-column=groupname:" +
+            "digest-algorithm=None:" +
+            "user-name-column=username");
+
+        cmd.add("eesamplesdigestrealm");
+
+        CliCommands.payaraGlassFish(cmd);
     }
 
     public static void setupContainerFileIdentityStore(String fileRealmName) {
 
-        String javaEEServer = System.getProperty("javaEEServer");
-
-        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
-
-            System.out.println("Setting up container File identity store for " + javaEEServer);
-
-            List<String> cmd = new ArrayList<>();
-
-            cmd.add("create-auth-realm");
-            cmd.add("--classname");
-            cmd.add("com.sun.enterprise.security.auth.realm.file.FileRealm");
-            cmd.add("--property");
-            cmd.add("jaas-context=fileRealm:file=" + fileRealmName);
-            cmd.add(fileRealmName);
-
-            CliCommands.payaraGlassFish(cmd);
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
+        List<String> cmd = new ArrayList<>();
+        cmd.add("create-auth-realm");
+        cmd.add("--classname");
+        cmd.add("com.sun.enterprise.security.auth.realm.file.FileRealm");
+        cmd.add("--property");
+        cmd.add("jaas-context=fileRealm:file=" + fileRealmName);
+        cmd.add(fileRealmName);
 
+        CliCommands.payaraGlassFish(cmd);
     }
 
-    public static X509Certificate createSelfSignedCertificate(KeyPair keys) {
-        try {
-            Provider provider = new BouncyCastleProvider();
-            Security.addProvider(provider);
-            return new JcaX509CertificateConverter()
-                    .setProvider(provider)
-                    .getCertificate(
-                            new X509v3CertificateBuilder(
-                                    new X500Name("CN=lfoo, OU=bar, O=kaz, L=zak, ST=lak, C=UK"),
-                                    ONE,
-                                    Date.from(now()),
-                                    Date.from(now().plus(1, DAYS)),
-                                    new X500Name("CN=lfoo, OU=bar, O=kaz, L=zak, ST=lak, C=UK"),
-                                    SubjectPublicKeyInfo.getInstance(keys.getPublic().getEncoded()))
-                                    .build(
-                                            new JcaContentSignerBuilder("SHA256WithRSA")
-                                                    .setProvider(provider)
-                                                    .build(keys.getPrivate())));
-        } catch (CertificateException | OperatorCreationException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    public static URL getHostFromCertificate(X509Certificate[] serverCertificateChain, URL existingURL) {
-        try {
-            URL httpsUrl = new URL(
-                    existingURL.getProtocol(),
-                    Certificates.getHostFromCertificate(serverCertificateChain),
-                    existingURL.getPort(),
-                    existingURL.getFile()
-            );
-
-            System.out.println("Changing base URL from " + existingURL + " into " + httpsUrl + "\n");
-
-            return httpsUrl;
-
-        } catch (MalformedURLException e) {
-            System.out.println("Failure creating HTTPS URL");
-            e.printStackTrace();
-
-            System.out.println("FAILED to get CN. Using existing URL: " + existingURL);
-
-            return existingURL;
-        }
-    }
 
     public static void enableSSLDebug() {
         System.setProperty("javax.net.debug", "ssl:handshake");
@@ -611,16 +418,14 @@ public class ServerOperations {
         System.getProperties().put("org.apache.commons.logging.simplelog.defaultlog", "debug");
         Logger.getLogger("com.gargoylesoftware.htmlunit.httpclient.HtmlUnitSSLConnectionSocketFactory").setLevel(FINEST);
         Logger.getLogger("org.apache.http.conn.ssl.SSLConnectionSocketFactory").setLevel(FINEST);
-        Log logger = LogFactory.getLog(org.apache.http.conn.ssl.SSLConnectionSocketFactory.class);
-        ((Jdk14Logger) logger).getLogger().setLevel(FINEST);
-        logger = LogFactory.getLog(com.gargoylesoftware.htmlunit.httpclient.HtmlUnitSSLConnectionSocketFactory.class);
-        ((Jdk14Logger) logger).getLogger().setLevel(FINEST);
+        Log sslLogger = LogFactory.getLog(org.apache.http.conn.ssl.SSLConnectionSocketFactory.class);
+        ((Jdk14Logger) sslLogger).getLogger().setLevel(FINEST);
+        sslLogger = LogFactory.getLog(com.gargoylesoftware.htmlunit.httpclient.HtmlUnitSSLConnectionSocketFactory.class);
+        ((Jdk14Logger) sslLogger).getLogger().setLevel(FINEST);
         Logger.getGlobal().getParent().getHandlers()[0].setLevel(FINEST);
     }
 
     public static String createClientKeyStore(){
-
-        Security.addProvider(new BouncyCastleProvider());
 
         // Enable to get detailed logging about the SSL handshake on the client
         // For an explanation of the TLS handshake see: https://tls.ulfheim.net
@@ -631,18 +436,18 @@ public class ServerOperations {
 
         // ### Generate keys for the client, create a certificate, and add those to a new local key store
         // Generate a Private/Public key pair for the client
-        KeyPair clientKeyPair = generateRandomRSAKeys();
+        KeyPair clientKeyPair = SecurityUtils.generateRandomRSAKeys();
 
         // Create a certificate containing the client public key and signed with the private key
-        X509Certificate clientCertificate = createSelfSignedCertificate(clientKeyPair);
+        X509Certificate clientCertificate = SecurityUtils.createSelfSignedCertificate(clientKeyPair);
 
         // Create a new local key store containing the client private key and the certificate
-        String clientKeyStorePath = createTempJKSKeyStore(clientKeyPair.getPrivate(), clientCertificate);
+        String clientKeyStorePath = SecurityUtils.createTempJKSKeyStore(clientKeyPair.getPrivate(), clientCertificate);
         System.setProperty("javax.net.ssl.keystore", clientKeyStorePath);
 
         // Enable to get detailed logging about the SSL handshake on the server
         if (System.getProperty("ssl.debug") != null) {
-            System.out.println("Setting server SSL debug on");
+            logger.info("Setting server SSL debug on");
             addContainerSystemProperty("javax.net.debug", "ssl:handshake");
         }
 
@@ -669,31 +474,29 @@ public class ServerOperations {
         // by the server
         X509Certificate[] serverCertificateChain = getCertificateChainFromServer(baseHttps.getHost(), baseHttps.getPort());
 
-        if (!isEmpty(serverCertificateChain)) {
+        if (serverCertificateChain.length == 0) {
+            throw new IllegalStateException("Could not obtain certificates from server.");
+        }
+        logger.info("Obtained certificate from server. Storing it in client trust store");
 
-            System.out.println("Obtained certificate from server. Storing it in client trust store");
+        String trustStorePath = SecurityUtils.createTempJKSTrustStore(serverCertificateChain);
+        System.setProperty("javax.net.ssl.truststore", trustStorePath);
 
-            String trustStorePath = createTempJKSTrustStore(serverCertificateChain);
-            System.setProperty("javax.net.ssl.truststore", trustStorePath);
+        logger.info("Reading trust store from: " + trustStorePath);
 
-            System.out.println("Reading trust store from: " + trustStorePath);
+        webClient.getOptions().setSSLTrustStore(new File(trustStorePath).toURI().toURL(), "changeit", "jks");
 
-            webClient.getOptions().setSSLTrustStore(new File(trustStorePath).toURI().toURL(), "changeit", "jks");
-
-            // If the use.cnHost property is we try to extract the host from the server
-            // certificate and use exactly that host for our requests.
-            // This is needed if a server is listening to multiple host names, for instance
-            // localhost and example.com. If the certificate is for example.com, we can't
-            // localhost for the request, as that will not be accepted.
-            if (System.getProperty("use.cnHost") != null) {
-                System.out.println("use.cnHost set. Trying to grab CN from certificate and use as host for requests.");
-                baseHttps = getHostFromCertificate(serverCertificateChain, baseHttps);
-            }
-        } else {
-            System.out.println("Could not obtain certificates from server. Continuing without custom truststore");
+        // If the use.cnHost property is we try to extract the host from the server
+        // certificate and use exactly that host for our requests.
+        // This is needed if a server is listening to multiple host names, for instance
+        // localhost and example.com. If the certificate is for example.com, we can't
+        // localhost for the request, as that will not be accepted.
+        if (System.getProperty("use.cnHost") != null) {
+            logger.info("use.cnHost set. Trying to grab CN from certificate and use as host for requests.");
+            baseHttps = getHostFromCertificate(serverCertificateChain, baseHttps);
         }
 
-        System.out.println("Using client key store from: " + clientKeyStorePath);
+        logger.info("Using client key store from: " + clientKeyStorePath);
 
         // Client -> Server : the key store's private keys and certificates are used to sign
         // and sent a reply to the server
@@ -706,19 +509,16 @@ public class ServerOperations {
         // Server -> client : the trust store certificates are used to validate the certificate sent
         // by the server
         X509Certificate[] serverCertificateChain = getCertificateChainFromServer(baseHttps.getHost(), baseHttps.getPort());
-
-        if (!isEmpty(serverCertificateChain)) {
-
-            System.out.println("Obtained certificate from server. Storing it in client trust store");
-
-            String trustStorePath = createTempJKSTrustStore(serverCertificateChain);
-            System.setProperty("javax.net.ssl.truststore", trustStorePath);
-
-            System.out.println("Reading trust store from: " + trustStorePath);
-            return new File(trustStorePath).toURI().toURL();
-        } else {
-            throw new IllegalStateException("Could not obtain certificates from server. Continuing without custom truststore");
+        if (serverCertificateChain.length == 0) {
+            throw new IllegalStateException("Could not obtain certificates from server.");
         }
+        logger.info("Obtained certificate from server. Storing it in client trust store");
+
+        String trustStorePath = SecurityUtils.createTempJKSTrustStore(serverCertificateChain);
+        System.setProperty("javax.net.ssl.truststore", trustStorePath);
+
+        logger.info("Reading trust store from: " + trustStorePath);
+        return new File(trustStorePath).toURI().toURL();
     }
 
     public static KeyStore getKeyStore(
@@ -741,44 +541,32 @@ public class ServerOperations {
     }
 
     public static void enableDataGridEncryption() {
-        String javaEEServer = System.getProperty("javaEEServer");
-        if ("payara-remote".equals(javaEEServer)) {
-            System.out.println("Enabling Data Grid Encryption");
-            CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "true");
-
-            System.out.println("Stopping Server");
-            String domain = getDomainName();
-            CliCommands.payaraGlassFish("stop-domain", domain);
-
-            System.out.println("Generating Encryption Key");
-            CliCommands.payaraGlassFish("-W",
-                    Paths.get("").toAbsolutePath() + "/src/test/resources/passwordfile.txt",
-                    "generate-encryption-key", domain);
-
-            System.out.println("Restarting Server");
-            CliCommands.payaraGlassFish("start-domain", domain);
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
+        logger.info("Enabling Data Grid Encryption");
+        CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "true");
+
+        logger.info("Stopping Server");
+        String domain = getDomainName();
+        CliCommands.payaraGlassFish("stop-domain", domain);
+
+        logger.info("Generating Encryption Key");
+        CliCommands.payaraGlassFish("-W",
+                Paths.get("").toAbsolutePath() + "/src/test/resources/passwordfile.txt",
+                "generate-encryption-key", domain);
+
+        logger.info("Restarting Server");
+        CliCommands.payaraGlassFish("start-domain", domain);
     }
 
     public static void disableDataGridEncryption() {
-        String javaEEServer = System.getProperty("javaEEServer");
-        if ("payara-remote".equals(javaEEServer)) {
-            System.out.println("Disabling Data Grid Encryption");
-            CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "false");
-            restartContainer(getDomainName());
-        } else {
-            if (javaEEServer == null) {
-                System.out.println("javaEEServer not specified");
-            } else {
-                System.out.println(javaEEServer + " not supported");
-            }
+        if (!isServer()) {
+            throw new IllegalStateException(ERR_MESSAGE_UNSUPPORTED);
         }
+        logger.info("Disabling Data Grid Encryption");
+        CliCommands.payaraGlassFish("set-hazelcast-configuration", "--encryptdatagrid", "false");
+        restartContainer(getDomainName());
     }
 
     public static String getDomainName() {

--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -100,7 +100,7 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        
+
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
@@ -113,13 +113,6 @@
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -259,6 +259,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
+                        <trimStackTrace>false</trimStackTrace>
                         <useSystemClassLoader>true</useSystemClassLoader>
                     </configuration>
                 </plugin>

--- a/nucleus/test-utils/pom.xml
+++ b/nucleus/test-utils/pom.xml
@@ -48,17 +48,17 @@
         <artifactId>payara-nucleus-parent</artifactId>
         <version>5.2020.8-SNAPSHOT</version>
     </parent>
-    
+
     <groupId>fish.payara.server.internal.test-utils</groupId>
     <artifactId>test-utils</artifactId>
     <packaging>pom</packaging>
-    <name>Test Utilities Modules</name>  
-    
+    <name>Test Utilities Modules</name>
+
     <modules>
         <module>utils</module>
         <module>utils-ng</module>
     </modules>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -71,5 +71,5 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-    </build>    
+    </build>
 </project>


### PR DESCRIPTION
## Description

- if something is broken, don't log it, but throw exception instead.
- tests should explicitly know what they are doing, not relying
      on ServerOperations/CliCommands magic
- if something depends on server, make a condition, etc., so reader knows
      there is some limitation
- test-utils renamed to samples-test-utils as another module existed with
     the same name
- SecurityUtils - split from ServerOperations to avoid dependency on BC+OmniFaces
      if they are not used at all.
- using own property for remote and managed
- Trimming stacktraces is off everywhere
- Clean the server's directory -> repeatable managed


## Testing

```
mvn clean install -Ppayara-samples,payara-micro-managed -fae -pl :payara-samples -amd
mvn clean install -Ppayara-samples,payara-server-managed -fae -pl :payara-samples -amd
asadmin start-domain
mvn clean install -Ppayara-samples,payara-server-remote -fae -pl :payara-samples -amd
asadmin stop-domain
```