### PR TITLE
[FISH-1297] Certain network configurations lead to NPE on startup

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryService.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -74,7 +74,8 @@ import org.glassfish.internal.api.ServerContext;
  */
 public class DomainDiscoveryService implements DiscoveryService {
     private static Logger logger = Logger.getLogger(DomainDiscoveryService.class.getName());
-    private final Holder.LazyHolder<InetAddress> chosenAddress = Holder.LazyHolder.lazyHolder(MemberAddressPicker::findMyAddress);
+    private final Holder.LazyHolder<InetAddress> chosenAddress =
+            Holder.LazyHolder.lazyHolder(MemberAddressPicker::findMyAddressOrLocalHost);
 
     public DomainDiscoveryService(DiscoveryServiceSettings settings) {
 
@@ -194,5 +195,4 @@ public class DomainDiscoveryService implements DiscoveryService {
     public Map<String, String> discoverLocalMetadata() {
         return Collections.emptyMap();
     }
-
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MemberAddressPicker.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MemberAddressPicker.java
@@ -158,7 +158,7 @@ public class MemberAddressPicker implements MemberAddressProvider {
     static InetAddress findMyAddressOrLocalHost() {
         InetAddress myAddress = findMyAddress();
         if (myAddress == null) {
-            return tryLocalHostOrLoopback(0).getAddress();
+            return tryLocalHostOrLoopback(0, true).getAddress();
         }
         return myAddress;
     }
@@ -171,19 +171,21 @@ public class MemberAddressPicker implements MemberAddressProvider {
             } else if (backupAddress.get() != null) {
                 targetAddress = new InetSocketAddress(backupAddress.get(), port);
             } else {
-                targetAddress = tryLocalHostOrLoopback(port);
+                targetAddress = tryLocalHostOrLoopback(port, false);
             }
         }
         return targetAddress;
     }
 
-    private static InetSocketAddress tryLocalHostOrLoopback(int port) {
+    private static InetSocketAddress tryLocalHostOrLoopback(int port, boolean warn) {
         try {
             // ok do the easy thing
-            logger.log(Level.FINE, "Could not find an appropriate address, falling back to local host");
+            logger.log(warn ? Level.WARNING : Level.FINE,
+                    "Could not find an appropriate address, falling back to local host");
             return new InetSocketAddress(InetAddress.getLocalHost(), port);
         } catch (UnknownHostException ex) {
-            logger.log(Level.FINE, "Could not find local host, falling back to loop back address");
+            logger.log(warn ? Level.WARNING : Level.FINE,
+                    "Could not find local host, falling back to loop back address");
             return new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
         }
     }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MemberAddressPicker.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MemberAddressPicker.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -155,6 +155,14 @@ public class MemberAddressPicker implements MemberAddressProvider {
         }
     }
 
+    static InetAddress findMyAddressOrLocalHost() {
+        InetAddress myAddress = findMyAddress();
+        if (myAddress == null) {
+            return tryLocalHostOrLoopback(0).getAddress();
+        }
+        return myAddress;
+    }
+
     private static InetSocketAddress ensureAddress(InetSocketAddress targetAddress, InetSocketAddress sourceAddress,
             LazyHolder<InetAddress> backupAddress, int port) {
         if (targetAddress == null) {
@@ -180,7 +188,7 @@ public class MemberAddressPicker implements MemberAddressProvider {
         }
     }
 
-    static InetAddress findMyAddress() {
+    private static InetAddress findMyAddress() {
         //add to list filtering out docker0
         HashSet<NetworkInterface> possibleInterfaces = new HashSet<>();
         try {


### PR DESCRIPTION
## Description
This is a bug fix.
Certain network configurations lead to chosenAddress variable to be null and prevent Payara to start
Fixes #5192

## Testing
### Testing Performed
Existing test suites
