### PR TITLE
FISH-642 Rebuild OpenMQ on Linux to fix line endings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
         <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
         <jms-api.version>2.0.2</jms-api.version>
-        <mq.version>5.1.1.final.payara-p6</mq.version>
+        <mq.version>5.1.1.final.payara-p6.0.1</mq.version>
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>


### PR DESCRIPTION
Title.
The scripts in OpenMQ were running into issues on Linux due to Windows line endings.

PatchedProjects PR: https://github.com/payara/Payara_PatchedProjects/pull/355