### PR TITLE
feature(config-api): Make MPCONFIG in TranslatedConfigView debugable / FISH-1079

### DIFF
--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -152,7 +152,7 @@ public class TranslatedConfigView implements ConfigView {
                 if (newValue != null && !newValue.isEmpty()) {
                     stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + newValue + m3.group(3)));
                     m3.reset(stringValue);
-                    Logger.getAnonymousLogger().fine("Found property '"+matchValue+"' in source '"+configValue.getSourceName()+"' with ordinal '"+configValue.getSourceOrdinal()+"'");
+                    Logger.getAnonymousLogger().fine("Found property '" + matchValue + "' in source '" + configValue.getSourceName() + "' with ordinal '" + configValue.getSourceOrdinal() + "'");
                 } else if (defaultValue != null) {
                     stringValue = defaultValue;
                     break;

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -43,6 +43,7 @@ package org.glassfish.config.support;
 
 import com.sun.enterprise.security.store.DomainScopedPasswordAliasStore;
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.ConfigBeanProxy;
@@ -146,13 +147,17 @@ public class TranslatedConfigView implements ConfigView {
                 String matchValue = envValue[0];
                 String defaultValue = envValue.length > 1 ? envValue[1] : null;
                 Config config = configResolver().getConfig();
-                Optional<String> newValue = config.getOptionalValue(matchValue, String.class);
-                if (newValue != null && newValue.isPresent()) {
-                    stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + newValue.get() + m3.group(3)));
+                ConfigValue cValue = config.getConfigValue(matchValue);
+                String newValue = cValue.getValue();
+                if (newValue != null && ! newValue.isEmpty()) {
+                    stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + newValue + m3.group(3)));
                     m3.reset(stringValue);
+                    Logger.getAnonymousLogger().fine("Found property '"+matchValue+"' in source '"+cValue.getSourceName()+"' with ordinal '"+cValue.getSourceOrdinal()+"'");
                 } else if (defaultValue != null) {
                     stringValue = defaultValue;
                     break;
+                } else {
+                    Logger.getAnonymousLogger().warning("MicroProfile Config: property '"+matchValue+"': no value found, no default given.");
                 }
                 i++;
             }

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -149,7 +149,7 @@ public class TranslatedConfigView implements ConfigView {
                 Config config = configResolver().getConfig();
                 ConfigValue configValue = config.getConfigValue(matchValue);
                 String newValue = configValue.getValue();
-                if (newValue != null && ! newValue.isEmpty()) {
+                if (newValue != null && !newValue.isEmpty()) {
                     stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + newValue + m3.group(3)));
                     m3.reset(stringValue);
                     Logger.getAnonymousLogger().fine("Found property '"+matchValue+"' in source '"+configValue.getSourceName()+"' with ordinal '"+configValue.getSourceOrdinal()+"'");
@@ -157,7 +157,7 @@ public class TranslatedConfigView implements ConfigView {
                     stringValue = defaultValue;
                     break;
                 } else {
-                    Logger.getAnonymousLogger().warning("MicroProfile Config: property '"+matchValue+"': no value found, no default given.");
+                    Logger.getAnonymousLogger().warning("MicroProfile Config: property '" + matchValue + "': no value found, no default given.");
                 }
                 i++;
             }

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -147,12 +147,12 @@ public class TranslatedConfigView implements ConfigView {
                 String matchValue = envValue[0];
                 String defaultValue = envValue.length > 1 ? envValue[1] : null;
                 Config config = configResolver().getConfig();
-                ConfigValue cValue = config.getConfigValue(matchValue);
-                String newValue = cValue.getValue();
+                ConfigValue configValue = config.getConfigValue(matchValue);
+                String newValue = configValue.getValue();
                 if (newValue != null && ! newValue.isEmpty()) {
                     stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + newValue + m3.group(3)));
                     m3.reset(stringValue);
-                    Logger.getAnonymousLogger().fine("Found property '"+matchValue+"' in source '"+cValue.getSourceName()+"' with ordinal '"+cValue.getSourceOrdinal()+"'");
+                    Logger.getAnonymousLogger().fine("Found property '"+matchValue+"' in source '"+configValue.getSourceName()+"' with ordinal '"+configValue.getSourceOrdinal()+"'");
                 } else if (defaultValue != null) {
                     stringValue = defaultValue;
                     break;


### PR DESCRIPTION
## Description

Closes #5126

Microprofile Config based variable substitution in TranslatedConfigView:

1. When no value can be found and no default has been given, a warning
   should be printed, so we have a useful error message. Important e. g.
   to track causes when DB connections fail, etc.
2. When a value has been found, it might be the wrong one due to wrong
   ordinal config, human mistake, etc etc. Enabling debugging
   with the TranslatedConfigView will reveal the origin of a value.
   (Thx, MicroProfile Config API 2.0!!!)

## Important Info
This is a demo to outline how this could be done. Might need polishing.

## Testing
### New tests
None yet.

### Testing Performed
None yet, except for the test cases already present.

### Testing Environment
AdoptJDK 11.0.9, Maven 3.6, Linux (Fedora 33)

## Documentation
None yet.

## Notes for Reviewers
None so far.