### PR TITLE
[FISH-1178] Resource Loading - new URLs no longer produce cached JAR files

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/NonCachedJarStreamHandler.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/NonCachedJarStreamHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.web.loader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.jar.JarFile;
+
+/**
+ * Wraps JarURLConnection to force no cache usage,
+ * which can bring in side effects
+ *
+ * @author lprimak
+ */
+public class NonCachedJarStreamHandler extends URLStreamHandler {
+    private static final NonCachedJarStreamHandler INSTANCE = new NonCachedJarStreamHandler();
+
+    /**
+     * JDK caches JarFiles, which causes unwanted side effects
+     * in multi-threaded environments.
+     * force URLs returned from the class loader to not used the cache
+     *
+     * @param url
+     * @return
+     */
+    public static URL forceNonCachedJarURL(URL url) {
+        if (url == null) {
+            return null;
+        } else if (!"jar".equals(url.getProtocol())) {
+            return url;
+        }
+        try {
+            return new URL(url, url.toExternalForm(), INSTANCE);
+        } catch (MalformedURLException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+
+    @Override
+    protected URLConnection openConnection(URL u) throws IOException {
+        return new JarURLConnection(u) {
+            private JarURLConnection urlConnection;
+
+            @Override
+            public JarFile getJarFile() throws IOException {
+                connect();
+                return urlConnection.getJarFile();
+            }
+
+            @Override
+            public void connect() throws IOException {
+                if (urlConnection == null) {
+                    // set our own flag for consistency's sake and easier debugging,
+                    // even though it is not used
+                    setUseCaches(false);
+                    URLConnection conn = new URL(u.toExternalForm()).openConnection();
+                    conn.setUseCaches(false);
+                    urlConnection = (JarURLConnection) conn;
+                }
+            }
+
+            @Override
+            public InputStream getInputStream() throws IOException {
+                connect();
+                return urlConnection.getInputStream();
+            }
+        };
+    }
+}

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -111,6 +111,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 import org.glassfish.api.deployment.GeneratedResourceEntry;
 import org.glassfish.api.deployment.ResourceEntry;
@@ -189,7 +190,6 @@ public class WebappClassLoader
     private static final Permission ALL_PERMISSION = new AllPermission();
 
     private static final String META_INF_SERVICES = "META-INF/services/";
-
 
     // ----------------------------------------------------- Instance Variables
 
@@ -1283,7 +1283,7 @@ public class WebappClassLoader
                 logger.log(Level.FINER, "    --> Resource not found, returning null");
             }
         }
-        return url;
+        return NonCachedJarStreamHandler.forceNonCachedJarURL(url);
     }
 
 
@@ -1336,8 +1336,9 @@ public class WebappClassLoader
             result.add(otherResourcePaths.nextElement());
         }
 
-        return Collections.enumeration(result);
-
+        return Collections.enumeration(result.stream()
+                .map(NonCachedJarStreamHandler::forceNonCachedJarURL)
+                .collect(Collectors.toList()));
     }
 
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/loader/StandardClassLoader.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/loader/StandardClassLoader.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2021] Payara Foundation and/or affiliates
 
 package org.apache.catalina.loader;
 
@@ -953,6 +953,7 @@ public class StandardClassLoader extends URLClassLoader implements Reloader {
                     JarURLConnection conn =
                         (JarURLConnection) url.openConnection();
                     conn.setAllowUserInteraction(false);
+                    conn.setUseCaches(false);
                     conn.setDoInput(true);
                     conn.setDoOutput(false);
                     conn.connect();

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -73,6 +73,7 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.SEVERE;
+import static org.glassfish.web.loader.NonCachedJarStreamHandler.forceNonCachedJarURL;
 import static org.glassfish.weld.WeldDeployer.WELD_BOOTSTRAP;
 import static org.glassfish.weld.connector.WeldUtils.*;
 
@@ -675,7 +676,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                 // use a throwaway classloader to load the application's beans.xml
                 ClassLoader throwAwayClassLoader =
                                       new URLClassLoader(new URL[]{archive.getURI().toURL()}, null);
-                URL beansXmlUrl = throwAwayClassLoader.getResource(entry);
+                URL beansXmlUrl = forceNonCachedJarURL(throwAwayClassLoader.getResource(entry));
                 if (beansXmlUrl != null && !beansXmlURLs.contains(beansXmlUrl)) { // http://java.net/jira/browse/GLASSFISH-17157
                     beansXmlURLs.add(beansXmlUrl);
                 }


### PR DESCRIPTION
Resource Loading - URL()s no longer produce cached JAR files,
thus fixing race conditions when JAR files are closed from outside the thread

## Description
During parallel resource loading from multiple apps, JARs are closed due to improper cachine.
Fixes a bug reported for GlassFish: https://github.com/eclipse-ee4j/glassfish/issues/22552

## Testing
### Testing Performed
Parallel-tested MP-TCK
