### PR TITLE
FISH-1311 Password alias optimization

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/PasswordAdapter.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/PasswordAdapter.java
@@ -57,6 +57,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.util.Enumeration;
+import java.util.Arrays;
 
 /**
  * This class implements an adapter for password manipulation a JCEKS.

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/PasswordAdapter.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/PasswordAdapter.java
@@ -299,7 +299,12 @@ public final class PasswordAdapter {
         // if the KeyStore exists, update it in a manner that doesn't destroy
         // the existing store if a failure occurs.
         if (keystoreExists) {
-            final KeyStore newKeyStore = duplicateKeyStore(masterPassword);
+            final KeyStore newKeyStore;
+            if (Arrays.equals(masterPassword, this.masterPassword)) {
+                newKeyStore = this.pwdStore;
+            } else {
+                newKeyStore = duplicateKeyStore(masterPassword);
+            }
 
             // 'newKeyStore' is now complete; rename the old KeyStore, the write the new one in its place
             final File saveOld = new File(keyFile.toString() + ".save");


### PR DESCRIPTION
ISSUE 5167 - asadmin create-password-alias is very slow when there are many aliases created 
Fixes #5167

## Description
This is a fix for the issue #5167 
asadmin create-password-alias is very slow when there are many aliases created.
The call to duplicateKeyStore in the writeKeyStoreSafe method of the PasswordAdapter class is what makes create-password-alias slow in this case.
Running duplicateKeyStore  only with masterPassword is changed resolve the problem.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
