### PR TITLE
FISH-1293 Disassociate ClusteredStore from tenants

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastTenant.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastTenant.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -120,13 +120,13 @@ public class PayaraHazelcastTenant implements TenantControl, DataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(contextInstance);
-        out.writeUTF(moduleName);
+        out.writeString(moduleName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         contextInstance = in.readObject();
-        moduleName = in.readUTF();
+        moduleName = in.readString();
     }
 
     @Override


### PR DESCRIPTION
## Description
Bug. 
Tenant control associates all Hazelcast objects to their calling applications by default.
However, internal maps that belong to `ClusteredStore` should not do this.
This fix prevents it from associating thus preventing blocking by tenant control
when application is undeployed

- pushing empty context in ClusteredStore to prevent association of Hazelcast maps to tenant applications

  that may be later undeployed and would leave maps orphan, which in turn will lead
  to Hazelcast blocking calls to those maps
- minor cleanup

## Testing
### Testing Performed
Ran Payara Samples twice, which is how I discovered this bug in the first place

## Review Notes
** Please use "ignore whitespace changes" to review,
otherwise it looks like changes don't make sense
