### PR TITLE
FISH-5640 Upgrade Jackson dependencies to version 2.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <hk2.version>2.6.1.payara-p6</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
         <snakeyaml.version>1.28</snakeyaml.version>
         <hazelcast.version>4.2</hazelcast.version>
         <hazelcast.kubernetes.version>2.2</hazelcast.kubernetes.version>


### PR DESCRIPTION
## Description
This is a dependency upgrade PR that fixes the `CVE-2020-25649` vulnerability caused by `jackson-databind` version `2.10.2`.

<img width="937" alt="Jackson-bind" src="https://user-images.githubusercontent.com/15934072/126450425-8f56e7bd-edb0-4a21-b8d1-0678a5262dcc.png">
