### PR TITLE
FISH-1415: Write updated log information all at once to logging.properties file.

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
@@ -201,6 +201,7 @@ public class LoggingHandlers {
         String config = (String)handlerCtx.getInputValue("config");
         Map<String, Object> props = new HashMap();
         try{
+            StringBuilder data = new StringBuilder();
             for (Map.Entry<String, Object> e : attrs.entrySet()) {
                 String key=e.getKey();
                 if ((key.equals("com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging")||
@@ -216,11 +217,15 @@ public class LoggingHandlers {
                         && (e.getValue() == null)) {
                     attrs.put(key, "false");
                 }
-                props.put("id", key + "='" + attrs.get(key) + "'");
-                props.put("target", config);
-                RestUtil.restRequest((String)GuiUtil.getSessionValue("REST_URL") + "/set-log-attributes",
-                        props, "POST", null, false, true);
+                if (data.length() > 0) {
+                    data.append(":");
+                }
+                data.append(key).append("='").append(attrs.get(key)).append("'");
             }
+            props.put("id", data.toString());
+            props.put("target", config);
+            RestUtil.restRequest((String) GuiUtil.getSessionValue("REST_URL") + "/set-log-attributes",
+                    props, "POST", null, false, true);
         }catch (Exception ex){
             GuiUtil.handleException(handlerCtx, ex);
             if (GuiUtil.getLogger().isLoggable(Level.FINE)){

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
  
 /*
  * InstanceHandler.java
@@ -48,25 +48,25 @@
  * To change this template, choose Tools | Template Manager
  * and open the template in the editor.
  */
-/**
- *
- * @author anilam
- */
 package org.glassfish.admingui.common.handlers;
 
 import com.sun.jsftemplating.annotation.Handler;
 import com.sun.jsftemplating.annotation.HandlerInput;
 import com.sun.jsftemplating.annotation.HandlerOutput;
 import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import org.glassfish.admingui.common.util.GuiUtil;
+import org.glassfish.admingui.common.util.RestUtil;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-import org.glassfish.admingui.common.util.GuiUtil;
-import org.glassfish.admingui.common.util.RestUtil;
 
-
+/**
+ *
+ * @author anilam
+ */
 public class LoggingHandlers {
 
     /** Creates a new instance of InstanceHandler */
@@ -195,25 +195,24 @@ public class LoggingHandlers {
         @HandlerInput(name = "attrs", type = Map.class, required=true),
         @HandlerInput(name = "config", type = String.class, required=true)
     })
-
     public static void saveLoggingAttributes(HandlerContext handlerCtx) {
         Map<String,Object> attrs = (Map<String,Object>) handlerCtx.getInputValue("attrs");
         String config = (String)handlerCtx.getInputValue("config");
-        Map<String, Object> props = new HashMap();
-        try{
+        Map<String, Object> props = new HashMap<>();
+        try {
             StringBuilder data = new StringBuilder();
             for (Map.Entry<String, Object> e : attrs.entrySet()) {
-                String key=e.getKey();
-                if ((key.equals("com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging")||
-                      key.equals("com.sun.enterprise.server.logging.GFFileHandler.logtoFile") ||
-                      key.equals("com.sun.enterprise.server.logging.GFFileHandler.logtoConsole") ||
-                      key.equals("com.sun.enterprise.server.logging.GFFileHandler.multiLineMode") ||
-                      key.equals("com.sun.enterprise.server.logging.GFFileHandler.rotationOnDateChange" ) ||
-                      key.equals("com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation") ||
-                      key.equals("com.sun.enterprise.server.logging.GFFileHandler.logStandardStreams") ||
-                      key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.logtoFile") ||
-                      key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.rotationOnDateChange") ||
-                      key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.compressOnRotation"))
+                String key = e.getKey();
+                if ((key.equals("com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.logtoFile") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.logtoConsole") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.multiLineMode") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.rotationOnDateChange") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.logStandardStreams") ||
+                        key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.logtoFile") ||
+                        key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.rotationOnDateChange") ||
+                        key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.compressOnRotation"))
                         && (e.getValue() == null)) {
                     attrs.put(key, "false");
                 }
@@ -226,9 +225,9 @@ public class LoggingHandlers {
             props.put("target", config);
             RestUtil.restRequest((String) GuiUtil.getSessionValue("REST_URL") + "/set-log-attributes",
                     props, "POST", null, false, true);
-        }catch (Exception ex){
+        } catch (Exception ex) {
             GuiUtil.handleException(handlerCtx, ex);
-            if (GuiUtil.getLogger().isLoggable(Level.FINE)){
+            if (GuiUtil.getLogger().isLoggable(Level.FINE)) {
                 ex.printStackTrace();
             }
         }


### PR DESCRIPTION
## Description
When using the Web console to update the logging properties of the server, they are sent one by one to the REST endpoints. This means that the file is updated multiple times and that the file contents is checked multiple times for changes.

## Testing

### Testing Performed
verified all changed data onsc reen is written to the file.

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.2.3 with Maven 3.6.3

## Documentation
None, fix issue within codebase


