### PR TITLE
FISH-1530 allow multiple servers and tags with empty url and name

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -39,17 +39,16 @@
  */
 package fish.payara.microprofile.openapi.impl.model;
 
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createList;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
-
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.info.InfoImpl;
 import fish.payara.microprofile.openapi.impl.model.security.SecurityRequirementImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createList;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
 import java.util.List;
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
@@ -147,17 +146,14 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
 
         final String serverUrl = server.getUrl();
 
-        if (serverUrl == null) {
-            return this;
-        }
-
         if (servers == null) {
             servers = createList();
         }
 
         for (Server existingServer : getServers()) {
-            // If a server with the same URL is found, merge them
-            if (serverUrl.equals(existingServer.getUrl())) {
+            // If a server with the same URL is found, merge them.
+            // Consider two servers without url as different in order to pass TCK.
+            if (serverUrl != null && serverUrl.equals(existingServer.getUrl())) {
                 ModelUtils.merge(server, existingServer, true);
                 return this;
             }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
@@ -159,6 +159,13 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
         return hash;
     }
 
+    /**
+     * Two tags are equal, if they have the same non-null name.
+     *
+     * @param obj the reference tag with which to compare.
+     * @return {@code true} if this tag has the same non-null name,
+     * {@code false} otherwise.
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -171,7 +178,7 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
             return false;
         }
         final TagImpl other = (TagImpl) obj;
-        return Objects.equals(this.name, other.name);
+        return this.name != null && Objects.equals(this.name, other.name);
     }
 
     @Override


### PR DESCRIPTION
## Description
Modify comparison of servers and tags in OpenApi to allow multiple entities without data (url or name). Without it, TCK fails.

GH issue: https://github.com/eclipse/microprofile-open-api/issues/453
This change is required by TCK, discussion is here:
https://github.com/eclipse/microprofile-open-api/issues/453

I added also a note how to improve the TCK.

## Testing
### Testing Performed
Tested manually, unit tests, TCK without modification
Checkout TCK runner from a branch: https://github.com/payara/MicroProfile-TCK-Runners/tree/FISH-1530

