### PR TITLE
FISH-1423 disable escaping asadmin

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1447,16 +1447,16 @@ public abstract class CLICommand implements PostConstruct {
     }
     
     protected LineReaderBuilder newLineReaderBuilder() {
-    	// In community this should be disabled by default
-    	boolean disabled = true;
-    	Environment environment = new Environment();
-    	if(environment.hasOption("DISABLE_EVENT_EXPANSION")) {
-    		disabled = environment.getBooleanOption("DISABLE_EVENT_EXPANSION");
-    	}
+        // In community this should be disabled by default
+        boolean disabled = true;
+        Environment environment = new Environment();
+        if(environment.hasOption("DISABLE_EVENT_EXPANSION")) {
+            disabled = environment.getBooleanOption("DISABLE_EVENT_EXPANSION");
+        }
         return LineReaderBuilder.builder()
-                .appName(ASADMIN)
-                // disable event expansion because it swallows backslashes and we don't need to support events
-                .option(LineReader.Option.DISABLE_EVENT_EXPANSION, disabled);
+            .appName(ASADMIN)
+            // disable event expansion because it swallows backslashes and we don't need to support events
+            .option(LineReader.Option.DISABLE_EVENT_EXPANSION, disabled);
     }
     
     protected void closeTerminal() {

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1449,8 +1449,9 @@ public abstract class CLICommand implements PostConstruct {
     protected LineReaderBuilder newLineReaderBuilder() {
     	// In community this should be disabled by default
     	boolean disabled = true;
-    	if(System.getenv("DISABLE_EVENT_EXPANSION") != null) {
-    		disabled = Boolean.valueOf(System.getenv("DISABLE_EVENT_EXPANSION"));
+    	Environment environment = new Environment();
+    	if(environment.hasOption("DISABLE_EVENT_EXPANSION")) {
+    		disabled = environment.getBooleanOption("DISABLE_EVENT_EXPANSION");
     	}
         return LineReaderBuilder.builder()
                 .appName(ASADMIN)

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1449,7 +1449,7 @@ public abstract class CLICommand implements PostConstruct {
     protected LineReaderBuilder newLineReaderBuilder() {
         // In community this should be disabled by default
         boolean disabled = true;
-        Environment environment = new Environment();
+        Environment environment = this.env;
         if(environment.hasOption("DISABLE_EVENT_EXPANSION")) {
             disabled = environment.getBooleanOption("DISABLE_EVENT_EXPANSION");
         }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 
@@ -1440,10 +1440,17 @@ public abstract class CLICommand implements PostConstruct {
     
     protected void buildLineReader() {
         if (lineReader == null) {
-            lineReader = LineReaderBuilder.builder()
+            lineReader = newLineReaderBuilder()
                     .terminal(terminal)
                     .build();
         }
+    }
+    
+    protected LineReaderBuilder newLineReaderBuilder() {
+        return LineReaderBuilder.builder()
+                .appName(ASADMIN)
+                // disable event expansion because it swallows backslashes and we don't need to support events
+                .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
     }
     
     protected void closeTerminal() {

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1447,10 +1447,15 @@ public abstract class CLICommand implements PostConstruct {
     }
     
     protected LineReaderBuilder newLineReaderBuilder() {
+    	// In community this should be disabled by default
+    	boolean disabled = true;
+    	if(System.getenv("DISABLE_EVENT_EXPANSION") != null) {
+    		disabled = Boolean.valueOf(System.getenv("DISABLE_EVENT_EXPANSION"));
+    	}
         return LineReaderBuilder.builder()
                 .appName(ASADMIN)
                 // disable event expansion because it swallows backslashes and we don't need to support events
-                .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
+                .option(LineReader.Option.DISABLE_EVENT_EXPANSION, disabled);
     }
     
     protected void closeTerminal() {

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 
@@ -61,7 +61,6 @@ import org.glassfish.hk2.utilities.BuilderHelper;
 import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Terminal;
@@ -149,8 +148,7 @@ public class MultimodeCommand extends CLICommand {
                         .encoding(encoding != null ? Charset.forName(encoding) : Charset.defaultCharset())
                         .build();
 
-                reader = LineReaderBuilder.builder()
-                        .appName(ASADMIN)
+                reader = newLineReaderBuilder()
                         .terminal(asadminTerminal)
                         .completer(completer)
                         .build();
@@ -183,9 +181,8 @@ public class MultimodeCommand extends CLICommand {
                 Terminal asadminTerminal = new ExternalTerminal(ASADMIN, "",
                         new FileInputStream(file), out, encoding != null ? Charset.forName(encoding) : Charset.defaultCharset());
                 
-                reader = LineReaderBuilder.builder()
+                reader = newLineReaderBuilder()
                         .terminal(asadminTerminal)
-                        .appName(ASADMIN)
                         .build();
             }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Allows the ability to enable/disable escape event 

## Testing
### Testing Performed
Tested by seeing if this the expected outcome is expected, and then setting the env variable AS_ADMIN_DISABLE_EVENT_EXPANSION to false and seeing if it is different

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
openjdk version "1.8.0_292"
ubunutu 20.04
maven 3.6.3

## Documentation PR
https://github.com/payara/Payara-Community-Documentation/pull/169
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
Started by @OndroMih 