### PR TITLE
[QACI-657] - Use jbcrypt 1.0.2 from central

### DIFF
--- a/nucleus/packager/external/trilead-ssh2/pom.xml
+++ b/nucleus/packager/external/trilead-ssh2/pom.xml
@@ -117,7 +117,20 @@
             <artifactId>trilead-ssh2</artifactId>
             <scope>compile</scope>
             <optional>true</optional>
+            <exclusions>
+        		<exclusion>
+          			<groupId>org.connectbot.jbcrypt</groupId>
+          			<artifactId>jbcrypt</artifactId>
+        		</exclusion>
+      		</exclusions>
         </dependency>
+        <!-- Import seperately to avoid http block in Maven 3.8.1 -->
+		<dependency>
+		    <groupId>org.connectbot</groupId>
+		    <artifactId>jbcrypt</artifactId>
+		    <version>1.0.2</version>
+		</dependency>
+
         <dependency>
             <groupId>net.i2p.crypto</groupId>
             <artifactId>eddsa</artifactId>


### PR DESCRIPTION
## Description
This is a component upgrade

## Important Info
This artifact causes Payara clean build to fail using maven 3.8.1 due to banning of http dependency collection - this blocks updates to CI

## Testing

### Testing Performed
Built successfully and manual tested

### Testing Environment
Maven 3.8.1
Zulu JDK 8.50.0.21
Mac OSX Catalina 10.15.7
