### PR TITLE
[FISH-1362] Logging parameter conversion fix

### DIFF
--- a/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
+++ b/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
@@ -56,6 +56,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Scanner;
@@ -63,6 +64,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 @RunWith(PayaraArquillianTestRunner.class)
@@ -162,12 +164,30 @@ public class JsonLogFormatIT {
     }
 
     @Test
-    public void testNumberFormat() {
+    public void testNumberFormat() throws FileNotFoundException {
+        ArrayList<String> command = new ArrayList<>();
+        ArrayList<String> output = new ArrayList<>();
+        command.add("rotate-log");
+        CliCommands.payaraGlassFish(command, output);
+        command.clear();
+        output.clear();
+
         Logger logger = Logger.getLogger(getClass().getName());
         logger.log(Level.INFO, "This number {0,number,#} is greater than this one {1,number,#}",
                 new Object[]{ new Long(50), new Long(33) });
         logger.log(Level.INFO, "This number {0} is greater than this one {1}",
                 new Object[]{ new Long(50), new Long(33) });
+
+        File logFile = getLogFile();
+        if (logFile == null) {
+            fail("Could not determine or read log file.");
+        }
+        try (Scanner scanner = new Scanner(new FileInputStream(logFile))) {
+            while (scanner.hasNext()) {
+                String line = scanner.nextLine();
+                assertFalse("there should be no errors in logs", line.contains("SEVERE"));
+            }
+        }
     }
 
     private File getLogFile() {

--- a/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
+++ b/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -59,6 +59,8 @@ import java.io.FileInputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -157,6 +159,15 @@ public class JsonLogFormatIT {
                     + ":com.sun.enterprise.server.logging.GFFileHandler.formatter=" + originalFileHandlerFormatter);
             CliCommands.payaraGlassFish(command, output);
         }
+    }
+
+    @Test
+    public void testNumberFormat() {
+        Logger logger = Logger.getLogger(getClass().getName());
+        logger.log(Level.INFO, "This number {0,number,#} is greater than this one {1,number,#}",
+                new Object[]{ new Long(50), new Long(33) });
+        logger.log(Level.INFO, "This number {0} is greater than this one {1}",
+                new Object[]{ new Long(50), new Long(33) });
     }
 
     private File getLogFile() {

--- a/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
+++ b/appserver/tests/payara-samples/samples/logging/src/test/java/fish/payara/samples/logging/JsonLogFormatIT.java
@@ -178,6 +178,14 @@ public class JsonLogFormatIT {
         logger.log(Level.INFO, "This number {0} is greater than this one {1}",
                 new Object[]{ new Long(50), new Long(33) });
 
+        command.clear();
+        output.clear();
+        // wait for log
+        command.add("list-applications");
+        CliCommands.payaraGlassFish(command, output);
+        command.clear();
+        output.clear();
+
         File logFile = getLogFile();
         if (logFile == null) {
             fail("Could not determine or read log file.");

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/GFLogRecord.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/GFLogRecord.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2020] [Payara Foundation]
+// Portions Copyright [2016-2021] [Payara Foundation]
 
 package com.sun.common.util.logging;
 
@@ -124,13 +124,13 @@ public class GFLogRecord extends LogRecord {
             return null;
         }
         Object[] result = new Object[params.length * 2];
+        System.arraycopy(params, 0, result, params.length, params.length);
         for (int stringParamsIndex = 0, originalParamsIndex = params.length;
                 stringParamsIndex < params.length;
                 ++stringParamsIndex, ++originalParamsIndex) {
             Object param = params[stringParamsIndex];
             if (param != null) {
                 result[stringParamsIndex] = param.toString();
-                result[originalParamsIndex] = params[stringParamsIndex];
             }
         }
         return result;

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/ODLLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/ODLLogFormatter.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2017-2020] [Payara Foundation and/or affiliates]
+// Portions Copyright [2017-2021] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.server.logging;
 
@@ -52,7 +52,6 @@ import org.jvnet.hk2.annotations.Service;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.logging.Formatter;
@@ -390,24 +389,7 @@ public class ODLLogFormatter extends AnsiColorFormatter implements LogEventBroad
         if (logMessage == null) {
             logMessage = "";
         }
-        if (logMessage.indexOf("{0") >= 0 && logMessage.contains("}") && record.getParameters() != null) {
-            // If we find {0} or {1} etc., in the message, then it's most
-            // likely finer level messages for Method Entry, Exit etc.,
-            logMessage = java.text.MessageFormat.format(
-                    logMessage, record.getParameters());
-        } else {
-            ResourceBundle rb = getResourceBundle(record.getLoggerName());
-            if (rb != null && rb.containsKey(logMessage)) {
-                try {
-                    logMessage = MessageFormat.format(
-                            rb.getString(logMessage),
-                            record.getParameters());
-                } catch (java.util.MissingResourceException e) {
-                    // If we don't find an entry, then we are covered
-                    // because the logMessage is initialized already
-                }
-            }
-        }
+        logMessage = UniformLogFormatter.formatLogMessage(logMessage, record, this::getResourceBundle);
         Throwable throwable = UniformLogFormatter.getThrowable(record);
         if (throwable != null) {
             StringBuilder buffer = new StringBuilder();

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -45,9 +45,9 @@ import com.sun.enterprise.server.logging.FormatterDelegate;
 import com.sun.enterprise.server.logging.LogEvent;
 import com.sun.enterprise.server.logging.LogEventBroadcaster;
 import com.sun.enterprise.server.logging.LogEventImpl;
+import com.sun.enterprise.server.logging.UniformLogFormatter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.logging.ErrorManager;
@@ -421,24 +421,7 @@ public class JSONLogFormatter extends Formatter implements LogEventBroadcaster {
                     }
                 }
             } else {
-                if (logMessage.contains("{0") && logMessage.contains("}")
-                        && null != record.getParameters()) {
-                    logMessage = MessageFormat
-                            .format(logMessage, record.getParameters());
-                } else {
-                    ResourceBundle bundle = getResourceBundle(record.getLoggerName());
-                    if (null != bundle) {
-                        try {
-                            logMessage = MessageFormat.format(bundle
-                                .getString(logMessage),
-                                record.getParameters());
-                        } catch (MissingResourceException ex) {
-                            // Leave logMessage as it is because it already has
-                            // an exception message
-                        }
-                    }
-                }
-
+                logMessage = UniformLogFormatter.formatLogMessage(logMessage, record, this::getResourceBundle);
                 StringBuilder logMessageBuilder = new StringBuilder();
                 logMessageBuilder.append(logMessage);
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Fixes #5228 
The fix catches the `IllegalArgumentException` in the log formatter, and falls back to the previous way of processing
arguments, because at this point there is no choice.
Sid-effect of this is that logs may lie when formatted this way, but there is nothing that can be done about it
without total brain-surgery of the logging system

## Testing
### New tests
Added new test to payara samples

### Testing Performed
Payara samples

### Testing Environment
Mac

