### PR TITLE
[FISH-387] client certificate enhancements

### DIFF
--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- 
-  Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
- 
+
+  Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
   and Distribution License("CDDL") (collectively, the "License").  You
@@ -12,20 +12,20 @@
   https://github.com/payara/Payara/blob/master/LICENSE.txt
   See the License for the specific
   language governing permissions and limitations under the License.
- 
+
   When distributing the software, include this License Header Notice in each
   file and include the License file at glassfish/legal/LICENSE.txt.
- 
+
   GPL Classpath Exception:
   The Payara Foundation designates this particular file as subject to the "Classpath"
   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
   file that accompanied this code.
- 
+
   Modifications:
   If applicable, add the following below the License Header, with the fields
   enclosed by brackets [] replaced by your own identifying information:
   "Portions Copyright [year] [name of copyright owner]"
- 
+
   Contributor(s):
   If you wish your version of this file to be governed by only the CDDL or
   only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -96,6 +96,8 @@
                                     io.opentracing,
                                     javax.inject,
                                     javax.enterprise.util,
+                                    javax.security.auth,
+                                    javax.security.auth.x500,
                                     javax.security.enterprise.credential,
                                     javax.security.enterprise.identitystore,
                                     javax.security.enterprise.authentication.mechanism.http,

--- a/api/payara-api/src/main/java/fish/payara/security/api/ClientCertificateValidator.java
+++ b/api/payara-api/src/main/java/fish/payara/security/api/ClientCertificateValidator.java
@@ -1,0 +1,65 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.api;
+
+import javax.security.auth.Subject;
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.X509Certificate;
+import java.util.ServiceLoader;
+
+/**
+ * Verify if the client certificate is valid in the trust store
+ *
+ * @author rdebusscher
+ * @author lprimak
+ */
+public interface ClientCertificateValidator {
+    /**
+     * Called from client certificate authentication realm to verify that certificate
+     * is valid. Implementations will be loaded via {@link ServiceLoader}
+     * and can be deployed as part of an application in Payara server
+     *
+     * @param subject
+     * @param principal
+     * @param certificate
+     * @return true if the certificate is valid
+     */
+    boolean isValid(Subject subject, X500Principal principal, X509Certificate certificate);
+}

--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 package com.sun.web.security;
 
 import com.sun.enterprise.deployment.Application;
@@ -175,6 +175,7 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
     private final static SecurityConstraint[] emptyConstraints = new SecurityConstraint[] {};
 
     private String moduleID;
+    private String componentId;
 
     @Inject
     private ServerContext serverContext;
@@ -255,6 +256,11 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
         moduleID = webDescriptor.getModuleID();
         jaspicRealm = new JaspicRealm(realmName, isSystemApp, webDescriptor, requestTracing);
         cNonceValidator = new CNonceValidator(webDescriptor, appCNonceCacheMapProvider, cNonceCacheFactoryProvider);
+    }
+
+    @Override
+    public void initializeRealm(String componentId) {
+        this.componentId = componentId;
     }
 
     /**
@@ -878,7 +884,7 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
         try {
             if (certs != null) {
                 // Certificate credential used to authenticate
-                WebAndEjbToJaasBridge.doX500Login(createSubjectWithCerts(certs), moduleID);
+                WebAndEjbToJaasBridge.doX500Login(createSubjectWithCerts(certs), moduleID, componentId);
             } else if (digestParams != null) {
                 // Digest credential used to authenticate
                 WebAndEjbToJaasBridge.login(new DigestCredentials(realmName, username, digestParams));

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/pom.xml
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>5.2021.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>client-certificate-validator</artifactId>
+    <name>Payara Samples - Payara - Client Certificate Validator</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/CdiBean.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/CdiBean.java
@@ -1,0 +1,53 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.client;
+
+import javax.enterprise.context.RequestScoped;
+
+/**
+ *
+ * @author lprimak
+ */
+@RequestScoped
+public class CdiBean {
+    public boolean isValid() {
+        return true;
+    }
+}

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/CertificateValidator.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/CertificateValidator.java
@@ -48,6 +48,7 @@ import fish.payara.security.api.ClientCertificateValidator;
 import static fish.payara.security.client.HelloServlet.validatorCalled;
 import javax.ejb.EJB;
 import javax.inject.Inject;
