### PR TITLE
FISH-1021 Add support for HSTS header

### DIFF
--- a/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
@@ -92,10 +92,11 @@
      <sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsLabel}" helpText="$resource{i18n.ssl.hstsLabelHelp}">
         <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsEnabled']}" selectedValue="true"/>
      </sun:property>
-     <sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsSubDomainsLabel}" helpText="$resource{i18n.ssl.hstsSubDomainsLabelHelp}">
-        <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsSubdomains']}" selectedValue="true"/>
-     </sun:property><!-- comment --><sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsPreloadLabel}" helpText="$resource{i18n.ssl.hstsPreloadLabelHelp}">
-        <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsPreload']}" selectedValue="true"/>
+     <sun:property id="HSTSSubDomainProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsSubDomainsLabel}" helpText="$resource{i18n.ssl.hstsSubDomainsLabelHelp}">
+        <sun:checkbox id="HSTSSubDomain" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsSubdomains']}" selectedValue="true"/>
+     </sun:property>
+     <sun:property id="HSTSPreloadProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsPreloadLabel}" helpText="$resource{i18n.ssl.hstsPreloadLabelHelp}">
+        <sun:checkbox id="HSTSPreload" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsPreload']}" selectedValue="true"/>
      </sun:property>
 
      <sun:property id="ClientAuthProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.clientAuthLabel}" helpText="$resource{i18n.ssl.clientAuthHelp}" >

--- a/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
@@ -92,6 +92,11 @@
      <sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsLabel}" helpText="$resource{i18n.ssl.hstsLabelHelp}">
         <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsEnabled']}" selectedValue="true"/>
      </sun:property>
+     <sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsSubDomainsLabel}" helpText="$resource{i18n.ssl.hstsSubDomainsLabelHelp}">
+        <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsSubdomains']}" selectedValue="true"/>
+     </sun:property><!-- comment --><sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsPreloadLabel}" helpText="$resource{i18n.ssl.hstsPreloadLabelHelp}">
+        <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsPreload']}" selectedValue="true"/>
+     </sun:property>
 
      <sun:property id="ClientAuthProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.clientAuthLabel}" helpText="$resource{i18n.ssl.clientAuthHelp}" >
         <sun:checkbox id="ClientAuth" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['clientAuthEnabled']}" selectedValue="true" />

--- a/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
@@ -88,6 +88,10 @@
      <sun:property id="TLSProp13"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.tlsLabel13}" helpText="$resource{i18n.ssl.tlsLabel13Help}" rendered="#{pageSession.showTLS13Prop}">
         <sun:checkbox id="TLS13" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['tls13Enabled']}" selectedValue="true"/>
      </sun:property>
+     
+     <sun:property id="HSTSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.hstsLabel}" helpText="$resource{i18n.ssl.hstsLabelHelp}">
+        <sun:checkbox id="HSTS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['hstsEnabled']}" selectedValue="true"/>
+     </sun:property>
 
      <sun:property id="ClientAuthProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.clientAuthLabel}" helpText="$resource{i18n.ssl.clientAuthHelp}" >
         <sun:checkbox id="ClientAuth" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['clientAuthEnabled']}" selectedValue="true" />

--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -1159,6 +1159,8 @@ ssl.tlsLabel11=TLS1.1:
 ssl.tlsLabel12=TLS1.2:
 ssl.tlsLabel13=TLS1.3:
 ssl.tlsLabel13Help=<b>-Dfish.payara.clientHttpsProtocol=TLSv1.3</b> java option will need to be added to the asadmin script for TLS 1.3 to work with asadmin CLI. If you are using Zulu JDK 8, you will also need to add the following Java Option: <b>-XX:+UseOpenJSSE</b>.
+ssl.hstsLabel=HSTS:
+ssl.hstsLabelHelp=Strict Transport Security.
 ssl.sniEnabledLabel=SNI Support
 ssl.sniEnabledHelp=With SNI Enabled the server will look for a certificate in the keystore using a nick name that matches the host name requested.
 ssl.ciphersLabel=Cipher Suites:

