### PR TITLE
[FISH-1419] Hazelcast domain group partitioning

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryService.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryService.java
@@ -42,8 +42,6 @@ package fish.payara.nucleus.hazelcast;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
-import com.hazelcast.spi.discovery.integration.DiscoveryService;
-import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Node;
 import com.sun.enterprise.util.io.InstanceDirs;
@@ -53,10 +51,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -64,7 +60,6 @@ import java.util.logging.Logger;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.grizzly.utils.Holder;
 import org.glassfish.internal.api.Globals;
-import org.glassfish.internal.api.ServerContext;
 
 /**
  * Provides a Discovery SPI implementation for Hazelcast that uses knowledge
@@ -72,26 +67,15 @@ import org.glassfish.internal.api.ServerContext;
  * @since 5.0
  * @author steve
  */
-public class DomainDiscoveryService implements DiscoveryService {
+public class DomainDiscoveryService {
     private static Logger logger = Logger.getLogger(DomainDiscoveryService.class.getName());
     private final Holder.LazyHolder<InetAddress> chosenAddress =
             Holder.LazyHolder.lazyHolder(MemberAddressPicker::findMyAddressOrLocalHost);
 
-    public DomainDiscoveryService(DiscoveryServiceSettings settings) {
-
-    }
-
-    @Override
-    public void start() {
-        //
-    }
-
-    @Override
     public Iterable<DiscoveryNode> discoverNodes() {
         logger.fine("Starting Domain Node Discovery");
         List<DiscoveryNode> nodes = new LinkedList<>();
         Domain domain = Globals.getDefaultHabitat().getService(Domain.class);
-        ServerContext ctxt = Globals.getDefaultHabitat().getService(ServerContext.class);
         ServerEnvironment env = Globals.getDefaultHabitat().getService(ServerEnvironment.class);
         // add the DAS
         HazelcastRuntimeConfiguration hzConfig = domain.getExtensionByType(HazelcastRuntimeConfiguration.class);
@@ -184,15 +168,5 @@ public class DomainDiscoveryService implements DiscoveryService {
         }
 
         return nodes;
-    }
-
-    @Override
-    public void destroy() {
-        //
-    }
-
-    @Override
-    public Map<String, String> discoverLocalMetadata() {
-        return Collections.emptyMap();
     }
 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryStrategy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryStrategy.java
@@ -1,0 +1,108 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.nucleus.hazelcast;
+
+import com.hazelcast.cluster.Member;
+import com.hazelcast.internal.partition.membergroup.DefaultMemberGroup;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.partitiongroup.MemberGroup;
+import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
+import static fish.payara.nucleus.hazelcast.HazelcastCore.INSTANCE_GROUP_ATTRIBUTE;
+import static fish.payara.nucleus.hazelcast.PayaraHazelcastDiscoveryFactory.HOST_AWARE_PARTITIONING;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Delegate to the Domain Discovery Service for node discovery.
+ * <p>
+ * Separate different domain instance groups into partition groups,
+ * and optionally implements host-aware partitioning
+ * since it's not possible to combine Hazelcast's (very) simple implementation
+ * of host-aware partitioning and custom API-based discovery strategy
+ *
+ * @author lprimak
+ */
+public final class DomainDiscoveryStrategy extends AbstractDiscoveryStrategy {
+    private final DomainDiscoveryService discovery = new DomainDiscoveryService();
+    private final boolean hostAwarePartitioning;
+
+    @SuppressWarnings("rawtypes")
+    public DomainDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
+        super(logger, properties);
+        hostAwarePartitioning = getOrDefault("fish.payara.cluster", HOST_AWARE_PARTITIONING, Boolean.FALSE);
+    }
+
+    @Override
+    public Iterable<DiscoveryNode> discoverNodes() {
+        getLogger().finest("Partition - Discover Nodes");
+        return discovery.discoverNodes();
+    }
+
+    @Override
+    public PartitionGroupStrategy getPartitionGroupStrategy(Collection<? extends Member> allMembers) {
+        getLogger().finest("Getting Partition Strategy");
+        Map<String, MemberGroup> memberGroups = new HashMap<>();
+        collectMembers(allMembers, memberGroups);
+        return memberGroups::values;
+    }
+
+    private void collectMembers(Collection<? extends Member> members, Map<String, MemberGroup> memberGroups) {
+        for (Member member : members) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(member.getAttribute(INSTANCE_GROUP_ATTRIBUTE));
+            if (hostAwarePartitioning) {
+                sb.append("|");
+                sb.append(member.getAddress().getHost());
+            }
+            memberGroups.compute(sb.toString(), (key, val) -> {
+                if (val == null) {
+                    val = new DefaultMemberGroup();
+                }
+                val.addMember(member);
+                getLogger().fine(String.format("added %s - %s to %s", member.getAddress(),
+                        member.getUuid(), key));
+                return val;
+            });
+        }
+    }
+}

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastDiscoveryFactory.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastDiscoveryFactory.java
@@ -1,0 +1,81 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.nucleus.hazelcast;
+
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.config.properties.PropertyTypeConverter;
+import com.hazelcast.config.properties.SimplePropertyDefinition;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import java.util.Collection;
+import static java.util.Collections.singletonList;
+import java.util.Map;
+
+/**
+ * factory for {@link DomainDiscoveryStrategy} instantiation and configuration
+ *
+ * @author lprimak
+ */
+public class PayaraHazelcastDiscoveryFactory implements DiscoveryStrategyFactory {
+    static final PropertyDefinition HOST_AWARE_PARTITIONING =
+            new SimplePropertyDefinition("host-aware-partitioning", true,
+                    PropertyTypeConverter.BOOLEAN);
+    private static final Collection<PropertyDefinition> PROPERTIES =
+            singletonList(HOST_AWARE_PARTITIONING);
+
+    @Override
+    public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+        return DomainDiscoveryStrategy.class;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
+                                                  Map<String, Comparable> properties) {
+        return new DomainDiscoveryStrategy(logger, properties);
+    }
+
+    @Override
+    public Collection<PropertyDefinition> getConfigurationProperties() {
+        return PROPERTIES;
+    }
+}

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,0 +1,1 @@
+fish.payara.nucleus.hazelcast.PayaraHazelcastDiscoveryFactory

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,8 @@
         <stax-api.version>1.0-2</stax-api.version>
         <jackson.version>2.10.2</jackson.version>
         <snakeyaml.version>1.28</snakeyaml.version>
-        <hazelcast.version>4.2</hazelcast.version>
-        <hazelcast.kubernetes.version>2.2</hazelcast.kubernetes.version>
+        <hazelcast.version>4.2.1-SNAPSHOT</hazelcast.version>
+        <hazelcast.kubernetes.version>2.2.3</hazelcast.kubernetes.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>
         <jaxb-impl.version>2.3.2</jaxb-impl.version>
         <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>


### PR DESCRIPTION
Use separate partition groups for Payara domain instance groups
Prevents partitions to be placed on instances where the application is not deployed

Depends on https://github.com/hazelcast/hazelcast/pull/18794