+import static fish.payara.security.client.HelloServlet.authenticationCheckSuccess;
 
 public class CertificateValidator implements ClientCertificateValidator {
     @Inject
@@ -70,7 +71,13 @@ public class CertificateValidator implements ClientCertificateValidator {
         isValid &= referredEjbBean.isValid();
         isValid &= injectedCDIBean.isValid();
 
-        validatorCalled.set(true);
+        isValid &= authenticationCheckSuccess;
+        authenticationCheckSuccess = true;
+
+        // so thread locals aren't left hanging around
+        if (isValid == true) {
+            validatorCalled.set(true);
+        }
         return isValid;
     }
 }

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/CertificateValidator.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/CertificateValidator.java
@@ -1,0 +1,76 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.client;
+
+
+import javax.security.auth.Subject;
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import fish.payara.security.api.ClientCertificateValidator;
+import static fish.payara.security.client.HelloServlet.validatorCalled;
+import javax.ejb.EJB;
+import javax.inject.Inject;
+
+public class CertificateValidator implements ClientCertificateValidator {
+    @Inject
+    EjbBean injectedEjbBean;
+
+    @EJB
+    EjbBean referredEjbBean;
+
+    @Inject
+    CdiBean injectedCDIBean;
+
+    @Override
+    public boolean isValid(Subject subject, X500Principal principal, X509Certificate certificate) {
+        Objects.requireNonNull(subject, "null subject");
+        Objects.requireNonNull(principal, "null pincipal");
+        Objects.requireNonNull(certificate, "null certificate");
+
+        boolean isValid = true;
+        isValid &= injectedEjbBean.isValid();
+        isValid &= referredEjbBean.isValid();
+        isValid &= injectedCDIBean.isValid();
+
+        validatorCalled.set(true);
+        return isValid;
+    }
+}

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/EjbBean.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/EjbBean.java
@@ -1,0 +1,53 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.client;
+
+import javax.ejb.Stateless;
+
+/**
+ *
+ * @author lprimak
+ */
+@Stateless
+public class EjbBean {
+    public boolean isValid() {
+        return true;
+    }
+}

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/HelloServlet.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/HelloServlet.java
@@ -1,0 +1,72 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.client;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet(value = "/secure/hello")
+@SuppressWarnings("serial")
+public class HelloServlet extends HttpServlet {
+    static final ThreadLocal<Boolean> validatorCalled = new ThreadLocal<Boolean>() {
+        @Override
+        protected Boolean initialValue() {
+            return false;
+        }
+    };
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            if (validatorCalled.get()) {
+                // Get the DN name of the Certificate
+                resp.getOutputStream().print("Hello " + req.getRemoteUser());
+            } else {
+                throw new IllegalStateException("Certificator Validator was not called");
+            }
+        } finally {
+            validatorCalled.remove();
+        }
+    }
+}

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/HelloServlet.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/HelloServlet.java
@@ -55,10 +55,15 @@ public class HelloServlet extends HttpServlet {
             return false;
         }
     };
