### PR TITLE
FISH-464 Revert.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
-        <grizzly.version>2.4.4.payara-p5</grizzly.version>
+        <grizzly.version>2.4.4.payara-p6</grizzly.version>
         <jax-rs-api.impl.version>2.1.6</jax-rs-api.impl.version>
         <jersey.version>2.30.payara-p4</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>


### PR DESCRIPTION
Appears to cause the JAXR TCK to fail

Depends on https://github.com/payara/Payara_PatchedProjects/pull/364 and https://github.com/payara/patched-src-grizzly/pull/29
