### PR TITLE
FISH-81 Fix Incorrect error "No valid EE environment for injection" for CDI reported for events

### DIFF
--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <optional>true</optional>
@@ -206,6 +210,11 @@
          <dependency>
              <groupId>jakarta.xml.ws</groupId>
              <artifactId>jakarta.xml.ws-api</artifactId>
+         </dependency>
+         <dependency>
+             <groupId>fish.payara.server.internal.concurrent</groupId>
+             <artifactId>concurrent-connector</artifactId>
+            <version>${project.version}</version>
          </dependency>
     </dependencies>
 </project>

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -142,6 +142,7 @@ import com.sun.enterprise.deployment.WebBundleDescriptor;
 import com.sun.enterprise.deployment.web.ContextParameter;
 import com.sun.enterprise.deployment.web.ServletFilterMapping;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
+import javax.naming.NamingException;
 import org.jboss.weld.manager.api.ExecutorServices;
 
 @Service
@@ -308,8 +309,12 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             ProxyServices proxyServices = new ProxyServicesImpl(services);
             deploymentImpl.getServices().add(ProxyServices.class, proxyServices);
 
-            ExecutorServices executorServices = new ExecutorServicesImpl(executorService);
-            deploymentImpl.getServices().add(ExecutorServices.class, executorServices);
+            try {
+                ExecutorServices executorServices = new ExecutorServicesImpl();
+                deploymentImpl.getServices().add(ExecutorServices.class, executorServices);
+            } catch (NamingException ex) {
+                throw new RuntimeException(ex);
+            }
 
             addWeldListenerToAllWars(context);
         } else {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -141,7 +141,6 @@ import com.sun.enterprise.deployment.JndiNameEnvironment;
 import com.sun.enterprise.deployment.WebBundleDescriptor;
 import com.sun.enterprise.deployment.web.ContextParameter;
 import com.sun.enterprise.deployment.web.ServletFilterMapping;
-import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import javax.naming.NamingException;
 import org.jboss.weld.manager.api.ExecutorServices;
 
@@ -204,9 +203,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
     @Inject
     private Deployment deployment;
-
-    @Inject
-    private PayaraExecutorService executorService;
 
     private Map<Application, WeldBootstrap> appToBootstrap = new HashMap<>();
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/ExecutorServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/ExecutorServicesImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/ExecutorServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/ExecutorServicesImpl.java
@@ -40,7 +40,6 @@
 package org.glassfish.weld.services;
 
 import com.sun.enterprise.util.Utility;
-import fish.payara.nucleus.executorservice.PayaraExecutorService;
 import java.util.Collection;
 import java.util.List;
 import java.util.ArrayList;
@@ -52,6 +51,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.Globals;
 
 import org.jboss.weld.executor.AbstractExecutorServices;
 import org.jboss.weld.manager.api.ExecutorServices;
@@ -65,12 +70,16 @@ public class ExecutorServicesImpl extends AbstractExecutorServices implements Ex
 
     private final ExecutorService taskExecutor;
     private final ContextualTimerExecutor timerExecutor;
-    private PayaraExecutorService executor;
+    private final ManagedExecutorService executor;
+    private final org.glassfish.concurrent.config.ManagedExecutorService config;
     
-    public ExecutorServicesImpl(PayaraExecutorService service) {
-        executor = service;
+    public ExecutorServicesImpl() throws NamingException {
+        InitialContext ctx = new InitialContext();
+        executor = (ManagedExecutorService) ctx.lookup("java:comp/DefaultManagedExecutorService");
         taskExecutor = new ContextualTaskExecutor();
         timerExecutor = new ContextualTimerExecutor();
+        this.config = Globals.getDefaultHabitat()
+                .getService(org.glassfish.concurrent.config.ManagedExecutorService.class);
     }
 
     @Override
@@ -89,7 +98,7 @@ public class ExecutorServicesImpl extends AbstractExecutorServices implements Ex
 
     @Override
     protected int getThreadPoolSize() {
-        return executor.getExecutorThreadPoolSize();
+        return Integer.parseInt(this.config.getMaximumPoolSize());
     }
 
     @Override
@@ -135,10 +144,10 @@ public class ExecutorServicesImpl extends AbstractExecutorServices implements Ex
     }
 
     class ContextualTaskExecutor implements ExecutorService {
-        private ExecutorService delegate;
+        private final ExecutorService delegate;
 
         ContextualTaskExecutor() {
-            this.delegate = executor.getUnderlyingExecutorService();
+            this.delegate = executor;
         }
 
         @Override
@@ -214,10 +223,12 @@ public class ExecutorServicesImpl extends AbstractExecutorServices implements Ex
     class ContextualTimerExecutor extends ContextualTaskExecutor implements ScheduledExecutorService {
         private final ScheduledExecutorService delegate;
 
-        ContextualTimerExecutor() {
-            this.delegate = executor.getUnderlyingScheduledExecutorService();
+        ContextualTimerExecutor() throws NamingException {
+            InitialContext ctx = new InitialContext();
+            this.delegate = (ManagedScheduledExecutorService) ctx.lookup("java:comp/DefaultManagedScheduledExecutorService");
         }
 
+        @Override
         protected ScheduledExecutorService delegate() {
             return this.delegate;
         }


### PR DESCRIPTION
## Description
This is a bug fix that causes the incorrect error message in the log on firing the async CDI events.

## Testing

### Testing Performed
Manually

## Documentation
Not required
