### PR TITLE
FISH-5545 upgrade jackson to the latest version, 2.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <hk2.version>2.6.1.payara-p6</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
         <snakeyaml.version>1.28</snakeyaml.version>
         <hazelcast.version>4.2</hazelcast.version>
         <hazelcast.kubernetes.version>2.2</hazelcast.kubernetes.version>


### PR DESCRIPTION
## Description
The original requirement was to upgrade jackson-databind, which is a part of the jackson package (jackson-databind is a transitive dependency). Updated to the latest stable version: 2.12.4.
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12.4

## Testing
### Testing Performed
All TCKs
