### PR TITLE
FISH-1186: Support server-node on k8s

### DIFF
--- a/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
@@ -2,6 +2,10 @@
 set -e
 
 DOCKER_CONTAINER_ID="$(cat /proc/self/cgroup | grep :/docker/  | sed s/\\//\\n/g | tail -1)"
+if [ -z "${DOCKER_CONTAINER_ID}" ]; then
+    echo "Fallback for Docker Container ID"
+    DOCKER_CONTAINER_ID=$HOSTNAME
+fi
 ASADMIN="${PAYARA_DIR}/bin/asadmin"
 echo "Docker Container ID is: ${DOCKER_CONTAINER_ID}"
 

--- a/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
@@ -152,7 +152,7 @@ function createNewInstance {
         fi
     fi
 
-    if [ -z "${DOCKER_CONTAINER_ID}" ]; then
+    if [ ! -z "${DOCKER_CONTAINER_ID}" ]; then
        # Register Docker container ID to DAS
        echo "Setting Docker Container ID for instance ${PAYARA_INSTANCE_NAME}: ${DOCKER_CONTAINER_ID}"
        ASADMIN_COMMAND="${ASADMIN} -I false -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} _set-docker-container-id --instance ${PAYARA_INSTANCE_NAME} --id ${DOCKER_CONTAINER_ID}"

--- a/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
@@ -2,10 +2,7 @@
 set -e
 
 DOCKER_CONTAINER_ID="$(cat /proc/self/cgroup | grep :/docker/  | sed s/\\//\\n/g | tail -1)"
-if [ -z "${DOCKER_CONTAINER_ID}" ]; then
-    echo "Fallback for Docker Container ID"
-    DOCKER_CONTAINER_ID=$HOSTNAME
-fi
+
 ASADMIN="${PAYARA_DIR}/bin/asadmin"
 echo "Docker Container ID is: ${DOCKER_CONTAINER_ID}"
 
@@ -155,11 +152,13 @@ function createNewInstance {
         fi
     fi
 
-    # Register Docker container ID to DAS
-    echo "Setting Docker Container ID for instance ${PAYARA_INSTANCE_NAME}: ${DOCKER_CONTAINER_ID}"
-    ASADMIN_COMMAND="${ASADMIN} -I false -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} _set-docker-container-id --instance ${PAYARA_INSTANCE_NAME} --id ${DOCKER_CONTAINER_ID}"
-    echo "${ASADMIN_COMMAND}"
-    ${ASADMIN_COMMAND}
+    if [ -z "${DOCKER_CONTAINER_ID}" ]; then
+       # Register Docker container ID to DAS
+       echo "Setting Docker Container ID for instance ${PAYARA_INSTANCE_NAME}: ${DOCKER_CONTAINER_ID}"
+       ASADMIN_COMMAND="${ASADMIN} -I false -H ${PAYARA_DAS_HOST} -p ${PAYARA_DAS_PORT} -W ${PAYARA_PASSWORD_FILE} _set-docker-container-id --instance ${PAYARA_INSTANCE_NAME} --id ${DOCKER_CONTAINER_ID}"
+       echo "${ASADMIN_COMMAND}"
+       ${ASADMIN_COMMAND}
+    fi
 }
 
 ### Setup ###


### PR DESCRIPTION
## Description
Fix value for DOCKER_CONTAINER_ID within entrypoint.sh of server-node image so it has meaningful value within k8s.

## Testing

### Testing Performed
Tested on Docker Desktop on Mac with k8s  1.19
