### PR TITLE
FISH-1416 MicroProfile Health Component Not Displaying in the Admin Console

### DIFF
--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/healthCheckConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/healthCheckConfiguration.jsf
@@ -2,7 +2,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/healthCheckConfiguration.jsf
+++ b/appserver/admingui/microprofile-console-plugin/src/main/resources/microprofile/specs/healthCheckConfiguration.jsf
@@ -51,7 +51,7 @@
     <!beforeCreate
         getRequestValue(key="configName" value="#{pageSession.configName}");
         setPageSessionAttribute(key="MICROPROFILE_HEALTHCHECK_URL", 
-                value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/metrics-health-check-configuration");
+                value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/microprofile-healthcheck-configuration");
         gf.restRequest(endpoint="#{pageSession.MICROPROFILE_HEALTHCHECK_URL}/get-microprofile-healthcheck-configuration?target=#{pageSession.configName}"  
                 method="GET" result="#{requestScope.resp}");         
         


### PR DESCRIPTION
## Description
Bug fix.
The upgrade to MicroProfile 4.0 broke this page - it was pointing to the wrong URL.

## Important Info
### Blockers
None.

## Testing
### New tests
None.

### Testing Performed
Went to the page and it works.

### Testing Environment
Windows 10, JDK 8
WSL OpenSUSE Leap 15.2, JDK 8

## Documentation
N/A

## Notes for Reviewers
None.
