### PR TITLE
FISH-1274 Vulnerability in Metro's WSDL Code Importing/Parsing - Remote Code Execution

### DIFF
--- a/appserver/webservices/jsr109-impl/src/test/java/org/glassfish/webservices/monitoring/WebServiceTesterServletTest.java
+++ b/appserver/webservices/jsr109-impl/src/test/java/org/glassfish/webservices/monitoring/WebServiceTesterServletTest.java
@@ -1,0 +1,112 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.webservices.monitoring;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WebServiceTesterServletTest {
+
+    @Test
+    public void testIpv4Regex() {
+        // Loopback should work
+        Assert.assertTrue(WebServiceTesterServlet.checkValidIpv4DottedDecimal("127.0.0.1"));
+
+        // Typical default should work
+        Assert.assertTrue(WebServiceTesterServlet.checkValidIpv4DottedDecimal("192.168.1.1"));
+
+        // Empty string should fail
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal(""));
+
+        // DNS name should fail
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("payara.fish"));
+
+        // All 0's allowed
+        Assert.assertTrue(WebServiceTesterServlet.checkValidIpv4DottedDecimal("0.0.0.0"));
+
+        // No 0 prefixes
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("012.168.35.64"));
+
+        // 0 suffixes allowed
+        Assert.assertTrue(WebServiceTesterServlet.checkValidIpv4DottedDecimal("102.120.35.240"));
+
+        // Numbers greater than 255 not allowed
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("192.168.43.256"));
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("192.168.43.1234"));
+
+        // Must be 4 segments
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("192"));
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("192.168"));
+        Assert.assertFalse(WebServiceTesterServlet.checkValidIpv4DottedDecimal("192.168.43"));
+    }
+
+    @Test
+    public void testDnsNameRegex() {
+        // Standalone name allowed e.g. "localhost"
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara"));
+
+        // "." allowed to denote segments
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara.fish"));
+
+        // "-" is allowed
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara-jaxws"));
+
+        // "-" is allowed, and "." allowed to denote segments
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara-jaxws.fish"));
+
+        // Letters and numbers allowed
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara2021"));
+
+        // Multiple segments allowed, and letters & numbers allowed
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara.2021.swims"));
+
+        // "-" is allowed, "." allowed to denote segments, and so is a trailing "."
+        Assert.assertTrue(WebServiceTesterServlet.checkValidDnsName("payara-jaxws.fish."));
+
+        // Double trailing "." not allowed
+        Assert.assertFalse(WebServiceTesterServlet.checkValidDnsName("payara-jaxws.fish.."));
+        // No non-ASCII alphanumerics allowed
+        Assert.assertFalse(WebServiceTesterServlet.checkValidDnsName("faß.de"));
+        // No symbol other than "-" or "." allowed
+        Assert.assertFalse(WebServiceTesterServlet.checkValidDnsName("malicious/payload.wsdl"));
+        Assert.assertFalse(WebServiceTesterServlet.checkValidDnsName("malicious/payload.wsdl#"));
+    }
+
+}

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -128,7 +128,7 @@
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
 
         <!-- JAX-B -->
-        <jaxb.version>2.3.3</jaxb.version>
+        <jaxb.version>2.3.2</jaxb.version>
 
         <management-api.version>1.1-rev-1</management-api.version>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -128,7 +128,7 @@
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
 
         <!-- JAX-B -->
-        <jaxb.version>2.3.2</jaxb.version>
+        <jaxb.version>2.3.3</jaxb.version>
 
         <management-api.version>1.1-rev-1</management-api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@
         <hibernate.validator-cdi.version>6.1.5.Final</hibernate.validator-cdi.version>
         <jakarta.el.version>3.0.3.payara-p4</jakarta.el.version>
         <jakarta.el-api.version>3.0.3.payara-p4</jakarta.el-api.version>
-        <jaxb-api.version>2.3.2</jaxb-api.version>
         <javax.cache-api.version>1.1.1</javax.cache-api.version>
         <mail.version>1.6.4.payara-p1</mail.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -156,8 +155,8 @@
         <snakeyaml.version>1.25</snakeyaml.version>
         <hazelcast.version>4.2</hazelcast.version>
         <hazelcast.kubernetes.version>2.2</hazelcast.kubernetes.version>
-        <jaxb-api.version>2.3.2</jaxb-api.version>
-        <jaxb-impl.version>2.3.2</jaxb-impl.version>
+        <jaxb-api.version>2.3.3</jaxb-api.version>
+        <jaxb-impl.version>2.3.3</jaxb-impl.version>
         <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>
         <jsp-api.version>2.3.6.payara-p1</jsp-api.version>
         <jsp-impl.version>2.3.4</jsp-impl.version>
