### PR TITLE
FISH-642 Workaround fix for OpenMQ blowing away logging on cluster instances.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
         <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
         <jms-api.version>2.0.2</jms-api.version>
-        <mq.version>5.1.1.final.payara-p4</mq.version>
+        <mq.version>5.1.1.final.payara-p5</mq.version>
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>


### PR DESCRIPTION

## Description
This is a part-fix / workaround.

Application logging breaks for clustered instances (as in Shoal/GMS clustered instances) due to OpenMQ blowing away logging configuration.

The cause of OpenMQ blowing it away is due to it running into an exception when starting the clustered broker, specifically that a loopback address is being used. Rather than exiting out at this point however, OpenMQ attempts to fallover to a non-clustered broker. This logic is currently flawed however due to the fact that the Broker which is being started gets "exited" before continuing to start using a non-clustered mbus - the broker doesn't exit due to being started in-process, and attempts to carry on despite having all configuration nulled, unsurprisingly running into NPEs (which you don't see because a side-effect of nulling the configuration is that it also blows away the logging configuration).

It should be pointed out that this flaw in OpenMQ exists regardless of this workaround / part-fix - the OpenMQ broker won't start regardless, but with this change you at least get told it hasn't started. This change doesn't cause OpenMQ to print quite the same exception that it would normally however (if it could actually print the exception). It still gets the same NPEs caused by throwing away all configuration, but in a slightly different place, causing it to not get wrapped in a nicer "Illegal Loopback Address Used" message.

## Important Info
### Blockers
https://github.com/payara/Payara_PatchedProjects/pull/349

## Testing
### New tests
None

### Testing Performed
Started cluster instances on Windows and Linux and deployed test application, hitting endpoint http://localhost:28080/ticket1567-logging/hello and checking logs to see if messages are printed out.

As noted above, clustered instances on Linux with a "default" networking setup will get errors related to OpenMQ not starting.

## Documentation
None
