### PR TITLE
Make Micro boot-time deployment more reliable / FISH-1094

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
@@ -72,7 +72,7 @@ public class DeploymentFileValidator extends Validator {
         }
 
         if (deployment.isFile() && !(filePath.endsWith(".rar") || filePath.endsWith(".jar") || filePath.endsWith(".war"))) {
-            throw new ValidationException(filePath + " is a not valid type of deployment file");
+            throw new ValidationException(filePath + " is a not valid type of deployment archive");
         }
 
         if (deployment.isDirectory() && !new File(filePath, "WEB-INF").exists()) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentGAVValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentGAVValidator.java
@@ -44,7 +44,7 @@ public class DeploymentGAVValidator extends Validator {
     @Override
     boolean validate(String optionValue) throws ValidationException {
         if (optionValue.split("[,:]").length != 3) {
-            throw new ValidationException(optionValue + " is a not valid Maven coordinates");
+            throw new ValidationException(optionValue + " is a not valid maven coordinates");
         }
         return true;
     }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentGAVValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentGAVValidator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,46 +39,13 @@
  */
 package fish.payara.micro.cmd.options;
 
-import java.io.File;
-import java.text.MessageFormat;
-
-/**
- *
- * @author Steve Millidge
- */
-public class DeploymentFileValidator extends Validator {
+public class DeploymentGAVValidator extends Validator {
 
     @Override
     boolean validate(String optionValue) throws ValidationException {
-        String filePath = optionValue;
-
-        // first look for a pathSeparator to indicate a context root
-        long separatorCount = filePath.chars().filter(ch -> ch == File.pathSeparatorChar).count();
-
-        if (separatorCount > 1) {
-            throw new ValidationException(filePath + " has an invalid context root");
-        } else if (separatorCount == 1) {
-            filePath = filePath.substring(0, optionValue.indexOf(File.pathSeparator));
+        if (optionValue.split("[,:]").length != 3) {
+            throw new ValidationException(optionValue + " is a not valid Maven coordinates");
         }
-
-        File deployment = new File(filePath);
-
-        if (!deployment.exists()) {
-            throw new ValidationException(MessageFormat.format(RuntimeOptions.commandlogstrings.getString("fileDoesNotExist"), filePath));
-        }
-
-        if (!deployment.canRead()) {
-            throw new ValidationException(MessageFormat.format(RuntimeOptions.commandlogstrings.getString("fileNotReadable"), filePath));
-        }
-
-        if (deployment.isFile() && !(filePath.endsWith(".rar") || filePath.endsWith(".jar") || filePath.endsWith(".war"))) {
-            throw new ValidationException(filePath + " is a not valid type of deployment file");
-        }
-
-        if (deployment.isDirectory() && !new File(filePath, "WEB-INF").exists()) {
-            throw new ValidationException(filePath + " is a not valid exploded web archive");
-        }
-
         return true;
     }
 }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -132,7 +132,7 @@ public enum RUNTIME_OPTION {
         this.optional = optionalValue;
     }
 
-    boolean validate(String optionValue) throws ValidationException {
+    public boolean validate(String optionValue) throws ValidationException {
         return validator.validate(optionValue);
     }
 

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -46,7 +46,7 @@ package fish.payara.micro.cmd.options;
 public enum RUNTIME_OPTION {
     nocluster(false),
     deploydir(true, new DirectoryValidator(true, true, false)),
-    deploy(true, new DeploymentFileValidator(true, true, false, true, true)),
+    deploy(true, new DeploymentFileValidator()),
     port(true, new PortValidator()),
     sslport(true, new PortValidator()),
     name(true),
@@ -75,7 +75,7 @@ public enum RUNTIME_OPTION {
     lite(false),
     enablehealthcheck(true),
     logo(false),
-    deployfromgav(true),
+    deployfromgav(true, new DeploymentGAVValidator()),
     additionalrepository(true),
     outputuberjar(true, new FileValidator(false, false, false)),
     outputlauncher(false),

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
@@ -131,7 +131,7 @@ public class RuntimeOptions {
                 }
             } else if (arg.endsWith(".war") || arg.endsWith(".rar") || arg.endsWith(".jar")) {
                 // we have a "raw" deployment
-                new FileValidator(true, true, false).validate(arg);
+                RUNTIME_OPTION.deploy.validate(arg);
                 options.add(new AbstractMap.SimpleImmutableEntry<>(RUNTIME_OPTION.deploy, arg));
             } else {
                 invalidArgs.add(arg);

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -40,7 +40,17 @@
 package fish.payara.micro.cmd.options;
 
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Class to specify the runtime options for Payara Micro
@@ -49,7 +59,7 @@ import java.util.*;
  */
 public class RuntimeOptions {
 
-    private Map<RUNTIME_OPTION, List<String>> options;
+    private final List<Map.Entry<RUNTIME_OPTION, String>> options;
     static ResourceBundle commandoptions = ResourceBundle.getBundle("commandoptions");
     static ResourceBundle commandlogstrings = ResourceBundle.getBundle("commandlogstrings");
 
@@ -67,24 +77,24 @@ public class RuntimeOptions {
             output.add(entry);
         }
         
-        //alphabetise
-        Collections.sort(output, String.CASE_INSENSITIVE_ORDER);
+        // alphabetise
+        output.sort(String.CASE_INSENSITIVE_ORDER);
         for (String s : output){
             System.err.println(s);
         }
     }
     
-    public Set<RUNTIME_OPTION> getOptions() {
-        return options.keySet();
+    public List<Map.Entry<RUNTIME_OPTION, String>> getOptions() {
+        return Collections.unmodifiableList(options);
     }
     
     public List<String> getOption(RUNTIME_OPTION option) {
-        return options.get(option);
+        return options.stream().filter(entry -> entry.getKey() == option).map(Map.Entry::getValue).collect(Collectors.toList());
     }
     
-    public RuntimeOptions(String args[]) throws ValidationException {
+    public RuntimeOptions(String[] args) throws ValidationException {
         // parse the arguments into a match 
-        options = new HashMap<>();
+        options = new LinkedList<>();
         Set<String> invalidArgs = new HashSet<>();
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
@@ -111,29 +121,19 @@ public class RuntimeOptions {
                              }
                         }
                     }
-                    List<String> values = options.get(option);
-                    if (values == null) {
-                        values = new LinkedList<>();
-                        options.put(option, values);
-                    }
-                    values.add(value);
+                    options.add(new AbstractMap.SimpleImmutableEntry<>(option, value));
                 } catch (IllegalArgumentException iae) {
-                    throw new ValidationException(MessageFormat.format(commandlogstrings.getString("notValidArgument"),arg));
+                    throw new ValidationException(MessageFormat.format(commandlogstrings.getString("notValidArgument"), arg));
                 } catch (IndexOutOfBoundsException ex) {
-                    throw new ValidationException(MessageFormat.format(commandlogstrings.getString("expectedArgument"),arg));
+                    throw new ValidationException(MessageFormat.format(commandlogstrings.getString("expectedArgument"), arg));
                 } catch (ValidationException ve) {
-                    throw new ValidationException(arg + " " + ve.getMessage(),ve);
+                    throw new ValidationException(arg + " " + ve.getMessage(), ve);
                 }
-            } else if (arg.endsWith(".war") || arg.endsWith(".ear") || arg.endsWith(".rar") || arg.endsWith(".jar")) {
+            } else if (arg.endsWith(".war") || arg.endsWith(".rar") || arg.endsWith(".jar")) {
                 // we have a "raw" deployment
-                List<String> values = options.get(RUNTIME_OPTION.deploy);
-                if (values == null) {
-                    values = new LinkedList<>();
-                    options.put(RUNTIME_OPTION.deploy, values);
-                }
-                values.add(arg);
-            }
-            else {
+                new FileValidator(true, true, false).validate(arg);
+                options.add(new AbstractMap.SimpleImmutableEntry<>(RUNTIME_OPTION.deploy, arg));
+            } else {
                 invalidArgs.add(arg);
             }
         }
@@ -143,7 +143,6 @@ public class RuntimeOptions {
     }
     
     private static int findLongestOption() {
-
         int longest = 0;
 
         for (RUNTIME_OPTION option : RUNTIME_OPTION.values()) {
@@ -155,15 +154,14 @@ public class RuntimeOptions {
     }
 
     private static String rightPad(String toPad, int paddedLength) {
-
         // return input if anything doesn't make sense
-        if (null == toPad || toPad.length() >= paddedLength || paddedLength < 1) {
+        if (null == toPad || toPad.length() >= paddedLength) {
             return toPad;
         }
+        StringBuilder sb = new StringBuilder(toPad);
         for (int i = toPad.length(); i < paddedLength; i++) {
-            toPad += " ";
+            sb.append(" ");
         }
-        return toPad;
+        return sb.toString();
     }
-
 }

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/DeploymentComparator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/DeploymentComparator.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.micro.impl;
 
 import java.io.File;
@@ -18,7 +57,6 @@ public class DeploymentComparator implements Comparator<File> {
         fileExtensions.add(".rar");
         fileExtensions.add(".jar");
         fileExtensions.add(".war");
-        fileExtensions.add(".ear");
     }
 
     /**
@@ -72,7 +110,7 @@ public class DeploymentComparator implements Comparator<File> {
     /**
      * Get the possible file extensions.
      *
-     * @return
+     * @return The possible file extensions
      */
     public List<String> getFileExtensions() {
         return fileExtensions;

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1504,13 +1504,15 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
         boolean contextRootAvailable = contextRoot != null;
         for (Map.Entry<RUNTIME_OPTION, String> deploymentOption : deploymentOptions) {
-            if (deploymentOption.getKey() == RUNTIME_OPTION.deploy) {
-                String fileName = deploymentOption.getValue();
+            RUNTIME_OPTION option = deploymentOption.getKey();
+            String value = deploymentOption.getValue();
+            if (option == RUNTIME_OPTION.deploy) {
+                String fileName = value;
 
                 String deploymentContext = null;
                 if (fileName.contains(File.pathSeparator)) {
-                    deploymentContext = fileName.substring(fileName.indexOf(File.pathSeparator) + 1);
                     fileName = fileName.substring(0, fileName.indexOf(File.pathSeparator));
+                    deploymentContext = value.substring(value.indexOf(File.pathSeparator) + 1);
                 }
 
                 File deployment = new File(fileName);
@@ -1524,7 +1526,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         contextRootAvailable = false;
                     }
                 }
-            } else if (deploymentOption.getKey() == RUNTIME_OPTION.deploydir || deploymentOption.getKey() == RUNTIME_OPTION.deploymentdir) {
+            } else if (option == RUNTIME_OPTION.deploydir || option == RUNTIME_OPTION.deploymentdir) {
                 // Get all files in the directory, and sort them by file type
                 File[] deploymentEntries = deploymentRoot.listFiles();
                 Arrays.sort(deploymentEntries, new DeploymentComparator());
@@ -1537,8 +1539,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         }
                     }
                 }
-            } else if (deploymentOption.getKey() == RUNTIME_OPTION.deployfromgav) {
-                Map.Entry<String, URI> gavEntry = getGAVURI(deploymentOption.getValue());
+            } else if (option == RUNTIME_OPTION.deployfromgav) {
+                Map.Entry<String, URI> gavEntry = getGAVURI(value);
                 URI artifactURI = gavEntry.getValue();
 
                 String artifactName = new File(artifactURI.getPath()).getName();

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,7 +39,34 @@
  */
 package fish.payara.micro.impl;
 
+import com.sun.appserv.server.util.Version;
+import com.sun.enterprise.glassfish.bootstrap.Constants;
+import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
+import com.sun.enterprise.server.logging.ODLLogFormatter;
+import fish.payara.appserver.rest.endpoints.config.admin.ListRestEndpointsCommand;
+import fish.payara.boot.runtime.BootCommand;
+import fish.payara.boot.runtime.BootCommands;
+import fish.payara.deployment.util.GAVConvertor;
+import fish.payara.micro.BootstrapException;
+import fish.payara.micro.PayaraMicroRuntime;
+import fish.payara.micro.boot.AdminCommandRunner;
+import fish.payara.micro.boot.PayaraMicroBoot;
 import fish.payara.micro.boot.PayaraMicroLauncher;
+import fish.payara.micro.boot.loader.OpenURLClassLoader;
+import fish.payara.micro.cmd.options.RUNTIME_OPTION;
+import fish.payara.micro.cmd.options.RuntimeOptions;
+import fish.payara.micro.cmd.options.ValidationException;
+import fish.payara.micro.data.InstanceDescriptor;
+import fish.payara.nucleus.executorservice.PayaraFileWatcher;
+import org.glassfish.embeddable.BootstrapProperties;
+import org.glassfish.embeddable.CommandRunner;
+import org.glassfish.embeddable.Deployer;
+import org.glassfish.embeddable.GlassFish;
+import org.glassfish.embeddable.GlassFish.Status;
+import org.glassfish.embeddable.GlassFishException;
+import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -54,6 +81,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
@@ -73,35 +102,6 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import com.sun.appserv.server.util.Version;
-import com.sun.enterprise.glassfish.bootstrap.Constants;
-import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
-import com.sun.enterprise.server.logging.ODLLogFormatter;
-
-import org.glassfish.embeddable.BootstrapProperties;
-import org.glassfish.embeddable.CommandRunner;
-import org.glassfish.embeddable.Deployer;
-import org.glassfish.embeddable.GlassFish;
-import org.glassfish.embeddable.GlassFish.Status;
-import org.glassfish.embeddable.GlassFishException;
-import org.glassfish.embeddable.GlassFishProperties;
-import org.glassfish.embeddable.GlassFishRuntime;
-
-import fish.payara.appserver.rest.endpoints.config.admin.ListRestEndpointsCommand;
-import fish.payara.boot.runtime.BootCommand;
-import fish.payara.boot.runtime.BootCommands;
-import fish.payara.deployment.util.GAVConvertor;
-import fish.payara.micro.BootstrapException;
-import fish.payara.micro.PayaraMicroRuntime;
-import fish.payara.micro.boot.AdminCommandRunner;
-import fish.payara.micro.boot.PayaraMicroBoot;
-import fish.payara.micro.boot.loader.OpenURLClassLoader;
-import fish.payara.micro.cmd.options.RUNTIME_OPTION;
-import fish.payara.micro.cmd.options.RuntimeOptions;
-import fish.payara.micro.cmd.options.ValidationException;
-import fish.payara.micro.data.InstanceDescriptor;
-import fish.payara.nucleus.executorservice.PayaraFileWatcher;
-
 /**
  * Main class for Bootstrapping Payara Micro Edition This class is used from
  * applications to create a full JavaEE runtime environment and deploy war
@@ -113,11 +113,12 @@ import fish.payara.nucleus.executorservice.PayaraFileWatcher;
  */
 public class PayaraMicroImpl implements PayaraMicroBoot {
 
+    private static final Logger LOGGER = Logger.getLogger("PayaraMicro");
+
     private static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
     private static final String USER_PROPS_FILE = "MICRO-INF/deploy/payaramicro.properties";
     private static final String CONTEXT_PROPS_FILE = "MICRO-INF/deploy/contexts.properties";
 
-    private static final Logger LOGGER = Logger.getLogger("PayaraMicro");
     private static PayaraMicroImpl instance;
 
     private String hzMulticastGroup;
@@ -135,7 +136,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private File deploymentRoot;
     private File alternateDomainXML;
     private File alternateHZConfigFile;
-    private List<File> deployments;
+    private List<Map.Entry<RUNTIME_OPTION, String>> deploymentOptions;
+    private Map<String, URI> deployments;
     private Properties contextRoots;
     private List<File> libraries;
     private GlassFish gf;
@@ -157,12 +159,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private String applicationDomainXml;
     private boolean enableHealthCheck = false;
     private boolean disablePhoneHome = false;
-    private List<String> GAVs;
     private File uberJar;
     private boolean outputLauncher;
     private File copyDirectory;
     private Properties userSystemProperties;
-    private Map<String, URL> deploymentURLsMap;
     private List<String> repositoryURLs;
     private final String defaultMavenRepository = "https://repo.maven.apache.org/maven2/";
     private final short defaultHttpPort = 8080;
@@ -574,7 +574,17 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     public PayaraMicroImpl setDeploymentDir(File deploymentRoot) {
         //if (runtime != null) {
         checkNotRunning();
+        if (!deploymentRoot.isDirectory() || !deploymentRoot.canRead()) {
+            throw new IllegalArgumentException(deploymentRoot.getPath() + " is a not valid deployment dir");
+        }
+        if (deploymentOptions == null) {
+            deploymentOptions = new LinkedList<>();
+        }
+        if (this.deploymentRoot != null) {
+            LOGGER.warning("Multiple deploy dirs only the last one will apply");
+        }
         this.deploymentRoot = deploymentRoot;
+        deploymentOptions.add(new AbstractMap.SimpleImmutableEntry<>(RUNTIME_OPTION.deploydir, null));
         return this;
     }
 
@@ -651,10 +661,14 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     public PayaraMicroImpl addDeploymentFile(File file) {
         //if (runtime != null) {
         checkNotRunning();
-        if (deployments == null) {
-            deployments = new LinkedList<>();
+        if ((file.isFile() && !hasJavaArchiveExtension(file.getName()))
+            || (file.isDirectory() && !new File(file.getPath(), "WEB-INF").exists())) {
+            throw new IllegalArgumentException(file.getPath() + " is a not valid deployment");
         }
-        deployments.add(file);
+        if (deploymentOptions == null) {
+            deploymentOptions = new LinkedList<>();
+        }
+        deploymentOptions.add(new AbstractMap.SimpleImmutableEntry<>(RUNTIME_OPTION.deploy, file.getPath()));
         return this;
     }
 
@@ -669,18 +683,13 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     public PayaraMicroImpl addDeployFromGAV(String GAV) {
         //if (runtime != null) {
         checkNotRunning();
-        if (GAVs == null) {
-            GAVs = new LinkedList<>();
+        if (GAV.split("[,:]").length != 3) {
+            throw new IllegalArgumentException(GAV + " is a not valid maven coordinates");
         }
-        GAVs.add(GAV);
-        if (GAVs != null) {
-            try {
-                // Convert the provided GAV Strings into target URLs
-                getGAVURLs();
-            } catch (GlassFishException ex) {
-                LOGGER.log(Level.SEVERE, null, ex);
-            }
+        if (deploymentOptions == null) {
+            deploymentOptions = new LinkedList<>();
         }
+        deploymentOptions.add(new AbstractMap.SimpleImmutableEntry<>(RUNTIME_OPTION.deployfromgav, GAV));
         return this;
     }
 
@@ -1102,7 +1111,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     @Override
     public void shutdown() throws BootstrapException {
         if (!isRunning()) {
-
             throw new IllegalStateException("Payara Micro is not running");
         }
         runtime.shutdown();
@@ -1120,7 +1128,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     }
 
     private void scanArgs(String[] args) {
-
         RuntimeOptions options = null;
         try {
             options = new RuntimeOptions(args);
@@ -1132,283 +1139,270 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         processUserProperties(options);
         setArgumentsFromSystemProperties();
 
-        for (RUNTIME_OPTION option : options.getOptions()) {
-            List<String> values = options.getOption(option);
-            for (String value : values) {
-                switch (option) {
-                    case port: {
-                        httpPort = Integer.parseInt(value);
-                        break;
+        for (Map.Entry<RUNTIME_OPTION, String> optionEntry : options.getOptions()) {
+            RUNTIME_OPTION option = optionEntry.getKey();
+            String value = optionEntry.getValue();
+            switch (option) {
+                case port: {
+                    httpPort = Integer.parseInt(value);
+                    break;
+                }
+                case sslport: {
+                    sslPort = Integer.parseInt(value);
+                    break;
+                }
+                case sslcert: {
+                    sslCert = value;
+                    break;
+                }
+                case version: {
+                    printVersion();
+                    System.exit(1);
+                    break;
+                }
+                case maxhttpthreads: {
+                    maxHttpThreads = Integer.parseInt(value);
+                    break;
+                }
+                case minhttpthreads: {
+                    minHttpThreads = Integer.parseInt(value);
+                    break;
+                }
+                case mcaddress:
+                    hzMulticastGroup = value;
+                    break;
+                case clustername:
+                    hzClusterName = value;
+                    break;
+                case clusterpassword:
+                    hzClusterPassword = value;
+                    break;
+                case hostaware: {
+                    hostAware = true;
+                    break;
+                }
+                case nohostaware: {
+                    hostAware = false;
+                    break;
+                }
+                case mcport: {
+                    hzPort = Integer.parseInt(value);
+                    break;
+                }
+                case startport:
+                    hzStartPort = Integer.parseInt(value);
+                    break;
+                case name:
+                    instanceName = value;
+                    break;
+                case instancegroup:
+                case group:
+                    instanceGroup = value;
+                    break;
+                case deploymentdir:
+                case deploydir:
+                    if (deploymentRoot != null) {
+                        LOGGER.warning("Multiple --deploydir arguments only the last one will apply");
                     }
-                    case sslport: {
-                        sslPort = Integer.parseInt(value);
-                        break;
+                    deploymentRoot = new File(value);
+                    if (deploymentOptions == null) {
+                        deploymentOptions = new LinkedList<>();
                     }
-                    case sslcert: {
-                        sslCert = value;
-                        break;
-                    }
-                    case version: {
-                        printVersion();
-                        System.exit(1);
-                        break;
-                    }
-                    case maxhttpthreads: {
-                        maxHttpThreads = Integer.parseInt(value);
-                        break;
-                    }
-                    case minhttpthreads: {
-                        minHttpThreads = Integer.parseInt(value);
-                        break;
-                    }
-                    case mcaddress:
-                        hzMulticastGroup = value;
-                        break;
-                    case clustername:
-                        hzClusterName = value;
-                        break;
-                    case clusterpassword:
-                        hzClusterPassword = value;
-                        break;
-                    case hostaware: {
-                        hostAware = true;
-                        break;
-                    }
-                    case nohostaware: {
-                        hostAware = false;
-                        break;
-                    }
-                    case mcport: {
-                        hzPort = Integer.parseInt(value);
-                        break;
-                    }
-                    case startport:
-                        hzStartPort = Integer.parseInt(value);
-                        break;
-                    case name:
-                        instanceName = value;
-                        break;
-                    case instancegroup:
-                    case group:
-                        instanceGroup = value;
-                        break;
-                    case deploymentdir:
-                    case deploydir:
-                        deploymentRoot = new File(value);
-                        break;
-                    case rootdir:
-                        rootDir = new File(value);
-                        break;
-                    case addlibs:
-                    case addjars:
-                        List<File> files = UberJarCreator.parseFileList(value, File.pathSeparator);
-                        if (!files.isEmpty()) {
-                            if (libraries == null) {
-                                libraries = new LinkedList<>();
-                            }
-                            libraries.addAll(files);
+                    deploymentOptions.add(new AbstractMap.SimpleImmutableEntry<>(option, null));
+                    break;
+                case rootdir:
+                    rootDir = new File(value);
+                    break;
+                case addlibs:
+                case addjars:
+                    List<File> files = UberJarCreator.parseFileList(value, File.pathSeparator);
+                    if (!files.isEmpty()) {
+                        if (libraries == null) {
+                            libraries = new LinkedList<>();
                         }
-                        break;
-                    case deploy:
-                        // check for context root definition
-                        if (deployments == null) {
-                            deployments = new LinkedList<>();
-                            contextRoots = new Properties();
-                        }
-                        String fileName = value;
-                        String deployContext = null;
-                        if (value != null && value.contains(File.pathSeparator)) {
-                            fileName = value.substring(0, value.indexOf(File.pathSeparatorChar));
-                            deployContext = value.substring(value.indexOf(File.pathSeparatorChar) + 1);
-                        }
-                        File deployment = new File(fileName);
-                        deployments.add(deployment);
-                        if (deployContext != null) {
-                            contextRoots.put(deployment.getName(), deployContext);
-                        }
-                        break;
-                    case domainconfig:
-                        alternateDomainXML = new File(value);
-                        break;
-                    case nocluster:
-                        noCluster = true;
-                        break;
-                    case lite:
-                        liteMember = true;
-                        break;
-                    case hzconfigfile:
-                        alternateHZConfigFile = new File(value);
-                        break;
-                    case autobindhttp:
-                        autoBindHttp = true;
-                        break;
-                    case autobindssl:
-                        autoBindSsl = true;
-                        break;
-                    case autobindrange:
-                        autoBindRange = Integer.parseInt(value);
-                        break;
-                    case enablehealthcheck:
-                        enableHealthCheck = Boolean.parseBoolean(value);
-                        break;
-                    case deployfromgav:
-                        if (GAVs == null) {
-                            GAVs = new LinkedList<>();
-                        }
-                        GAVs.add(value);
-                        break;
-                    case additionalrepository:
-                        repositoryURLs.add(value);
-                        break;
-                    case outputuberjar:
-                        uberJar = new File(value);
-                        break;
-                    case copytouberjar:
-                        copyDirectory = new File(value);
-                        break;
-                    case outputlauncher:
-                        outputLauncher = true;
-                        break;
-                    case warmup:
-                        warmup = true;
-                        break;
-                    case disablephonehome:
-                        disablePhoneHome = true;
-                        break;
-                    case enablerequesttracing:
-                        enableRequestTracing = true;
+                        libraries.addAll(files);
+                    }
+                    break;
+                case deploy:
+                case deployfromgav:
+                    if (deploymentOptions == null) {
+                        deploymentOptions = new LinkedList<>();
+                    }
+                    deploymentOptions.add(new AbstractMap.SimpleImmutableEntry<>(option, value));
+                    break;
+                case domainconfig:
+                    alternateDomainXML = new File(value);
+                    break;
+                case nocluster:
+                    noCluster = true;
+                    break;
+                case lite:
+                    liteMember = true;
+                    break;
+                case hzconfigfile:
+                    alternateHZConfigFile = new File(value);
+                    break;
+                case autobindhttp:
+                    autoBindHttp = true;
+                    break;
+                case autobindssl:
+                    autoBindSsl = true;
+                    break;
+                case autobindrange:
+                    autoBindRange = Integer.parseInt(value);
+                    break;
+                case enablehealthcheck:
+                    enableHealthCheck = Boolean.parseBoolean(value);
+                    break;
+                case additionalrepository:
+                    repositoryURLs.add(value);
+                    break;
+                case outputuberjar:
+                    uberJar = new File(value);
+                    break;
+                case copytouberjar:
+                    copyDirectory = new File(value);
+                    break;
+                case outputlauncher:
+                    outputLauncher = true;
+                    break;
+                case warmup:
+                    warmup = true;
+                    break;
+                case disablephonehome:
+                    disablePhoneHome = true;
+                    break;
+                case enablerequesttracing:
+                    enableRequestTracing = true;
 
-                        // Check if a value has actually been given
-                        // Split strings from numbers
-                        if (value != null) {
-                            String[] requestTracing = value.split("(?<=\\d)(?=\\D)|(?=\\d)(?<=\\D)");
-                            // If valid, there should be no more than 2 entries
-                            if (requestTracing.length <= 2) {
-                                // If the first entry is a number
-                                if (requestTracing[0].matches("\\d+")) {
-                                    requestTracingThresholdValue = parseArgument(requestTracing[0],
-                                            "request tracing threshold value", Long::parseLong);
-                                    // If there is a second entry, and it's a String
-                                    if (requestTracing.length == 2 && requestTracing[1].matches("\\D+")) {
-                                        requestTracingThresholdUnit = parseTimeUnit(requestTracing[1],
-                                                "request tracing threshold unit").name();
-                                    }
-                                } // If the first entry is a String
-                                else if (requestTracing[0].matches("\\D+")) {
-                                    requestTracingThresholdUnit = parseTimeUnit(requestTracing[0],
+                    // Check if a value has actually been given
+                    // Split strings from numbers
+                    if (value != null) {
+                        String[] requestTracing = value.split("(?<=\\d)(?=\\D)|(?=\\d)(?<=\\D)");
+                        // If valid, there should be no more than 2 entries
+                        if (requestTracing.length <= 2) {
+                            // If the first entry is a number
+                            if (requestTracing[0].matches("\\d+")) {
+                                requestTracingThresholdValue = parseArgument(requestTracing[0],
+                                        "request tracing threshold value", Long::parseLong);
+                                // If there is a second entry, and it's a String
+                                if (requestTracing.length == 2 && requestTracing[1].matches("\\D+")) {
+                                    requestTracingThresholdUnit = parseTimeUnit(requestTracing[1],
                                             "request tracing threshold unit").name();
                                 }
-                            } else {
-                                throw new IllegalArgumentException();
+                            } // If the first entry is a String
+                            else if (requestTracing[0].matches("\\D+")) {
+                                requestTracingThresholdUnit = parseTimeUnit(requestTracing[0],
+                                        "request tracing threshold unit").name();
                             }
+                        } else {
+                            throw new IllegalArgumentException();
                         }
-                        break;
-                    case requesttracingthresholdunit:
-                        requestTracingThresholdUnit = parseTimeUnit(value, "value for --requestTracingThresholdUnit").name();
-                        break;
-                    case requesttracingthresholdvalue:
-                        requestTracingThresholdValue = parseArgument(value, "value for --requestTracingThresholdValue",
-                                Long::parseLong);
-                        break;
-                    case enablerequesttracingadaptivesampling:
-                        enableRequestTracingAdaptiveSampling = true;
-                        break;
-                    case requesttracingadaptivesamplingtargetcount:
-                        enableRequestTracingAdaptiveSampling = true;
-                        requestTracingAdaptiveSamplingTargetCount = parseArgument(value,
-                                "value for --requestTracingAdaptiveSamplingTargetCount", Integer::parseInt);
-                        break;
-                    case requesttracingadaptivesamplingtimevalue:
-                        enableRequestTracingAdaptiveSampling = true;
-                        requestTracingAdaptiveSamplingTimeValue = parseArgument(value,
-                                "value for --requestTracingAdaptiveSamplingTimeValue", Integer::parseInt);
-                        break;
-                    case requesttracingadaptivesamplingtimeunit:
-                        enableRequestTracingAdaptiveSampling = true;
-                        requestTracingAdaptiveSamplingTimeUnit = parseTimeUnit(value,
-                                "value for --requestTracingAdaptiveSamplingTimeUnit").name();
-                        break;
-                    case help:
-                        RuntimeOptions.printHelp();
-                        System.exit(1);
-                        break;
-                    case logtofile:
-                        setUserLogFile(value);
-                        break;
-                    case accesslog:
-                        File file = new File(value);
-                        setAccessLogDir(file.getAbsolutePath());
-                        break;
-                    case accesslogformat:
-                        setAccessLogFormat(value);
-                        break;
-                    case logproperties:
-                        setLogPropertiesFile(new File(value));
-                        break;
-                    case enabledynamiclogging:
-                        enableDynamicLogging = true;
-                        break;
-                    case logo:
-                        generateLogo = true;
-                        break;
-                    case postbootcommandfile:
-                        postBootFileName = value;
-                        break;
-                    case prebootcommandfile:
-                        preBootFileName = value;
-                        break;
-                    case postdeploycommandfile:
-                        postDeployFileName = value;
-                        break;
-                    case clustermode:
-                        clustermode = value;
-                        break;
-                    case interfaces:
-                        interfaces = value;
-                        break;
-                    case secretsdir:
-                        secretsDir = value;
-                        break;
-                    case showservletmappings:
-                        showServletMappings = true;
-                        break;
-                    case enablesni:
-                        sniEnabled = true;
-                        break;
-                    case hzpublicaddress:
-                        publicAddress = value;
-                        break;
-                    case shutdowngrace:
-                        System.setProperty(GlassFishImpl.PAYARA_SHUTDOWNGRACE_PROPERTY, value);
-                        break;
-                    case hzinitialjoinwait:
-                        initialJoinWait = Integer.parseInt(value);
-                        break;
-                    case contextroot:
-
-                        if (contextRoot != null) {
-                            LOGGER.warning("Multiple --contextroot arguments only the last one will apply");
-                        }
-                        contextRoot = value;
-                        if (contextRoot.equals("ROOT")) {
-                            contextRoot = "/";
-                        }
-                        break;
-                    case accessloginterval:
-                        accessLogInterval = Integer.parseInt(value);
-                        break;
-                    case accesslogsuffix:
-                        accessLogSuffix = value;
-                        break;
-                    case accesslogprefix:
-                        accessLogPrefix = value;
-                        break;
-                    default:
-                        break;
-                }
+                    }
+                    break;
+                case requesttracingthresholdunit:
+                    requestTracingThresholdUnit = parseTimeUnit(value, "value for --requestTracingThresholdUnit").name();
+                    break;
+                case requesttracingthresholdvalue:
+                    requestTracingThresholdValue = parseArgument(value, "value for --requestTracingThresholdValue",
+                            Long::parseLong);
+                    break;
+                case enablerequesttracingadaptivesampling:
+                    enableRequestTracingAdaptiveSampling = true;
+                    break;
+                case requesttracingadaptivesamplingtargetcount:
+                    enableRequestTracingAdaptiveSampling = true;
+                    requestTracingAdaptiveSamplingTargetCount = parseArgument(value,
+                            "value for --requestTracingAdaptiveSamplingTargetCount", Integer::parseInt);
+                    break;
+                case requesttracingadaptivesamplingtimevalue:
+                    enableRequestTracingAdaptiveSampling = true;
+                    requestTracingAdaptiveSamplingTimeValue = parseArgument(value,
+                            "value for --requestTracingAdaptiveSamplingTimeValue", Integer::parseInt);
+                    break;
+                case requesttracingadaptivesamplingtimeunit:
+                    enableRequestTracingAdaptiveSampling = true;
+                    requestTracingAdaptiveSamplingTimeUnit = parseTimeUnit(value,
+                            "value for --requestTracingAdaptiveSamplingTimeUnit").name();
+                    break;
+                case help:
+                    RuntimeOptions.printHelp();
+                    System.exit(1);
+                    break;
+                case logtofile:
+                    setUserLogFile(value);
+                    break;
+                case accesslog:
+                    File file = new File(value);
+                    setAccessLogDir(file.getAbsolutePath());
+                    break;
+                case accesslogformat:
+                    setAccessLogFormat(value);
+                    break;
+                case logproperties:
+                    setLogPropertiesFile(new File(value));
+                    break;
+                case enabledynamiclogging:
+                    enableDynamicLogging = true;
+                    break;
+                case logo:
+                    generateLogo = true;
+                    break;
+                case postbootcommandfile:
+                    postBootFileName = value;
+                    break;
+                case prebootcommandfile:
+                    preBootFileName = value;
+                    break;
+                case postdeploycommandfile:
+                    postDeployFileName = value;
+                    break;
+                case clustermode:
+                    clustermode = value;
+                    break;
+                case interfaces:
+                    interfaces = value;
+                    break;
+                case secretsdir:
+                    secretsDir = value;
+                    break;
+                case showservletmappings:
+                    showServletMappings = true;
+                    break;
+                case enablesni:
+                    sniEnabled = true;
+                    break;
+                case hzpublicaddress:
+                    publicAddress = value;
+                    break;
+                case shutdowngrace:
+                    System.setProperty(GlassFishImpl.PAYARA_SHUTDOWNGRACE_PROPERTY, value);
+                    break;
+                case hzinitialjoinwait:
+                    initialJoinWait = Integer.parseInt(value);
+                    break;
+                case contextroot:
+                    if (contextRoot != null) {
+                        LOGGER.warning("Multiple --contextroot arguments only the last one will apply");
+                    }
+                    contextRoot = value;
+                    if (contextRoot.equals("ROOT")) {
+                        contextRoot = "/";
+                    }
+                    break;
+                case accessloginterval:
+                    accessLogInterval = Integer.parseInt(value);
+                    break;
+                case accesslogsuffix:
+                    accessLogSuffix = value;
+                    break;
+                case accesslogprefix:
+                    accessLogPrefix = value;
+                    break;
+                default:
+                    break;
             }
         }
-
     }
 
     private void configureRequestTracingService() {
@@ -1497,6 +1491,91 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
     }
 
+    private void processDeploymentOptions() throws GlassFishException {
+        if (deploymentOptions == null) {
+            return;
+        }
+
+        if (deployments == null) {
+            deployments = new LinkedHashMap<>();
+        }
+
+        for (Map.Entry<RUNTIME_OPTION, String> deploymentOption : deploymentOptions) {
+            if (deploymentOption.getKey() == RUNTIME_OPTION.deploy) {
+                String fileName = deploymentOption.getValue();
+
+                String deploymentContext = null;
+                if (fileName.contains(File.pathSeparator)) {
+                    deploymentContext = fileName.substring(fileName.indexOf(File.pathSeparator) + 1);
+                    fileName = fileName.substring(0, fileName.indexOf(File.pathSeparator));
+                }
+
+                File deployment = new File(fileName);
+
+                deployments.put(deployment.getName(), deployment.toURI());
+
+                if ((deployment.isFile() && deployment.getName().endsWith(".war"))
+                    || (deployment.isDirectory() && new File(deployment.getPath(), "WEB-INF").exists())) {
+                    if (deploymentContext == null) {
+                        if (contextRoot != null) {
+                            deploymentContext = contextRoot;
+                            contextRoot = null; // use only once
+                        } else if (deployment.isDirectory()) {
+                            deploymentContext = deployment.getName();
+                        }
+                    }
+                    if (deploymentContext != null) {
+                        addDeploymentContext(deployment.getName(), deploymentContext);
+                    }
+                }
+            } else if (deploymentOption.getKey() == RUNTIME_OPTION.deploydir || deploymentOption.getKey() == RUNTIME_OPTION.deploymentdir) {
+                // Get all files in the directory, and sort them by file type
+                File[] deploymentEntries = deploymentRoot.listFiles();
+                Arrays.sort(deploymentEntries, new DeploymentComparator());
+
+                for (File deploymentEntry : deploymentEntries) {
+                    if (deploymentEntry.isFile() && deploymentEntry.canRead() && hasJavaArchiveExtension(deploymentEntry.getName())) {
+                        deployments.put(deploymentEntry.getName(), deploymentEntry.toURI());
+
+                        if (deploymentEntry.getName().endsWith(".war")) {
+                            String deploymentContext = contextRoot;
+                            contextRoot = null; // use only once
+                            if (deploymentContext != null) {
+                                addDeploymentContext(deploymentEntry.getName(), deploymentContext);
+                            }
+                        }
+                    }
+                }
+            } else if (deploymentOption.getKey() == RUNTIME_OPTION.deployfromgav) {
+                Map.Entry<String, URI> gavEntry = resolveGAV(deploymentOption.getValue());
+                URI artifactURI = gavEntry.getValue();
+
+                String artifactName = new File(artifactURI.getPath()).getName();
+
+                deployments.put(artifactName, artifactURI);
+
+                if (artifactName.endsWith(".war")) {
+                    String deploymentContext = contextRoot;
+                    contextRoot = null; // use only once
+                    if (deploymentContext == null) {
+                        deploymentContext = gavEntry.getKey();
+                    }
+                    addDeploymentContext(artifactName, deploymentContext);
+                }
+            }
+        }
+    }
+
+    private void addDeploymentContext(String fileName, String deploymentContext) {
+        if (contextRoots == null) {
+            contextRoots = new Properties();
+        }
+        if ("ROOT".equals(deploymentContext)) {
+            deploymentContext = "/";
+        }
+        contextRoots.put(fileName, deploymentContext);
+    }
+
     private void deployAll() throws GlassFishException {
         // Deploy from within the jar first.
         int deploymentCount = 0;
@@ -1505,7 +1584,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         // load context roots from uber jar
         try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(CONTEXT_PROPS_FILE)) {
             if (is != null) {
-
                 Properties props = new Properties();
                 props.load(is);
 
@@ -1515,11 +1593,12 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     }
                     contextRoots.setProperty((String) entry.getKey(), (String) entry.getValue());
                 }
-
             }
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "", ex);
         }
+
+        processDeploymentOptions();
 
         // search and deploy from MICRO-INF/deploy directory.
         // if there is a deployment called ROOT deploy to the root context /
@@ -1540,136 +1619,66 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                 }
 
                 for (String entry : microInfEntries) {
-                    File file = new File(entry);
-                    String deployContext = removeJavaArchiveExtension(file.getName());
-                    String name = deployContext;
-                    if (deployContext.equals("ROOT")) {
-                        deployContext = "/";
+                    File deployment = new File(entry);
+                    String deploymentName = removeJavaArchiveExtension(deployment.getName());
+
+                    List<String> deploymentParams = new ArrayList<>();
+                    deploymentParams.add("--availabilityenabled=true");
+                    deploymentParams.add("--force=true");
+                    deploymentParams.add("--loadOnly=true");
+                    deploymentParams.add("--name=" + deploymentName);
+
+                    if (deployment.getName().endsWith(".war")) {
+                        String deploymentContext = deploymentName;
+                        if (contextRoots != null) {
+                            deploymentContext = contextRoots.getProperty(deployment.getName(), deploymentName);
+                        }
+                        if ("ROOT".equals(deploymentContext)) {
+                            deploymentContext = "/";
+                        }
+                        deploymentParams.add("--contextroot=" + deploymentContext);
                     }
 
-                    if (contextRoots != null && contextRoots.containsKey(file.getName())) {
-                        deployContext = contextRoots.getProperty(file.getName());
-                    }
-                    deployer.deploy(this.getClass().getClassLoader().getResourceAsStream(entry), "--availabilityenabled",
-                            "true", "--contextroot",
-                            deployContext, "--name", name, "--force", "true", "--loadOnly", "true");
+                    deployer.deploy(this.getClass().getClassLoader().getResourceAsStream(entry), deploymentParams.toArray(new String[0]));
 
                     deploymentCount++;
                 }
             } catch (IOException ioe) {
-                LOGGER.log(Level.WARNING, "Could not deploy jar entry {0}",
-                        entryName);
+                LOGGER.log(Level.WARNING, "Could not deploy jar entry {0}", entryName);
             }
         } else {
             LOGGER.info("No META-INF/deploy directory");
         }
 
-        // Deploy command line provided files
         if (deployments != null) {
-            for (File deploymentFile : deployments) {
-                if (deploymentFile.exists() && deploymentFile.canRead()) {
-                    String deployContext = null;
-                    if (contextRoots != null && contextRoots.containsKey(deploymentFile.getName())) {
-                        deployContext = contextRoots.getProperty(deploymentFile.getName());
-                    } else if (contextRoot != null) {
-                        deployContext = contextRoot;
-                        //unset so only used once
-                        contextRoot = null;
-                    }
+            for (Map.Entry<String, URI> deploymentEntry : deployments.entrySet()) {
+                String deploymentName = deploymentEntry.getKey();
+                URI deploymentURI = deploymentEntry.getValue();
 
-                    if (deploymentFile.getName().startsWith("ROOT.")) {
-                        deployer.deploy(deploymentFile, "--availabilityenabled=true", "--force=true", "--contextroot=/", "--loadOnly", "true");
-                    } else {
-                        if (deployContext != null) {
-                            if (deployContext.equals("ROOT")) {
-                                deployContext = "/";
-                            }
+                List<String> deploymentParams = new ArrayList<>();
+                deploymentParams.add("--availabilityenabled=true");
+                deploymentParams.add("--force=true");
+                deploymentParams.add("--loadOnly=true");
 
-                            deployContext = removeJavaArchiveExtension(deployContext);
-
-                            deployer.deploy(deploymentFile, "--availabilityenabled=true", "--force=true", "--loadOnly", "true", "--contextroot", deployContext);
-                        } else if (deploymentFile.isDirectory()) {
-                            deployer.deploy(deploymentFile, "--availabilityenabled=true", "--force=true", "--loadOnly", "true", "--contextroot", deploymentFile.getName());
-                        } else {
-                            deployer.deploy(deploymentFile, "--availabilityenabled=true", "--force=true", "--loadOnly", "true");
+                if (contextRoots != null) {
+                    String deploymentContext = contextRoots.getProperty(deploymentName);
+                    if (deploymentContext != null) {
+                        if ("ROOT".equals(removeJavaArchiveExtension(deploymentName))) {
+                            deploymentContext = "/";
                         }
-                    }
-
-                    deploymentCount++;
-                } else {
-                    LOGGER.log(Level.WARNING, "{0} is not a valid deployment", deploymentFile.getAbsolutePath());
-                }
-            }
-        }
-
-        // Deploy from deployment directory
-        if (deploymentRoot != null) {
-
-            // Get all files in the directory, and sort them by file type
-            List<File> deploymentDirEntries = Arrays.asList(deploymentRoot.listFiles());
-            deploymentDirEntries.sort(new DeploymentComparator());
-
-            for (File entry : deploymentDirEntries) {
-                String entryPath = entry.getAbsolutePath();
-                if (entry.isFile() && entry.canRead() && hasJavaArchiveExtension(entryPath)) {
-                    String deployContext = null;
-                    if (contextRoots != null && contextRoots.containsKey(entry.getName())) {
-                        deployContext = contextRoots.getProperty(entry.getName());
-                    } else if (contextRoot != null) {
-                        deployContext = contextRoot;
-                        // unset so only used once
-                        contextRoot = null;
-                    }
-
-                    if (entry.getName().startsWith("ROOT.")) {
-                        deployer.deploy(entry, "--availabilityenabled=true", "--force=true", "--contextroot=/", "--loadOnly", "true");
-                    } else {
-                        if (deployContext != null) {
-                            if (deployContext.equals("ROOT")) {
-                                deployContext = "/";
-                            }
-
-                            deployContext = removeJavaArchiveExtension(deployContext);
-
-                            deployer.deploy(entry, "--availabilityenabled=true", "--force=true", "--loadOnly", "true", "--contextroot", deployContext);
-                        } else {
-                            deployer.deploy(entry, "--availabilityenabled=true", "--force=true", "--loadOnly", "true");
-                        }
-                    }
-
-                    deploymentCount++;
-                }
-            }
-        }
-
-        // Deploy from URI only called if GAVs provided
-        if (GAVs != null) {
-            // Convert the provided GAV Strings into target URLs
-            getGAVURLs();
-
-            if (!deploymentURLsMap.isEmpty()) {
-                for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLsMap.entrySet()) {
-                    try {
-                        // Convert the URL to a URI for use with the deploy method
-                        URI artefactURI = deploymentMapEntry.getValue().toURI();
-                        String artefactName = removeJavaArchiveExtension(new File(artefactURI.getPath()).getName());
-
-                        deployer.deploy(artefactURI,
-                                "--availabilityenabled", "true",
-                                "--contextroot", deploymentMapEntry.getKey(),
-                                "--name", artefactName,
-                                "--force=true", "--loadOnly", "true");
-
-                        deploymentCount++;
-                    } catch (URISyntaxException ex) {
-                        LOGGER.log(Level.WARNING, "{0} could not be converted to a URI,"
-                                        + " artefact will be skipped",
-                                deploymentMapEntry.getValue().toString());
+                        deploymentParams.add("--contextroot=" + deploymentContext);
                     }
                 }
+
+                if (!"file".equalsIgnoreCase(deploymentURI.getScheme())) {
+                    deploymentParams.add("--name=" + removeJavaArchiveExtension(deploymentName));
+                }
+
+                deployer.deploy(deploymentURI, deploymentParams.toArray(new String[0]));
+
+                deploymentCount++;
             }
         }
-
         LOGGER.log(Level.INFO, "Deployed {0} archive(s)", deploymentCount);
     }
 
@@ -1685,7 +1694,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         if (filePath == null) {
             return false;
         }
-        return filePath.endsWith(".war") || filePath.endsWith(".ear") || filePath.endsWith(".jar") || filePath.endsWith(".rar");
+        return filePath.endsWith(".war") || filePath.endsWith(".jar") || filePath.endsWith(".rar");
     }
 
     private void addShutdownHook() {
@@ -1759,7 +1768,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     currentProps.setProperty("java.util.logging.FileHandler.level", "INFO");
                     currentProps.setProperty("java.util.logging.FileHandler.formatter", "java.util.logging.SimpleFormatter");
                     currentProps.setProperty("java.util.logging.FileHandler.append", "true");
-
                 } catch (IOException ex) {
                     LOGGER.log(Level.SEVERE, "Unable to load the logging properties from the runtime directory", ex);
                 }
@@ -2043,47 +2051,13 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
     }
 
-    /**
-     * Converts the GAVs provided to a URLs, and stores them in the
-     * deploymentURLsMap.
-     */
-    private void getGAVURLs() throws GlassFishException {
+    private Map.Entry<String, URI> resolveGAV(String gav) throws GlassFishException {
         GAVConvertor gavConvertor = new GAVConvertor();
-
-        for (String gav : GAVs) {
-            try {
-                Map.Entry<String, URL> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURLs);
-
-                if (deploymentURLsMap == null) {
-                    deploymentURLsMap = new LinkedHashMap<>();
-                }
-
-                String defaultContext = artefactMapEntry.getKey();
-                if (this.contextRoot == null) {
-                    if ("ROOT".equals(defaultContext)) {
-                        defaultContext = "/";
-                    }
-                } else {
-                    defaultContext = this.contextRoot;
-                    contextRoot = null; // use only once
-                }
-
-                deploymentURLsMap.put(defaultContext, artefactMapEntry.getValue());
-            } catch (MalformedURLException ex) {
-                throw new GlassFishException(ex.getMessage());
-            }
-        }
-
-        if (deploymentURLsMap != null) {
-            if (contextRoots == null) {
-                contextRoots = new Properties();
-            }
-
-            for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLsMap.entrySet()) {
-                String artefactName = new File(deploymentMapEntry.getValue().getPath()).getName();
-                String defaultContext = deploymentMapEntry.getKey();
-                contextRoots.put(artefactName, defaultContext);
-            }
+        try {
+            Map.Entry<String, URL> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURLs);
+            return new AbstractMap.SimpleImmutableEntry<>(artefactMapEntry.getKey(), artefactMapEntry.getValue().toURI());
+        } catch (MalformedURLException | URISyntaxException ex) {
+            throw new GlassFishException(ex.getMessage());
         }
     }
 
@@ -2202,7 +2176,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     }
 
     private void setArgumentsFromSystemProperties() {
-
         // Set the domain.xml
         String alternateDomainXMLStr = getProperty("payaramicro.domainConfig");
         if (alternateDomainXMLStr != null && !alternateDomainXMLStr.isEmpty()) {
@@ -2277,9 +2250,11 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
     }
 
-    private void packageUberJar() {
+    private void packageUberJar() throws GlassFishException {
+        processDeploymentOptions();
 
         UberJarCreator creator = new UberJarCreator(uberJar);
+
         if (rootDir != null) {
             creator.setDomainDir(rootDir);
         }
@@ -2301,8 +2276,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         }
 
         if (deployments != null) {
-            for (File deployment : deployments) {
-                creator.addDeployment(deployment);
+            for (Map.Entry<String, URI> deployment : deployments.entrySet()) {
+                creator.addDeployment(deployment.getKey(), deployment.getValue());
             }
         }
 
@@ -2312,27 +2287,13 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             }
         }
 
-        if (deploymentRoot != null) {
-            creator.setDeploymentDir(deploymentRoot);
-        }
-
         if (copyDirectory != null) {
             creator.setDirectoryToCopy(copyDirectory);
         }
 
-        if (GAVs != null) {
-            try {
-                // Convert the provided GAV Strings into target URLs
-                getGAVURLs();
-                for (URL deployment : deploymentURLsMap.values()) {
-                    creator.addDeployment(new File(deployment.getPath()).getName(), deployment);
-                }
-            } catch (GlassFishException ex) {
-                LOGGER.log(Level.SEVERE, "Unable to process maven deployment units", ex);
-            }
+        if (contextRoots != null) {
+            creator.setContextRoots(contextRoots);
         }
-
-        creator.setContextRoots(contextRoots);
 
         // write the system properties file
         Properties props = new Properties();

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1617,7 +1617,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     deploymentParams.add("--loadOnly=true");
                     deploymentParams.add("--name=" + deploymentName);
 
-                    if (supportsContextRoot(deployment)) {
+                    if (deployment.getName().endsWith(".war")) {
                         String deploymentContext;
                         if ("ROOT".equals(deploymentName)) {
                             deploymentContext = "/";
@@ -1629,7 +1629,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         if ("ROOT".equals(deploymentContext)) {
                             deploymentContext = "/";
                         }
-                        deploymentParams.add("--contextroot" + deploymentContext);
+                        deploymentParams.add("--contextroot=" + deploymentContext);
                     }
 
                     deployer.deploy(this.getClass().getClassLoader().getResourceAsStream(entry), deploymentParams.toArray(new String[0]));

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1522,7 +1522,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         contextRootAvailable = false;
                     }
                 }
-            } else if (deploymentOption.getKey() == RUNTIME_OPTION.deploydir || deploymentOption.getKey() == RUNTIME_OPTION.deploymentdir) {
+            } else if ((deploymentOption.getKey() == RUNTIME_OPTION.deploydir || deploymentOption.getKey() == RUNTIME_OPTION.deploymentdir) && deploymentRoot != null) {
                 // Get all files in the directory, and sort them by file type
                 File[] deploymentEntries = deploymentRoot.listFiles();
                 Arrays.sort(deploymentEntries, new DeploymentComparator());
@@ -1535,6 +1535,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         }
                     }
                 }
+                deploymentRoot = null;
             } else if (deploymentOption.getKey() == RUNTIME_OPTION.deployfromgav) {
                 Map.Entry<String, URI> gavEntry = getGAVURI(deploymentOption.getValue());
                 URI artifactURI = gavEntry.getValue();

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -46,9 +46,17 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
-import java.util.*;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
@@ -58,12 +66,13 @@ import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 
 /**
- *
  * Class for creating the UberJar
  *
  * @author steve
  */
 public class UberJarCreator {
+
+    private static final Logger LOGGER = Logger.getLogger(UberJarCreator.class.getName());
 
     private File outputFile;
     private String mainClassName;
@@ -72,11 +81,9 @@ public class UberJarCreator {
     private File domainDir;
     private final List<File> libs = new LinkedList<>();
     private final List<File> classes = new LinkedList<>();
-    private final List<File> deployments = new LinkedList<>();
-    private final Map<String, URL> deploymentURLs = new LinkedHashMap<>();
-    private List<File> copiedFiles = new LinkedList();
+    private final Map<String, URI> deployments = new LinkedHashMap<>();
+    private final List<File> copiedFiles = new LinkedList<>();
 
-    private File deploymentDir;
     private File copyDirectory;
     private final Properties bootProperties = new Properties();
     private Properties loggingProperties;
@@ -87,7 +94,6 @@ public class UberJarCreator {
     private File postBootCommands;
     private Properties contextRoots;
 
-    private static final Logger LOGGER = Logger.getLogger(UberJarCreator.class.getName());
     private File postDeployCommands;
 
     UberJarCreator(String fileName) {
@@ -118,10 +124,6 @@ public class UberJarCreator {
         contextRoots = props;
     }
 
-    public void setDeploymentDir(File deploymentDir) {
-        this.deploymentDir = deploymentDir;
-    }
-
     public void setDomainDir(File domainDir) {
         this.domainDir = domainDir;
     }
@@ -140,7 +142,7 @@ public class UberJarCreator {
 
     /**
      * Directory to be copied into the root of the uber Jar file
-     * @param copyDirectory
+     * @param copyDirectory the copied directory
      */
     public void setDirectoryToCopy(File copyDirectory){
         this.copyDirectory = copyDirectory;
@@ -158,12 +160,8 @@ public class UberJarCreator {
         libs.add(jar);
     }
 
-    public void addDeployment(File jar) {
-        deployments.add(jar);
-    }
-
-    public void addDeployment(String name, URL url) {
-        deploymentURLs.put(name, url);
+    public void addDeployment(String name, URI uri) {
+        deployments.put(name, uri);
     }
 
     public void setDomainXML(File domainXML) {
@@ -171,7 +169,7 @@ public class UberJarCreator {
     }
 
     public void addBootProperties(Properties props) {
-        Enumeration names = props.propertyNames();
+        Enumeration<?> names = props.propertyNames();
         while (names.hasMoreElements()) {
             String name = (String) names.nextElement();
             bootProperties.setProperty(name, props.getProperty(name));
@@ -201,8 +199,8 @@ public class UberJarCreator {
                     // skip the entry as we will add later
                 } else {
                     JarEntry newEntry = new JarEntry(entry.getName());
-                    if (entry.getName().endsWith("jar") || entry.getName().endsWith("rar")) {
-                        newEntry.setMethod(entry.STORED);
+                    if (entry.getName().endsWith(".jar") || entry.getName().endsWith(".rar")) {
+                        newEntry.setMethod(JarEntry.STORED);
                         newEntry.setSize(entry.getSize());
                         newEntry.setCrc(entry.getCrc());
                         if (entry.getMethod() == JarEntry.STORED) {
@@ -212,7 +210,7 @@ public class UberJarCreator {
                     jos.putNextEntry(newEntry);
                     try (InputStream is = getInputStream(jFile, entry)) {
                         byte[] buffer = new byte[4096];
-                        int bytesRead = 0;
+                        int bytesRead;
                         while ((bytesRead = is.read(buffer)) != -1) {
                             jos.write(buffer, 0, bytesRead);
                         }
@@ -230,8 +228,8 @@ public class UberJarCreator {
 
                     try (CheckedInputStream check = new CheckedInputStream(new FileInputStream(lib), new CRC32());
                          BufferedInputStream in = new BufferedInputStream(check)) {
-                        while (in.read(new byte[3000]) != -1){
-                            //read in file completly
+                        while (in.read(new byte[3000]) != -1) {
+                            // read in file completely
                         }
                         libEntry.setCrc(check.getChecksum().getValue());
                         jos.putNextEntry(libEntry);
@@ -242,58 +240,34 @@ public class UberJarCreator {
                 }
             }
 
-            if (deployments != null) {
-                for (File deployment : deployments) {
-                    JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + deployment.getName());
-                    jos.putNextEntry(deploymentEntry);
-                    Files.copy(deployment.toPath(), jos);
-                    jos.flush();
-                    jos.closeEntry();
-                }
-            }
-
-            if (deploymentDir != null) {
-                for (File deployment : deploymentDir.listFiles()) {
-                    if (deployment.isFile()) {
-                        JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + deployment.getName());
-                        jos.putNextEntry(deploymentEntry);
-                        Files.copy(deployment.toPath(), jos);
-                        jos.flush();
-                        jos.closeEntry();
-
+            for (Map.Entry<String, URI> deployment : deployments.entrySet()) {
+                JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + deployment.getKey());
+                jos.putNextEntry(deploymentEntry);
+                URI deploymentURI = deployment.getValue();
+                if ("file".equalsIgnoreCase(deploymentURI.getScheme())) {
+                    Files.copy(Paths.get(deploymentURI), jos);
+                } else {
+                    try (InputStream is = deploymentURI.toURL().openStream()) {
+                        byte[] buffer = new byte[4096];
+                        int bytesRead;
+                        while ((bytesRead = is.read(buffer)) != -1) {
+                            jos.write(buffer, 0, bytesRead);
+                        }
                     }
                 }
+                jos.flush();
+                jos.closeEntry();
             }
 
             if (copyDirectory != null) {
                 String basePath = copyDirectory.getCanonicalPath().replaceAll(copyDirectory + "$", "");
                 List<File> filesToCopy = fillFiles(copyDirectory);
                 for (File file : filesToCopy) {
-
                         JarEntry deploymentEntry = new JarEntry(file.getCanonicalPath().replace(basePath, ""));
                         jos.putNextEntry(deploymentEntry);
                         Files.copy(file.toPath(), jos);
                         jos.flush();
                         jos.closeEntry();
-                }
-            }
-
-            // add deployment URLs
-            for (Map.Entry<String, URL> deploymentMapEntry : deploymentURLs.entrySet()) {
-                URL deployment = deploymentMapEntry.getValue();
-                String name = deploymentMapEntry.getKey();
-                try (InputStream is = deployment.openStream()) {
-                    JarEntry deploymentEntry = new JarEntry("MICRO-INF/deploy/" + name);
-                    jos.putNextEntry(deploymentEntry);
-                    byte[] buffer = new byte[4096];
-                    int bytesRead = 0;
-                    while ((bytesRead = is.read(buffer)) != -1) {
-                        jos.write(buffer, 0, bytesRead);
-                    }
-                    jos.flush();
-                    jos.closeEntry();
-                } catch (IOException ioe) {
-                    LOGGER.log(Level.WARNING, "Error adding deployment " + name + " to the Uber Jar Skipping...", ioe);
                 }
             }
 
@@ -368,8 +342,8 @@ public class UberJarCreator {
                             appEntry.setSize(app.length());
                             try (CheckedInputStream check = new CheckedInputStream(new FileInputStream(app), new CRC32());
                                  BufferedInputStream in = new BufferedInputStream(check)) {
-                                while (in.read(new byte[300]) != -1){
-                                //read in file completly
+                                while (in.read(new byte[300]) != -1) {
+                                    // read in file completely
                                 }
                                 appEntry.setCrc(check.getChecksum().getValue());
                                 jos.putNextEntry(appEntry);
@@ -382,11 +356,9 @@ public class UberJarCreator {
                 }
             }
             LOGGER.info("Built Uber Jar " + outputFile.getAbsolutePath() + " in " + (System.currentTimeMillis() - start) + " (ms)");
-
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Error creating Uber Jar " + outputFile.getAbsolutePath(), ex);
         }
-
     }
 
     private InputStream getInputStream(JarFile jFile, JarEntry entry) throws IOException {
@@ -412,15 +384,15 @@ public class UberJarCreator {
     /**
      * Returns a list of all files in directory and subdirectories
      * @param directory The parent directory to search within
-     * @return
+     * @return the list of files
      */
     public static List<File> fillFiles(File directory){
         List<File> allFiles = new LinkedList<>();
-        for (File file : directory.listFiles()){
-            if (file.isDirectory()){
+        for (File file : directory.listFiles()) {
+            if (file.isDirectory()) {
                 allFiles.addAll(fillFiles(file));
             } else {
-                if (file.canRead()){
+                if (file.canRead()) {
                     allFiles.add(file);
                 } else {
                     LOGGER.log(Level.WARNING, "Unable to read file " + file.getAbsolutePath() + ", skipping...");
@@ -449,5 +421,4 @@ public class UberJarCreator {
         }
         return files;
     }
-
 }

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -84,7 +84,7 @@ public class GAVConvertor {
         
         final String relativeURLString = constructRelativeURLString(GAVMap);
         final URL artefactURL = findArtefactURL(repositoryURLs, relativeURLString);
-        artefactMapEntry = new AbstractMap.SimpleEntry<>(GAVMap.get("artefactId"), artefactURL);
+        artefactMapEntry = new AbstractMap.SimpleImmutableEntry<>(GAVMap.get("artefactId"), artefactURL);
         
         return artefactMapEntry;
     }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Now Payara Micro  boot-time deployment has some limitations:

* it is impossible to deploy RAR remotely from maven and application using it locally with --deploy option - we get an deployment error
* context root option, when present, is assigned to a first deploy archive, not to a first appropriate

In this patch I tried fix this:

* deploy, deployFromGAV and deploymentdir options proceed in order as they encountered
* contextroot is assigned to a first *appropriate* archive (WAR)
* when a particular deploy archive defined more than once, then archive deployed at the first occurrence but with the last defined value

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 10 Pro, Azul Zulu OpenJDK 1.8.0_282
