### PR TITLE
FISH-753 Remove production domain template from Payara Server Community distributions

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -113,7 +113,6 @@
 	  <fileset dir="${runtimedir}" includes="console-**-plugin.jar"/>
 	  <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
 	  <fileset dir="${runtimedir}" includes="**/appserver-domain*.jar"/>
-	  <fileset dir="${runtimedir}" includes="**/production-domain*.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/nucleus-domain.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/weld-se-shaded.jar"/>
 	  <fileset dir="${runtimedir}" includes="**/weld-environment-common.jar"/>
@@ -187,7 +186,7 @@
     <target name="addKeystores">
         <unzip dest="${tempdir}">
             <fileset dir="${runtimedir}/${install.dir.name}/glassfish/common/templates/gf">
-                <include name="production-domain.jar"/>
+                <include name="appserver-domain.jar"/>
             </fileset>
         </unzip>
         <copy todir="${domaindir}">

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2016-2021 Payara Foundation and/or its affiliates -->
 
 <project name="payara-micro" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>

--- a/appserver/packager/glassfish-nucleus/pom.xml
+++ b/appserver/packager/glassfish-nucleus/pom.xml
@@ -139,19 +139,9 @@
            <artifactId>appserver-domain</artifactId>
            <version>${project.version}</version>
        </dependency>
-        <dependency>
-           <groupId>fish.payara.server.internal.admin</groupId>
-           <artifactId>production-domain</artifactId>
-           <version>${project.version}</version>
-       </dependency>
        <dependency>
            <groupId>fish.payara.server.internal.admin</groupId>
            <artifactId>appserver-domain-web</artifactId>
-           <version>${project.version}</version>
-       </dependency>
-       <dependency>
-           <groupId>fish.payara.server.internal.admin</groupId>
-           <artifactId>production-domain-web</artifactId>
            <version>${project.version}</version>
        </dependency>
     </dependencies>

--- a/appserver/packager/glassfish-nucleus/pom.xml
+++ b/appserver/packager/glassfish-nucleus/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2019] [Payara Foundation and/or affiliates] -->
+<!-- Portions Copyright 2017-2021 Payara Foundation and/or affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION

## Description
Removes the _production_ domain template from the Community distributions.

## Important Info
### Blockers
None

## Testing
### New tests
Nope

### Testing Performed
Built the server and checked that the template is no longer present.

Started Micro with https enabled and an app deployed, poking on HTTPS port worked and no **_new_** expired certs in log (though there are some)

### Testing Environment
Windows 10, JDK 8

## Documentation
Nada

## Notes for Reviewers
Zilch
