### PR TITLE
CUSTOM-55 possibly stale log records are propagated

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/logger/FileLoggerHandler.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/logger/FileLoggerHandler.java
@@ -155,7 +155,7 @@ public class FileLoggerHandler extends Handler {
                 return;
         }
 
-        GFLogRecord wrappedRecord = new GFLogRecord(record);
+        GFLogRecord wrappedRecord = GFLogRecord.wrap(record, false);
         try {
             pendingRecords.add(wrappedRecord);
         } catch(IllegalStateException e) {

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/logger/FileLoggerHandler.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/logger/FileLoggerHandler.java
@@ -37,14 +37,16 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web.logger;
 
 /**
- * An implementation of FileLoggerHandler which logs to virtual-server property 
+ * An implementation of FileLoggerHandler which logs to virtual-server property
  * log-file when enabled
  */
 
+import com.sun.common.util.logging.GFLogRecord;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -73,7 +75,7 @@ public class FileLoggerHandler extends Handler {
     FileLoggerHandler(String logFile) {
         setLevel(Level.ALL);
         this.logFile = logFile;
-    
+
         try {
             printWriter = new PrintWriter(new FileOutputStream(logFile, true));
     	} catch (IOException e) {
@@ -95,7 +97,7 @@ public class FileLoggerHandler extends Handler {
 
     private void writeLogRecord(LogRecord record) {
         if (printWriter != null) {
-            printWriter.write(getFormatter().format(record)); 
+            printWriter.write(getFormatter().format(record));
             printWriter.flush();
         }
     }
@@ -134,9 +136,9 @@ public class FileLoggerHandler extends Handler {
     public boolean isAssociated() {
         return (association.get() > 0);
     }
-    
+
     /**
-     * Overridden method used to capture log entries   
+     * Overridden method used to capture log entries
      *
      * @param record The log record to be written out.
      */
@@ -152,20 +154,21 @@ public class FileLoggerHandler extends Handler {
             if ( !getFilter().isLoggable(record) )
                 return;
         }
-        
+
+        GFLogRecord wrappedRecord = new GFLogRecord(record);
         try {
-            pendingRecords.add(record);
+            pendingRecords.add(wrappedRecord);
         } catch(IllegalStateException e) {
             // queue is full, start waiting
             try {
-                pendingRecords.put(record);
+                pendingRecords.put(wrappedRecord);
             } catch(InterruptedException ex) {
                 // too bad, record is lost...
             }
         }
     }
 
-    
+
     /**
      * Called to close this log handler.
      */
@@ -194,8 +197,8 @@ public class FileLoggerHandler extends Handler {
             }
         }
     }
- 
-    
+
+
     /**
      * Called to flush any cached data that
      * this log handler may contain.

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/GFLogRecord.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/GFLogRecord.java
@@ -86,6 +86,29 @@ public class GFLogRecord extends LogRecord {
     }
 
     /**
+     * wrap log record with {@link GFLogRecord} if not already
+     * if setThreadName is true, sets thread name to current
+     *
+     * @param record
+     * @param setThreadName
+     * @return wrapped record
+     */
+    public static GFLogRecord wrap(LogRecord record, boolean setThreadName) {
+        GFLogRecord wrappedRecord;
+        if (record instanceof GFLogRecord) {
+            wrappedRecord = (GFLogRecord)record;
+        } else {
+            wrappedRecord = new GFLogRecord(record);
+        }
+        // Check there is actually a set thread name
+        if (setThreadName && wrappedRecord.getThreadName() == null) {
+            wrappedRecord.setThreadName(Thread.currentThread().getName());
+        }
+
+        return wrappedRecord;
+    }
+
+    /**
      * CUSTOM-55
      * in case of an object passed as a parameter, call it's toString() method
      * to resolve it's values in the current thread, instead of waiting for queues / etc
@@ -96,17 +119,18 @@ public class GFLogRecord extends LogRecord {
      * @param params
      * @return parameter array
      */
-    private Object[] transformParameters(Object[] params) {
+    private static Object[] transformParameters(Object[] params) {
         if (params == null) {
             return null;
         }
         Object[] result = new Object[params.length * 2];
-        for (int stringIndex = 0, originalIndex = params.length; stringIndex < params.length;
-                ++stringIndex, ++originalIndex) {
-            Object param = params[stringIndex];
+        for (int stringParamsIndex = 0, originalParamsIndex = params.length;
+                stringParamsIndex < params.length;
+                ++stringParamsIndex, ++originalParamsIndex) {
+            Object param = params[stringParamsIndex];
             if (param != null) {
-                result[stringIndex] = param.toString();
-                result[originalIndex] = params[stringIndex];
+                result[stringParamsIndex] = param.toString();
+                result[originalParamsIndex] = params[stringParamsIndex];
             }
         }
         return result;

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/SyslogHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/SyslogHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
@@ -51,6 +51,7 @@ import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.hk2.api.PreDestroy;
 
 import com.sun.common.util.logging.BooleanLatch;
+import com.sun.common.util.logging.GFLogRecord;
 
 import javax.inject.Singleton;
 
@@ -93,7 +94,7 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
         }
 
         //set up the connection
-        setupConnection();       
+        setupConnection();
         initializePump();
     }
 
@@ -115,7 +116,7 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
         };
         pump.start();
     }
-    
+
     private void setupConnection(){
         try {
             sysLogger = new Syslog("localhost");  //for now only write to this host
@@ -124,7 +125,7 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
             return;
         }
     }
-    
+
     public void preDestroy() {
         if (LogFacade.LOGGING_LOGGER.isLoggable(Level.FINE)) {
             LogFacade.LOGGING_LOGGER.fine("SysLog Logger handler killed");
@@ -182,13 +183,14 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
     public void publish( LogRecord record ) {
         if (pump == null)
             return;
-            
+
+        GFLogRecord wrappedRecord = new GFLogRecord(record);
         try {
-            pendingRecords.add(record);
+            pendingRecords.add(wrappedRecord);
         } catch(IllegalStateException e) {
             // queue is full, start waiting.
             try {
-                pendingRecords.put(record);
+                pendingRecords.put(wrappedRecord);
             } catch (InterruptedException e1) {
                 // to bad, record is lost...
             }
@@ -200,7 +202,7 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
     }
 
     public void flush() {
-        
+
     }
 
     public void setSystemLogging(boolean systemLogging) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/SyslogHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/SyslogHandler.java
@@ -180,11 +180,12 @@ public class SyslogHandler extends Handler implements PostConstruct, PreDestroy 
     /**
      * Publishes the logrecord storing it in our queue
      */
+    @Override
     public void publish( LogRecord record ) {
         if (pump == null)
             return;
 
-        GFLogRecord wrappedRecord = new GFLogRecord(record);
+        GFLogRecord wrappedRecord = GFLogRecord.wrap(record, false);
         try {
             pendingRecords.add(wrappedRecord);
         } catch(IllegalStateException e) {


### PR DESCRIPTION
force toString() during the same thread as the logging happens so objects

don't get passed around different threads in logging and have a chance to get
out of sync and be inconsistent

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Pragmatic & minimalist fix to remove race conditions in log records causing stale state to be printed in log message

## Important Info
### Blockers
None

## Testing
### New tests
Existing tests

### Testing Environment
Jenkins

## Notes for Reviewers
This is a simplest fix for the issue, not touching anything that doesn't directly relate
Choose "hide whitespace changes" from GitHub setup to make the review easier
