### PR TITLE
FISH-1323 Zulu JDK Update

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -15,8 +15,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk8.tag>8u262</docker.jdk8.tag>
-        <docker.jdk11.tag>11.0.7</docker.jdk11.tag>
+        <docker.jdk8.tag>8u292</docker.jdk8.tag>
+        <docker.jdk11.tag>11.0.9</docker.jdk11.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description

See https://docs.azul.com/zulu/release-notes/april-2021.html

* Changes broke some tests after the JDK update, so before it would affect anyone else or Jenkins, I fixed tests already in master branch here.
* most important changes: the TLS 1.0 and TLS 1.1 are disabled by default, quite large set of ciphers is out too.

## Tests

PrintCertificateCommandTest
CertificateRealmITest (in #5019) also reproduced the issue.
Payara default keystores seems not affected.

## Note

We should discuss possible consequences before the upgrade. This is not just about docker images, users will upgrade their JDK distributions soon too.
