### PR TITLE
FISH-5544 upgrade json-smart to the latest version, 2.4.7

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -92,7 +92,7 @@
 
         <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
         <accessors-smart.version>1.2.payara-p2</accessors-smart.version>
-        <json-smart.version>2.3</json-smart.version>
+        <json-smart.version>2.4.7</json-smart.version>
         <reactor-core.version>3.4.0</reactor-core.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jcip-annotations.version>1.0-1</jcip-annotations.version>


### PR DESCRIPTION
## Description
Upgrade json-smart library to the latest version 2.4.7 as it solves https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31684

## Testing
### Testing Performed
I tested MP TCKs.
