### PR TITLE
[FISH-1178 FISH-1283] fixes resource loading Jakarta TCK failures

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/NonCachedJarStreamHandler.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/NonCachedJarStreamHandler.java
@@ -44,6 +44,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.jar.JarFile;
 
 /**
@@ -70,9 +73,10 @@ public class NonCachedJarStreamHandler extends URLStreamHandler {
             return url;
         }
         try {
-            return new URL(url, url.toExternalForm(), INSTANCE);
-        } catch (MalformedURLException ex) {
-            throw new IllegalArgumentException(ex);
+            return AccessController.doPrivileged((PrivilegedExceptionAction<URL>)
+                    () -> new URL(url, url.toExternalForm(), INSTANCE));
+        } catch (PrivilegedActionException ex) {
+            throw new IllegalArgumentException(ex.getException());
         }
     }
 


### PR DESCRIPTION
Resource URL instantiation needs to be privileged action because otherwise it fails the TCK

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Jakarta TCK fails due to insuficient permissions
Using `doPrivileged()` block for security manager

## Tailing TCK stack trace:
```
  [runcts] OUT => [javatest.batch] ************************************************************
   [runcts] OUT => [javatest.batch] * props file set to "/tmp/jenkins-cts-props.txt"
   [runcts] OUT => [javatest.batch] ************************************************************
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  Opened connection to http://localhost:8001/jsonprovidertests_jsp_vehicle_web/jsp_vehicle.jsp
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  Test status from a jsp:  1:Test case throws exception: jsonProviderTest11 Failed:
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  Test: returning from running in a jsp vehicle
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR: setup ok
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR: Calling SPI provider method: public JsonArrayBuilder createArrayBuilder()
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR-ERROR: Test case throws exception: jsonProviderTest11 Failed:
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR-ERROR: Exception at:  
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR-ERROR: java.security.AccessControlException: access denied ("java.net.NetPermission" "specifyStreamHandler")
   [runcts] OUT => [javatest.batch] 	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
   [runcts] OUT => [javatest.batch] 	at java.security.AccessController.checkPermission(AccessController.java:886)
   [runcts] OUT => [javatest.batch] 	at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
   [runcts] OUT => [javatest.batch] 	at java.net.URL.checkSpecifyHandler(URL.java:674)
   [runcts] OUT => [javatest.batch] 	at java.net.URL.<init>(URL.java:544)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.web.loader.NonCachedJarStreamHandler.forceNonCachedJarURL(NonCachedJarStreamHandler.java:73)
   [runcts] OUT => [javatest.batch] 	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
   [runcts] OUT => [javatest.batch] 	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
   [runcts] OUT => [javatest.batch] 	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
   [runcts] OUT => [javatest.batch] 	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
   [runcts] OUT => [javatest.batch] 	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
   [runcts] OUT => [javatest.batch] 	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
   [runcts] OUT => [javatest.batch] 	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.web.loader.WebappClassLoader.findResources(WebappClassLoader.java:1341)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.web.loader.WebappClassLoader.getResources(WebappClassLoader.java:1569)
   [runcts] OUT => [javatest.batch] 	at java.util.ServiceLoader$LazyIterator.hasNextService(ServiceLoader.java:348)
   [runcts] OUT => [javatest.batch] 	at java.util.ServiceLoader$LazyIterator.access$600(ServiceLoader.java:323)
   [runcts] OUT => [javatest.batch] 	at java.util.ServiceLoader$LazyIterator$1.run(ServiceLoader.java:396)
   [runcts] OUT => [javatest.batch] 	at java.util.ServiceLoader$LazyIterator$1.run(ServiceLoader.java:395)
   [runcts] OUT => [javatest.batch] 	at java.security.AccessController.doPrivileged(Native Method)
   [runcts] OUT => [javatest.batch] 	at java.util.ServiceLoader$LazyIterator.hasNext(ServiceLoader.java:398)
   [runcts] OUT => [javatest.batch] 	at java.util.ServiceLoader$1.hasNext(ServiceLoader.java:474)
   [runcts] OUT => [javatest.batch] 	at javax.json.spi.JsonProvider.provider(JsonProvider.java:68)
   [runcts] OUT => [javatest.batch] 	at javax.json.Json.createArrayBuilder(Json.java:238)
   [runcts] OUT => [javatest.batch] 	at com.sun.ts.tests.jsonp.pluggability.jsonprovidertests.Client.jsonProviderTest11(Client.java:349)
   [runcts] OUT => [javatest.batch] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
   [runcts] OUT => [javatest.batch] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
   [runcts] OUT => [javatest.batch] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   [runcts] OUT => [javatest.batch] 	at java.lang.reflect.Method.invoke(Method.java:498)
   [runcts] OUT => [javatest.batch] 	at com.sun.ts.lib.harness.EETest.run(EETest.java:596)
   [runcts] OUT => [javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:115)
   [runcts] OUT => [javatest.batch] 	at org.apache.jsp.jsp_005fvehicle_jsp.runTest(jsp_005fvehicle_jsp.java:31)
   [runcts] OUT => [javatest.batch] 	at org.apache.jsp.jsp_005fvehicle_jsp._jspService(jsp_005fvehicle_jsp.java:133)
   [runcts] OUT => [javatest.batch] 	at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:111)
   [runcts] OUT => [javatest.batch] 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
   [runcts] OUT => [javatest.batch] 	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:411)
   [runcts] OUT => [javatest.batch] 	at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:473)
   [runcts] OUT => [javatest.batch] 	at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:377)
   [runcts] OUT => [javatest.batch] 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
   [runcts] OUT => [javatest.batch] 	at sun.reflect.GeneratedMethodAccessor188.invoke(Unknown Source)
   [runcts] OUT => [javatest.batch] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   [runcts] OUT => [javatest.batch] 	at java.lang.reflect.Method.invoke(Method.java:498)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.security.SecurityUtil$1.run(SecurityUtil.java:316)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.security.SecurityUtil$1.run(SecurityUtil.java:314)
   [runcts] OUT => [javatest.batch] 	at java.security.AccessController.doPrivileged(Native Method)
   [runcts] OUT => [javatest.batch] 	at javax.security.auth.Subject.doAsPrivileged(Subject.java:549)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.security.SecurityUtil.execute(SecurityUtil.java:349)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.security.SecurityUtil.doAsPrivilege(SecurityUtil.java:207)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.core.StandardWrapper.service(StandardWrapper.java:1620)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:259)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:161)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.core.StandardPipeline.doInvoke(StandardPipeline.java:757)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.core.StandardPipeline.invoke(StandardPipeline.java:577)
   [runcts] OUT => [javatest.batch] 	at com.sun.enterprise.web.WebPipeline.invoke(WebPipeline.java:99)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:158)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.connector.CoyoteAdapter.doService(CoyoteAdapter.java:371)
   [runcts] OUT => [javatest.batch] 	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:238)
   [runcts] OUT => [javatest.batch] 	at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
   [runcts] OUT => [javatest.batch] 	at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:182)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:156)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:218)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:524)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:89)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:94)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$100(WorkerThreadIOStrategy.java:33)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:114)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
   [runcts] OUT => [javatest.batch] 	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
   [runcts] OUT => [javatest.batch] 	at java.lang.Thread.run(Thread.java:748)
   [runcts] OUT => [javatest.batch] 
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR: cleanup ok
   [runcts] OUT => [javatest.batch] 03-30-2021 03:48:30:  SVR: Test running in jsp vehicle failed
   [runcts] OUT => [javatest.batch] STATUS:Failed.Test case throws exception: jsonProviderTest11 Failed:
   [runcts] OUT => [javatest.batch] Failed. Test case throws exception: jsonProviderTest11 Failed:
   [runcts] OUT => [javatest.batch] ********************************************************************************
   [runcts] OUT => [javatest.batch] Finished Test:  FAILED........com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/Client.java#jsonProviderTest11_from_jsp
```

## Important Info
## Testing
Jakarta TCK
