### PR TITLE
FISH-987 Extra Logging and Option to Disable Evaluating Class References

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
         <hibernate.validator.version>6.1.5.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>6.1.5.Final</hibernate.validator-cdi.version>
-        <jakarta.el.version>3.0.3.payara-p3</jakarta.el.version>
-        <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
+        <jakarta.el.version>3.0.3.payara-p4</jakarta.el.version>
+        <jakarta.el-api.version>3.0.3.payara-p4</jakarta.el-api.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>
         <javax.cache-api.version>1.1.1</javax.cache-api.version>
         <mail.version>1.6.4.payara-p1</mail.version>
@@ -159,7 +159,7 @@
         <jaxb-api.version>2.3.2</jaxb-api.version>
         <jaxb-impl.version>2.3.2</jaxb-impl.version>
         <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>
-        <jsp-api.version>2.3.6</jsp-api.version>
+        <jsp-api.version>2.3.6.payara-p1</jsp-api.version>
         <jsp-impl.version>2.3.4</jsp-impl.version>
         <jstl-api.version>1.2.7</jstl-api.version>
         <jstl-impl.version>1.2.5</jstl-impl.version>


### PR DESCRIPTION
## Description
Feature.

Port from Payara 4.

> Payara Server 4 introduces a breaking change in EL (at least when it's used in a JSP). An EL expression in JSP which is evaluated correctly on GF 3 might confuse Payara Server 4 and 5 to thing that the expression contains a reference to an imported class and attempts to load that class. This ends in ClassNotFoundException. This happens every time the expression is evaluated. If there's a higher load on the server and the EL needs to be evaluated very often, the Classloader spends a significant amount of time searching for the class. Classloader puts a lock on the class and all the other threads that are evaluating the same expression have to wait for the lock. This can lead to too many threads blocked for a long time.
> 
> To fix this, we need to introduce a configuration option (system property) that reverts the behavior to be backwards compatible with GF 3. In other words, the EL engine should skip loading the imported classes if this option is enabled.

Changes are here: 
* https://github.com/payara/patched-src-el-ri/pull/3
* https://github.com/payara/patched-src-jsp-api/pull/3

## Important Info
### Blockers
None.

## Testing
### New tests
None.

### Testing Performed
Pending...

## Documentation
Pending...

## Notes for Reviewers

