### PR TITLE
FISH-876 Failure to connect to hashicorp vault no longer blocks deployment

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -120,22 +120,20 @@ public class HashiCorpSecretsConfigSource extends ConfiguredExtensionConfigSourc
             secretsURL = vaultAddress + "/v1/" + secretsEnginePath + "/" + secretsPath;
         }
 
-        final WebTarget secretsTarget = client
-                .target(secretsURL);
-
-        final Response secretsResponse = secretsTarget
-                .request()
-                .accept(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + hashiCorpVaultToken)
-                .get();
-
-        if (secretsResponse.getStatus() != 200) {
-            LOGGER.log(Level.WARNING, "Unable to get secrets from the vault using the following URL: " + secretsURL + ". "
-                    + "Make sure all the configurtaion options has been entered correctly and HashiCorp Vault Token is correct");
-            return results;
-        }
-
+        final WebTarget secretsTarget = client.target(secretsURL);
         try {
+            final Response secretsResponse = secretsTarget
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + hashiCorpVaultToken)
+                    .get();
+
+            if (secretsResponse.getStatus() != 200) {
+                LOGGER.log(Level.WARNING, "Unable to get secrets from the vault using the following URL: " + secretsURL
+                        + ". Make sure all the configurtaion options has been entered correctly and HashiCorp Vault Token is correct");
+                return results;
+            }
+
             final String secretString = readSecretString((InputStream) secretsResponse.getEntity());
 
             try (final StringReader reader = new StringReader(secretString)) {


### PR DESCRIPTION
## Description
This is a bug fix.

## Important Info


## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
(No access to or installation of Vault needed to reproduce problem)
```
./asadmin start-domain
./asadmin create-password-alias HASHICORP_VAULT_TOKEN
(you can enter 12345 as password)
./asadmin set-hashicorp-config-source-configuration --enabled true --dynamic true --api-version 2 --vault-address http://127.0.0.1:8200 --secrets-engine-path secret --secrets-path hello
./asadmin deploy clusterjsp.war
```
Before PR deployment fails, afterwards deployment succeeds.

### Testing Environment
Zulu JDK 1.8_272 on Ubuntu 20.10 with Maven 3.6.3
