### PR TITLE
FISH-1497 Improve deploying an application from a Maven repository feature to support snapshot version

### DIFF
--- a/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
+++ b/nucleus/deployment/common/src/main/java/fish/payara/deployment/util/GAVConvertor.java
@@ -147,9 +147,8 @@ public final class GAVConvertor {
      * @return A String representing the relative URI of the provided GAV.
      */
     private static String constructRelativeURIString(Map<String, String> GAVMap, Collection<String> repositoryURIs) {
-        String relativeURI = GAVMap.get("groupId") + "/" + GAVMap.get("artefactId") + "/"
-                + GAVMap.get("versionNumber");
-        String artefactFileName = GAVMap.get("artefactId") + "-" + GAVMap.get("versionNumber");
+        String relativeURI = String.format("%s/%s/%s", GAVMap.get("groupId"), GAVMap.get("artefactId"), GAVMap.get("versionNumber")); 
+        String artefactFileName = String.format("%s-%s", GAVMap.get("artefactId"),GAVMap.get("versionNumber"));
         
         //Check if version is not a snapshot
         if (!relativeURI.endsWith("SNAPSHOT")) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
If version ends with SNAPSHOT, get maven-metadata.xml from maven repo. Get value which is latest SNAPSHOT version 

## Testing
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing with local repo and payara nexus repo. 

Asadmin command for nexus repo 
<h5>asadmin deploy-remote-archive --additionalRepositories https://nexus.payara.fish/repository/payara-snapshots fish.payara.extras,ejb-http-client,5.2021.5-SNAPSHOT<h5>

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
openjdk version "1.8.0_292"
ubunutu 20.04
maven 3.6.3