### PR TITLE
FISH-5694 Fix Sonar warnings for autoclosable resources

### DIFF
--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/ExtensionFileManager.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/ExtensionFileManager.java
@@ -280,16 +280,11 @@ public class ExtensionFileManager implements PostConstruct {
                 continue;
             }
 
-            try {
-                JarFile nextJarFile = new JarFile(absNextFile);
-                try {
-                    Attributes attrs = getMainAttrs(nextJarFile);
-                    Set<Extension> newExtensions = getReferencedExtensions(attrs);
-                    result.addAll(newExtensions);
-                    filesToProcess.addAll(extensionsToFiles(newExtensions));
-                } finally {
-                    nextJarFile.close();
-                }
+            try (JarFile nextJarFile = new JarFile(absNextFile)) {
+                Attributes attrs = getMainAttrs(nextJarFile);
+                Set<Extension> newExtensions = getReferencedExtensions(attrs);
+                result.addAll(newExtensions);
+                filesToProcess.addAll(extensionsToFiles(newExtensions));
             } catch (Exception e) {
                 invalidLibPaths.append(nextFile.getPath()).append(" ");
             }

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/jar/JarFile.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/jar/JarFile.java
@@ -337,22 +337,16 @@ public class JarFile extends java.util.jar.JarFile {
 	void setupEntryCertificates(JarEntry entry) {
 		// Fallback to JarInputStream to obtain certificates, not fast but hopefully not
 		// happening that often.
-		try {
-			JarInputStream inputStream = new JarInputStream(
-					getData().getInputStream(ResourceAccess.ONCE));
-			try {
-				java.util.jar.JarEntry certEntry = inputStream.getNextJarEntry();
-				while (certEntry != null) {
-					inputStream.closeEntry();
-					if (entry.getName().equals(certEntry.getName())) {
-						setCertificates(entry, certEntry);
-					}
-					setCertificates(getJarEntry(certEntry.getName()), certEntry);
-					certEntry = inputStream.getNextJarEntry();
+		try (JarInputStream inputStream = new JarInputStream(
+					getData().getInputStream(ResourceAccess.ONCE))) {
+			java.util.jar.JarEntry certEntry = inputStream.getNextJarEntry();
+			while (certEntry != null) {
+				inputStream.closeEntry();
+				if (entry.getName().equals(certEntry.getName())) {
+					setCertificates(entry, certEntry);
 				}
-			}
-			finally {
-				inputStream.close();
+				setCertificates(getJarEntry(certEntry.getName()), certEntry);
+				certEntry = inputStream.getNextJarEntry();
 			}
 		}
 		catch (IOException ex) {


### PR DESCRIPTION
This pull request fixes two SonarQube violations of rule [2093](https://rules.sonarsource.com/java/RSPEC-2093).

Motivation:
Closing autocloseable resources by manually invoking `.close()` is error-prone, can lead to resource leaks and makes the code harder to follow. This pull request refactors the code to instead close the resources automatically using `try-with-resource` statements.

The SonarQube violations are listed here:

* https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW-B1Nbfql1jQuQn6HOw&open=AW-B1Nbfql1jQuQn6HOw
* https://sonarcloud.io/project/issues?id=fish.payara.server%3Apayara-aggregator&issues=AW-B1PeXql1jQuQn6HPD&open=AW-B1PeXql1jQuQn6HPD

This patch was generated automatically using the static analyzer [Logifix](https://github.com/lyxell/logifix.git).