### PR TITLE
FISH-1375 Improve remote archive deployment

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/DeploymentFileValidator.java
@@ -39,6 +39,8 @@
  */
 package fish.payara.micro.cmd.options;
 
+import fish.payara.deployment.util.JavaArchiveUtils;
+
 import java.io.File;
 import java.text.MessageFormat;
 
@@ -64,19 +66,19 @@ public class DeploymentFileValidator extends Validator {
         File deployment = new File(filePath);
 
         if (!deployment.exists()) {
-            throw new ValidationException(MessageFormat.format(RuntimeOptions.commandlogstrings.getString("fileDoesNotExist"), filePath));
+            throw new ValidationException(MessageFormat.format(RuntimeOptions.commandlogstrings.getString("fileDoesNotExist"), deployment.getPath()));
         }
 
         if (!deployment.canRead()) {
-            throw new ValidationException(MessageFormat.format(RuntimeOptions.commandlogstrings.getString("fileNotReadable"), filePath));
+            throw new ValidationException(MessageFormat.format(RuntimeOptions.commandlogstrings.getString("fileNotReadable"), deployment.getPath()));
         }
 
-        if (deployment.isFile() && !(filePath.endsWith(".rar") || filePath.endsWith(".jar") || filePath.endsWith(".war"))) {
-            throw new ValidationException(filePath + " is a not valid type of deployment archive");
+        if (deployment.isFile() && !JavaArchiveUtils.hasJavaArchiveExtension(deployment.getName(), false)) {
+            throw new ValidationException(deployment.getPath() + " is a not valid type of deployment archive");
         }
 
-        if (deployment.isDirectory() && !new File(filePath, "WEB-INF").exists()) {
-            throw new ValidationException(filePath + " is a not valid exploded web archive");
+        if (deployment.isDirectory() && !JavaArchiveUtils.hasWebInf(deployment)) {
+            throw new ValidationException(deployment.getPath() + " is a not valid exploded web archive");
         }
 
         return true;

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/cmd/options/RuntimeOptions.java
@@ -39,6 +39,8 @@
  */
 package fish.payara.micro.cmd.options;
 
+import fish.payara.deployment.util.JavaArchiveUtils;
+
 import java.text.MessageFormat;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -129,7 +131,7 @@ public class RuntimeOptions {
                 } catch (ValidationException ve) {
                     throw new ValidationException(arg + " " + ve.getMessage(), ve);
                 }
-            } else if (arg.endsWith(".war") || arg.endsWith(".rar") || arg.endsWith(".jar")) {
+            } else if (JavaArchiveUtils.hasJavaArchiveExtension(arg, false)) {
                 // we have a "raw" deployment
                 RUNTIME_OPTION.deploy.validate(arg);
                 options.add(new AbstractMap.SimpleImmutableEntry<>(RUNTIME_OPTION.deploy, arg));

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -166,7 +166,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private boolean outputLauncher;
     private File copyDirectory;
     private Properties userSystemProperties;
-    private List<String> repositoryURIs;
+    private final List<String> repositoryURIs;
     private final short defaultHttpPort = 8080;
     private final short defaultHttpsPort = 8181;
     private final BootCommands preBootCommands;
@@ -212,7 +212,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      * --help Shows this message and exits\n
      * @throws BootstrapException If there is a problem booting the server
      */
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         create(args);
     }
 
@@ -716,9 +716,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     public PayaraMicroImpl addRepoUrl(String... URLs) {
         //if (runtime != null) {
         checkNotRunning();
-        if (repositoryURIs == null) {
-            repositoryURIs = new LinkedList<>();
-        }
         repositoryURIs.addAll(Arrays.asList(URLs));
         return this;
     }
@@ -1111,6 +1108,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
     private PayaraMicroImpl() {
         // Initialise a random instance name
+        repositoryURIs = new LinkedList<>();
         preBootCommands = new BootCommands();
         postBootCommands = new BootCommands();
         postDeployCommands = new BootCommands();
@@ -1243,9 +1241,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     enableHealthCheck = Boolean.parseBoolean(value);
                     break;
                 case additionalrepository:
-                    if (repositoryURIs == null) {
-                        repositoryURIs = new LinkedList<>();
-                    }
                     repositoryURIs.add(value);
                     break;
                 case outputuberjar:

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -164,8 +164,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private boolean outputLauncher;
     private File copyDirectory;
     private Properties userSystemProperties;
-    private List<String> repositoryURLs;
-    private final String defaultMavenRepository = "https://repo.maven.apache.org/maven2/";
+    private List<String> repositoryURIs;
     private final short defaultHttpPort = 8080;
     private final short defaultHttpsPort = 8181;
     private final BootCommands preBootCommands;
@@ -715,7 +714,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     public PayaraMicroImpl addRepoUrl(String... URLs) {
         //if (runtime != null) {
         checkNotRunning();
-        repositoryURLs.addAll(Arrays.asList(URLs));
+        if (repositoryURIs == null) {
+            repositoryURIs = new LinkedList<>();
+        }
+        repositoryURIs.addAll(Arrays.asList(URLs));
         return this;
     }
 
@@ -1107,11 +1109,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
     private PayaraMicroImpl() {
         // Initialise a random instance name
-        repositoryURLs = new LinkedList<>();
         preBootCommands = new BootCommands();
         postBootCommands = new BootCommands();
         postDeployCommands = new BootCommands();
-        repositoryURLs.add(defaultMavenRepository);
         addShutdownHook();
     }
 
@@ -1241,7 +1241,10 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                     enableHealthCheck = Boolean.parseBoolean(value);
                     break;
                 case additionalrepository:
-                    repositoryURLs.add(value);
+                    if (repositoryURIs == null) {
+                        repositoryURIs = new LinkedList<>();
+                    }
+                    repositoryURIs.add(value);
                     break;
                 case outputuberjar:
                     uberJar = new File(value);
@@ -2066,7 +2069,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private Map.Entry<String, URI> getGAVURI(String gav) throws GlassFishException {
         GAVConvertor gavConvertor = new GAVConvertor();
         try {
-            Map.Entry<String, URI> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURLs);
+            Map.Entry<String, URI> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURIs);
             return new AbstractMap.SimpleImmutableEntry<>(artefactMapEntry.getKey(), artefactMapEntry.getValue());
         } catch (URISyntaxException ex) {
             throw new GlassFishException(ex.getMessage());

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -2051,9 +2051,8 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     }
 
     private Map.Entry<String, URI> getGAVURI(String gav) throws GlassFishException {
-        GAVConvertor gavConvertor = new GAVConvertor();
         try {
-            Map.Entry<String, URI> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURIs);
+            Map.Entry<String, URI> artefactMapEntry = GAVConvertor.getArtefactMapEntry(gav, repositoryURIs);
             return new AbstractMap.SimpleImmutableEntry<>(artefactMapEntry.getKey(), artefactMapEntry.getValue());
         } catch (URISyntaxException ex) {
             throw new GlassFishException(ex.getMessage());

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -2066,9 +2066,9 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private Map.Entry<String, URI> getGAVURI(String gav) throws GlassFishException {
         GAVConvertor gavConvertor = new GAVConvertor();
         try {
-            Map.Entry<String, URL> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURLs);
-            return new AbstractMap.SimpleImmutableEntry<>(artefactMapEntry.getKey(), artefactMapEntry.getValue().toURI());
-        } catch (MalformedURLException | URISyntaxException ex) {
+            Map.Entry<String, URI> artefactMapEntry = gavConvertor.getArtefactMapEntry(gav, repositoryURLs);
+            return new AbstractMap.SimpleImmutableEntry<>(artefactMapEntry.getKey(), artefactMapEntry.getValue());
+        } catch (URISyntaxException ex) {
             throw new GlassFishException(ex.getMessage());
         }
     }

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/data/InstanceDescriptorImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/data/InstanceDescriptorImpl.java
@@ -17,39 +17,37 @@
  */
 package fish.payara.appserver.micro.services.data;
 
-import static java.lang.Boolean.TRUE;
-import static javax.json.stream.JsonGenerator.PRETTY_PRINTING;
-
-import java.io.StringWriter;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
+import fish.payara.micro.data.ApplicationDescriptor;
+import fish.payara.micro.data.InstanceDescriptor;
+import fish.payara.micro.data.ModuleDescriptor;
+import org.glassfish.internal.data.ApplicationInfo;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonWriter;
-
-import org.glassfish.internal.data.ApplicationInfo;
-
-import fish.payara.micro.data.ApplicationDescriptor;
-import fish.payara.micro.data.InstanceDescriptor;
-import fish.payara.micro.data.ModuleDescriptor;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+
+import static java.lang.Boolean.TRUE;
+import static javax.json.stream.JsonGenerator.PRETTY_PRINTING;
 
 /**
  *
@@ -82,7 +80,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
 
     public void addApplication(ApplicationInfo info) {
         if (deployedApplications == null) {
-            deployedApplications = new HashMap<>(3);
+            deployedApplications = new LinkedHashMap<>();
         }
 
         ApplicationDescriptorImpl ad = new ApplicationDescriptorImpl(info);
@@ -91,7 +89,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
 
     public void addApplication(ApplicationDescriptor descriptor) {
         if (deployedApplications == null) {
-            deployedApplications = new HashMap<>(3);
+            deployedApplications = new LinkedHashMap<>();
         }
 
         deployedApplications.put(descriptor.getName(), descriptor);
@@ -150,7 +148,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
     @Override
     public Collection<ApplicationDescriptor> getDeployedApplications() {
         if (deployedApplications == null) {
-            return new HashSet<>();
+            return new LinkedHashSet<>();
         }
         return deployedApplications.values();
     }
@@ -172,7 +170,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
 
     public void removeApplication(ApplicationDescriptor applicationInfo) {
         if (deployedApplications == null) {
-            deployedApplications = new HashMap<>(3);
+            deployedApplications = new LinkedHashMap<>();
         }
 
         deployedApplications.remove(applicationInfo.getName());
@@ -189,7 +187,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
     /**
      * Overrides hashcode based purely on the UUID hashcode
      *
-     * @return
+     * @return The UUID-based hash code.
      */
     @Override
     public int hashCode() {
@@ -340,9 +338,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
                 // List the module mappings if verbose is specified
                 if (verbose) {
                     JsonObjectBuilder servletMappings = Json.createObjectBuilder();
-                    module.getServletMappings().forEach((key, value) -> {
-                        servletMappings.add(key, value);
-                    });
+                    module.getServletMappings().forEach(servletMappings::add);
                     appBuilder.add("Mappings", servletMappings.build());
                 }
 
@@ -362,9 +358,7 @@ public class InstanceDescriptorImpl implements InstanceDescriptor {
                     // Create an object of mappings if verbose is specified
                     if (verbose) {
                         JsonObjectBuilder servletMappings = Json.createObjectBuilder();
-                        module.getServletMappings().forEach((key, value) -> {
-                            servletMappings.add(key, value);
-                        });
+                        module.getServletMappings().forEach(servletMappings::add);
                         moduleBuilder.add("Mappings", servletMappings.build());
                     }
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
@@ -46,14 +46,35 @@ import com.sun.enterprise.universal.io.SmartFile;
 import com.sun.enterprise.util.CULoggerInfo;
 import com.sun.enterprise.util.OS;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.RandomAccessFile;
+import java.io.Writer;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -806,6 +827,26 @@ public class FileUtils  {
             deleteOnExit(f); // just in case
         }
         return f;
+    }
+
+    public static File createTempFile(InputStream in, String prefix, String suffix) throws IOException {
+        File file = File.createTempFile(prefix, suffix);
+
+        deleteOnExit(file);
+
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            copy(in, out, Long.MAX_VALUE);
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+        }
+
+        return file;
     }
 
     /**

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.util.io;
 

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationRegistry.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationRegistry.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.data;
 

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationRegistry.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationRegistry.java
@@ -47,6 +47,7 @@ import org.jvnet.hk2.annotations.Service;
 import javax.inject.Singleton;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.glassfish.internal.deployment.Deployment;
@@ -63,7 +64,7 @@ import org.glassfish.internal.deployment.Deployment;
 @Singleton
 public class ApplicationRegistry {
 
-    private Map<String, ApplicationInfo> apps = new HashMap<>();
+    private final Map<String, ApplicationInfo> apps = new LinkedHashMap<>();
     private final Map<String, Deployment.ApplicationDeployment> transientDeployments = new HashMap<>();
 
     public synchronized void add(String name, ApplicationInfo info) {
@@ -75,7 +76,6 @@ public class ApplicationRegistry {
     }
 
     public synchronized void remove(String name) {
-
         apps.remove(name);
     }
 
@@ -101,5 +101,4 @@ public class ApplicationRegistry {
     public Deployment.ApplicationDeployment getTransient(String appName) {
         return transientDeployments.get(appName);
     }
-
 }

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -137,6 +137,8 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
                     name = path.substring(path.lastIndexOf("/") + 1, path.indexOf(".war"));
                 } else if (path.endsWith(".ear")) {
                     name = path.substring(path.lastIndexOf("/") + 1, path.indexOf(".ear"));
+                } else if (path.endsWith(".rar")) {
+                    name = path.substring(path.lastIndexOf("/") + 1, path.indexOf(".rar"));
                 }
             }
 
@@ -148,6 +150,8 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
                     contextroot = "/" + path.substring(path.lastIndexOf("/") + 1, path.indexOf(".war"));
                 } else if (path.endsWith(".ear")) {
                     contextroot = "/" + path.substring(path.lastIndexOf("/") + 1, path.indexOf(".ear"));
+                } else if (path.endsWith(".rar")) {
+                    contextroot = "/" + path.substring(path.lastIndexOf("/") + 1, path.indexOf(".rar"));
                 }
             }
         } else {

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -145,8 +145,7 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
                 logger.log(Level.FINE, "Path does not appear to be a URI, will attempt to read as GAV coordinate");
 
                 // Get the URI for the given GAV coordinate
-                GAVConvertor gavConvertor = new GAVConvertor();
-                Entry<String, URI> artefactEntry = gavConvertor.getArtefactMapEntry(path, additionalRepositories);
+                Entry<String, URI> artefactEntry = GAVConvertor.getArtefactMapEntry(path, additionalRepositories);
 
                 // Download the file to temp, and return a File object to pass to the deploy command
                 fileToDeploy = URIUtils.convertToFile(artefactEntry.getValue());

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -45,6 +45,7 @@ import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.util.io.FileUtils;
 import fish.payara.deployment.util.GAVConvertor;
+import fish.payara.deployment.util.URIUtils;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.AdminCommand;
@@ -322,7 +323,7 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
 
 
     private File convertUriToFile(URI uri) throws URISyntaxException, IOException {
-        try (InputStream in = uri.toURL().openStream()) {
+        try (InputStream in = URIUtils.openHttpConnection(uri).getInputStream()) {
             return createFile(in);
         }
     }

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -202,11 +202,14 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
 
     private List<URL> formatRepositoryUrls(List<String> additionalRepositories) throws MalformedURLException {
         List<URL> repositoryUrls = new ArrayList<>();
-        for (String repository : additionalRepositories) {
-            if (!repository.endsWith("/")) {
-                repositoryUrls.add(new URL(repository + "/"));
-            } else {
-                repositoryUrls.add(new URL(repository));
+
+        if (additionalRepositories != null) {
+            for (String repository : additionalRepositories) {
+                if (!repository.endsWith("/")) {
+                    repositoryUrls.add(new URL(repository + "/"));
+                } else {
+                    repositoryUrls.add(new URL(repository));
+                }
             }
         }
 

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -71,7 +71,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -106,8 +105,6 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
 
     @Inject
     ServiceLocator serviceLocator;
-
-    private static final String defaultMavenRepository = "https://repo.maven.apache.org/maven2/";
 
     @Override
     public void execute(AdminCommandContext context) {
@@ -158,15 +155,9 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
                 // If the path String doesn't start with Http or Https, then assume it's a GAV coordinate
                 logger.log(Level.FINE, "Path does not appear to be a URI, will attempt to read as GAV coordinate");
 
-                List<String> repositoryUris = new LinkedList<>();
-                repositoryUris.add(defaultMavenRepository);
-                if (additionalRepositories != null) {
-                    repositoryUris.addAll(additionalRepositories);
-                }
-
                 // Get the URI for the given GAV coordinate
                 GAVConvertor gavConvertor = new GAVConvertor();
-                Entry<String, URI> artefactEntry = gavConvertor.getArtefactMapEntry(path, repositoryUris);
+                Entry<String, URI> artefactEntry = gavConvertor.getArtefactMapEntry(path, additionalRepositories);
 
                 // Download the file to temp, and return a File object to pass to the deploy command
                 fileToDeploy = convertUriToFile(artefactEntry.getValue());

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -164,7 +164,8 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
 
                 // If a name hasn't been provided, get it from the artefact name
                 if (name == null) {
-                    name = artefactEntry.getKey();
+                    String fileName = new File(artefactEntry.getValue().getPath()).getName();
+                    name = fileName.substring(0, fileName.length() - 4);
                 }
 
                 // If a context root hasn't been provided, get it from the artefact name

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -203,6 +203,8 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
     private List<URL> formatRepositoryUrls(List<String> additionalRepositories) throws MalformedURLException {
         List<URL> repositoryUrls = new ArrayList<>();
 
+        repositoryUrls.add(new URL(defaultMavenRepository));
+
         if (additionalRepositories != null) {
             for (String repository : additionalRepositories) {
                 if (!repository.endsWith("/")) {

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -115,8 +115,11 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
         // Initialise to null so we can do a null check later
         File fileToDeploy = null;
 
+        // Should treat uppercase letters as equivalent to lowercase in scheme names
+        // (section 3.1 of the RFC 2396)
+        String lowerPath = path.toLowerCase();
         // Assume only Http or Https connections are direct URIs
-        if (path.startsWith("http://") || path.startsWith("https://")) {
+        if (lowerPath.startsWith("http://") || lowerPath.startsWith("https://")) {
             try {
                 // Download the file to temp, and return a File object to pass to the deploy command
                 fileToDeploy = convertUriToFile(new URI(path));

--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -326,6 +326,10 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
 
 
     private File convertUriToFile(URI uri) throws URISyntaxException, IOException {
+        if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return new File(uri);
+        }
+
         try (InputStream in = URIUtils.openHttpConnection(uri).getInputStream()) {
             return createFile(in);
         }

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -53,9 +53,9 @@ import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -83,9 +83,7 @@ public class GAVConvertor {
     public Map.Entry<String, URI> getArtefactMapEntry(String GAV, Collection<String> repositoryURIs) throws URISyntaxException {
         final Map<String, String> GAVMap = splitGAV(GAV);
 
-        List<String> repoURIs = new LinkedList<>();
-
-        repoURIs.add(defaultMavenRepository);
+        Set<String> repoURIs = new LinkedHashSet<>();
 
         if (repositoryURIs != null) {
             for (String uri : repositoryURIs) {
@@ -96,6 +94,8 @@ public class GAVConvertor {
                 repoURIs.add(convertedURI);
             }
         }
+
+        repoURIs.add(defaultMavenRepository);
 
         final String relativeURIString = constructRelativeURIString(GAVMap);
         final URI artefactURI = findArtefactURI(repoURIs, relativeURIString);
@@ -151,7 +151,7 @@ public class GAVConvertor {
      * @throws URISyntaxException Thrown if an artefact cannot be found for
      * the provided GAV
      */
-    private URI findArtefactURI(List<String> repositoryURIs, String relativeURIString) throws URISyntaxException {
+    private URI findArtefactURI(Collection<String> repositoryURIs, String relativeURIString) throws URISyntaxException {
         final String[] archiveTypes = new String[] {".jar", ".war", ".ear", ".rar"};
 
         // For each URI...

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -61,11 +61,16 @@ import java.util.logging.Logger;
  * coordinates into a URI.
  * @author Andrew Pielage
  */
-public class GAVConvertor {
+public final class GAVConvertor {
     
     private static final Logger logger = Logger.getLogger("PayaraMicro");
 
     private static final String defaultMavenRepository = "https://repo.maven.apache.org/maven2/";
+
+    // Suppress default constructor
+    private GAVConvertor() {
+        throw new AssertionError();
+    }
     
     /**
      * Returns a valid URI for a provided GAV (GroupId, ArtifactId, Version).
@@ -77,7 +82,7 @@ public class GAVConvertor {
      * @throws URISyntaxException Thrown if an artefact cannot be found for
      * the provided GAV
      */
-    public Map.Entry<String, URI> getArtefactMapEntry(String GAV, Collection<String> repositoryURIs) throws URISyntaxException {
+    public static Map.Entry<String, URI> getArtefactMapEntry(String GAV, Collection<String> repositoryURIs) throws URISyntaxException {
         final Map<String, String> GAVMap = splitGAV(GAV);
 
         Set<String> repoURIs = new LinkedHashSet<>();
@@ -108,7 +113,7 @@ public class GAVConvertor {
      * @return A Map containing the groupId, artefactId, and versionNumber of 
      * the provided GAV as Strings
      */
-    private Map<String, String> splitGAV(String GAV) throws URISyntaxException {
+    private static Map<String, String> splitGAV(String GAV) throws URISyntaxException {
         final String[] splitGAV = GAV.split("[,:]");
         final Map<String, String> GAVMap = new HashMap<>();
         try {
@@ -130,7 +135,7 @@ public class GAVConvertor {
      * and version number.
      * @return A String representing the relative URI of the provided GAV.
      */
-    private String constructRelativeURIString(Map<String, String> GAVMap) {
+    private static String constructRelativeURIString(Map<String, String> GAVMap) {
         final String artefactFileName = GAVMap.get("artefactId") + "-" + GAVMap.get("versionNumber");
 
         return GAVMap.get("groupId") + "/" + GAVMap.get("artefactId") + "/"
@@ -148,7 +153,7 @@ public class GAVConvertor {
      * @throws URISyntaxException Thrown if an artefact cannot be found for
      * the provided GAV
      */
-    private URI findArtefactURI(Collection<String> repositoryURIs, String relativeURIString) throws URISyntaxException {
+    private static URI findArtefactURI(Collection<String> repositoryURIs, String relativeURIString) throws URISyntaxException {
         final String[] archiveTypes = new String[] {".jar", ".war", ".ear", ".rar"};
 
         // For each URI...

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -43,13 +43,10 @@ package fish.payara.deployment.util;
 import org.glassfish.config.support.TranslatedConfigView;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
@@ -162,18 +159,8 @@ public class GAVConvertor {
                 try {
                     artefactURI = new URI(repositoryURI + relativeURIString + archiveType);
 
-                    if ("file".equalsIgnoreCase(artefactURI.getScheme())) {
-                        if (Files.exists(Paths.get(artefactURI))) {
-                            return artefactURI;
-                        }
-                    } else {
-                        HttpURLConnection httpConnection = URIUtils.openHttpConnection(artefactURI);
-
-                        httpConnection.setRequestMethod("HEAD");
-
-                        if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_OK) {
-                            return artefactURI;
-                        }
+                    if (URIUtils.exists(artefactURI)) {
+                        return artefactURI;
                     }
 
                     logger.log(Level.FINE, "Artefact not found at URI: {0}", artefactURI.toString());

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -67,6 +67,8 @@ import java.util.logging.Logger;
 public class GAVConvertor {
     
     private static final Logger logger = Logger.getLogger("PayaraMicro");
+
+    private static final String defaultMavenRepository = "https://repo.maven.apache.org/maven2/";
     
     /**
      * Returns a valid URI for a provided GAV (GroupId, ArtifactId, Version).
@@ -82,12 +84,17 @@ public class GAVConvertor {
         final Map<String, String> GAVMap = splitGAV(GAV);
 
         List<String> repoURIs = new LinkedList<>();
-        for (String uri : repositoryURIs) {
-            String convertedURI = TranslatedConfigView.expandValue(uri);
-            if (!convertedURI.endsWith("/")) {
-              convertedURI += "/";
+
+        repoURIs.add(defaultMavenRepository);
+
+        if (repositoryURIs != null) {
+            for (String uri : repositoryURIs) {
+                String convertedURI = TranslatedConfigView.expandValue(uri);
+                if (!convertedURI.endsWith("/")) {
+                    convertedURI += "/";
+                }
+                repoURIs.add(convertedURI);
             }
-            repoURIs.add(convertedURI);
         }
 
         final String relativeURIString = constructRelativeURIString(GAVMap);

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -40,16 +40,17 @@
 
 package fish.payara.deployment.util;
 
+import org.glassfish.config.support.TranslatedConfigView;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -57,11 +58,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.glassfish.config.support.TranslatedConfigView;
 
 /**
  * Performs the functions required for converting GAV (group, artefact, version)
- * coordinates into a URL.
+ * coordinates into a URI.
  * @author Andrew Pielage
  */
 public class GAVConvertor {
@@ -69,46 +69,31 @@ public class GAVConvertor {
     private static final Logger logger = Logger.getLogger("PayaraMicro");
     
     /**
-     * Returns a valid URL for a provided GAV (GroupId, ArtifactId, Version).
+     * Returns a valid URI for a provided GAV (GroupId, ArtifactId, Version).
      * @param GAV A comma separated list of the groupId, artifactId, 
      * and version number
-     * @param repositoryURLs A list of repository URLs to search for the 
+     * @param repositoryURIs A collection of repository URIs to search for the
      * target artefact in
-     * @return A URL matching the provided GAV
-     * @throws MalformedURLException Thrown if an artefact cannot be found for
+     * @return A URI matching the provided GAV
+     * @throws URISyntaxException Thrown if an artefact cannot be found for
      * the provided GAV
      */
-    public Map.Entry<String, URL> getArtefactMapEntry(String GAV, List<URL> repositoryURLs) throws MalformedURLException {
+    public Map.Entry<String, URI> getArtefactMapEntry(String GAV, Collection<String> repositoryURIs) throws URISyntaxException {
         final Map<String, String> GAVMap = splitGAV(GAV);
-        Map.Entry<String, URL> artefactMapEntry;
-        
-        final String relativeURLString = constructRelativeURLString(GAVMap);
-        final URL artefactURL = findArtefactURL(repositoryURLs, relativeURLString);
-        artefactMapEntry = new AbstractMap.SimpleImmutableEntry<>(GAVMap.get("artefactId"), artefactURL);
-        
-        return artefactMapEntry;
-    }
-    
-    /**
-     * Returns a valid URL for a provided GAV (GroupId, ArtifactId, Version).
-     * @param GAV A comma separated list of the groupId, artifactId, 
-     * and version number
-     * @param repositoryURLs A collection of repository URLs to search for the 
-     * target artefact in
-     * @return A URL matching the provided GAV
-     * @throws MalformedURLException Thrown if an artefact cannot be found for
-     * the provided GAV
-     */
-    public Map.Entry<String, URL> getArtefactMapEntry(String GAV, Collection<String> repositoryURLs) throws MalformedURLException {
-        List<URL> repoURLs = new LinkedList<>();
-        for (String url: repositoryURLs) {
-            String convertedURL = TranslatedConfigView.expandValue(url);
-            if (!convertedURL.endsWith("/")) {
-              convertedURL += "/";
+
+        List<String> repoURIs = new LinkedList<>();
+        for (String uri : repositoryURIs) {
+            String convertedURI = TranslatedConfigView.expandValue(uri);
+            if (!convertedURI.endsWith("/")) {
+              convertedURI += "/";
             }
-            repoURLs.add(new URL(convertedURL));
+            repoURIs.add(convertedURI);
         }
-        return getArtefactMapEntry(GAV, repoURLs);
+
+        final String relativeURIString = constructRelativeURIString(GAVMap);
+        final URI artefactURI = findArtefactURI(repoURIs, relativeURIString);
+
+        return new AbstractMap.SimpleImmutableEntry<>(GAVMap.get("artefactId"), artefactURI);
     }
     
     /**
@@ -119,7 +104,7 @@ public class GAVConvertor {
      * @return A Map containing the groupId, artefactId, and versionNumber of 
      * the provided GAV as Strings
      */
-    private Map<String, String> splitGAV(String GAV) throws MalformedURLException {
+    private Map<String, String> splitGAV(String GAV) throws URISyntaxException {
         final String[] splitGAV = GAV.split("[,:]");
         final Map<String, String> GAVMap = new HashMap<>();
         try {
@@ -129,19 +114,19 @@ public class GAVConvertor {
         } catch (ArrayIndexOutOfBoundsException ex) {
             logger.log(Level.WARNING, "Error converting String \"{0}\" to GAV, make sure it takes the form of "
                     + "groupId,artifactId,version", GAV);
-            throw new MalformedURLException(ex.toString() + "\nGAV does not appear to be in the correct format");
+            throw new URISyntaxException("\nGAV does not appear to be in the correct format", ex.toString());
         }
         
         return GAVMap;
     }
     
     /**
-     * Constructs the relative URL of the provided GAV as a String.
+     * Constructs the relative URI of the provided GAV as a String.
      * @param GAVMap A map containing the target artefact's groupId, artifactId,
      * and version number.
-     * @return A String representing the relative URL of the provided GAV.
+     * @return A String representing the relative URI of the provided GAV.
      */
-    private String constructRelativeURLString(Map<String, String> GAVMap) {
+    private String constructRelativeURIString(Map<String, String> GAVMap) {
         final String artefactFileName = GAVMap.get("artefactId") + "-" + GAVMap.get("versionNumber");
 
         return GAVMap.get("groupId") + "/" + GAVMap.get("artefactId") + "/"
@@ -149,77 +134,56 @@ public class GAVConvertor {
     }
     
     /**
-     * Searches for a valid URL for the target artefact in the list of
+     * Searches for a valid URI for the target artefact in the list of
      * provided repositories. 
-     * @param repositoryURLs A list of the repositories to search for
+     * @param repositoryURIs A list of the repositories to search for
      * the artefact in.
-     * @param relativeURLString A String representation of the relative
-     * artefact URL.
-     * @return A valid URL to download the target artefact from.
-     * @throws MalformedURLException Thrown if an artefact cannot be found for
+     * @param relativeURIString A String representation of the relative
+     * artefact URI.
+     * @return A valid URI to download the target artefact from.
+     * @throws URISyntaxException Thrown if an artefact cannot be found for
      * the provided GAV
      */
-    private URL findArtefactURL(List<URL> repositoryURLs, String relativeURLString) throws MalformedURLException {     
-        final String[] archiveTypes = new String[]{".jar", ".war", ".ear", ".rar"};
-        
-        boolean validURLFound = false;
-        
-        URL artefactURL = null;
-        
-        // For each URL...
-        for (URL repositoryURL : repositoryURLs) {    
-            // Append each archive type until a valid URL is found
+    private URI findArtefactURI(List<String> repositoryURIs, String relativeURIString) throws URISyntaxException {
+        final String[] archiveTypes = new String[] {".jar", ".war", ".ear", ".rar"};
+
+        // For each URI...
+        for (String repositoryURI : repositoryURIs) {
+            URI artefactURI = null;
+            // Append each archive type until a valid URI is found
             for (String archiveType : archiveTypes) { 
                 try {
-                    artefactURL = new URL(repositoryURL, relativeURLString + archiveType);
+                    artefactURI = new URI(repositoryURI + relativeURIString + archiveType);
 
-                    if ("file".equalsIgnoreCase(artefactURL.getProtocol())) {
-                        if (Files.exists(Paths.get(artefactURL.toURI()))) {
-                            validURLFound = true;
+                    if ("file".equalsIgnoreCase(artefactURI.getScheme())) {
+                        if (Files.exists(Paths.get(artefactURI))) {
+                            return artefactURI;
                         }
                     } else {
-                        HttpURLConnection httpConnection = (HttpURLConnection) artefactURL.openConnection();
-
-                        String auth = artefactURL.getUserInfo();
-                        if (auth != null) {
-                            String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
-                            httpConnection.setRequestProperty("Authorization", "Basic " + encodedAuth);
-                        }
+                        HttpURLConnection httpConnection = URIUtils.openHttpConnection(artefactURI);
 
                         httpConnection.setRequestMethod("HEAD");
 
                         if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_OK) {
-                            validURLFound = true;
+                            return artefactURI;
                         }
                     }
 
-                    if (validURLFound) {
-                        break;
-                    } else {
-                        logger.log(Level.FINE, "Artefact not found at URL: {0}", artefactURL.toString());
-                    }
-                } catch (MalformedURLException ex) {
-                    String[] errorParameters = new String[]{repositoryURL.toString(), relativeURLString, archiveType};
-                    logger.log(Level.WARNING, "Error creating URL from repository URL, {0}, relative URL, {1}, and archive"
-                            + " type, {2}", errorParameters);
+                    logger.log(Level.FINE, "Artefact not found at URI: {0}", artefactURI.toString());
                 } catch (URISyntaxException ex) {
-                    logger.log(Level.WARNING, "Error creating URI from artefact URL, {0}", artefactURL.toString());
+                    String[] errorParameters = new String[] {repositoryURI, relativeURIString, archiveType};
+                    logger.log(Level.WARNING, "Error creating URI from repository URI, {0}, relative URI, {1}, and archive"
+                            + " type, {2}", errorParameters);
+                } catch (MalformedURLException ex) {
+                    logger.log(Level.WARNING, "Error creating URL from artefact URI, {0}", artefactURI.toString());
                 } catch (ProtocolException ex) {
                     logger.log(Level.WARNING,"Error setting request method to \"HEAD\"");
                 } catch (IOException ex) {
                     logger.log(Level.WARNING, "Error getting HTTP connection response code");
                 }      
             }
-            
-            if (validURLFound) {
-                break;
-            }
         }
-        
-        if (!validURLFound) {
-            throw new MalformedURLException("No artefact can be found for relative URL: "+ relativeURLString);
-        }
-        
-        return artefactURL;
+
+        throw new URISyntaxException(relativeURIString, "No artefact can be found for relative URI");
     }
 }

--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/JavaArchiveUtils.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/JavaArchiveUtils.java
@@ -1,0 +1,121 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.deployment.util;
+
+import java.io.File;
+
+/**
+ * General Java Archive manipulation utilities.
+ */
+public final class JavaArchiveUtils {
+    //Suppress default constructor
+    private JavaArchiveUtils() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Tests whether a file name has the Java archive extension.
+     *
+     * @param fileName the file name to test.
+     * @param processEar if {@code true}, tests the EAR extension.
+     * @return {@code true} if the file name is not {@code null} and has Java archive extension; {@code false} otherwise.
+     */
+    public static boolean hasJavaArchiveExtension(String fileName, boolean processEar) {
+        if (fileName == null) {
+            return false;
+        }
+        return fileName.endsWith(".war") || fileName.endsWith(".rar") || fileName.endsWith(".jar") || (processEar && fileName.endsWith(".ear"));
+    }
+
+    /**
+     * Removes the Java archive extension from the file name.
+     *
+     * @param fileName the file name.
+     * @param processEar if {@code true}, removes the EAR extension.
+     * @return The file name without extension.
+     */
+    public static String removeJavaArchiveExtension(String fileName, boolean processEar) {
+        if (hasJavaArchiveExtension(fileName, processEar)) {
+            return fileName.substring(0, fileName.length() - 4);
+        }
+        return fileName;
+    }
+
+    /**
+     * Tests whether a file name has the Web archive extension.
+     *
+     * @param fileName the file name to test.
+     * @return {@code true} if the file name has Web archive extension; {@code false} otherwise.
+     */
+    public static boolean hasWebArchiveExtension(String fileName) {
+        if (fileName == null) {
+            return false;
+        }
+        return fileName.endsWith(".war");
+    }
+
+    /**
+     * Tests whether {@code archive} contains {@code WEB-INF} subdirectory.
+     *
+     * @param archive the archive to test.
+     * @return {@code true} if the archive contains {@code WEB-INF} subdirectory; {@code false} otherwise.
+     */
+    public static boolean hasWebInf(File archive) {
+        if (archive == null) {
+            return false;
+        }
+        return new File(archive, "WEB-INF").exists();
+    }
+
+    /**
+     * Tests whether {@code archive} has context root.
+     * <p/>
+     * Note: now tests only Web archives.
+     *
+     * @param archive the archive to test.
+     * @return {@code true} if the archive has context root; {@code false} otherwise.
+     */
+    public static boolean hasContextRoot(File archive) {
+        if (archive == null) {
+            return false;
+        }
+        return archive.isFile() ? hasWebArchiveExtension(archive.getName()) : archive.isDirectory() && hasWebInf(archive);
+    }
+}


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Improve remote archive deployment

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
***Bug fixes***
* `deploy-remote-archive` command: NPE when `additionalRepositories` option is missing for GAV archive
* `deploy-remote-archive` command: Maven Central is not defined as default repository when deploy GAV archive
* `deploy-remote-archive` command: Application name and context is not set from URI when RAR archive deploy from HTTP(S)
* `deploy-remote-archive` command: Add appropriate name to GAV archive

***Enhancements***
* `deploy-remote-archive` command: Add Basic Auth support
* `deploy-remote-archive` command: Make HTTP(S) scheme check case insensitive

***Improvements***
* Switch GAV converter to use URI instead of URL thus eliminate unnecessary conversion
* Check each additional repository only once
* Check Maven Central in last order
* `Payara Micro`: Print deployed applications summary in order as they deployed
* Refactor and eliminate code duplicates

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Did some manual testing

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 10 Pro, Zulu Community 1.8.0_292, Maven 3.6.3
