### PR TITLE
FISH-380 Allow JDBC Connection Pools to set min-size to zero

### DIFF
--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -643,7 +643,7 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         @Override
         public String getSteadyPoolSize() {
             int minPoolSize = desc.getMinPoolSize();
-            if (minPoolSize <= 0) {
+            if (minPoolSize < 0) {
                 _logger.log(Level.WARNING, "Value of steadyPoolSize Given, {0}, was outside the bounds"
                         + ", default value of 8 will be used - PLEASE UPDATE YOUR VALUE", minPoolSize);
                 minPoolSize = 8;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Customer Feature Request

## Testing
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Created test application with min pool size of 0

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
openjdk version "1.8.0_292"
ubunutu 20.04
maven 3.6.3