--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 TODO=
 TBD=TBD
@@ -1160,7 +1160,11 @@ ssl.tlsLabel12=TLS1.2:
 ssl.tlsLabel13=TLS1.3:
 ssl.tlsLabel13Help=<b>-Dfish.payara.clientHttpsProtocol=TLSv1.3</b> java option will need to be added to the asadmin script for TLS 1.3 to work with asadmin CLI. If you are using Zulu JDK 8, you will also need to add the following Java Option: <b>-XX:+UseOpenJSSE</b>.
 ssl.hstsLabel=HSTS:
-ssl.hstsLabelHelp=Strict Transport Security.
+ssl.hstsLabelHelp=Strict Transport Security header
+ssl.hstsSubDomainsLabel=HSTS SubDomains
+ssl.hstsSubDomainsLabelHelp=Include subdomains in HSTS header
+ssl.hstsPreloadLabel=HSTS Preload
+ssl.hstsPreloadLabelHelp=Set preload flag in HSTS header
 ssl.sniEnabledLabel=SNI Support
 ssl.sniEnabledHelp=With SNI Enabled the server will look for a certificate in the keystore using a nick name that matches the host name requested.
 ssl.ciphersLabel=Cipher Suites:

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admin.mbeanserver;
 
@@ -424,6 +424,7 @@ final class RMIConnectorStarter extends ConnectorStarter {
         sslParams.setSsl3TlsCiphers(sslConfig.getSsl3TlsCiphers());
         sslParams.setTlsEnabled(sslConfig.getTlsEnabled());
         sslParams.setTlsRollbackEnabled(sslConfig.getTlsRollbackEnabled());
+        sslParams.setHstsEnabled(sslConfig.getHstsEnabled());
 
         return sslParams;
     }

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
@@ -88,6 +88,8 @@ public class SSLParams {
     private Boolean tlsEnabled=true;
     private Boolean tlsRollBackEnabled=false;
     private Boolean hstsEnabled = false;
+    private Boolean hstsSubDomains = false;
+    private Boolean hstsPreload = false;
 
 
 
@@ -347,6 +349,22 @@ public class SSLParams {
 
     public void setHstsEnabled(String hstsEnabled) {
         this.hstsEnabled = Boolean.parseBoolean(hstsEnabled);
+    }
+
+    public Boolean getHstsSubDomains() {
+        return hstsSubDomains;
+    }
+
+    public void setHstsSubDomains(Boolean hstsSubDomains) {
+        this.hstsSubDomains = hstsSubDomains;
+    }
+
+    public Boolean getHstsPreload() {
+        return hstsPreload;
+    }
+
+    public void setHstsPreload(Boolean hstsPreload) {
+        this.hstsPreload = hstsPreload;
     }
 
 }

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2021] Payara Foundation and/or affiliates
 
 package org.glassfish.admin.mbeanserver.ssl;
 
