### PR TITLE
FISH-1286: Update JDK 11 packages for OSGI.

### DIFF
--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -407,6 +407,7 @@ jre-11=\
  javax.imageio.metadata, \
  javax.imageio.plugins.bmp, \
  javax.imageio.plugins.jpeg, \
+ javax.imageio.plugins.tiff, \
  javax.imageio.spi, \
  javax.imageio.stream, \
  javax.lang.model, \
@@ -444,6 +445,7 @@ jre-11=\
  javax.security.auth.x500, \
  javax.security.cert, \
  javax.security.sasl, \
+ javax.smartcardio, \ 
  javax.sound.midi, \
  javax.sound.midi.spi, \
  javax.sound.sampled, \
@@ -459,7 +461,11 @@ jre-11=\
  javax.swing.filechooser, \
  javax.swing.plaf, \
  javax.swing.plaf.basic, \
+ javax.swing.plaf.basic.icons, \ 
  javax.swing.plaf.metal, \
+ javax.swing.plaf.metal.icons, \
+ javax.swing.plaf.metal.icons.oceans, \
+ javax.swing.plaf.metal.sourds, \  
  javax.swing.plaf.multi, \
  javax.swing.plaf.nimbus, \
  javax.swing.plaf.synth, \
@@ -468,6 +474,7 @@ jre-11=\
  javax.swing.text.html, \
  javax.swing.text.html.parser, \
  javax.swing.text.rtf, \
+ javax.swing.text.rtf.charsets, \
  javax.swing.tree, \
  javax.swing.undo, \
  javax.tools, \
@@ -491,11 +498,40 @@ jre-11=\
  javax.xml.transform.stream, \
  javax.xml.validation, \
  javax.xml.xpath, \
+ jdk.jfr, \
+ jdk.jfr.consumer, \
+ jdk.jfr.events, \
+ jdk.management.jfr, \ 
+ jdk.nashorn.api.linker, \
+ jdk.nashorn.api.scripting, \
+ jdk.nashorn.api.scripting.resources, \
+ jdk.nashorn.api.tree, \
+ jdk.nashorn.tools, \
+ jdk.nashorn.tools.resources, \
+ jdk.net, \
+ jdk.nio, \
+ jdk.nio.zipfs, \
+ jdk.security.jarsigner, \
+ jdk.swing.interop, \
+ jdk.tools.jimage, \
+ jdk.tools.jimage.resources, \
+ jdk.tools.jlink.builder, \
+ jdk.tools.jlink.plugin, \
+ jdk.tools.jlink.resources, \
+ jdk.tools.jmod, \
+ jdk.tools.jmod.resources, \
  org.ietf.jgss, \
  org.w3c.dom, \
  org.w3c.dom.bootstrap, \
+ org.w3c.dom.css, \
  org.w3c.dom.events, \
+ org.w3c.dom.html, \
  org.w3c.dom.ls, \
+ org.w3c.dom.ranges, \
+ org.w3c.dom.stylesheets, \
+ org.w3c.dom.traversal, \
+ org.w3c.dom.views, \
+ org.w3c.dom.xpath, \
  org.xml.sax, \
  org.xml.sax.ext, \
  org.xml.sax.helpers, \

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -56,14 +56,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 
 #
 # Framework config properties.
 #
 
 # Packages exported by system bundle when framework is Felix.
-# Unlike Equinox, Felix requires us to list all packages from felix.jar 
+# Unlike Equinox, Felix requires us to list all packages from felix.jar
 # while using org.osgi.framework.system.packages property.
 Felix.system.packages=\
  org.osgi.dto; version=1.0, \
@@ -89,7 +89,7 @@ Felix.system.packages=\
  ${extra-system-packages}
 
 
-# As much as we prefer system.packages.extra to system.packages, we are forced to 
+# As much as we prefer system.packages.extra to system.packages, we are forced to
 # configure system bundle using system.packages property because neither
 # Equinox nor Knopflerfish have the correct list of Java SE packages. Only
 # Felix has it after we supplied them the patch. It's a pity that something like
@@ -100,7 +100,7 @@ org.osgi.framework.system.packages=${${GlassFish_Platform}.system.packages}
 extra-system-packages=${jre-${java.specification.version}}, org.glassfish.embeddable;org.glassfish.embeddable.spi;version=3.1.1
 
 # Although Eclipselink imports these packages, in typical GlassFish installation,
-# Oracle JDBC driver may not be available as a bundle, so we ask user to install it in 
+# Oracle JDBC driver may not be available as a bundle, so we ask user to install it in
 # java.ext.dirs and the bootdelegation helps there.
 eclipselink.bootdelegation=oracle.sql, oracle.sql.*
 
@@ -111,7 +111,7 @@ eclipselink.bootdelegation=oracle.sql, oracle.sql.*
 org.osgi.framework.bootdelegation=${eclipselink.bootdelegation}, \
                                   com.sun.btrace, com.sun.btrace.*, \
                                   org.netbeans.lib.profiler, org.netbeans.lib.profiler.*
