### PR TITLE
FISH-1287 Admin console retrieves info about remote instances much faster

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstanceGeneral.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstanceGeneral.jsf
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-    Portions Copyright [2018] [nPayara Foundation and/or its affiliates]
+    Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 -->
 
 <!initPage

--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstanceGeneral.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstanceGeneral.jsf
@@ -70,7 +70,9 @@
             if ("#{pageSession.status}=REQUIRES_RESTART"){
                 setAttribute(key="isRestartRequired" value="#{true}");
             }
-            gfr.getInstanceDebugInfo();
+            if (! #{pageSession.isStopped}){
+                gfr.getInstanceDebugInfo();
+            }
 
        />
     </event>

--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneTreeNode.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneTreeNode.jsf
@@ -37,6 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
+    Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 
 -->
 

--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneTreeNode.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneTreeNode.jsf
@@ -52,7 +52,7 @@
 	url="/cluster/standalone/standaloneInstances.jsf">
     <ui:event type="beforeCreate">
 	setResourceBundle(key="i18ncs" bundle="org.glassfish.cluster.admingui.Strings");
-	gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances.json?standaloneonly=true" method="get" result="#{requestScope.resp}"); 
+	gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances.json?standaloneonly=true&nostatus=true" method="get" result="#{requestScope.resp}"); 
 	setAttribute(key="children" value="#{requestScope.resp.data.extraProperties.instanceList}");
     </ui:event>
 </dynamicTreeNode>

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
@@ -82,7 +82,8 @@ public class TargetUtil {
         List<String> result = new ArrayList<>();
         String endpoint = GuiUtil.getSessionValue("REST_URL") + "/list-instances" ;
         Map<String, Object> attrsMap = new HashMap<>();
-        attrsMap.put("standaloneonly", "true"); attrsMap.put("nostatus", "true");
+        attrsMap.put("standaloneonly", "true");
+        attrsMap.put("nostatus", "true");
         try{
             Map<String, Object> responseMap = RestUtil.restRequest( endpoint , attrsMap, "get" , null, false);
             Map<?, ?>  dataMap = (Map<?, ?>) responseMap.get("data");

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
@@ -82,7 +82,7 @@ public class TargetUtil {
         List<String> result = new ArrayList<>();
         String endpoint = GuiUtil.getSessionValue("REST_URL") + "/list-instances" ;
         Map<String, Object> attrsMap = new HashMap<>();
-        attrsMap.put("standaloneonly", "true");
+        attrsMap.put("standaloneonly", "true"); attrsMap.put("nostatus", "true");
         try{
             Map<String, Object> responseMap = RestUtil.restRequest( endpoint , attrsMap, "get" , null, false);
             Map<?, ?>  dataMap = (Map<?, ?>) responseMap.get("data");

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admingui.common.util;
 

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2018] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2021] Payara Foundation and/or affiliates
  */
 
 package com.sun.enterprise.admin.remote;

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
@@ -127,6 +127,7 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
     private static final String COMMAND_NAME_REGEXP =
                                     "^[a-zA-Z_][-a-zA-Z0-9_]*$";
     private static final String READ_TIMEOUT = "AS_ADMIN_READTIMEOUT";
+    private static final String CONNECT_TIMEOUT = "AS_ADMIN_CONNECTTIMEOUT";
     public static final String COMMAND_MODEL_MATCH_HEADER = "X-If-Command-Model-Match";
     private static final String MEDIATYPE_TXT = "text/plain";
     private static final String MEDIATYPE_JSON = "application/json";
@@ -134,6 +135,7 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
     private static final String MEDIATYPE_SSE = "text/event-stream";
     private static final String EOL = StringUtils.EOL;
     private static final int DEFAULT_READ_TIMEOUT; // read timeout for URL conns
+    private static final int DEFAULT_CONNECT_TIMEOUT; // connect timeout for URL conns
 
     private String              responseFormatType = "hk2-agent";
     // return output string rather than printing it
@@ -170,7 +172,7 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
     private CommandModel        commandModel;
     private boolean             commandModelFromCache = false;
     private int                 readTimeout = DEFAULT_READ_TIMEOUT;
-    private int                 connectTimeout = -1;
+    private int                 connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private boolean             interactive = true;
 
     private final List<Header>  requestHeaders = new ArrayList<>();
@@ -190,6 +192,21 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
             DEFAULT_READ_TIMEOUT = Integer.parseInt(rt);
         } else {
             DEFAULT_READ_TIMEOUT = 10 * 60 * 1000;       // 10 minutes
+        }
+    }
+
+    /*
+     * Set a default connect timeout for URL connections.
+     */
+    static {
+        String ct = System.getProperty(CONNECT_TIMEOUT);
+        if (ct == null) {
+            ct = System.getenv(CONNECT_TIMEOUT);
+        }
+        if (ct != null) {
+            DEFAULT_CONNECT_TIMEOUT = Integer.parseInt(ct);
+        } else {
+            DEFAULT_CONNECT_TIMEOUT = 10 * 1000;       // 10 seconds
         }
     }
 
