### PR TITLE
Remove reflective access for processing ENV variables in logging.properties file

### DIFF
--- a/nucleus/common/common-util/src/main/java/fish/payara/logging/PayaraLogManager.java
+++ b/nucleus/common/common-util/src/main/java/fish/payara/logging/PayaraLogManager.java
@@ -1,0 +1,65 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.logging;
+
+import com.sun.enterprise.util.PropertyPlaceholderHelper;
+
+
+import java.io.*;
+import java.util.Properties;
+import java.util.logging.LogManager;
+
+public class PayaraLogManager extends LogManager {
+
+    @Override
+    public void readConfiguration(InputStream ins) throws IOException, SecurityException {
+
+        Properties configuration = new Properties();
+        configuration.load(ins);
+
+        // transform
+        configuration = new PropertyPlaceholderHelper(System.getenv(), PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
+
+        StringWriter writer = new StringWriter();
+        configuration.list(new PrintWriter(writer));
+
+        super.readConfiguration(new ByteArrayInputStream(writer.getBuffer().toString().getBytes()));
+    }
+}

--- a/nucleus/common/common-util/src/main/java/fish/payara/logging/PayaraLogManager.java
+++ b/nucleus/common/common-util/src/main/java/fish/payara/logging/PayaraLogManager.java
@@ -58,7 +58,7 @@ public class PayaraLogManager extends LogManager {
         configuration = new PropertyPlaceholderHelper(System.getenv(), PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
 
         StringWriter writer = new StringWriter();
-        configuration.list(new PrintWriter(writer));
+        configuration.store(new PrintWriter(writer), null);
 
         super.readConfiguration(new ByteArrayInputStream(writer.getBuffer().toString().getBytes()));
     }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -38,10 +38,12 @@
  * holder.
  *
  */
-// Portions Copyright [2017-2019] Payara Foundation and/or affilates
+// Portions Copyright [2017-2021] Payara Foundation and/or affilates
 
 package com.sun.enterprise.glassfish.bootstrap;
 
+import fish.payara.boot.runtime.BootCommands;
+import fish.payara.logging.PayaraLogManager;
 import org.glassfish.embeddable.*;
 
 import java.io.BufferedReader;
@@ -50,16 +52,16 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import static com.sun.enterprise.module.bootstrap.ArgumentManager.argsToMap;
-import fish.payara.boot.runtime.BootCommands;
-import static java.util.logging.Level.SEVERE;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.sun.enterprise.module.bootstrap.ArgumentManager.argsToMap;
+import static java.util.logging.Level.SEVERE;
 
 /**
  * @author Sanjeeb.Sahoo@Sun.COM
@@ -68,22 +70,30 @@ public class GlassFishMain {
 
     private static final Pattern COMMAND_PATTERN = Pattern.compile("([^\"']\\S*|\".*?\"|'.*?')\\s*");
     private static final String[] COMMAND_TYPE = new String[0];
-    private static final Logger LOGGER = Logger.getLogger(GlassFishMain.class.getName());
+    private static final Logger LOGGER;
 
     // TODO(Sahoo): Move the code to ASMain once we are ready to phase out ASMain
+
+    static {
+        // This is not a JVM parameter in the domain as users should not have the possibility to not use the Payara Log Manager.
+        System.setProperty("java.util.logging.manager", PayaraLogManager.class.getName());
+
+        // Do not use as variable initialization as that will trigger LogManager before System property is set.
+        LOGGER = Logger.getLogger(GlassFishMain.class.getName());
+    }
 
     public static void main(final String args[]) throws Exception {
         MainHelper.checkJdkVersion();
 
         final Properties argsAsProps = argsToMap(args);
-        
+
         String platform = MainHelper.whichPlatform();
 
         System.out.println("Launching Payara Server on " + platform + " platform");
 
         // Set the system property if downstream code wants to know about it
         System.setProperty(Constants.PLATFORM_PROPERTY_KEY, platform); // TODO(Sahoo): Why is this a system property?
-        
+
         File installRoot = MainHelper.findInstallRoot();
 
         // domainDir can be passed as argument, so pass the agrgs as well.

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
@@ -49,7 +49,6 @@ import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.module.bootstrap.EarlyLogHandler;
 import com.sun.enterprise.util.EarlyLogger;
-import com.sun.enterprise.util.PropertyPlaceholderHelper;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.logging.AgentFormatterDelegate;
 import fish.payara.enterprise.server.logging.JSONLogFormatter;
@@ -58,7 +57,6 @@ import java.beans.PropertyChangeEvent;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.lang.reflect.Field;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,7 +68,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -401,16 +398,6 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
             }
             
             logMgr.readConfiguration();
-
-            // replace placehoders with values from system environment variables
-            try {
-                final Field propsLogManagerField = logMgr.getClass().getDeclaredField("props");
-                propsLogManagerField.setAccessible(true);
-                Properties props = (Properties) propsLogManagerField.get(logMgr);
-                propsLogManagerField.set(logMgr, new PropertyPlaceholderHelper(System.getenv(), PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(props));
-            } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException ex) {
-                LOGGER.log(Level.SEVERE, LogFacade.ERROR_PLACEHOLDERS_REPLACEMENT, ex);
-            }
 
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, LogFacade.ERROR_READING_CONF_FILE, e);


### PR DESCRIPTION
## Description
Fix for reflective access introduced here https://github.com/payara/Payara/pull/3310

## Testing

### Testing Performed
used ENV variables in logging.properties and verified if they are replaced.

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.2.3 with Maven 3.6.3

## Documentation
TODO: Check existing documentation for feature

