### PR TITLE
Basic Auth support for the remote GAV retrieval during uber jar creation in Payara Micro / FISH-1304

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/UberJarCreator.java
@@ -39,6 +39,8 @@
  */
 package fish.payara.micro.impl;
 
+import fish.payara.deployment.util.URIUtils;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -247,7 +249,7 @@ public class UberJarCreator {
                 if ("file".equalsIgnoreCase(deploymentURI.getScheme())) {
                     Files.copy(Paths.get(deploymentURI), jos);
                 } else {
-                    try (InputStream is = deploymentURI.toURL().openStream()) {
+                    try (InputStream is = URIUtils.openHttpConnection(deploymentURI).getInputStream()) {
                         byte[] buffer = new byte[4096];
                         int bytesRead;
                         while ((bytesRead = is.read(buffer)) != -1) {

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/URIUtils.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/URIUtils.java
@@ -1,0 +1,83 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.deployment.util;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.Base64;
+
+/**
+ * General URI manipulation utilities.
+ *
+ * @author avpinchuk
+ */
+public final class URIUtils {
+    // Suppress default constructor
+    private URIUtils() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Returns a {@link HttpURLConnection} instance that represents a connection to the
+     * remote object referred by the {@code uri}.
+     * <p/>
+     * The {@code uri} must represent a HTTP(S) resource.
+     * <p/>
+     * If {@code uri} contains the user info part, set the <em>Authorization</em> header
+     * with Basic authentication credentials.
+     *
+     * @param uri the {@code URI} to open connection from.
+     * @return A {@code HttpURLConnection} to the {@code uri}.
+     * @throws IOException if an I/O exception occurs.
+     * @throws ClassCastException if the connection is not instance of {@code HttpURLConnection}.
+     */
+    public static HttpURLConnection openHttpConnection(URI uri) throws IOException {
+        URL url = uri.toURL();
+        HttpURLConnection httpConnection = (HttpURLConnection) url.openConnection();
+        String userInfo = url.getUserInfo();
+        if (userInfo != null) {
+            String encodedUserInfo = Base64.getEncoder().encodeToString(userInfo.getBytes());
+            httpConnection.setRequestProperty("Authorization", "Basic " + encodedUserInfo);
+        }
+        return httpConnection;
+    }
+}


### PR DESCRIPTION
## Description

Now Payara Micro does not support Basic authorization for remote repositories when creates uber jar.

## Testing
### Testing Performed
Did some manual tests

### Testing Environment
Win 10 Pro, Zulu 1.8.0_282