+    static boolean authenticationCheckSuccess = true;
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         try {
+            String nextFailureStr = req.getParameter("setNextFailure");
+            if (nextFailureStr != null) {
+                authenticationCheckSuccess = !Boolean.parseBoolean(nextFailureStr);
+            }
             if (validatorCalled.get()) {
                 // Get the DN name of the Certificate
                 resp.getOutputStream().print("Hello " + req.getRemoteUser());

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/ValidatorTest.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/ValidatorTest.java
@@ -1,0 +1,101 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.client;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.ServerOperations;
+import fish.payara.samples.SincePayara;
+import java.io.IOException;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author lprimak
+ */
+@RunWith(PayaraArquillianTestRunner.class)
+@SincePayara("5.2021.4")
+@NotMicroCompatible
+public class ValidatorTest {
+    @ArquillianResource
+    private URL base;
+
+    @Test
+    @RunAsClient
+    public void clientConnect() throws IOException {
+        WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        URL baseHttps = ServerOperations.createClientTrustStore(webClient, base,
+                ServerOperations.addClientCertificateFromServer(base));
+        doConnect(webClient, baseHttps);
+        doConnect(webClient, baseHttps);
+        doConnect(webClient, baseHttps);
+    }
+
+    private void doConnect(WebClient webClient, URL baseHttps) throws FailingHttpStatusCodeException, IOException {
+        WebResponse response = webClient.getPage(baseHttps + "secure/hello").getWebResponse();
+        assertEquals("http status code", 200, response.getStatusCode());
+        assertEquals("Hello C=UK,ST=lak,L=zak,O=kaz,OU=bar,CN=lfoo", response.getContentAsString());
+    }
+
+    @Deployment
+    public static WebArchive deploy() {
+        String serviceLoaderFile = "META-INF/services/fish.payara.security.api.ClientCertificateValidator";
+        WebArchive archive = PayaraTestShrinkWrap.getWebArchive()
+                .addPackage(ValidatorTest.class.getPackage())
+                .addAsWebInfResource("glassfish-web.xml")
+                .addAsWebInfResource("web.xml")
+                .addAsResource(serviceLoaderFile, serviceLoaderFile)
+                ;
+//        System.out.println(archive.toString(true));
+        return archive;
+    }
+}

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/ValidatorTest.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/ValidatorTest.java
@@ -75,15 +75,32 @@ public class ValidatorTest {
         webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
         URL baseHttps = ServerOperations.createClientTrustStore(webClient, base,
                 ServerOperations.addClientCertificateFromServer(base));
-        doConnect(webClient, baseHttps);
-        doConnect(webClient, baseHttps);
-        doConnect(webClient, baseHttps);
+        doConnect(webClient, baseHttps, false);
+        doConnect(webClient, baseHttps, false);
+        doConnect(webClient, baseHttps, false);
+        setNextRunFailure(webClient, baseHttps, true);
+        doConnect(webClient, baseHttps, true);
+        setNextRunFailure(webClient, baseHttps, true);
+        doConnect(webClient, baseHttps, true);
+        setNextRunFailure(webClient, baseHttps, false);
+        doConnect(webClient, baseHttps, false);
     }
 
-    private void doConnect(WebClient webClient, URL baseHttps) throws FailingHttpStatusCodeException, IOException {
+    private void doConnect(WebClient webClient, URL baseHttps,
+            boolean isFailureExpected) throws FailingHttpStatusCodeException, IOException {
         WebResponse response = webClient.getPage(baseHttps + "secure/hello").getWebResponse();
+        if (isFailureExpected) {
+            assertEquals("http status code", 401, response.getStatusCode());
+        } else {
+            assertEquals("http status code", 200, response.getStatusCode());
+            assertEquals("Hello C=UK,ST=lak,L=zak,O=kaz,OU=bar,CN=lfoo", response.getContentAsString());
+        }
+    }
+
+
+    private void setNextRunFailure(WebClient webClient, URL baseHttps, boolean fail) throws IOException {
+        WebResponse response = webClient.getPage(baseHttps + String.format("secure/hello?setNextFailure=%s", fail)).getWebResponse();
         assertEquals("http status code", 200, response.getStatusCode());
-        assertEquals("Hello C=UK,ST=lak,L=zak,O=kaz,OU=bar,CN=lfoo", response.getContentAsString());
     }
 
     @Deployment

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/ValidatorTest.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/security/client/ValidatorTest.java
@@ -62,7 +62,7 @@ import org.junit.runner.RunWith;
  * @author lprimak
  */
 @RunWith(PayaraArquillianTestRunner.class)
-@SincePayara("5.2021.4")
+@SincePayara("5.2021.3")
 @NotMicroCompatible
 public class ValidatorTest {
     @ArquillianResource

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/resources/META-INF/services/fish.payara.security.api.ClientCertificateValidator
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/resources/META-INF/services/fish.payara.security.api.ClientCertificateValidator
@@ -1,0 +1,1 @@
+fish.payara.security.client.CertificateValidator

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/resources/glassfish-web.xml
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/resources/glassfish-web.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD
+GlassFish Application Server 3.1 Servlet 3.0//EN"
+        "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+    <!-- configure access to the Hello Servlet -->
+    <security-role-mapping>
+        <role-name>myRole</role-name>
+        <group-name>myGroup</group-name>
+        <principal-name>C=UK,ST=lak,L=zak,O=kaz,OU=bar,CN=lfoo</principal-name>
+    </security-role-mapping>
+    <security-role-mapping>
+        <role-name>myRole</role-name>
+        <group-name>myGroup</group-name>
+        <principal-name>C=UK,ST=lak,L=zak,O=kaz,OU=bar,CN=lfoo-XXX</principal-name>
+    </security-role-mapping>
+</glassfish-web-app>

--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/resources/web.xml
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/resources/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <login-config>
+        <auth-method>CLIENT-CERT</auth-method>
+        <realm-name>certificate</realm-name>
+    </login-config>
+
+    <security-constraint>
+        <!-- Make sure only the 2 client certificates have access to the Servlet -->
+        <web-resource-collection>
+            <web-resource-name>secureAccess</web-resource-name>
+            <url-pattern>/secure/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>myRole</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>myRole</role-name>
+    </security-role>
+</web-app>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -39,6 +39,7 @@
         <module>ejb-http-remoting</module>
         <module>remote-ejb-tracing</module>
         <module>rolesallowed-unprotected-methods</module>
+        <module>client-certificate-validator</module>
     </modules>
 
     <dependencies>

--- a/appserver/web/gf-web-connector/src/main/java/fish/payara/appserver/context/ContextImpl.java
+++ b/appserver/web/gf-web-connector/src/main/java/fish/payara/appserver/context/ContextImpl.java
@@ -39,7 +39,11 @@
  */
 package fish.payara.appserver.context;
 
+import com.sun.enterprise.container.common.spi.JCDIService;
 import com.sun.enterprise.container.common.spi.util.ComponentEnvManager;
+import com.sun.enterprise.container.common.spi.util.InjectionException;
+import com.sun.enterprise.container.common.spi.util.InjectionManager;
+import com.sun.enterprise.deployment.BundleDescriptor;
 import com.sun.enterprise.util.Utility;
 import java.util.List;
 import java.util.Map;
@@ -69,17 +73,33 @@ class ContextImpl {
                     invocation, invocation.getComponentId());
         }
 
+        @Override
+        public <TT> TT inject(TT instance, boolean invokePostConstruct) {
+            try {
+                injectionMgr.injectInstance(instance, invokePostConstruct);
+                if (jcdiService.isCurrentModuleJCDIEnabled()) {
+                    jcdiService.injectManagedObject(instance, (BundleDescriptor)invocation.getJNDIEnvironment());
+                }
+            } catch (InjectionException ex) {
+                throw new IllegalStateException(ex);
+            }
+            return instance;
+        }
 
         private final ComponentInvocation invocation;
         private final InvocationManager invMgr;
         private final ComponentEnvManager compEnvMgr;
+        private final InjectionManager injectionMgr;
+        private final JCDIService jcdiService;
         private final ClassLoader oldClassLoader;
 
         public Context(ComponentInvocation invocation, InvocationManager invMgr, ComponentEnvManager compEnvMgr,
-                ClassLoader oldClassLoader) {
+                InjectionManager injectionMgr, JCDIService jcdiService, ClassLoader oldClassLoader) {
             this.invocation = invocation;
             this.invMgr = invMgr;
             this.compEnvMgr = compEnvMgr;
+            this.injectionMgr = injectionMgr;
+            this.jcdiService = jcdiService;
             this.oldClassLoader = oldClassLoader;
         }
     }

--- a/appserver/web/gf-web-connector/src/main/java/fish/payara/appserver/context/JavaEEContextUtilImpl.java
+++ b/appserver/web/gf-web-connector/src/main/java/fish/payara/appserver/context/JavaEEContextUtilImpl.java
@@ -39,7 +39,9 @@
  */
 package fish.payara.appserver.context;
 
+import com.sun.enterprise.container.common.spi.JCDIService;
 import com.sun.enterprise.container.common.spi.util.ComponentEnvManager;
+import com.sun.enterprise.container.common.spi.util.InjectionManager;
 import com.sun.enterprise.deployment.BundleDescriptor;
 import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.deployment.JndiNameEnvironment;
@@ -52,6 +54,7 @@ import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.grizzly.utils.Holder;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.data.ApplicationRegistry;
@@ -73,6 +76,12 @@ public class JavaEEContextUtilImpl implements JavaEEContextUtil, Serializable {
     private transient ApplicationRegistry appRegistry;
     @Inject
     private transient InvocationManager invocationManager;
+    @Inject
+    private transient InjectionManager injectionManager;
+    // JCDIService hangs HK2 on startup if @Injected
+    private transient final Holder.LazyHolder<JCDIService> jcdiService
+            = Holder.LazyHolder.lazyHolder(() -> Globals.getDefaultHabitat()
+                    .getService(JCDIService.class));
 
 
     @Override
@@ -171,7 +180,7 @@ public class JavaEEContextUtilImpl implements JavaEEContextUtil, Serializable {
         return false;
     }
 
-    // deals with @Injected transient fields correctly
+    // deals with @Injected and final transient fields correctly
     private Object readResolve() {
         return Globals.getDefaultHabitat().getService(JavaEEContextUtil.class);
     }
@@ -232,11 +241,13 @@ public class JavaEEContextUtilImpl implements JavaEEContextUtil, Serializable {
             }
             if (!isValidAndNotEmpty()) {
                 // same as invocation, or app not running
-                return new ContextImpl.Context(null, invocationManager, compEnvMgr, null);
+                return new ContextImpl.Context(null, invocationManager, compEnvMgr,
+                        injectionManager, jcdiService.get(), null);
             }
             ComponentInvocation newInvocation = ensureCached(true).clone();
             invocationManager.preInvoke(newInvocation);
-            return new ContextImpl.Context(newInvocation, invocationManager, compEnvMgr,
+            return new ContextImpl.Context(newInvocation, invocationManager,
+                    compEnvMgr, injectionManager, jcdiService.get(),
                     Utility.setContextClassLoader(getInvocationClassLoader()));
         }
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/integration/RealmInitializer.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/integration/RealmInitializer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security.integration;
 
 /**
@@ -57,7 +57,7 @@ public interface RealmInitializer {
      *            any other configured in the descriptor.
      */
     void initializeRealm(Object bundleDescriptor, boolean isSystemApp, String defaultRealmName);
-
+    default void initializeRealm(String componentId) { }
 
     /**
      * Sets the realm's virtual server container.

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/ContextProducer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/ContextProducer.java
@@ -154,7 +154,7 @@ public interface ContextProducer {
 
     interface Context extends Closeable {
         boolean isValid();
-        default <TT> TT inject(TT instance, boolean invokePostContruct) { return instance; }
+        default <TT> TT inject(TT instance, boolean invokePostConstruct) { return instance; }
     };
 
     interface Closeable extends AutoCloseable {

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/ContextProducer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/ContextProducer.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -154,6 +154,7 @@ public interface ContextProducer {
 
     interface Context extends Closeable {
         boolean isValid();
+        default <TT> TT inject(TT instance, boolean invokePostContruct) { return instance; }
     };
 
     interface Closeable extends AutoCloseable {

--- a/nucleus/security/core/pom.xml
+++ b/nucleus/security/core/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -51,9 +51,9 @@
     </parent>
     <artifactId>security</artifactId>
     <packaging>glassfish-jar</packaging>
-    
+
     <name>Security Core Classes</name>
-    
+
     <developers>
         <developer>
             <id>kumarjayanti</id>
@@ -167,7 +167,7 @@
                  <!--<outputDirectory>${maven.project.build.outputDirectory}</outputDirectory>-->
                  <outputDirectory>target/classes</outputDirectory>
                </configuration>
-             </execution>           
+             </execution>
            </executions>
          </plugin>
         </plugins>
@@ -207,6 +207,11 @@
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency> <!-- for FindBugs -->
             <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
@@ -230,6 +235,10 @@
             <groupId>org.glassfish.annotations</groupId>
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/JaspicToJaasBridge.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/JaspicToJaasBridge.java
@@ -152,7 +152,7 @@ public class JaspicToJaasBridge {
             }
 
             // Sets security context
-            certRealm.authenticate(validSubject, x500Principal);
+            certRealm.authenticate(validSubject, x500Principal, null);
         } catch (Exception ex) {
             LOGGER.log(INFO, auditAtnRefusedError, callerPrincipalName);
 

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/WebAndEjbToJaasBridge.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/WebAndEjbToJaasBridge.java
@@ -192,7 +192,7 @@ public final class WebAndEjbToJaasBridge {
             doGSSUPLogin(subject);
 
         } else if (credentialClass.equals(X500Principal.class)) {
-            doX500Login(subject, null);
+            doX500Login(subject, null, null);
 
         } else {
             LOGGER.log(INFO, unknownCredentialError, credentialClass.toString());
@@ -200,8 +200,8 @@ public final class WebAndEjbToJaasBridge {
         }
     }
 
-    public static void doX500Login(Subject subject, String appModuleID) {
-        doX500Login(subject, CertificateRealm.AUTH_TYPE, appModuleID);
+    public static void doX500Login(Subject subject, String appModuleID, String componentId) {
+        doX500Login(subject, CertificateRealm.AUTH_TYPE, appModuleID, componentId);
     }
 
     /**
@@ -215,7 +215,7 @@ public final class WebAndEjbToJaasBridge {
      * @throws LoginException when login fails
      *
      */
-    public static void doX500Login(Subject subject, String realmName, String appModuleID) {
+    public static void doX500Login(Subject subject, String realmName, String appModuleID, String componentId) {
         LOGGER.finest(() -> String.format("doX500Login(subject=%s, realmName=%s, appModuleID=%s)",
             subject, realmName, appModuleID));
 
@@ -255,7 +255,7 @@ public final class WebAndEjbToJaasBridge {
                 }
 
                 // The name that the cert realm decided to set as the caller principal name
-                user = certRealm.authenticate(subject, x500principal);
+                user = certRealm.authenticate(subject, x500principal, componentId);
 
                 auditAuthenticate(user, realmName, true);
             } else {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/certificate/CertificateRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/certificate/CertificateRealm.java
@@ -37,18 +37,22 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security.auth.realm.certificate;
 
-import java.security.Principal;
+import com.sun.enterprise.security.BaseRealm;
+import com.sun.enterprise.security.SecurityContext;
+import com.sun.enterprise.security.auth.login.DistinguishedPrincipalCredential;
+import com.sun.enterprise.security.auth.login.common.LoginException;
+import com.sun.enterprise.security.auth.realm.BadRealmException;
+import com.sun.enterprise.security.auth.realm.NoSuchRealmException;
+import com.sun.enterprise.util.Utility;
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
@@ -56,15 +60,28 @@ import javax.naming.ldap.Rdn;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.x500.X500Principal;
-
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.glassfish.security.common.Group;
 import org.jvnet.hk2.annotations.Service;
-
-import com.sun.enterprise.security.BaseRealm;
-import com.sun.enterprise.security.SecurityContext;
-import com.sun.enterprise.security.auth.login.DistinguishedPrincipalCredential;
-import com.sun.enterprise.security.auth.realm.BadRealmException;
-import com.sun.enterprise.security.auth.realm.NoSuchRealmException;
+import fish.payara.security.api.ClientCertificateValidator;
+import java.security.cert.CertificateException;
+import org.glassfish.grizzly.utils.Holder.LazyHolder;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.api.JavaEEContextUtil;
+import org.glassfish.internal.api.JavaEEContextUtil.Context;
 
 /**
  * Realm wrapper for supporting certificate authentication.
@@ -103,6 +120,17 @@ public final class CertificateRealm extends BaseRealm {
     /** Descriptive string of the authentication type of this realm. */
     public static final String AUTH_TYPE = "certificate";
 
+    private boolean doValidation = true;
+    private final Map<ClassLoader,
+            // ServiceLoader keeps a reference to ClassLoader, so it has
+            // to be explicitly weak as well
+            WeakReference<ServiceLoader<ClientCertificateValidator>>> clientCertificateValidatorMap
+            = Collections.synchronizedMap(new WeakHashMap<>());
+    private final Map<ClassLoader, Set<ClientCertificateValidator>> injectedClasses
+            = Collections.synchronizedMap(new WeakHashMap<>());
+    private final LazyHolder<JavaEEContextUtil> ctxUtil = LazyHolder.lazyHolder(() ->
+                    Globals.getDefaultHabitat().getService(JavaEEContextUtil.class));
+
     @Override
     protected void init(Properties props) throws BadRealmException, NoSuchRealmException {
         super.init(props);
@@ -115,6 +143,9 @@ public final class CertificateRealm extends BaseRealm {
 
         final String dnPartsForGroup = props.getProperty(DN_PARTS_USED_FOR_GROUPS);
         setProperty(DN_PARTS_USED_FOR_GROUPS, dnPartsForGroup);
+
+        String validationCheckProperty = props.getProperty("validation-check");
+        doValidation = validationCheckProperty != null ? Boolean.parseBoolean(validationCheckProperty) : true;
     }
 
     /**
@@ -146,9 +177,16 @@ public final class CertificateRealm extends BaseRealm {
     /**
      * @param subject The Subject object for the authentication request.
      * @param principal The Principal object from the user certificate.
+     * @param componentId
      * @return principal's name
+     * @throws java.security.cert.CertificateException
      */
-    public String authenticate(Subject subject, X500Principal principal) {
+    public String authenticate(Subject subject, X500Principal principal, String componentId) throws CertificateException {
+        X509Certificate certificate = getCertificateFromSubject(subject, principal);
+        if (doValidation) {
+            certificate.checkValidity();
+        }
+        validateSubjectViaAPI(subject, principal, certificate, componentId);
         _logger.finest(() -> String.format("authenticate(subject=%s, principal=%s)", subject, principal));
 
         final LdapName dn = getLdapName(principal);
@@ -175,6 +213,67 @@ public final class CertificateRealm extends BaseRealm {
         return principalName;
     }
 
+    private void validateSubjectViaAPI(Subject subject, X500Principal principal,
+            X509Certificate certificate, String componentId) throws LoginException {
+        List<ClientCertificateValidator> validatorList = Collections.emptyList();
+        try {
+            validatorList = loadValidatorClasses();
+        } catch (Throwable exc) {
+            _logger.log(Level.WARNING, "Exception while loading certificate validation class", exc);
+            clientCertificateValidatorMap.remove(Utility.getClassLoader());
+        }
+
+        boolean failed = false;
+        if (!validatorList.isEmpty() && componentId != null) {
+            try (Context context = ctxUtil.get().fromComponentId(componentId).pushContext()) {
+                failed = validatorList.stream().anyMatch(validator
+                        -> !inject(validator, context).isValid(subject, principal, certificate));
+            } catch (Exception exc) {
+                _logger.log(Level.WARNING, "Exception from certificate validation class", exc);
+                clientCertificateValidatorMap.remove(Utility.getClassLoader());
+            }
+
+            if (failed) {
+                throw new LoginException("Certificate Validation Failed via API");
+            }
+        } else if (componentId == null) {
+            _logger.severe("No Jakarta EE Component available for Certificate Validation");
+        }
+    }
+
+    private ClientCertificateValidator inject(ClientCertificateValidator validator, Context context) {
+        Set<ClientCertificateValidator> injectedSet = injectedClasses.computeIfAbsent(Utility.getClassLoader(),
+                key -> Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>())));
+        if (injectedSet.add(validator)) {
+            return context.inject(validator, false);
+        } else {
+            return validator;
+        }
+    }
+
+    private List<ClientCertificateValidator> loadValidatorClasses() {
+        AtomicReference<ServiceLoader<ClientCertificateValidator>> serviceLoader = new AtomicReference<>();
+        clientCertificateValidatorMap.compute(Utility.getClassLoader(), (cl, weak) -> {
+                            serviceLoader.set(weak != null ? weak.get() : null);
+                            if (serviceLoader.get() == null) {
+                                serviceLoader.set(ServiceLoader.load(ClientCertificateValidator.class));
+                                return new WeakReference<>(serviceLoader.get());
+                            } else {
+                                return weak;
+                            }
+                        });
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(serviceLoader.get().iterator(),
+                Spliterator.ORDERED), false).collect(Collectors.toList());
+    }
+
+    private X509Certificate getCertificateFromSubject(Subject subject, X500Principal principal) {
+        return subject.getPublicCredentials(List.class).stream()
+                .flatMap(Collection<?>::stream)
+                .filter(X509Certificate.class::isInstance)
+                .map(X509Certificate.class::cast)
+                .filter(cert -> principal.equals(cert.getIssuerX500Principal()))
+                .findAny().get();
+    }
 
     private LdapName getLdapName(final X500Principal principal) {
         try {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/certificate/CertificateRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/certificate/CertificateRealm.java
@@ -145,7 +145,7 @@ public final class CertificateRealm extends BaseRealm {
         setProperty(DN_PARTS_USED_FOR_GROUPS, dnPartsForGroup);
 
         String validationCheckProperty = props.getProperty("validation-check");
-        doValidation = validationCheckProperty != null ? Boolean.parseBoolean(validationCheckProperty) : true;
+        doValidation = validationCheckProperty == null || Boolean.parseBoolean(validationCheckProperty);
     }
 
     /**


### PR DESCRIPTION
- added API for checking client certificates
- checking validity of the certificate (expiration) when authenticating

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Added an API to `CertificateRealm` to be able to plug in additional checks via service loader
add `META-INF/services/fish.payara.security.api.ClientCertificateValidator` with class name to activate
Able to `@Inject` other beans and use EE services

## Important Info
## Testing
### New tests
New Payara Sample to test this

### Testing Performed
With @rdebusscher veto.zip

## Documentation
New "Additional Property" for Certificate Realm: `validation-check`
Default is true. If set to false, time validity (e.g. expiration) will not be checked
Able to inject EJB and CDI beans into the validator, however, lifecycle `@PostConstruct/@PreDestroy`
will not work because validators are not true EE objects and not managed by the container

New Service Loader `fish.payara.security.api.ClientCertificateValidator` can be added to
do custom validation of certificates

## Notes for Reviewers
Use GitHub "ignore whitespace changes" when reviewing