### PR TITLE
FISH-1069 Rationalise Fault Tolerance Configuration

### DIFF
--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/fish/payara/admingui/microprofile/Strings.properties
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/fish/payara/admingui/microprofile/Strings.properties
@@ -1,6 +1,6 @@
 #     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-#     Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+#     Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
 #
 #     The contents of this file are subject to the terms of either the GNU
 #     General Public License Version 2 only ("GPL") or the Common Development
@@ -69,10 +69,10 @@ microprofile.specs.configuration.openAPI.pageTitleHelpText=Configuration option 
 microprofile.specs.configuration.openTracing.pageTitle=OpenTracing API
 microprofile.specs.configuration.openTracing.pageTitleHelpText=OpenTracing is integrated into the Request Tracing Service. You can find configuration options for the Request Tarcing Service <a href="#{request.contextPath}/payaraExtras/requestTracing/requestTracing.jsf?configName=#{pageSession.configName}">here</a>.
 
-faultTolerance.configuration.asyncExecutorPoolMaxSize=Asynchronous Maximum Pool Size
-faultTolerance.configuration.asyncExecutorPoolMaxSizeHelp=The maximum size of the executor thread pool executing asynchronous methods.
-faultTolerance.configuration.delayExecutorMaxPoolSize=Delay Maximum Pool Size
-faultTolerance.configuration.delayExecutorMaxPoolSizeHelp=The maximum size of the executor thread pool scheduling delays and timeouts.
+faultTolerance.configuration.managedExecutorServiceName=Managed Executor Service Name
+faultTolerance.configuration.managedExecutorServiceNameHelp=The name of the managed executor to execute asynchronous methods.
+faultTolerance.configuration.managedScheduledExecutorServiceName=Managed Scheduled Executor Service Name
+faultTolerance.configuration.managedScheduledExecutorServiceNameHelp=The name of the managed executor to schedule delays and timeouts.
 
 healthCheck.configuration.enabled=Enabled
 healthCheck.configuration.enabledHelp=Enables or Disables the Health Check.

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/faultToleranceConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/faultToleranceConfiguration.jsf
@@ -2,7 +2,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -85,19 +85,19 @@
 <sun:propertySheet id="propertySheet">
 #include "/common/shared/configNameSection.inc"
     <sun:propertySheetSection id="faultToleranceProps">
-        <sun:property id="asyncMaxPoolSizeProp" labelAlign="left" 
+        <sun:property id="managedExecutorServiceNameProp" labelAlign="left" 
                       noWrap="#{true}" overlapLabel="#{false}" 
-                      label="$resource{i18n_microprofile.faultTolerance.configuration.asyncExecutorPoolMaxSize}"  
-                      helpText="$resource{i18n_microprofile.faultTolerance.configuration.asyncExecutorPoolMaxSizeHelp}">
-            <sun:textField id="asyncMaxPoolSize" columns="$int{20}" maxLength="5" 
-                      text="#{pageSession.valueMap['asyncMaxPoolSize']}"/>
+                      label="$resource{i18n_microprofile.faultTolerance.configuration.managedExecutorServiceName}"  
+                      helpText="$resource{i18n_microprofile.faultTolerance.configuration.managedExecutorServiceNameHelp}">
+            <sun:textField id="managedExecutorServiceName" columns="$int{60}"
+                      text="#{pageSession.valueMap['managedExecutorServiceName']}"/>
         </sun:property>
-        <sun:property id="delayMaxPoolSizeProp" labelAlign="left" 
+        <sun:property id="managedScheduledExecutorServiceNameProp" labelAlign="left" 
                       noWrap="#{true}" overlapLabel="#{false}" 
-                      label="$resource{i18n_microprofile.faultTolerance.configuration.delayExecutorMaxPoolSize}"  
-                      helpText="$resource{i18n_microprofile.faultTolerance.configuration.delayExecutorMaxPoolSizeHelp}">
-            <sun:textField id="delayMaxPoolSize" columns="$int{20}" maxLength="5" 
-                      text="#{pageSession.valueMap['delayMaxPoolSize']}"/>
+                      label="$resource{i18n_microprofile.faultTolerance.configuration.managedScheduledExecutorServiceName}"  
+                      helpText="$resource{i18n_microprofile.faultTolerance.configuration.managedScheduledExecutorServiceNameHelp}">
+            <sun:textField id="managedScheduledExecutorServiceName" columns="$int{60}"
+                      text="#{pageSession.valueMap['managedScheduledExecutorServiceName']}"/>
         </sun:property>
     </sun:propertySheetSection>
    </sun:propertySheet>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceServiceConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -39,9 +39,6 @@
  */
 package fish.payara.microprofile.faulttolerance;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-
 import org.glassfish.api.admin.config.ConfigExtension;
 import org.jvnet.hk2.config.Attribute;
 import org.jvnet.hk2.config.Configured;
