### PR TITLE
QACI-672 Tests that specify @SincePayara with an Enterprise version always run in Community

### DIFF
--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELPerSessionInEarTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELPerSessionInEarTest.java
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
  */
 @NotMicroCompatible
 @RunWith(PayaraArquillianTestRunner.class)
-@SincePayara("5.29.0")
+@SincePayara("5.2021.5")
 public class OpenIdELPerSessionInEarTest {
 
     private static final String TEST_RESOURCES_PREFIX = "elpersessiontests";

--- a/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELPerSessionTest.java
+++ b/appserver/tests/payara-samples/samples/openid/src/test/java/fish/payara/security/oidc/test/OpenIdELPerSessionTest.java
@@ -61,7 +61,7 @@ import org.junit.runner.RunWith;
  */
 @NotMicroCompatible
 @RunWith(PayaraArquillianTestRunner.class)
-@SincePayara("5.29.0")
+@SincePayara("5.2021.5")
 public class OpenIdELPerSessionTest {
 
     private static final String TEST_RESOURCES_PREFIX = "elpersessiontests";


### PR DESCRIPTION
## Description
This is a bug fix which resolves tests with an Enterprise @SincePayara annotation version always running on Community, even if the payara.version set was released before the version in the annotation. As there is no way to compare past and future Enterprise versions to Community versions reliably the version used within the annotation should reflect the edition it's present in.

## Important Info
## Testing

### Testing Performed
Manually tested each change to ensure the test is skipped when a Community payara version is specified that was released before the version in the annotation.

### Testing Environment
Windows 10 Pro, Maven 3.6.3, JDK8

## Documentation
No documentation as this is internal info. 'Tests and Payara Versions' updated with a small comment on Confluence

## Notes for Reviewers
The title of this PR is slightly different from the QACI-672 ticket as that ticket only specifies the issue failing on Enterprise however a similar issue is present in Community with the SincePayara annotation.