### PR TITLE
FISH-84 Fix for using EL to configure OpenId in EAR

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/cdiDevMode/cdiDevModeApplication.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/cdiDevMode/cdiDevModeApplication.jsf
@@ -1,7 +1,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   
-   Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,7 @@
    holder.
 -->
 <sun:hyperlink id="cdiDevModeLink" rendered="#{requestScope.isCDIDevMode[td.value.name]}" text="$resource{i18nhc.cdiDevMode.toolLink}"
-               onClick="var win=window.open('#{request.contextPath}/payaraExtras/cdiDevMode/cdiDevMode.jsf?appName=#{pageSession.encodedAppName}&contextRoot=#{td.value.contextRoot}','ViewerWindow','width='+.75*screen.width+',height='+.75*screen.height+',top='+.1*screen.height+',left='+.1*screen.width+',toolbar=yes,status=yes,menubar=yes,scrollbars=yes,resizable=yes,directories=yes,location=yes');win.focus(); return false;" >
+               onClick="var win=window.open('#{request.contextPath}/payaraExtras/cdiDevMode/cdiDevMode.jsf?appName=#{pageSession.encodedAppName}&contextRoot=#{pageSession.td.value.contextRoot}','ViewerWindow','width='+.75*screen.width+',height='+.75*screen.height+',top='+.1*screen.height+',left='+.1*screen.width+',toolbar=yes,status=yes,menubar=yes,scrollbars=yes,resizable=yes,directories=yes,location=yes');win.focus(); return false;" >
     <!beforeCreate
         setResourceBundle(key="i18nhc" bundle="fish.payara.admingui.extras.Strings");
         setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -40,10 +40,15 @@
 package fish.payara.security.openid;
 
 import java.util.Optional;
+import java.util.Random;
 import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.el.ELProcessor;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import org.eclipse.microprofile.config.Config;
 import org.glassfish.config.support.TranslatedConfigView;
 
@@ -71,11 +76,24 @@ public final class OpenIdUtil {
         }
         if (type == String.class && isELExpression((String) value)) {
             ELProcessor elProcessor = new ELProcessor();
-            BeanManager beanManager = CDI.current().getBeanManager();
+            BeanManager beanManager = getBeanManagerForCurrentModule();
             elProcessor.getELManager().addELResolver(beanManager.getELResolver());
             result = (T) elProcessor.getValue(toRawExpression((String) result), type);
         }
         return result;