@@ -186,9 +185,9 @@
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>
-        <jaxws-api.version>2.3.2</jaxws-api.version>
+        <jaxws-api.version>2.3.3</jaxws-api.version>
         <jakarta.jws-api.version>1.1.1</jakarta.jws-api.version>
-        <webservices.version>2.4.3.payara-p3</webservices.version>
+        <webservices.version>2.4.4.payara-p1</webservices.version>
         <woodstox.version>5.1.0</woodstox.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,8 +155,8 @@
         <snakeyaml.version>1.25</snakeyaml.version>
         <hazelcast.version>4.2</hazelcast.version>
         <hazelcast.kubernetes.version>2.2</hazelcast.kubernetes.version>
-        <jaxb-api.version>2.3.3</jaxb-api.version>
-        <jaxb-impl.version>2.3.3</jaxb-impl.version>
+        <jaxb-api.version>2.3.2</jaxb-api.version>
+        <jaxb-impl.version>2.3.2</jaxb-impl.version>
         <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>
         <jsp-api.version>2.3.6.payara-p1</jsp-api.version>
         <jsp-impl.version>2.3.4</jsp-impl.version>
@@ -185,9 +185,9 @@
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>
-        <jaxws-api.version>2.3.3</jaxws-api.version>
+        <jaxws-api.version>2.3.2</jaxws-api.version>
         <jakarta.jws-api.version>1.1.1</jakarta.jws-api.version>
-        <webservices.version>2.4.4.payara-p1</webservices.version>
+        <webservices.version>2.4.3.payara-p4</webservices.version>
         <woodstox.version>5.1.0</woodstox.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>


### PR DESCRIPTION
## Description
This is a bug fix.

The Webservice Tester servlet had a possible Host Header attack vector, allowing for a malicious WSDL to potentially be imported. Combined with a code injection vulnerability in Metro, this allowed an attacker to potentially run their own code on a machine. This PR adds extra validation to the tester servlet to ensure the host header is a valid one, and also adds extra validation to Metro itself to help ensure that any replacement being done is a valid variable to help prevent code injection.

## Important Info

I'm not entirely sure if checking if the variable replacement is a valid _java_ variable is in accordance with the spec (I can't find anything saying one way or the other), but I inferred it to be true given that Metro is already validating that the variable being replaced isn't a Java keyword.

### Dependant PRs
* Metro-JAX-WS: https://github.com/payara/patched-src-metro-jax-ws/pull/5
* Metro-WSIT: https://github.com/payara/patched-src-metro-wsit/pull/9

Tags haven't been made yet as I'm trying to get this tested.

### Blockers

~~Metro-JAX-WS has been compiled and deployed to https://nexus.payara.fish/repository/payara-artifacts, for some reason however when I try to deploy Metro-WSIT I get a 401 on the org.glassfish.metro:webservices-osgi:jar:2.4.4.payara-p1 artifact - numerous other artifacts deploy successfully, for some reason it hates this one.~~

Resolved.

## Testing
Test outlined in the issue: https://payara.atlassian.net/browse/FISH-1274
It now rejects the request with an error.

Also tested using `payara5/glassfish/bin/wsimport` and the evil payload.wsdl directly, since fixing the Host Header attack prevents the wsimport from happening in the first place.
It now throws an error during import so that no code gets compiled and written out - without the fix it would import "successfully", with the evil code injection happening (with breakpoints you would see it write out the java class with the evil code injected)

### New tests
None yet.

### Testing Environment
WSL OpenSUSE Leap, Zulu JDK 8 and 11

## Documentation
N/A

## Notes for Reviewers
Anyone who knows JAX-WS / JAXB appreciated!

I'd also appreciate someone to double-check my regex:

- https://github.com/payara/Payara-Enterprise/pull/362/files#diff-eadcbc7652f76beffdef81b64d24379fc19ef8d8f668eb4bf6f05b0400988a0dR707
- https://github.com/payara/Payara-Enterprise/pull/362/files#diff-eadcbc7652f76beffdef81b64d24379fc19ef8d8f668eb4bf6f05b0400988a0dR714
- https://github.com/payara/patched-src-metro-jax-ws/commit/ee5e35b63d083a7ec2059600bd2a8b0af8d12aab#diff-cf002804ccada9bd9517ee6204b4189673735e0349a52d89519523b077e730a4R917