### PR TITLE
FISH-877 Add config ordinal to cloud config sources

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/aws/AWSSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/aws/AWSSecretsConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -71,6 +71,8 @@ import org.jvnet.hk2.annotations.Service;
 
 import fish.payara.microprofile.config.extensions.aws.client.AwsRequestBuilder;
 import fish.payara.nucleus.microprofile.config.source.extension.ConfiguredExtensionConfigSource;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
+import javax.inject.Inject;
 
 @Service(name = "aws-secrets-config-source")
 public class AWSSecretsConfigSource extends ConfiguredExtensionConfigSource<AWSSecretsConfigSourceConfiguration> {
@@ -80,6 +82,9 @@ public class AWSSecretsConfigSource extends ConfiguredExtensionConfigSource<AWSS
     private final ObjectMapper mapper = new ObjectMapper();
 
     private AwsRequestBuilder builder;
+    
+    @Inject
+    MicroprofileConfigConfiguration mpconfig;
 
     @Override
     public void bootstrap() {
@@ -163,6 +168,11 @@ public class AWSSecretsConfigSource extends ConfiguredExtensionConfigSource<AWSS
     @Override
     public String getName() {
         return "aws";
+    }
+    
+    @Override
+    public int getOrdinal() {
+        return Integer.parseInt(mpconfig.getCloudOrdinality());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/azure/AzureSecretsConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -52,6 +52,7 @@ import fish.payara.microprofile.config.extensions.azure.model.Secret;
 import fish.payara.microprofile.config.extensions.azure.model.SecretHolder;
 import fish.payara.microprofile.config.extensions.azure.model.SecretsResponse;
 import fish.payara.nucleus.microprofile.config.source.extension.ConfiguredExtensionConfigSource;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
 import fish.payara.security.oauth2.OAuth2Client;
 import java.io.File;
 import java.nio.file.Files;
@@ -96,6 +97,9 @@ public class AzureSecretsConfigSource extends ConfiguredExtensionConfigSource<Az
 
     @Inject
     private ServerEnvironment env;
+    
+    @Inject
+    MicroprofileConfigConfiguration mpconfig;
 
     @Override
     public void bootstrap() {
@@ -257,6 +261,11 @@ public class AzureSecretsConfigSource extends ConfiguredExtensionConfigSource<Az
     @Override
     public String getName() {
         return "azure";
+    }
+    
+    @Override
+    public int getOrdinal() {
+        return Integer.parseInt(mpconfig.getCloudOrdinality());
     }
 
     private File getPrivateKeyFile() {

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/dynamodb/DynamoDBConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/dynamodb/DynamoDBConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -70,6 +70,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import fish.payara.microprofile.config.extensions.aws.client.AwsRequestBuilder;
 import fish.payara.nucleus.microprofile.config.source.extension.ConfiguredExtensionConfigSource;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
+import javax.inject.Inject;
 
 @Service(name = "dynamodb-config-source")
 public class DynamoDBConfigSource extends ConfiguredExtensionConfigSource<DynamoDBConfigSourceConfiguration> {
@@ -78,6 +80,9 @@ public class DynamoDBConfigSource extends ConfiguredExtensionConfigSource<Dynamo
     public static final Set<String> SUPPORTED_DATA_TYPES = new HashSet<>(Arrays.asList("S", "N", "B", "BOOL", "NULL"));
     private static final Logger LOGGER = Logger.getLogger(DynamoDBConfigSource.class.getName());
     private AwsRequestBuilder builder;
+    
+    @Inject
+    MicroprofileConfigConfiguration mpconfig;
 
     @Override
     public void bootstrap() {
@@ -198,6 +203,11 @@ public class DynamoDBConfigSource extends ConfiguredExtensionConfigSource<Dynamo
     @Override
     public String getName() {
         return "dynamodb";
+    }
+    
+    @Override
+    public int getOrdinal() {
+        return Integer.parseInt(mpconfig.getCloudOrdinality());
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/gcp/GCPSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/gcp/GCPSecretsConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -86,6 +86,7 @@ import fish.payara.microprofile.config.extensions.gcp.model.Secret;
 import fish.payara.microprofile.config.extensions.gcp.model.SecretHolder;
 import fish.payara.microprofile.config.extensions.gcp.model.SecretsResponse;
 import fish.payara.nucleus.microprofile.config.source.extension.ConfiguredExtensionConfigSource;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
 import fish.payara.security.oauth2.OAuth2Client;
 
 @Service(name = "gcp-secrets-config-source")
@@ -106,6 +107,9 @@ public class GCPSecretsConfigSource extends ConfiguredExtensionConfigSource<GCPS
 
     @Inject
     private ServerEnvironment env;
+    
+    @Inject
+    MicroprofileConfigConfiguration mpconfig;
 
     @Override
     public void bootstrap() {
@@ -323,6 +327,11 @@ public class GCPSecretsConfigSource extends ConfiguredExtensionConfigSource<GCPS
     @Override
     public String getName() {
         return "gcp";
+    }
+    
+    @Override
+    public int getOrdinal() {
+        return Integer.parseInt(mpconfig.getCloudOrdinality());
     }
 
     // Helpers

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSource.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.stream.JsonParser;
@@ -74,11 +75,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import fish.payara.microprofile.config.extensions.hashicorp.model.SecretHolder;
 import fish.payara.nucleus.microprofile.config.source.extension.ConfiguredExtensionConfigSource;
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
 
 @Service(name = "hashicorp-secrets-config-source")
 public class HashiCorpSecretsConfigSource extends ConfiguredExtensionConfigSource<HashiCorpSecretsConfigSourceConfiguration> {
 
     private static final Logger LOGGER = Logger.getLogger(HashiCorpSecretsConfigSource.class.getName());
+    
+    @Inject
+    MicroprofileConfigConfiguration mpconfig;
 
     private Client client = ClientBuilder.newClient();
     protected String hashiCorpVaultToken;
@@ -166,7 +171,7 @@ public class HashiCorpSecretsConfigSource extends ConfiguredExtensionConfigSourc
         properties.put(secretName, secretValue);
         return modifySecret(properties);
     }
-
+    
     private boolean modifySecret(Map<String, String> properties) {
         //Use version 2 of API by default
         String secretsURL = vaultAddress + "/v1/" + secretsEnginePath + "/data/" + secretsPath;
@@ -246,7 +251,12 @@ public class HashiCorpSecretsConfigSource extends ConfiguredExtensionConfigSourc
     public String getName() {
         return "hashicorp";
     }
-
+    
+    @Override
+    public int getOrdinal() {
+        return Integer.parseInt(mpconfig.getCloudOrdinality());
+    }
+    
     private static void printMisconfigurationMessage() {
         LOGGER.warning("HashiCorp Secrets Config Source isn't configured correctly. "
                 + "Make sure that the password aliases HASHICORP_VAULT_TOKEN exist.");

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/test/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSourceTest.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/test/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSourceTest.java
@@ -1,5 +1,45 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.microprofile.config.extensions.hashicorp;
 
+import fish.payara.nucleus.microprofile.config.spi.MicroprofileConfigConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,6 +73,7 @@ public class HashiCorpSecretsConfigSourceTest {
     private HashiCorpSecretsConfigSource configSource = new HashiCorpSecretsConfigSource();
     private static Response fakeResponse;
     private static WebTarget fakeTarget;
+    private static MicroprofileConfigConfiguration fakeMPConfig;
 
     @Before
     public void initMocks() {
@@ -52,6 +93,10 @@ public class HashiCorpSecretsConfigSourceTest {
         fakeResponse = mock(Response.class);
         when(fakeBuilder.get()).thenReturn(fakeResponse);
         when(fakeResponse.getStatus()).thenReturn(200);
+        
+        fakeMPConfig = mock(MicroprofileConfigConfiguration.class);
+        when(fakeMPConfig.getCloudOrdinality()).thenReturn("180");
+        configSource.mpconfig = fakeMPConfig;
 
     }
 
@@ -71,5 +116,10 @@ public class HashiCorpSecretsConfigSourceTest {
         final String apiVersion2GetResult = "{\"request_id\":\"666f6576-8e81-5938-fcc8-bc8fe914c219\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":36000,\"data\": {\"data\": {\"key\": \"value\",\"secretkey\": \"secretvalue\"}},\"wrap_info\":null,\"warnings\":null,\"auth\":null}";
         when(fakeResponse.getEntity()).thenReturn(new ByteArrayInputStream(apiVersion2GetResult.getBytes()));;
         assertEquals("Incorrect property value", "value", configSource.getValue("key"));
+    }
+    
+    @Test
+    public void testOrdinal() {
+        assertEquals(180, configSource.getOrdinal());
     }
 }


### PR DESCRIPTION
## Description
This is a bug fix

## Important Info
### Blockers

## Testing
### New tests
New test add at https://github.com/payara/Payara/compare/master...Cousjava:FISH-877-mp-config-ordinals-cloud?expand=1#diff-04fc586ba2c85eee6bd5376c25be567f24a810aba8d3b61b686ddb8064cfe54fR122

### Testing Performed
Using the reproducer from FISH-892, also added a config property with the same key but a different value to the domain config properties. Used curl on the endpoint to get the cloud value. Changed the ordinal of cloud config source to be less then that of domain and ran curl again, this time got the value from the domain config.

### Testing Environment
Zulu JDK 1.8_272 on Ubuntu 20.10 with Maven 3.6.3
