### PR TITLE
FISH-5654 - Fixed JSON Logging not working with JDK11

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/SortedLoggingProperties.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/SortedLoggingProperties.java
@@ -1,3 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
 package com.sun.common.util.logging;
 
 import java.util.*;
@@ -37,6 +77,20 @@ public class SortedLoggingProperties extends Properties {
         LoggingKeySorter keySorter = new LoggingKeySorter(keys, keyPatternIndex);
         keys.sort(keySorter);
         return Collections.enumeration(keys);
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<Object, Object>> entrySet() {
+        List<Object> keys = Collections.list(properties.keys());
+
+        List<Integer> keyPatternIndex
+                = keys.stream().map(k -> defineIndex(k.toString())).collect(Collectors.toList());
+        LoggingKeySorter keySorter = new LoggingKeySorter(keys, keyPatternIndex);
+
+        TreeMap<Object, Object> propertiesMap = new TreeMap<>(keySorter);
+        propertiesMap.putAll(properties);
+        Set<Map.Entry<Object, Object>> propertiesSet = propertiesMap.entrySet();
+        return propertiesSet;
     }
 
     private Integer defineIndex(String key) {


### PR DESCRIPTION
## Description
This is a bug fix that causes the intended behaviour on JDK11 when setting the server log properties to JSON which also fixes the failing tests.

## Important Info
## Testing

### Testing Performed
Ensured SortedLoggingPropertiesTest and JSONLogFormatIT now pass on JDK11. Manually tested once JSON formatting is selected the logs can be seen from the admin console and the logging.properties file is in the order set out in FISH-1509.

### Testing Environment
Windows 10 Pro, Maven 3.6.3. Tested with both JDK8 and Zulu JDK11.

## Documentation
No documentation required.