@@ -86,7 +87,7 @@ public class SSLParams {
     private String ssl3TlsCiphers;
     private Boolean tlsEnabled=true;
     private Boolean tlsRollBackEnabled=false;
-
+    private Boolean hstsEnabled = false;
 
 
 
@@ -335,6 +336,17 @@ public class SSLParams {
 
     public void setTlsRollbackEnabled(String tlsRollBackEnabled) {
         this.tlsRollBackEnabled = Boolean.parseBoolean(tlsRollBackEnabled);
+    }
+
+    /**
+     * Determines whether Strict Transport Security is set
+     */
+    public Boolean getHstsEnabled() {
+        return hstsEnabled;
+    }
+
+    public void setHstsEnabled(String hstsEnabled) {
+        this.hstsEnabled = Boolean.parseBoolean(hstsEnabled);
     }
 
 }

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -139,5 +139,10 @@
              <version>${grizzly.npn.api.version}</version>
              <scope>test</scope>
          </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -512,7 +512,7 @@ public class GenericGrizzlyListener implements GrizzlyListener {
                         try {
                             // temporary add SSL Filter, so subprotocol
                             // will see it
-                            extraSslPUFilterChainBuilder.add(addedSSLFilter);;
+                            extraSslPUFilterChainBuilder.add(addedSSLFilter);
                             configureSubProtocol(habitat, networkListener,
                                     subProtocol, extraSslPUFilterChainBuilder);
                         } finally {

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -505,7 +505,6 @@ public class GenericGrizzlyListener implements GrizzlyListener {
                         final Filter addedSSLFilter = configureSsl(
                                 habitat, getSsl(subProtocol),
                                 subProtocolFilterChainBuilder);
-                        final Filter hstsFilter = configureHSTSSupport(habitat, getSsl(subProtocol), filterChainBuilder);
                         subProtocolFilterChainBuilder.add(extraSslPUFilter);
                         final FilterChainBuilder extraSslPUFilterChainBuilder =
                             extraSslPUFilter.getPUFilterChainBuilder();
@@ -513,14 +512,12 @@ public class GenericGrizzlyListener implements GrizzlyListener {
                         try {
                             // temporary add SSL Filter, so subprotocol
                             // will see it
-                            extraSslPUFilterChainBuilder.add(addedSSLFilter);
-                            extraSslPUFilterChainBuilder.add(hstsFilter);
+                            extraSslPUFilterChainBuilder.add(addedSSLFilter);;
                             configureSubProtocol(habitat, networkListener,
                                     subProtocol, extraSslPUFilterChainBuilder);
                         } finally {
                             // remove SSL Filter
                             extraSslPUFilterChainBuilder.remove(addedSSLFilter);
-                            extraSslPUFilterChainBuilder.remove(hstsFilter);
                         }
                         
                         extraSslPUFilter.register(protocolFinder,

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/HSTSFilter.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/HSTSFilter.java
@@ -1,0 +1,107 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or affiliates
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.grizzly.config;
+
+import java.io.IOException;
+import org.glassfish.grizzly.Buffer;
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.config.dom.NetworkListener;
+import org.glassfish.grizzly.config.dom.Ssl;
+import org.glassfish.grizzly.filterchain.FilterChainContext;
+import org.glassfish.grizzly.filterchain.NextAction;
+import org.glassfish.grizzly.http.HttpContent;
+import org.glassfish.grizzly.http.HttpHeader;
+import org.glassfish.grizzly.http.HttpServerFilter;
+import org.glassfish.grizzly.http.util.HeaderValue;
+import org.glassfish.hk2.api.ServiceLocator;
+
+/**
+ * Filter that adds HSTS header to all requests
+ * @author jonathan coustick
+ * @since 5.28.0
+ */
+public class HSTSFilter extends HttpServerFilter implements ConfigAwareElement<Ssl> {
+    
+    private static final String HSTS_HEADER = "Strict-Transport-Security";
+    private static final String MAX_AGE = "max-age=31536000"; //1 year
+    
+    private boolean enabled;
+
+
+
+    @Override
+    public void configure(ServiceLocator habitat, NetworkListener networkListener, Ssl configuration) {
+        enabled = Boolean.parseBoolean(configuration.getHstsEnabled());
+    }
+
+    @Override
+    public NextAction handleRead(FilterChainContext ctx) throws IOException {
+        Object message = ctx.getMessage();
+        if (message instanceof HttpContent) {
+            HttpContent content = (HttpContent) message;
+            content.getHttpHeader().addHeader(HSTS_HEADER, MAX_AGE);
+            
+        }     
+        
+        return ctx.getInvokeAction();
+    }
+
+    @Override
+    public NextAction handleWrite(FilterChainContext ctx) throws IOException {
+        Object message = ctx.getMessage();
+        if (message instanceof HttpContent) {
+            HttpContent content = (HttpContent) message;
+            content.getHttpHeader().addHeader(HSTS_HEADER, MAX_AGE);
+            
+        }     
+        
+        return ctx.getInvokeAction();
+    }
+    
+
+    @Override
+    protected boolean onHttpHeaderParsed(HttpHeader httpHeader, Buffer buffer, FilterChainContext ctx) {
+        httpHeader.addHeader(HSTS_HEADER, MAX_AGE);
+        return false;
+    }
+    
+    
+    
+}

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
@@ -62,7 +62,9 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     boolean TLS12_ENABLED = true;
     boolean TLS13_ENABLED = false;
     boolean TLS_ROLLBACK_ENABLED = true;
-    boolean HSTS_ENABLED = true;
+    boolean HSTS_ENABLED = false;
+    boolean HSTS_SUBDOMAINS = false;
+    boolean HSTS_PRELOAD = false;
     boolean RENEGOTIATE_ON_CLIENT_AUTH_WANT = true;
     int MAX_CERT_LENGTH = 5;
     int DEFAULT_SSL_INACTIVITY_TIMEOUT = 30;
@@ -244,6 +246,14 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     @Attribute(defaultValue = "" + HSTS_ENABLED, dataType = Boolean.class)
     String getHstsEnabled();
     void setHstsEnabled(String value);
+    
+    @Attribute(defaultValue = "" + HSTS_SUBDOMAINS, dataType = Boolean.class)
+    String getHstsSubdomainsEnabled();
+    void setHstsSubdomainsEnabled();
+    
+    @Attribute(defaultValue = "" + HSTS_PRELOAD, dataType = Boolean.class)
+    String getHstsPreloadEnabled();
+    void setHstsPreloadEnabled(String value);
 
     @Attribute
     String getTrustAlgorithm();

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package org.glassfish.grizzly.config.dom;
 
@@ -62,6 +62,7 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     boolean TLS12_ENABLED = true;
     boolean TLS13_ENABLED = false;
     boolean TLS_ROLLBACK_ENABLED = true;
+    boolean HSTS_ENABLED = true;
     boolean RENEGOTIATE_ON_CLIENT_AUTH_WANT = true;
     int MAX_CERT_LENGTH = 5;
     int DEFAULT_SSL_INACTIVITY_TIMEOUT = 30;
@@ -236,6 +237,13 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     String getTlsRollbackEnabled();
 
     void setTlsRollbackEnabled(String value);
+    
+    /**
+     * Determines whether Strict Transport Security is set
+     */
+    @Attribute(defaultValue = "" + HSTS_ENABLED, dataType = Boolean.class)
+    String getHstsEnabled();
+    void setHstsEnabled(String value);
 
     @Attribute
     String getTrustAlgorithm();

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
@@ -248,12 +248,12 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     void setHstsEnabled(String value);
     
     @Attribute(defaultValue = "" + HSTS_SUBDOMAINS, dataType = Boolean.class)
-    String getHstsSubdomainsEnabled();
-    void setHstsSubdomainsEnabled();
+    String getHstsSubdomains();
+    void setHstsSubdomains();
     
     @Attribute(defaultValue = "" + HSTS_PRELOAD, dataType = Boolean.class)
-    String getHstsPreloadEnabled();
-    void setHstsPreloadEnabled(String value);
+    String getHstsPreload();
+    void setHstsPreload(String value);
 
     @Attribute
     String getTrustAlgorithm();


### PR DESCRIPTION
## Description
This is a feature

## Important Info
### Blockers


## Testing
### New tests
New test included in PR

### Testing Performed
Go to admin console and enable HSTS from SSL page of http-listner-2, `asadmin restart-http-listeners` then curl localhost:8181 with curl and check the headers.

### Testing Environment
Zulu JDK 1.8_272 on Ubuntu 20.10 with Maven 3.6.3

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
