### PR TITLE
FISH-1214 ConfigParser now accepts XML with content outside elements

### DIFF
--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2020-2021] Payara Foundation and/or affiliates
 
 package org.jvnet.hk2.config;
 
@@ -169,7 +170,7 @@ public class ConfigParser {
             // flush the sub element content from the parser
             int depth=1;
             while(depth>0) {
-                final int tag = in.nextTag();
+                final int tag = in.next();
                 if (tag==START_ELEMENT && in.getLocalName().equals(localName)) {
                     if (Logger.getAnonymousLogger().isLoggable(Level.FINE)) {
                         Logger.getAnonymousLogger().fine("Found child of same type "+localName+" ignoring too");

--- a/nucleus/hk2/hk2-config/src/test/java/org/jvnet/hk2/config/test/GenericConfig.java
+++ b/nucleus/hk2/hk2-config/src/test/java/org/jvnet/hk2/config/test/GenericConfig.java
@@ -37,9 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2021] Payara Foundation and/or affiliates
 
 package org.jvnet.hk2.config.test;
 
+import java.util.List;
 import org.jvnet.hk2.config.Attribute;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.Configured;
@@ -54,4 +56,7 @@ public interface GenericConfig extends ConfigBeanProxy {
     @Element
     GenericConfig getGenericConfig();
     void setGenericConfig(GenericConfig genericConfig);
+    
+    @Element("foo")
+    List<String> getStrings();
 }

--- a/nucleus/hk2/hk2-config/src/test/resources/domain.xml
+++ b/nucleus/hk2/hk2-config/src/test/resources/domain.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2021] Payara Foundation and/or affiliates -->
 
 <simple-connector>
     <ejb-container-availability/>
@@ -47,6 +48,7 @@
         <generic-config name="test1">
           <generic-config name="test">
             <generic-config name="test"/>
+                <foo>bar</foo>
           </generic-config>
         </generic-config>
         <generic-config name="test2">


### PR DESCRIPTION
## Description
This is a bug fix.



## Important Info

## Testing

### New tests
Update to test included in PR

### Testing Performed
After the first commit to revert the work-around in, run the upgrade-server command which throws a ParseException. After the new commit it doesn't.

### Test suites executed
- Java EE7 Samples

### Testing Environment
Zulu JDK 1.8_272 on Ubuntu 20.10 with Maven 3.6.3

## Notes for Reviewers
This is the community version of payara/payara-enterprise#363
