### PR TITLE
FISH-744 Resource Adapter Config lists thread pools from all instances in the admin console

### DIFF
--- a/appserver/admingui/jca/src/main/java/org/glassfish/jca/admingui/handlers/ConnectorsHandlers.java
+++ b/appserver/admingui/jca/src/main/java/org/glassfish/jca/admingui/handlers/ConnectorsHandlers.java
@@ -37,18 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2020] Payara Foundation and/or affiliates
 
-/*
- * ConnectorHandlers.java
- *
- * Created on Sept 1, 2006, 8:32 AM
- *
- * To change this template, choose Tools | Template Manager
- * and open the template in the editor.
- */
-/**
- *
- */
 package org.glassfish.jca.admingui.handlers;
 
 import com.sun.jsftemplating.annotation.Handler;
@@ -63,9 +53,15 @@ import java.util.HashMap;
 
 
 import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.glassfish.admingui.common.util.GuiUtil;
+import org.glassfish.admingui.common.util.RestUtil;
 
-
+/**
+ * Handlers for the admingui for connector connection pools and adaptors
+ * @since Sept 1 2006
+ */
 public class ConnectorsHandlers {
 
     /** Creates a new instance of ConnectorsHandler */
@@ -227,6 +223,34 @@ public class ConnectorsHandlers {
             }
         }
         handlerCtx.setOutputValue("convertedList", convertedList);
+    }
+    
+    /**
+     * Gets a list of all thread pools in all instances of Payara in the domain.
+     * @param handlerCtx 
+     */
+    @Handler(id = "py.allThreadPools",
+        input = {
+            @HandlerInput(name = "endpoint", type = String.class)},
+        output = {
+            @HandlerOutput(name = "result", type = java.util.List.class)
+    })
+    public static void getAllThreadPools(HandlerContext handlerCtx) {
+        String endpoint = (String) handlerCtx.getInputValue("endpoint");
+        Map<String, Object> attrs = new HashMap<>();
+        try {
+            Map<String, Object> response = RestUtil.restRequest(endpoint, attrs, "GET", handlerCtx, true);
+            Map data = (Map) response.get("data");
+            List poolChildren = (List) data.get("children");
+            List<String> poolNames = new ArrayList<>(poolChildren.size());
+            for (Object threadPoolObject : poolChildren) {
+                Map threadPool = (Map) threadPoolObject;
+                poolNames.add((String) threadPool.get("message"));
+            }
+            handlerCtx.setOutputValue("result", poolNames);
+        } catch (Exception ex) {
+            GuiUtil.handleException(handlerCtx, ex);
+        }
     }
 
 

--- a/appserver/admingui/jca/src/main/resources/resourceAdapterConfigAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/resourceAdapterConfigAttr.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2020] Payara Foundation and/or affiliates -->
 
 <!-- jca/resourceAdapterConfigAttr.inc -->
 <!-- used by resourceAdapterConfigNew.jsf and resourceAdapterConfigEdit.jsf -->
@@ -102,7 +103,7 @@
             //<sun:textField id="threadpoolsid" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.resourceAdapterConfig.ThreadPoolId']}" text="#{pageSession.valueMap['threadPoolIds']}" />
             <sun:dropDown id="threadpoolsid" selected="#{pageSession.valueMap['threadPoolIds']}" labels="#{pageSession.threadPoolList}" >
                 <!beforeCreate
-                    gf.getChildrenNamesList(endpoint="#{sessionScope.REST_URL}/configs/config/server-config/thread-pools/thread-pool"
+                    py.allThreadPools(endpoint="#{sessionScope.REST_URL}/configs/config/server-config/thread-pools/list-threadpools"
                         result="#{requestScope.tmpList}");
                     addEmptyFirstElement(in="#{requestScope.tmpList}" out="#{pageSession.threadPoolList}")
                 />

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/list-threadpools.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/list-threadpools.1
@@ -4,7 +4,7 @@ NAME
        list-threadpools - lists all the thread pools
 
 SYNOPSIS
-           list-threadpools [--help] target
+           list-threadpools [--help] [target]
 
 DESCRIPTION
        The list-threadpools subcommand lists the GlassFish Server thread
@@ -47,6 +47,16 @@ EXAMPLES
                thread-pool-1
                Command list-threadpools executed successfully.
 
+        Example 2, Listing Thread Pools on all instances
+           This example lists the names of thread pools on all instances.
+           N.B. It does not indicate which instances the thread pools are available on.
+
+               asadmin> list-threadpools
+               admin-thread-pool
+               http-thread-pool
+               thread-pool-1
+               remote-create-thread-pool
+
 EXIT STATUS
        0
            subcommand executed successfully
@@ -59,4 +69,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Java EE 8                         20 Dec 2010              list-threadpools(1)
+Jakarta EE 8                         16 Dec 2020              list-threadpools(1)


### PR DESCRIPTION
## Description
This is a bug fix.

Community PR of Jonathan's https://github.com/payara/Payara-Enterprise/pull/264

## Important Info

## Testing

### Testing Performed
Created a new instance with a new config, then created a thread pool in that instance's config. Create a resource adapter config and check that the name of the new thread pool is in the drop down menu for Thread Pool IDs.

### Test suites executed
- Java EE7 Samples

### Testing Environment
Zulu JDK 1.8_272 on Ubuntu 20.04 with Maven 3.6.3

## Documentation
Updated man page in this PR for list-threadpools command
