### PR TITLE
FISH-514 Fix Inconsistent behaviour when a domain backup is created

### DIFF
--- a/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/BackupManager.java
+++ b/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/BackupManager.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright 2021 Payara Foundation and/or its affiliates.
+
 package com.sun.enterprise.backup;
 
 import com.sun.enterprise.backup.util.BackupUtils;

--- a/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/BackupManager.java
+++ b/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/BackupManager.java
@@ -46,7 +46,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Date;
-import java.util.logging.Logger;
 
 /**
  *


### PR DESCRIPTION
## Description
This is a bug fix

If an error was encountered creating a domain backup (e.g. insufficient permissions on a file), the backup would not stop, and you'd end up with a corrupt backup zip.

This fixes this by cancelling out the backup and deleting the backup.

## Important Info

### Dependant PRs
None

### Blockers
None

## Testing

### New tests
None

### Testing Performed
* Attempt backup: `asadmin backup-domain`
* Command should succeed with a backup created: `ls payara5/glassfish/domains/domain1/backups`
* Change owner of login.conf file to root: `sudo chown root payara5/glassfish/domains/domain1/config/login.conf`
* Attempt backup: `asadmin backup-domain`
* Command should fail, useful error message, and no corrupt backup created: `ls payara5/glassfish/domains/domain1/backups`

### Testing Environment
WSL OpenSUSE JDK 8

## Documentation
N/A

## Notes for Reviewers
None
