### PR TITLE
FISH-1315 Improve loading time for REST application when there are many password aliases #5177

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -106,29 +106,40 @@ public class OpenApiService {
         this.withCorsHeaders = withCorsHeaders;
     }
 
-	public void registerApp(String applicationId, DeploymentContext ctx) {
+    public void registerApp(String applicationId, DeploymentContext ctx) {
         final WebBundleDescriptorImpl descriptor = ctx.getModuleMetaData(WebBundleDescriptorImpl.class);
         final String contextRoot = descriptor.getContextRoot();
         final ReadableArchive archive = ctx.getSource();
         final ClassLoader classLoader = ctx.getClassLoader();
-        documents.put(applicationId, new OpenAPISupplier(applicationId, contextRoot, archive, classLoader));
-        cachedResult = null;
-	}
 
-	public void deregisterApp(String applicationId) {
-        documents.remove(applicationId);
+        if (this.enabled) {
+            documents.put(applicationId, new OpenAPISupplier(applicationId, contextRoot, archive, classLoader));
+        }
         cachedResult = null;
-	}
+    }
 
-	public void resumeApp(String applicationId) {
-        documents.get(applicationId).setEnabled(true);
+    public void deregisterApp(String applicationId) {
+        if (documents.get(applicationId) != null) {
+            documents.remove(applicationId);
+        }
         cachedResult = null;
-	}
+    }
 
