### PR TITLE
[FISH-995] EJB Web Services survive network listener restart

### DIFF
--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesApplication.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesApplication.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 package org.glassfish.webservices;
 
 import java.net.URL;
@@ -61,6 +61,10 @@ import com.sun.enterprise.deployment.BundleDescriptor;
 import com.sun.enterprise.deployment.WebService;
 import com.sun.enterprise.deployment.WebServiceEndpoint;
 import com.sun.enterprise.deployment.WebServicesDescriptor;
+import java.net.MalformedURLException;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.webservices.deployment.WebServiceGrizzlyListenerAdapter;
+import org.glassfish.webservices.deployment.WebServiceGrizzlyRestartListener;
 
 /**
  * This class implements the ApplicationContainer and will be used
@@ -73,18 +77,20 @@ import com.sun.enterprise.deployment.WebServicesDescriptor;
  * @author Bhakti Mehta
  */
 
-public class WebServicesApplication implements ApplicationContainer<Object> {
+public class WebServicesApplication implements ApplicationContainer<Object>, WebServiceGrizzlyRestartListener {
 
     private static final Logger logger = LogUtils.getLogger();
 
     private ArrayList<EjbEndpoint> ejbendpoints;
-    private ServletHandler httpHandler;
+    private final ServletHandler httpHandler;
     private final RequestDispatcher dispatcher;
-    private DeploymentContext deploymentCtx;
+    private final DeploymentContext deploymentCtx;
 
     private ClassLoader cl;
     private Application app;
-    private Set<String> publishedFiles;
+    private final Set<String> publishedFiles;
+    private String virtualServers;
+    private final WebServiceGrizzlyListenerAdapter grizzlyRestartListener;
 
     public WebServicesApplication(DeploymentContext context,  RequestDispatcher dispatcherString, Set<String> publishedFiles){
         this.deploymentCtx = context;
@@ -92,6 +98,8 @@ public class WebServicesApplication implements ApplicationContainer<Object> {
         this.ejbendpoints = getEjbEndpoints();
         this.httpHandler = new EjbWSAdapter();
         this.publishedFiles = publishedFiles;
+        this.grizzlyRestartListener = Globals.getDefaultHabitat()
+                .getService(WebServiceGrizzlyListenerAdapter.class);
     }
 
     @Override
@@ -101,38 +109,59 @@ public class WebServicesApplication implements ApplicationContainer<Object> {
 
     @Override
     public boolean start(ApplicationContext startupContext) throws Exception {
-
         cl = startupContext.getClassLoader();
+        app = deploymentCtx.getModuleMetaData(Application.class);
+        DeployCommandParameters commandParams = ((DeploymentContext) startupContext).getCommandParameters(DeployCommandParameters.class);
+        virtualServers = commandParams.virtualservers;
+        createEndpoints();
+        grizzlyRestartListener.addListener(this);
+        return true;
+    }
 
+    private void createEndpoints() {
         try {
-           app = deploymentCtx.getModuleMetaData(Application.class);
-
-            DeployCommandParameters commandParams = ((DeploymentContext)startupContext).getCommandParameters(DeployCommandParameters.class);
-            String virtualServers = commandParams.virtualservers;
+            if (app == null || cl == null) {
+                return;
+            }
             Iterator<EjbEndpoint> iter = ejbendpoints.iterator();
-            EjbEndpoint ejbendpoint = null;
-            while(iter.hasNext()) {
+            EjbEndpoint ejbendpoint;
+            while (iter.hasNext()) {
                 ejbendpoint = iter.next();
                 String contextRoot = ejbendpoint.contextRoot;
                 WebServerInfo wsi = new WsUtil().getWebServerInfoForDAS();
                 URL rootURL = wsi.getWebServerRootURL(ejbendpoint.isSecure);
                 dispatcher.registerEndpoint(contextRoot, httpHandler, this, virtualServers);
                 //Fix for issue 13107490 and 17648
-                if (wsi.getHttpVS() != null && wsi.getHttpVS().getPort()!=0) {
+                if (wsi.getHttpVS() != null && wsi.getHttpVS().getPort() != 0) {
                     logger.log(Level.INFO, LogUtils.EJB_ENDPOINT_REGISTRATION,
-                            new Object[] {app.getAppName(), rootURL + contextRoot});
+                            new Object[]{app.getAppName(), rootURL + contextRoot});
                 }
             }
 
+        } catch (EndpointRegistrationException | MalformedURLException e) {
+            logger.log(Level.SEVERE, LogUtils.ENDPOINT_REGISTRATION_ERROR, e.toString());
+        }
+    }
+
+    private boolean destroyEndpoints() {
+        try {
+            Iterator<EjbEndpoint> iter = ejbendpoints.iterator();
+            String contextRoot;
+            EjbEndpoint endpoint;
+            while(iter.hasNext()) {
+                endpoint = iter.next();
+                contextRoot = endpoint.contextRoot;
+                dispatcher.unregisterEndpoint(contextRoot);
+            }
         } catch (EndpointRegistrationException e) {
-            logger.log(Level.SEVERE,  LogUtils.ENDPOINT_REGISTRATION_ERROR, e.toString());
+            logger.log(Level.SEVERE, LogUtils.ENDPOINT_UNREGISTRATION_ERROR, e.toString());
+            return false;
         }
         return true;
     }
 
-
     private ArrayList<EjbEndpoint> getEjbEndpoints() {
-        ejbendpoints = new ArrayList<EjbEndpoint>();
+        ejbendpoints = new ArrayList<>();
 
         Application app = deploymentCtx.getModuleMetaData(Application.class);
 
@@ -158,20 +187,8 @@ public class WebServicesApplication implements ApplicationContainer<Object> {
 
     @Override
     public boolean stop(ApplicationContext stopContext) {
-        try {
-            Iterator<EjbEndpoint> iter = ejbendpoints.iterator();
-            String contextRoot;
-            EjbEndpoint endpoint;
-            while(iter.hasNext()) {
-                endpoint = iter.next();
-                contextRoot = endpoint.contextRoot;
-                dispatcher.unregisterEndpoint(contextRoot);
-            }
-        } catch (EndpointRegistrationException e) {
-            logger.log(Level.SEVERE,  LogUtils.ENDPOINT_UNREGISTRATION_ERROR ,e.toString());
-            return false;
-        }
-        return true;
+        grizzlyRestartListener.removeListener(this);
+        return destroyEndpoints();
     }
 
     @Override
@@ -191,6 +208,12 @@ public class WebServicesApplication implements ApplicationContainer<Object> {
 
     Application getApplication() {
         return app;
+    }
+
+    @Override
+    public void restartEndpoints() {
+        destroyEndpoints();
+        createEndpoints();
     }
 
     static class EjbEndpoint {

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/deployment/WebServiceGrizzlyListenerAdapter.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/deployment/WebServiceGrizzlyListenerAdapter.java
@@ -1,0 +1,90 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.webservices.deployment;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import org.jvnet.hk2.annotations.Service;
+import org.glassfish.api.container.GrizzlyNetworkListenerRestartAdapter;
+
+/**
+ * Grizzly calls {@link #restartEndpoints()} whenever a network listener is enabled,
+ * reconfigured or restarted
+ * <p>
+ * EJB Web Services use this to re-register it's endpoints that are outside of Servlet container
+ *
+ * @author lprimak
+ */
+@Service
+public class WebServiceGrizzlyListenerAdapter implements GrizzlyNetworkListenerRestartAdapter {
+    private final Set<WebServiceGrizzlyRestartListener> listeners =
+            Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
+
+    /**
+     * adds listener
+     *
+     * @param listener
+     * @return
+     * @see Set#add(java.lang.Object)
+     */
+    public boolean addListener(WebServiceGrizzlyRestartListener listener) {
+        return listeners.add(listener);
+    }
+
+    /**
+     * removes  listener
+     *
+     * @param listener
+     * @return
+     * @see Set#remove(java.lang.Object)
+     */
+    public boolean removeListener(WebServiceGrizzlyRestartListener listener) {
+        return listeners.remove(listener);
+    }
+
+    /**
+     * Called by Grizzly
+     */
+    @Override
+    public void restartEndpoints() {
+        listeners.forEach(WebServiceGrizzlyRestartListener::restartEndpoints);
+    }
+}

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/deployment/WebServiceGrizzlyRestartListener.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/deployment/WebServiceGrizzlyRestartListener.java
@@ -1,0 +1,53 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.webservices.deployment;
+
+/**
+ * Listens for Grizzly network interface restart, used by WebServiceGrizzlyRestartListener
+ *
+ * @author lprimak
+ */
+@FunctionalInterface
+public interface WebServiceGrizzlyRestartListener {
+    /**
+     * @see WebServiceGrizzlyListenerAdapter#addListener(org.glassfish.webservices.deployment.WebServiceGrizzlyRestartListener)
+     */
+    public void restartEndpoints();
+}

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/container/GrizzlyNetworkListenerRestartAdapter.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/container/GrizzlyNetworkListenerRestartAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.api.container;
+
+import org.jvnet.hk2.annotations.Contract;
+
+/**
+ * HK2-based implementations of this interfaces will be called whenever
+ * any Grizzly-based network interfaces are enabled, reconfigured or restarted.
+ * <p>
+ * Implementations can re-register endpoints
+ *
+ * @author lprimak
+ */
+@Contract
+public interface GrizzlyNetworkListenerRestartAdapter {
+    /**
+     * Called by Grizzly when a network interface is restarted
+     */
+    void restartEndpoints();
+}


### PR DESCRIPTION
 EJB Web Services survive network listener restart / reconfigure

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This is a bug fix. When doing rolling upgrades and disabling / enabling HTTP interfaces,
EJB web services no longer work without re-loading the application.

## Important Info
## Testing
Current test suite
### New tests
Manual testing was done, as no integration tests for this currently exist, and
it would be very difficult to set those up.

## Notes for Reviewers
Please use "ignore whitespace changes" when reviewing