### PR TITLE
FISH-505 prevent loading apps to instance app not assigned to

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.server;
 
@@ -243,7 +243,10 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         while (iter.hasNext()) {
           Application app = (Application)iter.next();
           ApplicationRef appRef = server.getApplicationRef(app.getName());
-          appDeployments.addAll(processApplication(app, appRef));
+          if (appRef != null) {
+            // Does the application need to be run on this instance?
+            appDeployments.addAll(processApplication(app, appRef));
+          }
         }
 
         // does the user want us to run a particular application


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This is a bug fix 

Applications are loaded to instances they are not assigned to. See Jira for reproducer. The effect of this can be seen in the node logs

Links to https://github.com/payara/Payara-Enterprise/pull/258
## Testing

### New tests
No new tests

### Testing Performed

### Test suites executed
<!-- Which test suites did you run this against? Keep corresponding items. Feel free to add others, for example bug reproducer project. -->
+ Quicklook
+ Payara Samples
+ Java EE7 Samples
+ Java EE8 Samples
+ Payara Microprofile TCKs Runner
+ Cargo Tracker

### Testing Environment
Internal Jenkins http://192.168.1.120:8080/job/BuildAndTestInParallel/1606/ (results ephemeral, kept 14 days)

## Documentation
n/a

## Notes for Reviewers
