### PR TITLE
Fix NPE when hotDeploy option is absent in Payara Micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -201,7 +201,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private String publicAddress = "";
     private int initialJoinWait = 1;
     private boolean warmup;
-    private Boolean hotDeploy;
+    private boolean hotDeploy;
 
     /**
      * Runs a Payara Micro server used via java -jar payara-micro.jar

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1283,7 +1283,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     warmup = true;
                     break;
                 case hotdeploy:
-                    hotDeploy = Boolean.parseBoolean(value);
+                    hotDeploy = true;
                     break;
                 case disablephonehome:
                     disablePhoneHome = true;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This is bug fix.

Payara Micro failed to start with NPE when --hotDeploy option is absent.

## Testing

### Testing Performed
Manual testing

### Testing Environment
Win 10 Pro, Payara Micro current, Zulu 1.8.0_282