-                                  
+
 # The OSGi R4.2 spec says boot delegation uses the boot class loader by default. We need
 # to configure it to use the framework class loader because that class loader is
 # configured with extra classes like jdk tools.jar, derby jars, etc. that must be
@@ -119,7 +119,7 @@ org.osgi.framework.bootdelegation=${eclipselink.bootdelegation}, \
 org.osgi.framework.bundle.parent=framework
 
 # We don't set this value here, as expanding GlassFish_Platform gives us a file name with upper case
-# char in it. GlassFish file layout does not recommend use of upper case char, because some 
+# char in it. GlassFish file layout does not recommend use of upper case char, because some
 # platforms like Windows don't honor case in file names. So, we don't set the cache dir here.
 # Instead, it is set in various PlatformHelper implementations.
 #org.osgi.framework.storage=${com.sun.aas.instanceRoot}/osgi-cache/${GlassFish_Platform}/
@@ -171,7 +171,7 @@ com.sun.enterprise.hk2.cacheDir=${org.osgi.framework.storage}
 glassfish.osgi.auto.install=\
  ${com.sun.aas.installRootURI}modules/osgi-resource-locator.jar \
  ${com.sun.aas.installRootURI}modules/ \
- ${com.sun.aas.installRootURI}modules/autostart/ 
+ ${com.sun.aas.installRootURI}modules/autostart/
 
 # This bundle is only needed to be activated if we want to use ondemqand mode.
 # Since ondemand mode is not the default mode, we don't activate it by default
@@ -222,13 +222,13 @@ glassfish.osgi.auto.start.level.2=${autostart.bundles}
 # the standard framework property called org.osgi.framework.startlevel.beginning
 glassfish.osgi.start.level.final=2
 
-# What should be the initial start level of framework. 
+# What should be the initial start level of framework.
 # For performance reason, initially we set the start level to 1 so that no optional
 # bundles can get activated while server is still starting. Once server is started,
 # the framework's start level is set to whatever is configured in glassfish.osgi.start.level.final property.
 org.osgi.framework.startlevel.beginning=1
 
-# Set bundle start level to be same or less than that of framework, 
+# Set bundle start level to be same or less than that of framework,
 # otherwise HK2 installed bundles won't be activated.
 # See issue #5934
 felix.startlevel.bundle=1
@@ -390,7 +390,7 @@ jre-1.6=\
  org.xml.sax.ext, \
  org.xml.sax.helpers
 
-#dtrace support 
+#dtrace support
 # TODO: We still need to add appropriate SE packages for 7 & 8.
 jre-1.7=${jre-1.6},com.sun.tracing
 jre-1.8=${jre-1.7}
@@ -445,7 +445,7 @@ jre-11=\
  javax.security.auth.x500, \
  javax.security.cert, \
  javax.security.sasl, \
- javax.smartcardio, \ 
+ javax.smartcardio, \
  javax.sound.midi, \
  javax.sound.midi.spi, \
  javax.sound.sampled, \
@@ -461,11 +461,11 @@ jre-11=\
  javax.swing.filechooser, \
  javax.swing.plaf, \
  javax.swing.plaf.basic, \
- javax.swing.plaf.basic.icons, \ 
+ javax.swing.plaf.basic.icons, \
  javax.swing.plaf.metal, \
  javax.swing.plaf.metal.icons, \
  javax.swing.plaf.metal.icons.oceans, \
- javax.swing.plaf.metal.sourds, \  
+ javax.swing.plaf.metal.sourds, \
  javax.swing.plaf.multi, \
  javax.swing.plaf.nimbus, \
  javax.swing.plaf.synth, \
@@ -501,7 +501,7 @@ jre-11=\
  jdk.jfr, \
  jdk.jfr.consumer, \
  jdk.jfr.events, \
- jdk.management.jfr, \ 
+ jdk.management.jfr, \
  jdk.nashorn.api.linker, \
  jdk.nashorn.api.scripting, \
  jdk.nashorn.api.scripting.resources, \
@@ -544,7 +544,7 @@ felix.cache.singlebundlefile=true
 # See GLASSFISH-14134 for more details.
 org.glassfish.osgjpa.extension.useHybridPersistenceProviderResolver=false
 
-# When HybridPersistenceProviderResolver is used, it can be configured to use a cache. 
+# When HybridPersistenceProviderResolver is used, it can be configured to use a cache.
 # Setting the next property to false, disables caching of providers.
 org.glassfish.osgjpa.extension.hybridPersistenceProviderResolver.cachingEnabled=true
 


### PR DESCRIPTION
## Description
Update of the JDK 11 packages for OSGI.

I left out packages marked as `internal` and related to javadoc and jshell.

## Testing

### Testing Performed
Smoke test and using the FlightRecorder packages in a custom OSGI module.

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.2.2 with Maven 3.6.3

