### PR TITLE
FISH-1171 FISH-1172 Make Enabled Parameter of set-admin-audit-configuration and set-healthcheck-configuration Commands Optional

### DIFF
--- a/appserver/tests/payara-samples/asadmin/src/test/java/fish/payara/samples/asadmin/SetHealthCheckConfigurationTest.java
+++ b/appserver/tests/payara-samples/asadmin/src/test/java/fish/payara/samples/asadmin/SetHealthCheckConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -66,8 +66,8 @@ public class SetHealthCheckConfigurationTest extends AsadminTest {
     }
 
     @Test
-    public void enabledIsMandatory() {
-        assertMissingParameter("enabled", asadmin("set-healthcheck-configuration"));
+    public void enabledIsOptional() {
+        assertSuccess(asadmin("set-healthcheck-configuration"));
     }
 
     @Test

--- a/appserver/tests/payara-samples/asadmin/src/test/java/fish/payara/samples/asadmin/SetHealthCheckNotifierConfigurationTest.java
+++ b/appserver/tests/payara-samples/asadmin/src/test/java/fish/payara/samples/asadmin/SetHealthCheckNotifierConfigurationTest.java
@@ -69,9 +69,8 @@ public class SetHealthCheckNotifierConfigurationTest extends AsadminTest {
     }
 
     @Test
-    public void enabledIsMandatory() {
-        assertMissingParameter("enabled", asadmin("set-healthcheck-configuration",
-                "--setNotifiers", "log-notifier"));
+    public void enabledIsOptional() {
+        assertSuccess(asadmin("set-healthcheck-configuration"));
     }
 
     @Test

--- a/nucleus/payara-modules/asadmin-audit/src/main/java/fish/payara/audit/admin/SetAdminAuditConfiguration.java
+++ b/nucleus/payara-modules/asadmin-audit/src/main/java/fish/payara/audit/admin/SetAdminAuditConfiguration.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019-2021 Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -99,7 +99,7 @@ public class SetAdminAuditConfiguration implements AdminCommand {
     @Param(name = "dynamic", optional = true, defaultValue = "false")
     private Boolean dynamic;
 
-    @Param(name = "enabled")
+    @Param(name = "enabled", optional = true)
     private Boolean enabled;
 
     @Param(name = "auditLevel", optional = true, acceptableValues = "MODIFIERS, ACCESSORS, INTERNAL")
@@ -140,8 +140,14 @@ public class SetAdminAuditConfiguration implements AdminCommand {
             ConfigSupport.apply(new SingleConfigCode<AdminAuditConfiguration>() {
                 @Override
                 public Object run(AdminAuditConfiguration proxy) throws PropertyVetoException, TransactionFailure {
-                    proxy.enabled(enabled.toString());
-                    proxy.setAuditLevel(auditLevel);
+                    if (enabled != null) {
+                        proxy.enabled(enabled.toString());
+                    }
+
+                    if (auditLevel != null) {
+                        proxy.setAuditLevel(auditLevel);
+                    }
+
 
                     List<String> notifiers = proxy.getNotifierList();
                     if (enableNotifiers != null) {

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/SetHealthCheckConfiguration.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/admin/SetHealthCheckConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -119,7 +119,7 @@ public class SetHealthCheckConfiguration implements AdminCommand {
     @Param(name = "target", optional = true, defaultValue = "server-config")
     private String target;
 
-    @Param(name = "enabled")
+    @Param(name = "enabled", optional = true)
     private Boolean enabled;
 
     @Param(name = "historical-trace-enabled", optional = true)
@@ -166,7 +166,10 @@ public class SetHealthCheckConfiguration implements AdminCommand {
         try {
             final Set<String> notifierNames = NotifierUtils.getNotifierNames(serviceLocator);
             ConfigSupport.apply(configProxy -> {
-                    configProxy.enabled(enabled.toString());
+                    if (enabled != null) {
+                        configProxy.enabled(enabled.toString());
+                    }
+
                     configProxy.setHistoricalTraceStoreSize(String.valueOf(historicalTraceStoreSize));
                     if (historicalTraceEnabled != null) {
                         configProxy.setHistoricalTraceEnabled(historicalTraceEnabled.toString());
@@ -223,7 +226,9 @@ public class SetHealthCheckConfiguration implements AdminCommand {
     }
 
     private void configureDynamically() {
-        healthCheck.setEnabled(enabled);
+        if (enabled != null) {
+            healthCheck.setEnabled(enabled);
+        }
         healthCheck.setHistoricalTraceStoreSize(historicalTraceStoreSize);
         if (historicalTraceEnabled != null) {
             healthCheck.setHistoricalTraceEnabled(historicalTraceEnabled);


### PR DESCRIPTION
## Description
They don't need to be mandatory. If mandatory it means you always need to have them present, even if not configuring the enabled status.

It also makes chaining to this command from another command a pain, since you'd have to pass it the current config setting.

Also adds a null check for `auditLevel`, since it didn't have one and needed it. 

## Important Info
### Blockers
None

## Testing
### New tests
None.

### Testing Performed
Ran the commands:

* `asadmin set-healthcheck-configuration` - `SUCCESS`
*  `asadmin get-healthcheck-configuration` - default settings
* `asadmin set-healthcheck-configuration --enabled true --dynamic true` - `SUCCESS`
*  `asadmin get-healthcheck-configuration` - changed settings
* `asadmin set-admin-audit-configuration` - `SUCCESS`
*  `asadmin get-admin-audit-configuration` - default settings
* `asadmin set-admin-audit-configuration --enabled true --dynamic true` - `SUCCESS`
*  `asadmin get-admin-audit-configuration` - changed settings

### Testing Environment
WSL, JDK8

## Documentation
Pending...

## Notes for Reviewers
None.
