### PR TITLE
FISH-1327 Fix unable to disable Wrapping of JDBC Objects

### DIFF
--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2020] Payara Foundation and/or affiliates
+// Portions Copyright [2020-2021] Payara Foundation and/or affiliates
 
 package org.glassfish.jdbc.admin.cli;
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -326,8 +326,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         initsql = (String) attrList.get(INIT_SQL);
         logJDBCCalls = (String) attrList.get(LOG_JDBC_CALLS);
         
-        // Can't be set to null as the default value is now the SilentSqlTraceListener class, which requires statement 
-        // wrapping to be enabled
+        // Can't be set to null as the default value is now the SilentSqlTraceListener class
         sqltracelisteners = (String) attrList.get(SQL_TRACE_LISTENERS);
         if (sqltracelisteners == null) {
             sqltracelisteners = "";

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 package org.glassfish.jdbc.config.validators;
 
 import com.sun.enterprise.config.serverbeans.ResourcePool;

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/validators/JdbcConnectionPoolValidator.java
@@ -128,9 +128,6 @@ public class JdbcConnectionPoolValidator implements ConstraintValidator<JdbcConn
         final String stmtCacheSize = jdbcPool.getStatementCacheSize();
         final String stmtLeakTimeout = jdbcPool.getStatementLeakTimeoutInSeconds();
         final boolean wrappingEnabled = isTrue(jdbcPool.getWrapJdbcObjects());
-        if (!wrappingEnabled && !isEmpty(jdbcPool.getSqlTraceListeners())) {
-            return false;
-        }
         if (!wrappingEnabled && isPositiveInt(stmtCacheSize)) {
             return false;
         }

--- a/appserver/jdbc/jdbc-config/src/test/java/org/glassfish/main/jdbc/config/validators/JdbcConnectionPoolValidatorTest.java
+++ b/appserver/jdbc/jdbc-config/src/test/java/org/glassfish/main/jdbc/config/validators/JdbcConnectionPoolValidatorTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/jdbc/jdbc-config/src/test/java/org/glassfish/main/jdbc/config/validators/JdbcConnectionPoolValidatorTest.java
+++ b/appserver/jdbc/jdbc-config/src/test/java/org/glassfish/main/jdbc/config/validators/JdbcConnectionPoolValidatorTest.java
@@ -190,12 +190,6 @@ public class JdbcConnectionPoolValidatorTest {
 
         updateMock(pool, p -> {
             expect(p.getWrapJdbcObjects()).andStubReturn("false");
-            expect(p.getSqlTraceListeners()).andStubReturn(SQLTraceListener.class.getName());
-        });
-        assertFalse("wrapping disabled, but trace listeners enabled", this.validator.isValid(pool, null));
-
-        updateMock(pool, p -> {
-            expect(p.getWrapJdbcObjects()).andStubReturn("false");
             expect(p.getSqlTraceListeners()).andStubReturn(null);
             expect(p.getStatementCacheSize()).andStubReturn("200");
         });


### PR DESCRIPTION
## Description
Fixed Wrapping JDBC Objects unable to be disabled if a SQL Trace Listener was present but it was impossible to have no listener. The validation preventing wrapping being disabled while a SQL Trace Listener was present has been removed along with the assertion testing this.

## Testing

### Testing Performed
Manually testing the expected behaviour on the ticket with the updated changes. Confirmed the Unit Tests in the module still all pass. Ran the EE7 Samples and confirmed all tests still pass with wrapping on and off.

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 20.04.2 with Maven 3.6.3
