### PR TITLE
FISH-659 Fix MP FT executor shutdown

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/service/FaultToleranceServiceImpl.java
@@ -75,7 +75,6 @@ import javax.naming.NamingException;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.event.EventListener;
-import org.glassfish.api.event.EventTypes;
 import org.glassfish.api.event.Events;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
@@ -137,13 +136,6 @@ public class FaultToleranceServiceImpl
             ApplicationInfo info = (ApplicationInfo) event.hook();
             deregisterApplication(info);
             FaultTolerancePolicy.clean(info.getAppClassLoader());
-        } else if (event.is(EventTypes.SERVER_SHUTDOWN)) {
-            if (asyncExecutorService != null) {
-                asyncExecutorService.shutdownNow();
-            }
-            if (delayExecutorService != null) {
-                delayExecutorService.shutdownNow();
-            }
         }
     }
 


### PR DESCRIPTION
Custom thread pools were swapped back to managed executors in the FT
implementation, so the shutdown methods would fail as the executors are
managed so don't require shutdown.

For reproducing the current error, shutdown the server and check the logs.