-	public void suspendApp(String applicationId) {
-        documents.get(applicationId).setEnabled(false);
+    public void resumeApp(String applicationId) {
+        OpenAPISupplier supplier=documents.get(applicationId);
+        if (supplier != null) {
+            supplier.setEnabled(true);
+        }
         cachedResult = null;
-	}
+    }
+
+    public void suspendApp(String applicationId) {
+        OpenAPISupplier supplier=documents.get(applicationId);
+        if (supplier != null) {
+            supplier.setEnabled(false);
+        }
+        cachedResult = null;
+    }
 
     /**
      * @return the document If multiple application deployed then merge all the

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -111,33 +111,22 @@ public class OpenApiService {
         final String contextRoot = descriptor.getContextRoot();
         final ReadableArchive archive = ctx.getSource();
         final ClassLoader classLoader = ctx.getClassLoader();
-
-        if (this.enabled) {
-            documents.put(applicationId, new OpenAPISupplier(applicationId, contextRoot, archive, classLoader));
-        }
+        documents.put(applicationId, new OpenAPISupplier(applicationId, contextRoot, archive, classLoader));
         cachedResult = null;
     }
 
     public void deregisterApp(String applicationId) {
-        if (documents.get(applicationId) != null) {
-            documents.remove(applicationId);
-        }
+        documents.remove(applicationId);
         cachedResult = null;
     }
 
     public void resumeApp(String applicationId) {
-        OpenAPISupplier supplier=documents.get(applicationId);
-        if (supplier != null) {
-            supplier.setEnabled(true);
-        }
+        documents.get(applicationId).setEnabled(true);
         cachedResult = null;
     }
 
     public void suspendApp(String applicationId) {
-        OpenAPISupplier supplier=documents.get(applicationId);
-        if (supplier != null) {
-            supplier.setEnabled(false);
-        }
+        documents.get(applicationId).setEnabled(false);
         cachedResult = null;
     }
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/PasswordAliasConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/PasswordAliasConfigSource.java
@@ -55,6 +55,9 @@ import java.util.logging.Logger;
 import org.glassfish.config.support.TranslatedConfigView;
 import org.glassfish.internal.api.Globals;
 
+import java.util.Set;
+import java.util.HashSet;
+
 /**
  *
  * @author steve
@@ -85,6 +88,20 @@ public class PasswordAliasConfigSource extends PayaraConfigSource {
         }
         return properties;
     }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        Set<String> propertyNames = new HashSet<>();
+        if (store != null) {
+            Iterator<String> keys = store.keys();
+            while (keys.hasNext()){
+                String key = keys.next();
+                propertyNames.add(key);
+            }
+        }
+        return propertyNames;
+    }
+
 
     @Override
     public String getValue(String name) {

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/PasswordAliasConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/PasswordAliasConfigSource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -47,7 +47,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -65,11 +64,11 @@ import java.util.HashSet;
 public class PasswordAliasConfigSource extends PayaraConfigSource {
 
     private final DomainScopedPasswordAliasStore store;
-    
+
     public PasswordAliasConfigSource() {
         store = Globals.getDefaultHabitat().getService(DomainScopedPasswordAliasStore.class);
     }
-    
+
     @Override
     public int getOrdinal() {
         return Integer.parseInt(configService.getMPConfig().getPasswordOrdinality());
@@ -79,26 +78,14 @@ public class PasswordAliasConfigSource extends PayaraConfigSource {
     @Override
     public Map<String, String> getProperties() {
         Map<String,String> properties = new HashMap<>();
-        if (store != null) {
-            Iterator<String> keys = store.keys();
-            while (keys.hasNext()){
-                String key = keys.next();
-                properties.put(key, new String(store.get(key)));
-            }
-        }
+        store.keys().forEachRemaining(key -> properties.put(key, new String(store.get(key))));
         return properties;
     }
 
     @Override
     public Set<String> getPropertyNames() {
         Set<String> propertyNames = new HashSet<>();
-        if (store != null) {
-            Iterator<String> keys = store.keys();
-            while (keys.hasNext()){
-                String key = keys.next();
-                propertyNames.add(key);
-            }
-        }
+        store.keys().forEachRemaining(propertyNames::add);
         return propertyNames;
     }
 
@@ -136,5 +123,4 @@ public class PasswordAliasConfigSource extends PayaraConfigSource {
     public String getName() {
         return "Password Alias";
     }
-    
 }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/PasswordAliasConfigSource.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/source/PasswordAliasConfigSource.java
@@ -56,6 +56,7 @@ import org.glassfish.internal.api.Globals;
 
 import java.util.Set;
 import java.util.HashSet;
+import java.util.Objects;
 
 /**
  *
@@ -92,9 +93,7 @@ public class PasswordAliasConfigSource extends PayaraConfigSource {
 
     @Override
     public String getValue(String name) {
-        if (name == null || store == null) {
-            return null;
-        }
+        Objects.requireNonNull(name, "Name perameter cannot be null");
 
         String value = null;
 

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -192,7 +192,7 @@ public class PayaraConfig implements Config {
     public Iterable<String> getPropertyNames() {
         List<String> result = new ArrayList<>();
         for (ConfigSource configSource : sources) {
-            result.addAll(configSource.getProperties().keySet());
+            result.addAll(configSource.getPropertyNames());
         }
         return result;
     }


### PR DESCRIPTION
ISSUE 5177 - Load of REST application is very slow (120 seconds) when there are many password aliases created

## Description
This is a fix for the issue #5177
Load of REST application is very slow (120 seconds) when there are many password aliases created.

In this situation (800 password aliases), the cause of this slowness is that Microprofile OpenAPI reads the Microprofile Config when register an application in OpenAPI. PasswordAlias is a config source and it's necessary to read the keystore that is a taxing process if there are many password aliases.

One possible solution to resolve this issue is disable OpenAPI, but disabling OpenAPI seems that only affect to publish /openapi url. OpenAPI service is started even if OpenAPI is disabled and always register the application causing the slowness.

In this PR I've changed the registerApp method of OpenService class to prepare the document only if OpenAPI is enabled. With this modification, instead of taking 130 seconds to load an application it only takes less than 6.

Instead of modifying OpenAPIService class, the OpenApiApplicationContainer class could have been modified to avoid calling OpenApiService, but I thought it could have other side effects.

## Important Info
### Blockers


## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
