### PR TITLE
FISH-760 Expand OpenAPI sniffer criteria

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/activation/OpenApiSniffer.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/activation/OpenApiSniffer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -70,7 +70,10 @@ public class OpenApiSniffer extends MicroProfileSniffer {
     public Class<? extends Annotation>[] getAnnotationTypes() {
         return new Class[] {
             // All JAX-RS applications are valid applications for OpenAPI
-            javax.ws.rs.Path.class
+            javax.ws.rs.Path.class,
+            javax.ws.rs.ApplicationPath.class,
+            // OpenAPI detector classes
+            org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition.class
         };
     }
 


### PR DESCRIPTION
OpenAPI applications without @Path annotations weren't being picked up.
For example, apps with an @OpenAPIDefinition and no actual endpoints.
This commit adds extra sniffer searches to expand this selection.