@@ -63,51 +60,4 @@ public interface FaultToleranceServiceConfiguration extends ConfigExtension {
     public String getManagedScheduledExecutorService();
     public void setManagedScheduledExecutorService(String managedScheduledExecutorServiceName);
 
-    /**
-     * @deprecated Managed thread pools are used since 5.2020.8 (again)
-     * @return The maximum number of threads used to run asynchronous methods concurrently. This is the upper limit. The
-     *         executor will vary the actual pool size depending on demand up to this upper limit. If no demand exist
-     *         the actual pool size is zero.
-     */
-    @Deprecated
-    @Attribute(defaultValue = "2000", dataType = Integer.class)
-    @Min(value = 20)
-    String getAsyncMaxPoolSize();
-    void setAsyncMaxPoolSize(String asyncMaxPoolSize);
-
-    /**
-     * @deprecated Managed thread pools are used since 5.2020.8 (again)
-     * @return The maximum number of threads used to schedule delayed execution and detect timeouts processing FT
-     *         semantics. This should be understood as upper limit. The implementation might choose to keep up to this
-     *         number of threads alive or vary the actual pool size according to demands.
-     */
-    @Deprecated
-    @Attribute(defaultValue = "20", dataType = Integer.class)
-    @Min(value = 1)
-    String getDelayMaxPoolSize();
-    void setDelayMaxPoolSize(String delayMaxPoolSize);
-
-    /**
-     * @deprecated Managed thread pools are used since 5.2020.8 (again)
-     * @return The number of seconds an idle worker in the async pool has to be out of work before it is disposed and
-     *         the pool scales down in size. Changes to this setting are dynamically applied and do not need a restart.
-     */
-    @Deprecated
-    @Attribute(defaultValue = "60", dataType = Integer.class)
-    @Min(value = 20)
-    @Max(value = 60 * 60)
-    String getAsyncPoolKeepAliveInSeconds();
-    void setAsyncPoolKeepAliveInSeconds(String asyncPoolKeepAliveInSeconds);
-
-    /**
-     * @deprecated cleaning of FT state has been removed in 5.2020.8
-     * @return The interval duration in minutes for the background job that cleans expired FT state. Changes do need a
-     *         restart of the server.
-     */
-    @Attribute(defaultValue = "1", dataType = Integer.class)
-    @Min(value = 1)
-    @Max(value = 60 * 24)
-    @Deprecated
-    String getCleanupIntervalInMinutes();
-    void setCleanupIntervalInMinutes(String cleanupIntervalInMinutes);
 }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/admin/GetFaultToleranceConfigurationCommand.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/admin/GetFaultToleranceConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -78,7 +78,10 @@ import org.jvnet.hk2.annotations.Service;
 })
 public class GetFaultToleranceConfigurationCommand implements AdminCommand {
 
-    private final String OUTPUT_HEADERS[] = { "Async Max Pool Size", "Delay Max Pool Size" };
+    private final String OUTPUT_HEADERS[] = {
+        "Managed Executor Service Name",
+        "Managed Scheduled Executor Service Name"
+    };
 
     @Inject
     private Target targetUtil;
@@ -100,14 +103,17 @@ public class GetFaultToleranceConfigurationCommand implements AdminCommand {
                 .getExtensionByType(FaultToleranceServiceConfiguration.class);
 
         ColumnFormatter columnFormatter = new ColumnFormatter(OUTPUT_HEADERS);
-        Object[] outputValues = { config.getAsyncMaxPoolSize(), config.getDelayMaxPoolSize() };
+        Object[] outputValues = {
+            config.getManagedExecutorService(),
+            config.getManagedScheduledExecutorService()
+        };
         columnFormatter.addRow(outputValues);
 
         acc.getActionReport().appendMessage(columnFormatter.toString());
 
         Map<String, Object> extraPropertiesMap = new HashMap<>();
-        extraPropertiesMap.put("asyncMaxPoolSize", config.getAsyncMaxPoolSize());
-        extraPropertiesMap.put("delayMaxPoolSize", config.getDelayMaxPoolSize());
+        extraPropertiesMap.put("managedExecutorServiceName", config.getManagedExecutorService());
+        extraPropertiesMap.put("managedScheduledExecutorServiceName", config.getManagedScheduledExecutorService());
         Properties extraProperties = new Properties();
         extraProperties.put("faultToleranceConfiguration", extraPropertiesMap);
         acc.getActionReport().setExtraProperties(extraProperties);


### PR DESCRIPTION
The Fault Tolerance configuration was a bit of a mess, with the correct
configuration parameters not being used, and the incorrect ones being
reported.

This commit makes the managed executor names the configurable options,
and removes the dead configuration options.

As an added bonus, the set command now validates the executor names.
This should work as expected in the admin console and from the command
line.

Docs: https://github.com/payara/Payara-Community-Documentation/pull/135