### PR TITLE
FISH-659: Fault Tolerance 3.0 full pass

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
@@ -100,12 +100,14 @@ public interface FaultToleranceServiceConfiguration extends ConfigExtension {
     void setAsyncPoolKeepAliveInSeconds(String asyncPoolKeepAliveInSeconds);
 
     /**
+     * @deprecated cleaning of FT state has been removed in 5.2020.8
      * @return The interval duration in minutes for the background job that cleans expired FT state. Changes do need a
      *         restart of the server.
      */
     @Attribute(defaultValue = "1", dataType = Integer.class)
     @Min(value = 1)
     @Max(value = 60 * 24)
+    @Deprecated
     String getCleanupIntervalInMinutes();
     void setCleanupIntervalInMinutes(String cleanupIntervalInMinutes);
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
@@ -55,11 +55,11 @@ import org.jvnet.hk2.config.Configured;
 @Configured(name = "microprofile-fault-tolerance-configuration")
 public interface FaultToleranceServiceConfiguration extends ConfigExtension {
 
-    @Attribute(defaultValue = "concurrent/__defaultManagedExecutorService", dataType = String.class)
+    @Attribute(defaultValue = "java:comp/DefaultManagedExecutorService", dataType = String.class)
     public String getManagedExecutorService();
     public void setManagedExecutorService(String managedExecutorServiceName);
 
-    @Attribute(defaultValue = "concurrent/__defaultManagedScheduledExecutorService", dataType = String.class)
+    @Attribute(defaultValue = "java:comp/DefaultManagedScheduledExecutorService", dataType = String.class)
     public String getManagedScheduledExecutorService();
     public void setManagedScheduledExecutorService(String managedScheduledExecutorServiceName);
 

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
@@ -64,29 +64,35 @@ public interface FaultToleranceServiceConfiguration extends ConfigExtension {
     public void setManagedScheduledExecutorService(String managedScheduledExecutorServiceName);
 
     /**
+     * @deprecated Managed thread pools are used since 5.2020.8 (again)
      * @return The maximum number of threads used to run asynchronous methods concurrently. This is the upper limit. The
      *         executor will vary the actual pool size depending on demand up to this upper limit. If no demand exist
      *         the actual pool size is zero.
      */
+    @Deprecated
     @Attribute(defaultValue = "2000", dataType = Integer.class)
     @Min(value = 20)
     String getAsyncMaxPoolSize();
     void setAsyncMaxPoolSize(String asyncMaxPoolSize);
 
     /**
+     * @deprecated Managed thread pools are used since 5.2020.8 (again)
      * @return The maximum number of threads used to schedule delayed execution and detect timeouts processing FT
      *         semantics. This should be understood as upper limit. The implementation might choose to keep up to this
      *         number of threads alive or vary the actual pool size according to demands.
      */
+    @Deprecated
     @Attribute(defaultValue = "20", dataType = Integer.class)
     @Min(value = 1)
     String getDelayMaxPoolSize();
     void setDelayMaxPoolSize(String delayMaxPoolSize);
 
     /**
+     * @deprecated Managed thread pools are used since 5.2020.8 (again)
      * @return The number of seconds an idle worker in the async pool has to be out of work before it is disposed and
      *         the pool scales down in size. Changes to this setting are dynamically applied and do not need a restart.
      */
+    @Deprecated
     @Attribute(defaultValue = "60", dataType = Integer.class)
     @Min(value = 20)
     @Max(value = 60 * 60)

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -56,13 +56,12 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
-import org.glassfish.internal.api.Globals;
-
 import fish.payara.microprofile.faulttolerance.FaultToleranceConfig;
 import fish.payara.microprofile.faulttolerance.FaultToleranceService;
 import fish.payara.microprofile.faulttolerance.policy.FaultTolerancePolicy;
 import fish.payara.microprofile.faulttolerance.service.Stereotypes;
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
+import org.glassfish.internal.api.Globals;
 
 @Interceptor
 @FaultTolerance
@@ -77,17 +76,18 @@ public class FaultToleranceInterceptor implements Stereotypes, Serializable {
     @Inject
     private Instance<RequestContextController> requestContextControllerInstance;
 
+    private FaultToleranceService faultToleranceService;
+
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         try {
-            FaultToleranceService env =
-                    Globals.getDefaultBaseServiceLocator().getService(FaultToleranceService.class);
+            initialize();
             AtomicReference<FaultToleranceConfig> lazyConfig = new AtomicReference<>();
             Supplier<FaultToleranceConfig> configSupplier = () -> //
-                lazyConfig.updateAndGet(value -> value != null ? value : env.getConfig(context, this));
+                    lazyConfig.updateAndGet(value -> value != null ? value : faultToleranceService.getConfig(context, this));
             FaultTolerancePolicy policy = FaultTolerancePolicy.get(context, configSupplier);
             if (policy.isPresent) {
-                return policy.proceed(context, () -> env.getMethodContext(context, policy, getRequestContextController()));
+                return policy.proceed(context, () -> faultToleranceService.getMethodContext(context, policy, getRequestContextController()));
             }
         } catch (FaultToleranceDefinitionException e) {
             logger.log(Level.SEVERE, "Effective FT policy contains illegal values, fault tolerance cannot be applied,"
@@ -95,6 +95,13 @@ public class FaultToleranceInterceptor implements Stereotypes, Serializable {
             // fall-through to normal proceed
         }
         return context.proceed();
+    }
+
+    private void initialize() {
+        if (this.faultToleranceService != null) {
+            return;
+        }
+        this.faultToleranceService = Globals.getDefaultBaseServiceLocator().getService(FaultToleranceService.class);
     }
 
     private RequestContextController getRequestContextController() {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
@@ -199,7 +199,7 @@ public class FaultToleranceServiceImpl
         if (event.is(Deployment.APPLICATION_UNLOADED)) {
             ApplicationInfo info = (ApplicationInfo) event.hook();
             deregisterApplication(info.getName());
-            FaultTolerancePolicy.clean();
+            FaultTolerancePolicy.clean(info.getAppClassLoader());
         } else if (event.is(EventTypes.SERVER_SHUTDOWN)) {
             if (asyncExecutorService != null) {
                 asyncExecutorService.shutdownNow();

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
@@ -53,19 +53,12 @@ import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.notification.requesttracing.RequestTraceSpan;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
 
-import static java.lang.Integer.parseInt;
-
-import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -122,7 +115,7 @@ public class FaultToleranceServiceImpl
     @Inject
     private MetricsService metricsService;
 
-    private final ConcurrentMap<String, ConcurrentMap<String, FaultToleranceMethodContextImpl>> contextByAppNameAndMethodId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<MethodKey, FaultToleranceMethodContextImpl> contextByMethod = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, BindableFaultToleranceConfig> configByAppName = new ConcurrentHashMap<>();
     private ExecutorService asyncExecutorService;
     private ScheduledExecutorService delayExecutorService;
@@ -136,48 +129,13 @@ public class FaultToleranceServiceImpl
         InitialContext context = new InitialContext();
         asyncExecutorService = (ManagedExecutorService) context.lookup(config.getManagedExecutorService());
         delayExecutorService = (ManagedScheduledExecutorService) context.lookup(config.getManagedScheduledExecutorService());
-        int interval = getCleanupIntervalInMinutes();
-        delayExecutorService.scheduleAtFixedRate(this::cleanMethodContexts, interval, interval, TimeUnit.MINUTES);
-    }
-
-    /**
-     * Since {@link Map#compute(Object, java.util.function.BiFunction)} locks the key entry for
-     * {@link ConcurrentHashMap} it is safe to remove the entry in case
-     * {@link FaultToleranceMethodContextImpl#isExpired(long)} as concurrent call to
-     * {@link Map#computeIfAbsent(Object, java.util.function.Function)} are going to wait for the completion of
-     * {@link Map#compute(Object, java.util.function.BiFunction)}.
-     */
-    private void cleanMethodContexts() {
-        final long ttl = TimeUnit.MINUTES.toMillis(1);
-        int cleaned = 0;
-        for (Map<String, FaultToleranceMethodContextImpl> appEntry : contextByAppNameAndMethodId.values()) {
-            for (String key : new HashSet<>(appEntry.keySet())) {
-                try {
-                    Object newValue = appEntry.compute(key,
-                            (k, methodContext) -> methodContext.isExpired(ttl) ? null : methodContext);
-                    if (newValue == null) {
-                        cleaned++;
-                    }
-                } catch (Exception e) {
-                    logger.log(Level.WARNING, "Failed to clean FT method context for " + key, e);
-                }
-            }
-        }
-        if (cleaned > 0) {
-            String allClean = contextByAppNameAndMethodId.isEmpty() ? ".All clean." : ".";
-            logger.log(Level.INFO, "Cleaned {0} expired FT method contexts" + allClean, cleaned);
-        }
-    }
-
-    private int getCleanupIntervalInMinutes() {
-        return config == null ? 1 : parseInt(config.getCleanupIntervalInMinutes());
     }
 
     @Override
     public void event(Event<?> event) {
         if (event.is(Deployment.APPLICATION_UNLOADED)) {
             ApplicationInfo info = (ApplicationInfo) event.hook();
-            deregisterApplication(info.getName());
+            deregisterApplication(info);
             FaultTolerancePolicy.clean(info.getAppClassLoader());
         } else if (event.is(EventTypes.SERVER_SHUTDOWN)) {
             if (asyncExecutorService != null) {
@@ -192,10 +150,9 @@ public class FaultToleranceServiceImpl
     @Override
     @MonitoringData(ns = "ft")
     public void collect(MonitoringDataCollector collector) {
-        for (Entry<String, ConcurrentMap<String, FaultToleranceMethodContextImpl>> appEntry : contextByAppNameAndMethodId.entrySet()) {
-            String app = appEntry.getKey();
-            for (Entry<String, FaultToleranceMethodContextImpl> methodEntry  : appEntry.getValue().entrySet()) {
-                MonitoringDataCollector methodCollector = collector.group(methodEntry.getKey()).tag("app", app);
+        for (Entry<MethodKey, FaultToleranceMethodContextImpl> methodEntry : contextByMethod.entrySet()) {
+                MonitoringDataCollector methodCollector = collector.group(methodEntry.getKey().getMethodId())
+                        .tag("app", methodEntry.getValue().getAppName());
                 FaultToleranceMethodContext context = methodEntry.getValue();
                 BlockingQueue<Thread> concurrentExecutions = context.getConcurrentExecutions();
                 if (concurrentExecutions != null) {
@@ -203,7 +160,6 @@ public class FaultToleranceServiceImpl
                     collectBulkheadSemaphores(methodCollector, concurrentExecutions, context.getQueuingOrRunningPopulation());
                 }
                 collectCircuitBreakerState(methodCollector, context.getState());
-            }
         }
     }
 
@@ -235,9 +191,9 @@ public class FaultToleranceServiceImpl
                 key -> new BindableFaultToleranceConfig(stereotypes)).bindTo(context);
     }
 
-    private MetricRegistry getBaseMetricRegistry() {
+    private MetricsService.MetricsContext getMetricsContext() {
         try {
-            return metricsService.getContext(true).getBaseRegistry();
+            return metricsService.getContext(true);
         } catch (Exception e) {
             return null;
         }
@@ -245,11 +201,12 @@ public class FaultToleranceServiceImpl
 
     /**
      * Removes an application from the enabled map, CircuitBreaker map, and bulkhead maps
-     * @param applicationName The name of the application to remove
+     * @param appInfo The name of the application to remove
      */
-    private void deregisterApplication(String applicationName) {
-        configByAppName.remove(applicationName);
-        contextByAppNameAndMethodId.remove(applicationName);
+    private void deregisterApplication(ApplicationInfo appInfo) {
+        configByAppName.remove(appInfo.getName());
+        contextByMethod.keySet().removeIf(methodKey ->
+                methodKey.targetClass.getClassLoader().equals(appInfo.getAppClassLoader()));
     }
 
     /**
@@ -292,43 +249,20 @@ public class FaultToleranceServiceImpl
     @Override
     public FaultToleranceMethodContext getMethodContext(InvocationContext context, FaultTolerancePolicy policy,
             RequestContextController requestContextController) {
-        return contextByAppNameAndMethodId.computeIfAbsent(getAppName(context), appId -> new ConcurrentHashMap<>())
-                    .computeIfAbsent(getTargetMethodId(context),
-                        methodId -> createMethodContext(methodId, context, requestContextController)).boundTo(context, policy);
+        return contextByMethod.computeIfAbsent(new MethodKey(context),
+                        methodKey -> createMethodContext(methodKey, context, requestContextController)).boundTo(context, policy);
     }
 
-    private FaultToleranceMethodContextImpl createMethodContext(String methodId, InvocationContext context,
-            RequestContextController requestContextController) {
-        MetricRegistry metricRegistry = getBaseMetricRegistry();
+    private FaultToleranceMethodContextImpl createMethodContext(MethodKey methodKey, InvocationContext context,
+                                                                RequestContextController requestContextController) {
+        MetricsService.MetricsContext metricsContext = getMetricsContext();
+        MetricRegistry metricRegistry = metricsContext != null ? metricsContext.getBaseRegistry() : null;
+        String appName = metricsContext != null ? metricsContext.getName() : "";
         FaultToleranceMetrics metrics = metricRegistry == null
                 ? FaultToleranceMetrics.DISABLED
                 : new MethodFaultToleranceMetrics(metricRegistry, FaultToleranceUtils.getCanonicalMethodName(context));
-        logger.log(Level.FINE, "Creating FT method context for {0}", methodId);
+        logger.log(Level.FINE, "Creating FT method context for {0}", methodKey);
         return new FaultToleranceMethodContextImpl(requestContextController, this, metrics, asyncExecutorService,
-                delayExecutorService, context.getTarget());
+                delayExecutorService, appName);
     }
-
-    /**
-     * It is essential that the computed signature is referring to the {@link Method} as defined by the target
-     * {@link Object} class not its declaring {@link Class} as this could be different when called via an abstract
-     * {@link Method} implemented or overridden by the target {@link Class}.
-     *
-     * Since MP FT 3.0 all instances of a class share same state object for the same method. Or in other words the FT
-     * context is not specific to an instance but to the annotated class and method.
-     */
-    public static String getTargetMethodId(InvocationContext context) {
-        Object target = context.getTarget();
-        Method method = context.getMethod();
-        StringBuilder methodId = new StringBuilder();
-        methodId.append(target.getClass().getName()).append('.').append(method.getName());
-        if (method.getParameterCount() > 0) {
-            methodId.append('(');
-            for (Class<?> param : method.getParameterTypes()) {
-                methodId.append(param.getName()).append(' ');
-            }
-            methodId.append(')');
-        }
-        return methodId.toString();
-    }
-
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/MethodKey.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/MethodKey.java
@@ -1,0 +1,64 @@
+package fish.payara.microprofile.faulttolerance.service;
+
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Identifier of method-related data in Fault Tolerance.
+ * It is essential that the computed signature is referring to the {@link Method} as defined by the target
+ * {@link Object} class not its declaring {@link Class} as this could be different when called via an abstract
+ * {@link Method} implemented or overridden by the target {@link Class}.
+ *
+ * Since MP FT 3.0 all instances of a class share same state object for the same method. Or in other words the FT
+ * context is not specific to an instance but to the annotated class and method.
+ */
+final class MethodKey {
+    final Class<?> targetClass;
+    final Method method;
+    private String methodId;
+
+    MethodKey(InvocationContext ctx) {
+        this.targetClass = ctx.getTarget().getClass();
+        this.method = ctx.getMethod();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MethodKey methodKey = (MethodKey) o;
+        return targetClass.equals(methodKey.targetClass) && method.equals(methodKey.method);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetClass, method);
+    }
+
+    String getMethodId() {
+        if (methodId != null) {
+            return methodId;
+        }
+        StringBuilder idBuilder = new StringBuilder();
+        idBuilder.append(targetClass.getName()).append('.').append(method.getName());
+        if (method.getParameterCount() > 0) {
+            idBuilder.append('(');
+            for (Class<?> param : method.getParameterTypes()) {
+                idBuilder.append(param.getName()).append(' ');
+            }
+            idBuilder.append(')');
+        }
+        methodId = idBuilder.toString();
+        return methodId;
+    }
+
+    @Override
+    public String toString() {
+        return getMethodId();
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractBulkheadTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractBulkheadTest.java
@@ -47,6 +47,8 @@ import fish.payara.microprofile.faulttolerance.FaultToleranceMethodContext;
 import fish.payara.microprofile.faulttolerance.service.FaultToleranceMethodContextStub;
 import fish.payara.microprofile.faulttolerance.service.FaultToleranceServiceStub;
 
+import java.util.function.BiFunction;
+
 /**
  * Base class for tests focusing on the behaviour of methods annotated with the {@link Bulkhead} annotation.
  *
@@ -59,10 +61,8 @@ abstract class AbstractBulkheadTest extends AbstractRecordingTest {
         return new FaultToleranceServiceStub() {
 
             @Override
-            protected FaultToleranceMethodContext createMethodContext(String methodId, InvocationContext context,
-                    FaultTolerancePolicy policy) {
-                return new FaultToleranceMethodContextStub(context, policy, state, concurrentExecutions, waitingQueuePopulation,
-                        (c, p) -> createMethodContext(methodId, c, p)) {
+            protected FaultToleranceMethodContext stubMethodContext(StubContext ctx) {
+                return new FaultToleranceMethodContextStub(ctx, state, concurrentExecutions, waitingQueuePopulation) {
 
                     @Override
                     public void delay(long delayMillis) throws InterruptedException {
@@ -70,7 +70,6 @@ abstract class AbstractBulkheadTest extends AbstractRecordingTest {
                     }
                 };
             }
-
         };
     }
 

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractMetricTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AbstractMetricTest.java
@@ -42,8 +42,6 @@ package fish.payara.microprofile.faulttolerance.policy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import javax.interceptor.InvocationContext;
-
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricRegistry.Type;
 
@@ -69,11 +67,9 @@ abstract class AbstractMetricTest extends AbstractRecordingTest {
         registry = new MetricRegistryImpl(Type.BASE);
         return new FaultToleranceServiceStub() {
             @Override
-            protected FaultToleranceMethodContext createMethodContext(String methodId, InvocationContext context,
-                    FaultTolerancePolicy policy) {
-                FaultToleranceMetrics metrics = new MethodFaultToleranceMetrics(registry, FaultToleranceUtils.getCanonicalMethodName(context));
-                return new FaultToleranceMethodContextStub(context, policy, state, concurrentExecutions, waitingQueuePopulation,
-                        (c, p) -> createMethodContext(methodId, c, p)) {
+            protected FaultToleranceMethodContext stubMethodContext(StubContext ctx) {
+                FaultToleranceMetrics metrics = new MethodFaultToleranceMetrics(registry, FaultToleranceUtils.getCanonicalMethodName(ctx.context));
+                return new FaultToleranceMethodContextStub(ctx, state, concurrentExecutions, waitingQueuePopulation) {
 
                     @Override
                     public FaultToleranceMetrics getMetrics() {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerBasicTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerBasicTest.java
@@ -75,10 +75,8 @@ public class CircuitBreakerBasicTest {
     private final FaultToleranceServiceStub service = new FaultToleranceServiceStub() {
 
         @Override
-        protected FaultToleranceMethodContext createMethodContext(String methodId, InvocationContext context,
-                FaultTolerancePolicy policy) {
-            return new FaultToleranceMethodContextStub(context, policy, state, concurrentExecutions, waitingQueuePopulation,
-                    (c, p) -> createMethodContext(methodId, c, p)) {
+        protected FaultToleranceMethodContext stubMethodContext(StubContext ctx) {
+            return new FaultToleranceMethodContextStub(ctx, state, concurrentExecutions, waitingQueuePopulation) {
 
                 @Override
                 public Future<?> runDelayed(long delayMillis, Runnable task) throws Exception {

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FaultToleranceStressTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FaultToleranceStressTest.java
@@ -66,8 +66,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.interceptor.InvocationContext;
-
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
@@ -119,12 +117,9 @@ public class FaultToleranceStressTest implements FallbackHandler<Future<String>>
 
     final ExecutorService executorService = Executors.newWorkStealingPool(NUMBER_OF_CALLERS / 2);
     final FaultToleranceServiceStub service = new FaultToleranceServiceStub() {
-
         @Override
-        protected FaultToleranceMethodContext createMethodContext(String methodId, InvocationContext context,
-                FaultTolerancePolicy policy) {
-            return new FaultToleranceMethodContextStub(context, policy, state, concurrentExecutions, waitingQueuePopulation,
-                    (c, p) -> createMethodContext(methodId, c, p)) {
+        protected FaultToleranceMethodContext stubMethodContext(StubContext ctx) {
+            return new FaultToleranceMethodContextStub(ctx, state, concurrentExecutions, waitingQueuePopulation) {
                 @Override
                 public CircuitBreakerState getState() {
                     circuitStateAccessCount.incrementAndGet();

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceMethodContextStub.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceMethodContextStub.java
@@ -71,17 +71,16 @@ public class FaultToleranceMethodContextStub implements FaultToleranceMethodCont
     private final AtomicInteger queuingOrRunningPopulation;
     private final BiFunction<InvocationContext, FaultTolerancePolicy, FaultToleranceMethodContext> binder;
 
-    public FaultToleranceMethodContextStub(InvocationContext context, FaultTolerancePolicy policy,
-            AtomicReference<CircuitBreakerState> state,
-            AtomicReference<BlockingQueue<Thread>> concurrentExecutions,
-            AtomicInteger queuingOrRunningPopulation,
-            BiFunction<InvocationContext, FaultTolerancePolicy, FaultToleranceMethodContext> binder) {
-        this.context = context;
-        this.policy = policy;
+    public FaultToleranceMethodContextStub(FaultToleranceServiceStub.StubContext ctx,
+                                           AtomicReference<CircuitBreakerState> state,
+                                           AtomicReference<BlockingQueue<Thread>> concurrentExecutions,
+                                           AtomicInteger queuingOrRunningPopulation) {
+        this.context = ctx.context;
+        this.policy = ctx.policy;
         this.state = state;
         this.concurrentExecutions = concurrentExecutions;
         this.queuingOrRunningPopulation = queuingOrRunningPopulation;
-        this.binder = binder;
+        this.binder = ctx.binder;
     }
 
     @Override


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Small refactorings in Fault Tolerance implementation to make all TCK test pass.

The core change was to return back to standard managed thread pools. These pools propagate application context correctly so the issue with having incorrect application name on invocation stack no longer applies.

However the need for application name was greatly reduced in next optimization, where actual class and method reference are used as keys into state map, further stabilizing the tests.

Also discovered and fixed is memory leak in `FaultTolerancePolicy`'s cache where entires were not deleted upon undeployment, which was troublesome especially for run of TCK. With these two changes together in became apparent that cleanup of method data can be removed, as data has relatively small footprint and keeping them removes confusion on what state of the system is.

## Important Info

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
Full FT 3.0 TCK passes:

payara/MicroProfile-TCK-Runners#133


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

```
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Java version: 1.8.0_275, vendor: Azul Systems, Inc.
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```

## Documentation
<!-- Link documentation if a PR exists -->
Documentation will require update, as all threadpool and cleanup related parameters are not applied anymore.

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->


/cc @jbee, if you have bit of time, check if I didn't misunderstood any of the original intentions of the code.
