### PR TITLE
FISH-1064 : Asadmin to clear out old job executions of JBatch in all supported databases (cont)

### DIFF
--- a/appserver/batch/glassfish-batch-commands/src/main/java/fish/payara/batch/CleanJbatchRepository.java
+++ b/appserver/batch/glassfish-batch-commands/src/main/java/fish/payara/batch/CleanJbatchRepository.java
@@ -77,7 +77,7 @@ public class CleanJbatchRepository implements AdminCommand {
     @Param(acceptableValues = "ALL,COMPLETED", defaultValue = "COMPLETED", optional = true)
     String status;
 
-    @Param(optional = false)
+    @Param(optional = true, defaultValue = "1")
     int days;
 
     @Param(name = "jobname", primary = true, optional = false)

--- a/appserver/batch/glassfish-batch-commands/src/main/java/fish/payara/batch/CleanJbatchRepository.java
+++ b/appserver/batch/glassfish-batch-commands/src/main/java/fish/payara/batch/CleanJbatchRepository.java
@@ -118,7 +118,19 @@ public class CleanJbatchRepository implements AdminCommand {
                 DataSource datasource = (DataSource) object;
                 Feedback feedback = new Feedback();
                 try (Connection conn = datasource.getConnection()) {
-
+                    try {
+                        boolean valid = conn.isValid(0);
+                        if (!valid) {
+                            report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+                            report.setMessage("Database not accessible" );
+                            return;
+                        }
+                    } catch (SQLException ex) {
+                        report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+                        report.setMessage("Database not accessible" );
+                        report.setFailureCause(ex);
+                        return;
+                    }
                     cleanTables(conn, feedback);
                 } catch (SQLException ex) {
                     Logger.getLogger("fish.payara.batch").log(Level.SEVERE, "Error cleaning repository with table " + feedback.tableToClean, ex);


### PR DESCRIPTION
## Description
- Make --days parameter optional for easier usage
- Show nice message when database is not accessible.

## Testing

### Testing Performed
Testing on supported databases.

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.2.2 with Maven 3.6.3

## Notes for Reviewers
Continuation of https://github.com/payara/Payara/pull/5158