### PR TITLE
FISH-1167 - Fix Inconsistent Synchronization in Password Alias Alterations for Remote Instances

### DIFF
--- a/appserver/admingui/common/src/main/resources/appServer/pswdAliasAttr.inc
+++ b/appserver/admingui/common/src/main/resources/appServer/pswdAliasAttr.inc
@@ -38,6 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2021] [Payara Foundation and/or affiliates]
 -->
 
     <sun:propertySheet id="propertySheet" requiredFields="true">
@@ -48,7 +49,7 @@
             </sun:property> 
 
             <sun:property id="aliasNameNew"  rendered="#{!edit}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.pswdAlias.aliasName}"  helpText="$resource{i18nc.pswdAlias.aliasNameHelp}">
-                <sun:textField id="aliasNameNew" styleClass="required" required="#{true}" text="#{pageSession.valueMap['aliasname']}" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.Name']}" />
+                <sun:textField id="aliasNameNew" styleClass="required" required="#{true}" text="#{pageSession.valueMap['id']}" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.Name']}" />
             </sun:property>
 
             <sun:property id="newPasswordProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.pswdAlias.password}"  helpText="$resource{i18nc.pswdAlias.passwordHelp}">

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreatePasswordAlias.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreatePasswordAlias.java
@@ -83,7 +83,7 @@ import javax.inject.Inject;
 @Service(name="create-password-alias")
 @PerLookup
 @I18n("create.password.alias")
-@ExecuteOn(RuntimeType.DAS)
+@ExecuteOn(RuntimeType.ALL)
 @TargetType({CommandTarget.DAS,CommandTarget.DOMAIN})
 @RestEndpoints({
     @RestEndpoint(configBean=Domain.class,


### PR DESCRIPTION
## Description
Reverted the changed made in ZDEP-1987, fixing the inconsistent behaviour described in FISH-1167 as the alias is now made everywhere. The bug which ZDEP-1987 fixed has been replaced by changing the aliasNameNew text property from the Admin Console UI to 'id'. This means the aliasname isn't lost later on due to it having a variable name that wasn't expected as the REST interface expects 'id'.

## Testing

### Testing Performed
All steps to reproduce in both FISH-1167 and ZDEP-1987 have been tested and work correctly. All unit tests within the modules passed.

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 20.04.2 with Maven 3.6.3