### PR TITLE
FISH-1076 hotDeploy runtime option support in Payara Micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RUNTIME_OPTION.java
@@ -112,7 +112,8 @@ public enum RUNTIME_OPTION {
     shutdowngrace(true, new IntegerValidator(1, Integer.MAX_VALUE)),
     hzinitialjoinwait(true, new IntegerValidator(0,100000)),
     contextroot(true),
-    warmup(false);
+    warmup(false),
+    hotdeploy(false);
 
     RUNTIME_OPTION(boolean hasValue) {
         this(hasValue, new Validator());

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -39,34 +39,6 @@
  */
 package fish.payara.micro.impl;
 
-import com.sun.appserv.server.util.Version;
-import com.sun.enterprise.glassfish.bootstrap.Constants;
-import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
-import com.sun.enterprise.server.logging.ODLLogFormatter;
-import fish.payara.appserver.rest.endpoints.config.admin.ListRestEndpointsCommand;
-import fish.payara.boot.runtime.BootCommand;
-import fish.payara.boot.runtime.BootCommands;
-import fish.payara.deployment.util.GAVConvertor;
-import fish.payara.micro.BootstrapException;
-import fish.payara.micro.PayaraMicroRuntime;
-import fish.payara.micro.boot.AdminCommandRunner;
-import fish.payara.micro.boot.PayaraMicroBoot;
-import fish.payara.micro.boot.PayaraMicroLauncher;
-import fish.payara.micro.boot.loader.OpenURLClassLoader;
-import fish.payara.micro.cmd.options.RUNTIME_OPTION;
-import fish.payara.micro.cmd.options.RuntimeOptions;
-import fish.payara.micro.cmd.options.ValidationException;
-import fish.payara.micro.data.InstanceDescriptor;
-import fish.payara.nucleus.executorservice.PayaraFileWatcher;
-import org.glassfish.embeddable.BootstrapProperties;
-import org.glassfish.embeddable.CommandRunner;
-import org.glassfish.embeddable.Deployer;
-import org.glassfish.embeddable.GlassFish;
-import org.glassfish.embeddable.GlassFish.Status;
-import org.glassfish.embeddable.GlassFishException;
-import org.glassfish.embeddable.GlassFishProperties;
-import org.glassfish.embeddable.GlassFishRuntime;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -124,13 +96,13 @@ import fish.payara.micro.BootstrapException;
 import fish.payara.micro.PayaraMicroRuntime;
 import fish.payara.micro.boot.AdminCommandRunner;
 import fish.payara.micro.boot.PayaraMicroBoot;
+import fish.payara.micro.boot.PayaraMicroLauncher;
 import fish.payara.micro.boot.loader.OpenURLClassLoader;
 import fish.payara.micro.cmd.options.RUNTIME_OPTION;
 import fish.payara.micro.cmd.options.RuntimeOptions;
 import fish.payara.micro.cmd.options.ValidationException;
 import fish.payara.micro.data.InstanceDescriptor;
 import fish.payara.nucleus.executorservice.PayaraFileWatcher;
-import java.util.ArrayList;
 
 /**
  * Main class for Bootstrapping Payara Micro Edition This class is used from
@@ -1661,7 +1633,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     deploymentParams.add("--force=true");
                     deploymentParams.add("--loadOnly=true");
                     deploymentParams.add("--name=" + deploymentName);
-
+                    if (hotDeploy) {
+                        deploymentParams.add("--hotDeploy=true");
+                    }
                     if (deployment.getName().endsWith(".war")) {
                         String deploymentContext;
                         if ("ROOT".equals(deploymentName)) {
@@ -1699,7 +1673,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                 deploymentParams.add("--availabilityenabled=true");
                 deploymentParams.add("--force=true");
                 deploymentParams.add("--loadOnly=true");
-
+                if (hotDeploy) {
+                    deploymentParams.add("--hotDeploy=true");
+                }
                 String deploymentContext = null;
                 if ("file".equalsIgnoreCase(deploymentURI.getScheme())) {
                     File deployment = new File(deploymentURI);
@@ -1715,7 +1691,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         } else if (deployment.isDirectory()) {
                             deploymentContext = fileName;
                         }
-                        deployer.deploy(deploymentFile, args.toArray(new String[0]));
                     }
                 } else {
                     deploymentParams.add("--name=" + removeJavaArchiveExtension(fileName));
@@ -1726,7 +1701,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                         } else {
                             deploymentContext = contextRoots.getProperty(fileName);
                         }
-                        deployer.deploy(entry, args.toArray(new String[0]));
                     }
                 }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloadService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloadService.java
@@ -172,9 +172,7 @@ public class DynamicReloadService implements ConfigListener, PostConstruct, PreD
                 0L,
                 pollIntervalInSeconds, 
                 TimeUnit.SECONDS);
-        logger.fine("[Reloader] Started, monitoring every " +
-                    pollIntervalInSeconds + " seconds"
-                    );
+        logger.log(Level.FINE, "[Reloader] Started, monitoring every {0} seconds", pollIntervalInSeconds);
     }
 
     private void stop() {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.server;
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -326,8 +326,8 @@ public class DynamicReloader implements Runnable {
         
         private Properties readReloadFile() {
             Properties prop = new Properties();
-            try {
-                prop.load(new FileInputStream(reloadFile));
+            try (InputStream istream = new FileInputStream(reloadFile) {
+                prop.load(istream);
             } catch (Exception ex) {
                 // skip
             }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -50,6 +50,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -250,7 +251,7 @@ public class DynamicReloader implements Runnable {
         deployParam.set(DeploymentProperties.KEEP_REPOSITORY_DIRECTORY, "true");
 
         Properties reloadFile = appInfo.readReloadFile();
-        boolean hotDeploy = Boolean.parseBoolean(reloadFile.get(DeployCommandParameters.ParameterNames.HOT_DEPLOY));
+        boolean hotDeploy = Boolean.parseBoolean(reloadFile.getProperty(DeployCommandParameters.ParameterNames.HOT_DEPLOY));
         if (hotDeploy) {
             deployParam.set(DeployCommandParameters.ParameterNames.HOT_DEPLOY, "true");
             boolean metadataChanged = Boolean.parseBoolean(reloadFile.getProperty(DeployCommandParameters.ParameterNames.METADATA_CHANGED));

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -250,7 +250,7 @@ public class DynamicReloader implements Runnable {
         deployParam.set(DeploymentProperties.KEEP_REPOSITORY_DIRECTORY, "true");
 
         Properties reloadFile = appInfo.readReloadFile();
-        boolean hotDeploy = Boolean.TRUE.toString().equals(reloadFile.get(DeployCommandParameters.ParameterNames.HOT_DEPLOY));
+        boolean hotDeploy = Boolean.parseBoolean(reloadFile.get(DeployCommandParameters.ParameterNames.HOT_DEPLOY));
         if (hotDeploy) {
             deployParam.set(DeployCommandParameters.ParameterNames.HOT_DEPLOY, "true");
             boolean metadataChanged = Boolean.TRUE.toString().equals(reloadFile.getProperty(DeployCommandParameters.ParameterNames.METADATA_CHANGED));

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -253,7 +253,7 @@ public class DynamicReloader implements Runnable {
         boolean hotDeploy = Boolean.parseBoolean(reloadFile.get(DeployCommandParameters.ParameterNames.HOT_DEPLOY));
         if (hotDeploy) {
             deployParam.set(DeployCommandParameters.ParameterNames.HOT_DEPLOY, "true");
-            boolean metadataChanged = Boolean.TRUE.toString().equals(reloadFile.getProperty(DeployCommandParameters.ParameterNames.METADATA_CHANGED));
+            boolean metadataChanged = Boolean.parseBoolean(reloadFile.getProperty(DeployCommandParameters.ParameterNames.METADATA_CHANGED));
             if (metadataChanged) {
                 deployParam.set(DeployCommandParameters.ParameterNames.METADATA_CHANGED, "true");
             }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -326,7 +326,7 @@ public class DynamicReloader implements Runnable {
         
         private Properties readReloadFile() {
             Properties prop = new Properties();
-            try (InputStream istream = new FileInputStream(reloadFile) {
+            try (InputStream istream = new FileInputStream(reloadFile)) {
                 prop.load(istream);
             } catch (Exception ex) {
                 // skip


### PR DESCRIPTION
## Description
This is a feature PR to pass `hotDeploy` runtime option on Payara Micro startup to save deployment state and read `.reload` file to fetch modified files and metadata details.

## Testing

### Testing Performed
Manually Tested with VSCode hotDeploy integration feature

### Testing Environment
VSCode 1.53.2, Windows 10, JDK 8
