### PR TITLE
Add appropriate application name to GAV deployments / FISH-1015

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -677,7 +677,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             try {
                 // Convert the provided GAV Strings into target URLs
                 getGAVURLs();
-            } catch (GlassFishException | URISyntaxException ex) {
+            } catch (GlassFishException ex) {
                 LOGGER.log(Level.SEVERE, null, ex);
             }
         }
@@ -1497,7 +1497,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
     }
 
-    private void deployAll() throws GlassFishException, URISyntaxException {
+    private void deployAll() throws GlassFishException {
         // Deploy from within the jar first.
         int deploymentCount = 0;
         Deployer deployer = gf.getDeployer();
@@ -1652,7 +1652,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     try {
                         // Convert the URL to a URI for use with the deploy method
                         URI artefactURI = deploymentMapEntry.getValue().toURI();
-                        String artefactName = removeJavaArchiveExtension(new File(artefactURI).getName());
+                        String artefactName = removeJavaArchiveExtension(new File(artefactURI.getPath()).getName());
 
                         deployer.deploy(artefactURI,
                                 "--availabilityenabled", "true",
@@ -2047,7 +2047,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      * Converts the GAVs provided to a URLs, and stores them in the
      * deploymentURLsMap.
      */
-    private void getGAVURLs() throws GlassFishException, URISyntaxException {
+    private void getGAVURLs() throws GlassFishException {
         GAVConvertor gavConvertor = new GAVConvertor();
 
         for (String gav : GAVs) {
@@ -2080,7 +2080,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             }
 
             for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLsMap.entrySet()) {
-                String artefactName = new File(deploymentMapEntry.getValue().toURI()).getName();
+                String artefactName = new File(deploymentMapEntry.getValue().getPath()).getName();
                 String defaultContext = deploymentMapEntry.getKey();
                 contextRoots.put(artefactName, defaultContext);
             }
@@ -2324,11 +2324,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             try {
                 // Convert the provided GAV Strings into target URLs
                 getGAVURLs();
-                for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLsMap.entrySet()) {
-                    URL deployment = deploymentMapEntry.getValue();
-                    creator.addDeployment(new File(deployment.toURI()).getName(), deployment);
+                for (URL deployment : deploymentURLsMap.values()) {
+                    creator.addDeployment(new File(deployment.getPath()).getName(), deployment);
                 }
-            } catch (GlassFishException | URISyntaxException ex) {
+            } catch (GlassFishException ex) {
                 LOGGER.log(Level.SEVERE, "Unable to process maven deployment units", ex);
             }
         }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1662,8 +1662,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         // Convert the URL to a URI for use with the deploy method
                         URI artefactURI = deploymentMapEntry.getValue().toURI();
 
-                        String artefactName= artefactURI.getPath().substring(artefactURI.getPath().lastIndexOf('/') + 1);
-                        // artefact name always has a valid extension
+                        String artefactName = getFileName(artefactURI.getPath());
                         String name = artefactName.substring(0, artefactName.length() - 4);
 
                         deployer.deploy(artefactURI,
@@ -1683,6 +1682,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
 
         LOGGER.log(Level.INFO, "Deployed {0} archive(s)", deploymentCount);
+    }
+
+    private String getFileName(String filePath) {
+        return filePath.substring(filePath.lastIndexOf('/') + 1);
     }
 
     private boolean hasJavaArchiveExtension(String filePath) {
@@ -2074,7 +2077,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                 }
 
                 URL artefactURL = artefactMapEntry.getValue();
-                String artefactName = artefactURL.getPath().substring(artefactURL.getPath().lastIndexOf('/') + 1);
+                String artefactName = getFileName(artefactURL.getPath());
 
                 deploymentURLsMap.put(defaultContext, artefactURL);
 

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -2054,10 +2054,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private void getGAVURLs() throws GlassFishException {
         GAVConvertor gavConvertor = new GAVConvertor();
 
-        if (contextRoots == null) {
-            contextRoots = new Properties();
-        }
-
         for (String gav : GAVs) {
             try {
                 Map.Entry<String, URL> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURLs);
@@ -2076,14 +2072,21 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     contextRoot = null; // use only once
                 }
 
-                URL artefactURL = artefactMapEntry.getValue();
-                String artefactName = getFileName(artefactURL.getPath());
-
-                deploymentURLsMap.put(defaultContext, artefactURL);
-
-                contextRoots.put(artefactName, defaultContext);
+                deploymentURLsMap.put(defaultContext, artefactMapEntry.getValue());
             } catch (MalformedURLException ex) {
                 throw new GlassFishException(ex.getMessage());
+            }
+        }
+
+        if (deploymentURLsMap != null) {
+            if (contextRoots == null) {
+                contextRoots = new Properties();
+            }
+
+            for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLsMap.entrySet()) {
+                String artefactName = getFileName(deploymentMapEntry.getValue().getPath());
+                String defaultContext = deploymentMapEntry.getKey();
+                contextRoots.put(artefactName, defaultContext);
             }
         }
     }
@@ -2327,7 +2330,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                 getGAVURLs();
                 for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLsMap.entrySet()) {
                     URL deployment = deploymentMapEntry.getValue();
-                    String name = deploymentMapEntry.getKey();
+                    String name = getFileName(deployment.getPath());
                     creator.addDeployment(name, deployment);
                 }
             } catch (GlassFishException ex) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -73,7 +73,7 @@ public class UberJarCreator {
     private final List<File> libs = new LinkedList<>();
     private final List<File> classes = new LinkedList<>();
     private final List<File> deployments = new LinkedList<>();
-    private final Map<String, URL> deploymentURLs = new HashMap<>();
+    private final Map<String, URL> deploymentURLs = new LinkedHashMap<>();
     private List<File> copiedFiles = new LinkedList();
 
     private File deploymentDir;
@@ -281,7 +281,7 @@ public class UberJarCreator {
             // add deployment URLs
             for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLs.entrySet()) {
                 URL deployment = deploymentMapEntry.getValue();
-                String name = deployment.getPath().substring(deployment.getPath().lastIndexOf('/') + 1);
+                String name = deploymentMapEntry.getKey();
                 try (InputStream is = deployment.openStream()) {
                     JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + name);
                     jos.putNextEntry(deploymentEntry);

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -281,7 +281,7 @@ public class UberJarCreator {
             // add deployment URLs
             for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLs.entrySet()) {
                 URL deployment = deploymentMapEntry.getValue();
-                String name = deploymentMapEntry.getKey();
+                String name = deployment.getPath().substring(deployment.getPath().lastIndexOf('/') + 1);
                 try (InputStream is = deployment.openStream()) {
                     JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + name);
                     jos.putNextEntry(deploymentEntry);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a bug fix.

Remote artifact deployed with a temporary name app...tmp. But, e.g., for MDBs we need to specify resource adapter name activation property and we get an deployment error. This fix changes deploy name to `artifactId-version`.

When creating an uber jar a GAV artifacts are added with a context name, not a filename. When executes this uber jar an exception throws if context name length less than or equal 4. In other case we have an incomplete application name (context - last four chars). This fix writes GAV artifacts with their filenames and adds their contexts to the contexts.properties during uber jar creation.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
