### PR TITLE
FISH-1173 NPE starting prod domain in ConfigProviderResolver

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
@@ -558,7 +558,9 @@ public class ConfigProviderResolverImpl extends ConfigProviderResolver implement
                 PayaraConfig appConfig = applicationRegistry.get(appName).getTransientAppMetaData(METADATA_KEY, PayaraConfig.class);
                 //Server will have already populated cache in deployment before this point,
                 //cache needs clearing as config extensions have not yet been loaded and may have values
-                appConfig.clearCache();
+                if (appConfig != null) {
+                    appConfig.clearCache();
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
This is a bug fix.

## Important Info

## Testing

### Testing Performed
`asadmin start-domain --debug --verbose production`
Before PR: NPE appears in log (does not prevent domain starting)
After: No errors or warning appear in log at startup.

### Test suites executed
- Quicklook

### Testing Environment
Zulu JDK 1.8_272 on Ubuntu 20.10 with Maven 3.6.3

## Notes for reviewers
This is the community PR for https://github.com/payara/Payara-Enterprise/pull/338