+    }
+    
+    private static BeanManager getBeanManagerForCurrentModule() {
+        /*
+         For some reason, CDI.current().getBeanManager() doesn't always return
+         the correct bean manager in EAR, therefore we're using JNDI lookup until this is fixed.
+         See https://lists.jboss.org/pipermail/cdi-dev/2016-April/008185.html
+        */
+        try {
+            return (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
+        } catch (NamingException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     public static boolean isELExpression(String expression) {

--- a/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/appserver/payara-appserver-modules/security-openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -40,13 +40,9 @@
 package fish.payara.security.openid;
 
 import java.util.Optional;
-import java.util.Random;
 import java.util.function.Predicate;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.el.ELProcessor;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import org.eclipse.microprofile.config.Config;

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/ear/SomeEJB.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/ear/SomeEJB.java
@@ -1,0 +1,8 @@
+package fish.payara.security.oidc.client.ear;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class SomeEJB {
+
+}

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/OpenidConfigBeanEL.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/OpenidConfigBeanEL.java
@@ -1,0 +1,12 @@
+package fish.payara.security.oidc.client.eltests;
+
+import javax.inject.Named;
+
+@Named
+public class OpenidConfigBeanEL {
+            
+    public String getTokenEndpointURL() {
+        return "http://localhost:8080/openid-server/webresources/oidc-provider";
+    }
+    
+}

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/OpenidConfigBeanEL.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/OpenidConfigBeanEL.java
@@ -1,3 +1,42 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
 package fish.payara.security.oidc.client.eltests;
 
 import javax.inject.Named;

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/SecuredPageEL.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/SecuredPageEL.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -44,7 +44,6 @@ import static fish.payara.security.oidc.server.OidcProvider.CLIENT_ID_VALUE;
 import static fish.payara.security.oidc.server.OidcProvider.CLIENT_SECRET_VALUE;
 import java.io.IOException;
 import javax.annotation.security.DeclareRoles;
-import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HttpConstraint;
 import javax.servlet.annotation.ServletSecurity;

--- a/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/SecuredPageEL.java
+++ b/appserver/tests/payara-samples/samples/openid/src/main/java/fish/payara/security/oidc/client/eltests/SecuredPageEL.java
@@ -1,0 +1,75 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.oidc.client.eltests;
+
+import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
+import static fish.payara.security.oidc.server.OidcProvider.CLIENT_ID_VALUE;
+import static fish.payara.security.oidc.server.OidcProvider.CLIENT_SECRET_VALUE;
+import java.io.IOException;
+import javax.annotation.security.DeclareRoles;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Gaurav Gupta
+ */
+@WebServlet("/Secured")
+@OpenIdAuthenticationDefinition(
+        providerURI = "#{openidConfigBeanEL.tokenEndpointURL}",
+        clientId = CLIENT_ID_VALUE,
+        clientSecret = CLIENT_SECRET_VALUE,
+        redirectURI = "${baseURL}/Callback"
+)
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class SecuredPageEL extends HttpServlet {
+    
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.getWriter().println("This is a secured web page");
+    }
+}

--- a/appserver/tests/payara-samples/samples/openid/src/main/resources/ear/META-INF/application.xml
+++ b/appserver/tests/payara-samples/samples/openid/src/main/resources/ear/META-INF/application.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee/ http://xmlns.jcp.org/xml/ns/javaee/application_8.xsd" version="8">
+  <display-name>ElBugExample-ear</display-name>
+  <module>
+    <web>
+      <web-uri>openid-client.war</web-uri>
+      <context-root>/openid-client</context-root>
+    </web>
+  </module>
+  <module>
+    <ejb>openid-client-dummy-ejb.jar</ejb>
+  </module>
+</application>

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELInEarTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELInEarTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELInEarTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELInEarTest.java
@@ -1,0 +1,85 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.oidc.test;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import java.io.IOException;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
+public class OpenIdELInEarTest {
+
+    @OperateOnDeployment("openid-client")
+    @ArquillianResource
+    private URL base;
+
+    @Deployment(name = "openid-server")
+    public static WebArchive createServerDeployment() {
+        return OpenIdTestUtil.createServerDeployment();
+    }
+
+    @Deployment(name = "openid-client")
+    public static EnterpriseArchive createClientDeployment() {
+        return OpenIdTestUtil.createClientDeploymentForELInEarTest();
+    }
+
+    @Test
+    @RunAsClient
+    public void testOpenIdConnect() throws IOException {
+        WebClient webClient = new WebClient();
+        OpenIdTestUtil.testOpenIdConnect(webClient, base);
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELTest.java
@@ -1,0 +1,84 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ * 
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ * 
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.oidc.test;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import java.io.IOException;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+@NotMicroCompatible
+@RunWith(PayaraArquillianTestRunner.class)
+public class OpenIdELTest {
+
+    @OperateOnDeployment("openid-client")
+    @ArquillianResource
+    private URL base;
+
+    @Deployment(name = "openid-server")
+    public static WebArchive createServerDeployment() {
+        return OpenIdTestUtil.createServerDeployment();
+    }
+
+    @Deployment(name = "openid-client")
+    public static WebArchive createClientDeployment() {
+        return OpenIdTestUtil.createClientDeploymentForELTest();
+    }
+
+    @Test
+    @RunAsClient
+    public void testOpenIdConnect() throws IOException {
+        WebClient webClient = new WebClient();
+        OpenIdTestUtil.testOpenIdConnect(webClient, base);
+    }
+
+}


### PR DESCRIPTION
## Description
This fixes https://github.com/payara/Payara/issues/4469.

Sometimes `CDI.current().getBeanManager()` returns a bean manager for another module in the EAR (in this case for the EJB JAR instead of for the WAR). As suggested in https://lists.jboss.org/pipermail/cdi-dev/2016-April/008185.html, looking up the bean manager using InitialContext returns the correct bean manager for the current module (WAR in this case).

Also fixes an issue in Admin Console: https://github.com/sharpedavid/el-bug-example has app to deploy to Payara. Go to admin console and click on the application name. At the bottom of the page there should be a component table with entries.

## Important Info

## Testing

### New tests
Tests in this PR, in tests/payara-samples/samples/openid:

* `OpenIdELInEarTest` - test for using EL to configure OpenID connector in EAR
* `OpenIdELTest` - test for using EL to configure OpenID connector in WAR, just in case

### Testing Performed

Manual test of the UI change in Admin Console. Automated tests in payara-samples.

### Test suites executed

- Quicklook (all passed)
- Payara Samples (RemoteEjbClientIT.transactionIdAddedAsBaggageIT failed but it's unrelated)

### Testing Environment

- Ubuntu 20.04.2 LTS
- OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9.1+1, mixed mode)
- Maven 3.6.3

