### PR TITLE
FISH-1418: JMXService can use all TLS 1.x versions

### DIFF
--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
@@ -423,6 +423,9 @@ final class RMIConnectorStarter extends ConnectorStarter {
         sslParams.setSsl3Enabled(sslConfig.getSsl3Enabled());
         sslParams.setSsl3TlsCiphers(sslConfig.getSsl3TlsCiphers());
         sslParams.setTlsEnabled(sslConfig.getTlsEnabled());
+        sslParams.setTls11Enabled(sslConfig.getTls11Enabled());
+        sslParams.setTls12Enabled(sslConfig.getTls12Enabled());
+        sslParams.setTls13Enabled(sslConfig.getTls13Enabled());
         sslParams.setTlsRollbackEnabled(sslConfig.getTlsRollbackEnabled());
         sslParams.setHstsEnabled(sslConfig.getHstsEnabled());
 

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLClientConfigurator.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLClientConfigurator.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package org.glassfish.admin.mbeanserver.ssl;
 
@@ -52,11 +52,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.*;
 import org.glassfish.admin.mbeanserver.Util;
-import static org.glassfish.grizzly.config.dom.Ssl.SSL2;
-import static org.glassfish.grizzly.config.dom.Ssl.SSL2_HELLO;
-import static org.glassfish.grizzly.config.dom.Ssl.SSL3;
-import static org.glassfish.grizzly.config.dom.Ssl.TLS1;
 import org.glassfish.logging.annotation.LogMessageInfo;
+
+import static org.glassfish.grizzly.config.dom.Ssl.*;
 
 /**
  * This class is a utility class that would configure a client socket factory using
@@ -421,7 +419,7 @@ public class SSLClientConfigurator {
     private void configureCiphersAndProtocols() {
         List<String> tmpSSLArtifactsList = new LinkedList<>();
         // first configure the protocols
-        System.out.println("SSLParams ="+ sslParams);
+
         if (sslParams.getSsl2Enabled()) {
             tmpSSLArtifactsList.add(SSL2);
         }
@@ -430,6 +428,15 @@ public class SSLClientConfigurator {
         }
         if (sslParams.getTlsEnabled()) {
             tmpSSLArtifactsList.add(TLS1);
+        }
+        if (sslParams.getTls11Enabled()) {
+            tmpSSLArtifactsList.add(TLS11);
+        }
+        if (sslParams.getTls12Enabled()) {
+            tmpSSLArtifactsList.add(TLS12);
+        }
+        if (sslParams.getTls13Enabled()) {
+            tmpSSLArtifactsList.add(TLS13);
         }
         if (sslParams.getSsl3Enabled() || sslParams.getTlsEnabled()) {
             tmpSSLArtifactsList.add(SSL2_HELLO);

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
@@ -86,6 +86,9 @@ public class SSLParams {
     private Boolean ssl3Enabled = true;
     private String ssl3TlsCiphers;
     private Boolean tlsEnabled=true;
+    private Boolean tls11Enabled=true;
+    private Boolean tls12Enabled=true;
+    private Boolean tls13Enabled=true;
     private Boolean tlsRollBackEnabled=false;
     private Boolean hstsEnabled = false;
     private Boolean hstsSubDomains = false;
@@ -326,7 +329,38 @@ public class SSLParams {
         this.tlsEnabled = Boolean.parseBoolean(tlsEnabled);
     }
 
+    /**
+     * Determines whether TLSv1.1 is enabled.
+     */
+    public Boolean getTls11Enabled() {
+        return tls11Enabled;
+    }
 
+    public void setTls11Enabled(String tls11Enabled) {
+        this.tls11Enabled = Boolean.parseBoolean(tls11Enabled);
+    }
+
+    /**
+     * Determines whether TLSv1.2 is enabled.
+     */
+    public Boolean getTls12Enabled() {
+        return tls12Enabled;
+    }
+
+    public void setTls12Enabled(String tls12Enabled) {
+        this.tls12Enabled = Boolean.parseBoolean(tls12Enabled);
+    }
+
+    /**
+     * Determines whether TLSv1.3 is enabled.
+     */
+    public Boolean getTls13Enabled() {
+        return tls13Enabled;
+    }
+
+    public void setTls13Enabled(String tls13Enabled) {
+        this.tls13Enabled = Boolean.parseBoolean(tls13Enabled);
+    }
     /**
      * Determines whether TLS rollback is enabled. TLS rollback should be enabled for Microsoft Internet Explorer 5.0
      * and 5.5. NOT Used in PE


### PR DESCRIPTION
## Description
JMXService only tried with TLS 1.0 to connect the MBean server. Since TLS 1.0 and 1.1 are disabled in the latest versions of JDK 8 and 11, the JMXService didn't start anymore.

## Important Info

## Testing

### Testing Performed
Tested on JDK 8u282, JDK 8u292, JDK 11.0.9, JDK 11.0.11.

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.2.3 with Maven 3.6.3

