### PR TITLE
FISH-229 change domain.xml to allow enable-monitoring in JDK 9+

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -271,6 +271,8 @@
                 <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
                 <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+                <!-- allow asadmin command enable-monitoring for JDK 9+ -->
+                <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -266,6 +266,8 @@
         <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+        <!-- allow asadmin command enable-monitoring for JDK 9+ -->
+        <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -222,6 +222,8 @@
         <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+        <!-- allow asadmin command enable-monitoring for JDK 9+ -->
+        <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -245,6 +245,8 @@
         <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+        <!-- allow asadmin command enable-monitoring for JDK 9+ -->
+        <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/extras/embedded/all/src/main/resources/config/domain.xml
+++ b/appserver/extras/embedded/all/src/main/resources/config/domain.xml
@@ -256,6 +256,8 @@
                 <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
                 <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+                <!-- allow asadmin command enable-monitoring for JDK 9+ -->
+                <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
             </java-config>
             <network-config>
                 <protocols>

--- a/appserver/extras/embedded/web/src/main/resources/config/domain.xml
+++ b/appserver/extras/embedded/web/src/main/resources/config/domain.xml
@@ -249,6 +249,8 @@
                 <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
                 <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+                <!-- allow asadmin command enable-monitoring for JDK 9+ -->
+                <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
             </java-config>
             <network-config>
                 <protocols>


### PR DESCRIPTION
## Description
add -Djdk.attach.allowAttachSelf=true to domain.xml templates; JDK 9+ requires this settings to allow to attach to its own virtual machine

## Testing
### Testing Performed
Compile, run appserver/distributions/payara/target/stage/payara5/glassfish/bin/asadmin
```
asadmin> start-domain
asadmin> enable-monitoring --modules jvm
```
output as expected:
`Command enable-monitoring executed successfully.`

### Testing Environment
Linux, OpenJDK 11.0.11

