### PR TITLE
FISH-1514 Glassfish deployment descriptor should have higher precedence by default as the WebLogic descriptor

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
@@ -155,7 +155,7 @@ public class DOLUtils {
     // set to true, WLS DD will have higher precedence over other DD. */
     private static final String WLSDD_PRECEDENCE = "wlsdd.precedence";
     
-    /** The system property to control the precedence between WLS DD
+    /** The system property to control the precedence between GF DD
     // and other DD when they are present. When this property is
     // set to true, GF DD will have higher precedence over other DD. */
     private static final String GFDD_PRECEDENCE = "gfdd.precedence";


### PR DESCRIPTION
## Description
This is a improvement PR to re-prioritize the deployment descriptor with the optional system properties to customize configuration precedence of DD.

#### Removed property
 `gfdd.over.wlsdd`  -  When this property is set to true, GF DD will have higher precedence over WLS DD.
#### New property
`wlsdd.precedence`  -    When this property is set to true, WLS DD will have higher precedence over other DD.
`gfdd.precedence`  -     When this property is set to true, GF DD will have higher precedence over other DD. 

## Testing
### Testing Performed
Manually deploying 'svc_scripting.ear'

## Documentation
TODO
