### PR TITLE
[FISH-1323] Downgrade JDK 8, upgrade JDK 11 (TLS 1.0,1 being disabled)

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -15,8 +15,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk8.tag>8u292</docker.jdk8.tag>
-        <docker.jdk11.tag>11.0.9</docker.jdk11.tag>
+        <docker.jdk8.tag>8u282</docker.jdk8.tag>
+        <docker.jdk11.tag>11.0.10</docker.jdk11.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>


### PR DESCRIPTION
- Downgrade to 8.282 due to TLS 1.0 being disabled
- Upgrade to 11.10 (11.11 not compatible due to TLS 1.0 being disabled)