@@ -1102,9 +1119,7 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
                 }
                 urlConnection.setRequestMethod(httpMethod);
                 urlConnection.setReadTimeout(readTimeout);
-                if (connectTimeout >= 0) {
-                    urlConnection.setConnectTimeout(connectTimeout);
-                }
+                urlConnection.setConnectTimeout(connectTimeout);
                 addAdditionalHeaders(urlConnection);
                 urlConnection.addRequestProperty("X-Requested-By", "cli");
                 cmd.prepareConnection(urlConnection);

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ListInstancesCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ListInstancesCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.v3.admin.cluster;
 
 import com.sun.enterprise.admin.util.InstanceStateService;

--- a/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
+++ b/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
 
-    Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 
  */

--- a/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
+++ b/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
@@ -282,6 +282,8 @@ public final class InstanceInfo {
             InstanceRestCommandExecutor ice =
                     new InstanceRestCommandExecutor(habitat, "__locations", FailurePolicy.Error, FailurePolicy.Error,
                     svr, host, port, logger, map, aReport, aResult);
+            ice.setConnectTimeout(timeoutInMsec);
+            ice.setReadTimeout(timeoutInMsec);
             return stateService.submitJob(svr, ice, aResult);
             /*
             String ret = rac.executeCommand(map).trim();


### PR DESCRIPTION
## Description

Port of PR @OndroMih made to Enterprise repo: https://github.com/payara/Payara-Enterprise/pull/354

Admin Console no longer hangs on every page if a remote instance responds slowly. Admin Console hangs for a much shorter time when displaying details about a remote instance. The `list-instances` command has shorter default timeout and therefore also doesn't hang for too long by default.

After the first commit, Admin Console doesn't ask for status of instances (which requires a REST call) when it only needs the name of the instance. This is also to display the instance names in the sidebar tree which is on every page. This was slowing down loading Admin Console pages significantly if remote instances were slow to respond.

After the second commit:

 - The list-instances command has shorter default timeout and it's configurable globally by a system property or env var. In case more time is needed, the timeout can be increased for the whole DAS.
 - This shorter timeout is also passed to the subsequent admin REST call so that both timeouts are in synch (and the REST call timeouts faster than usually).
 - The REST calls now respect a system property and env var also for connection timeout, not only for read timeout.
 - Debug info is only printed for running instances, this saves a useless REST call that always fails if an instance isn't running.

## Important Info

## Testing

### New tests
No new tests added.

### Testing Performed
Manual testing, with breakpoints to make sure the behavior is expected. I simulated slow remote instances using a firewall rule to block and unblock communication between DAS and the remote instance. However, I also observed that the communication was very slow even with unblocked communication but it later improved so I had to simulate it using the firewall to finish debugging and testing.

### Test suites executed
No tests suites executed. The change is very local and doesn't impact functionality of Payara Server, only improves performance.

### Testing Environment

* Zulu 8.42.0.21-CA-linux64 (OpenJDK 1.8.0_232) to build
* AdoptOpenJDK 11.0.9.1 to run
* Ubuntu 20.04
* Maven 3.6.3

## Documentation

Nothing to document.

