### PR TITLE
FISH-1423 Disable escaping events in Asadmin CLI

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 
@@ -1440,10 +1440,17 @@ public abstract class CLICommand implements PostConstruct {
     
     protected void buildLineReader() {
         if (lineReader == null) {
-            lineReader = LineReaderBuilder.builder()
+            lineReader = newLineReaderBuilder()
                     .terminal(terminal)
                     .build();
         }
+    }
+    
+    protected LineReaderBuilder newLineReaderBuilder() {
+        return LineReaderBuilder.builder()
+                .appName(ASADMIN)
+                // disable event expansion because it swallows backslashes and we don't need to support events
+                .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
     }
     
     protected void closeTerminal() {

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 
@@ -61,7 +61,6 @@ import org.glassfish.hk2.utilities.BuilderHelper;
 import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Terminal;
@@ -149,8 +148,7 @@ public class MultimodeCommand extends CLICommand {
                         .encoding(encoding != null ? Charset.forName(encoding) : Charset.defaultCharset())
                         .build();
 
-                reader = LineReaderBuilder.builder()
-                        .appName(ASADMIN)
+                reader = newLineReaderBuilder()
                         .terminal(asadminTerminal)
                         .completer(completer)
                         .build();
@@ -183,9 +181,8 @@ public class MultimodeCommand extends CLICommand {
                 Terminal asadminTerminal = new ExternalTerminal(ASADMIN, "",
                         new FileInputStream(file), out, encoding != null ? Charset.forName(encoding) : Charset.defaultCharset());
                 
-                reader = LineReaderBuilder.builder()
+                reader = newLineReaderBuilder()
                         .terminal(asadminTerminal)
-                        .appName(ASADMIN)
                         .build();
             }
 


### PR DESCRIPTION
## Description

JLink 3 changed how escaping works and now interprets every \ as an escape character and not only when it precedes a special character. This means that any single \ character is just removed from the command and not only when it's followed by one of the 2 special characters. This also happens when the expression is enclosed in quotes so there's no way to avoid it without using double \ instead of a single \. 

Most people don't expect this because before Payara 5.193, it was only necessary to escape 2 special characters and most people didn't use them. Admin recorder also doesn't generate the additional escape character when it outputs \ in the command so sometimes it's not possible to take the generated command and use it with asadmin without any changes.

Using [escaping events](https://www.gnu.org/software/bash/manual/html_node/Event-Designators.html) is an undocumented feature and more a sideeffect of using JLink underneath. It's better to remove it to avoid confusion.

## Testing

### Testing Performed
Manual testing to see how some expressions are interpreted.

On command line, following now works (before it was necessary to use \\ in quotes and \\\\ outside of quotes):

```
bin/asadmin create-system-properties 'test_one=colons\:and\=equal\=signs'
bin/asadmin create-system-properties test_one=colons\\:and\\=equal\\=signs
```

In multimode, the same commands also work (before it was again necessary to use \\ in quotes and \\\\ outside of quotes):

```
asadmin> create-system-properties 'test_one=colons\:and\=equal\=signs'
asadmin> create-system-properties test_one=colons\\:and\\=equal\\=signs
```

Asadmin recorder generates a matching output (however it's still needed to enclose the argument in quotes but that was also required before Payara Server 5.193):

```
create-system-properties --target=server test_one=colons\:and\=equal\=signs
```


