### PR TITLE
FISH-1068 in generated openapi omit default style for parameter

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -93,7 +93,6 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
-import org.eclipse.microprofile.openapi.models.parameters.Parameter.Style;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
@@ -431,7 +430,6 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
         Parameter newParameter = new ParameterImpl();
         newParameter.setName(name);
         newParameter.setIn(in);
-        newParameter.setStyle(Style.SIMPLE);
         newParameter.setRequired(required);
         SchemaImpl schema = new SchemaImpl();
         String defaultValue = getDefaultValueIfPresent(element);


### PR DESCRIPTION
## Description
Fix for https://github.com/payara/Payara/issues/5111
The solution is simple -- don't fill style parameter as the value "simple" is incorrect for some usages (e.g. query of header parameters). The standard has meaningful defaults, so it is not necessary to calculate the value based on usage.

## Testing
### Testing Performed
manually - in the generated openapi is missing "style: simple" in the parameter

I also tried openapi-generator-cli and there is no problem without style.
