### PR TITLE
FISH-990 OpenTracing Active Span is NULL when retrieved in EJB tracer on remote execution

### DIFF
--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -77,6 +77,7 @@ public class OpenTracingService implements EventListener {
 
     // The tracer instances
     private static final Map<String, Tracer> tracers = new ConcurrentHashMap<>();
+    private static final ScopeManager scopeManager = new fish.payara.opentracing.ScopeManager();
     
     // The name of the Corba RMI Tracer
     public static final String PAYARA_CORBA_RMI_TRACER_NAME = "__PAYARA_CORBA_RMI";
@@ -137,13 +138,7 @@ public class OpenTracingService implements EventListener {
             if (Boolean.getBoolean("USE_OPENTRACING_MOCK_TRACER")) {
                 tracer = new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
             } else if (tracer == null) {
-                // Check if we have an ORB Tracer so that we can use its scope manager
-                Tracer orbTracer = tracers.get(PAYARA_CORBA_RMI_TRACER_NAME);
-                if (orbTracer != null) {
-                    tracer = new fish.payara.opentracing.tracer.Tracer(applicationName, orbTracer.scopeManager());
-                } else {
-                    tracer = new fish.payara.opentracing.tracer.Tracer(applicationName);
-                }
+                tracer = new fish.payara.opentracing.tracer.Tracer(applicationName, scopeManager);
             }
 
             // Register the tracer instance to the application

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -137,9 +137,9 @@ public class OpenTracingService implements EventListener {
             if (Boolean.getBoolean("USE_OPENTRACING_MOCK_TRACER")) {
                 tracer = new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
             } else if (tracer == null) {
-                // Check if we have an ORB Tracer with an active span
-                Tracer orbTracer = tracers.get("__PAYARA_CORBA_RMI");
-                if (orbTracer != null && orbTracer.activeSpan() != null) {
+                // Check if we have an ORB Tracer so that we can use its scope manager
+                Tracer orbTracer = tracers.get(PAYARA_CORBA_RMI_TRACER_NAME);
+                if (orbTracer != null) {
                     tracer = new fish.payara.opentracing.tracer.Tracer(applicationName, orbTracer.scopeManager());
                 } else {
                     tracer = new fish.payara.opentracing.tracer.Tracer(applicationName);

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/tracer/Tracer.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/tracer/Tracer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -95,12 +95,8 @@ public class Tracer implements io.opentracing.Tracer {
      * Constructor that registers this Tracer to an application.
      *
      * @param applicationName The application to register this tracer to
+     * @param scopeManager The {@link io.opentracing.ScopeManager} to use with this Tracer
      */
-    public Tracer(String applicationName) {
-        this.applicationName = applicationName;
-        scopeManager = new fish.payara.opentracing.ScopeManager();
-    }
-
     public Tracer(String applicationName, io.opentracing.ScopeManager scopeManager) {
         this.applicationName = applicationName;
         this.scopeManager = scopeManager;


### PR DESCRIPTION

## Description
This is a bug fix.

There were certain scenarios where it was possible for the span propagated from a remote EJB client to not get picked up by the server-side Tracer. This was traced back to the getTracer method - the server-side tracer wasn't using the scope manager of the RMI tracer. There was essentially a race condition present in the creation of Tracers - everything worked _as long as_ the RMI tracer was initialised first _and_ had an active span.

I've changed it so that we now use a shared scope manager across all tracers. The scope manager is focussed on maintaining the thread local active scope, so I don't _think_ this will cause any issues with span scopes bleeding across the different tracers when they shouldn't be.

## Important Info
### Blockers
None

## Testing
### New tests
None.

### Testing Performed
Turned on Request Tracing, and configured it to print out to the log for any trace over 30 microseconds.

Ran the [remote-ejb-tracing](https://github.com/payara/Payara/tree/master/appserver/tests/payara-samples/samples/remote-ejb-tracing) sample, [my old microprofile on micro example](https://github.com/Pandrex247/Payara-Examples/tree/MicroProfileOnMicro/microprofile/microprofile-on-micro), and the project attached to the Jira.

### Testing Environment
Windows 10, JDK 8

## Documentation
N/A

## Notes for Reviewers
I highly recommend you try using your own examples to trigger the traces. Tracing is quite delicate and touches many different parts of code, so poking it in many different ways would be appreciated.

Be aware that since these changes are to the internal tracer, the MicroProfile OpenTracing TCK is of limited use as a testing mechanism here (since it uses the MockTracer).