### PR TITLE
FISH-5639 Added warning message to change-master-password command

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt.cli;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
@@ -41,21 +41,23 @@
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
-import com.sun.enterprise.admin.cli.CLICommand;
-import com.sun.enterprise.util.io.DomainDirs;
-import com.sun.enterprise.universal.i18n.LocalStringsImpl;
-import org.glassfish.api.Param;
-import org.glassfish.api.admin.CommandException;
-
-import org.jvnet.hk2.annotations.Service;
-import org.glassfish.hk2.api.PerLookup;
-import org.glassfish.hk2.api.ServiceLocator;
-
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+
+import com.sun.enterprise.admin.cli.CLICommand;
+import com.sun.enterprise.universal.i18n.LocalStringsImpl;
+import com.sun.enterprise.util.io.DomainDirs;
+
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.CommandException;
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
 
 /**
  * The change-master-password command.
@@ -105,8 +107,6 @@ public class ChangeMasterPasswordCommand extends CLICommand {
 
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(ChangeMasterPasswordCommand.class);
 
-
-
     @Override
     protected int executeCommand() throws CommandException {
         CLICommand command = null;
@@ -143,8 +143,6 @@ public class ChangeMasterPasswordCommand extends CLICommand {
             }
         } catch (IOException e) {
             throw new CommandException(e.getMessage(),e);
-        } finally {
-            System.out.println("WARNING: Additional Truststores are not re-encrypted, it is your responsibility to do this.");
         }
     }
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
@@ -117,16 +117,16 @@ public class ChangeMasterPasswordCommand extends CLICommand {
         try {
             if (isDomain()) {  // is it domain
                 command = CLICommand.getCommand(habitat,
-                        CHANGE_MASTER_PASSWORD_DAS);
+                CHANGE_MASTER_PASSWORD_DAS);
                 return command.execute(argv);
             }
-
+            
             if (nodeDir != null) {
                 command = CLICommand.getCommand(habitat,
-                        CHANGE_MASTER_PASSWORD_NODE);
+                CHANGE_MASTER_PASSWORD_NODE);
                 return command.execute(argv);
             } else {
-
+                
                 // nodeDir is not specified and domainNameOrNodeName is not a domain.
                 // It could be a node
                 // We add defaultNodeDir parameter to args
@@ -136,13 +136,15 @@ public class ChangeMasterPasswordCommand extends CLICommand {
                 arguments.add(getDefaultNodesDirs().getAbsolutePath());
                 arguments.add(domainNameOrNodeName);
                 String[] newargs = (String[]) arguments.toArray(new String[arguments.size()]);
-
+                
                 command = CLICommand.getCommand(habitat,
-                        CHANGE_MASTER_PASSWORD_NODE);
+                CHANGE_MASTER_PASSWORD_NODE);
                 return command.execute(newargs);
             }
         } catch (IOException e) {
             throw new CommandException(e.getMessage(),e);
+        } finally {
+            System.out.println("WARNING: Additional Truststores are not re-encrypted, it is your responsibility to do this.");
         }
     }
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -137,7 +137,7 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
             }
 
             try {
-                getAdditionalTrustandKeyStores();
+                checkAdditionalTrustandKeyStores();
             } catch (IOException | XMLStreamException exception) {
                 logger.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
             }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -137,7 +137,7 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
             }
 
             try {
-                checkAdditionalTrustandKeyStores();
+                checkAdditionalTrustAndKeyStores();
             } catch (IOException | XMLStreamException exception) {
                 logger.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
             }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -61,7 +61,7 @@ import org.jvnet.hk2.annotations.Service;
 /**
  * The change-master-password command for the DAS. This is a hidden command
  * which is called from change-master-password command.
- * 
+ *
  * @author Bhakti Mehta
  */
 @Service(name = "_change-master-password-das")
@@ -137,21 +137,9 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
             }
 
             try {
-                HashMap<String, String> additionalTrustandKeyStores = getAdditionalTrustandKeyStores();
-                if (additionalTrustandKeyStores.containsKey("additionalKeyStores")) {
-                    logger.log(Level.INFO,
-                            "The passwords of the additional KeyStores {0} have not been changed - please update these manually to continue using them.",
-                            Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(":")));
-
-                }
-                if (additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
-                    logger.log(Level.INFO,
-                            "The passwords of the additional TrustStores {0} have not been changed - please update these manually to continue using them.",
-                            Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":")));
-                }
+                getAdditionalTrustandKeyStores();
             } catch (IOException | XMLStreamException exception) {
-                logger.warning(
-                        "Could not fetch additional Trust and Keystores - if there are additional Trust Stores or Key Stores, the passwords need to be updated in order to continue using them.");
+                logger.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
             }
 
             return 0;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -661,7 +661,7 @@ public abstract class LocalServerCommand extends CLICommand {
         return installRootPath;
     }
 
-    protected HashMap<String, String> getAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
+    protected void getAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
         HashMap<String, String> additionalTrustandKeyStores = new HashMap<>();
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -692,10 +692,9 @@ public abstract class LocalServerCommand extends CLICommand {
                         "The passwords of additional TrustStores {0} have not been changed - please update these manually to continue using them.",
                         Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":(?!\\\\)")));
             }
-        } catch (ParserConfigurationException | SAXException | IOException exception) {
+        } catch (ParserConfigurationException | SAXException exception) {
             logger.warning(
                     "Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
         }
-        return additionalTrustandKeyStores;
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -49,6 +49,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.security.KeyStore;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -73,8 +75,16 @@ import java.net.InetSocketAddress;
 
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.CommandException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -82,36 +92,38 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.XMLEvent;
 
 /**
- * A class that's supposed to capture all the behavior common to operation
- * on a "local" server.
- * It's getting fairly complicated thus the "section headers" comments.
- * This class plays two roles, <UL><LI>a place for putting common code - which
- * are final methods.  A parent class that is communicating with its own unknown
- * sub-classes.  These are non-final methods
+ * A class that's supposed to capture all the behavior common to operation on a
+ * "local" server. It's getting fairly complicated thus the "section headers"
+ * comments. This class plays two roles,
+ * <UL>
+ * <LI>a place for putting common code - which are final methods. A parent class
+ * that is communicating with its own unknown sub-classes. These are non-final
+ * methods
  *
  * @author Byron Nevins
  */
 public abstract class LocalServerCommand extends CLICommand {
-    
+
     ////////////////////////////////////////////////////////////////
-    /// Section:  private variables
+    /// Section: private variables
     ////////////////////////////////////////////////////////////////
     private ServerDirs serverDirs;
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(LocalDomainCommand.class);
     private final static int IS_RUNNING_DEFAULT_TIMEOUT = 2000;
-    
+
     ////////////////////////////////////////////////////////////////
-    /// Section:  protected variables
+    /// Section: protected variables
     ////////////////////////////////////////////////////////////////
     protected static final String DEFAULT_MASTER_PASSWORD = "changeit";
-    
+
     ////////////////////////////////////////////////////////////////
-    /// Section:  protected methods that are OK to override
+    /// Section: protected methods that are OK to override
     ////////////////////////////////////////////////////////////////
     /**
-     * Override this method and return false to turn-off the file validation.
-     * E.g. it demands that config/domain.xml be present.  In special cases like
+     * Override this method and return false to turn-off the file validation. E.g.
+     * it demands that config/domain.xml be present. In special cases like
      * Synchronization -- this is how you turn off the testing.
+     * 
      * @return true - do the checks, false - don't do the checks
      */
     protected boolean checkForSpecialFiles() {
@@ -119,32 +131,31 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     ////////////////////////////////////////////////////////////////
-    /// Section:  protected methods that are notOK to override.
+    /// Section: protected methods that are notOK to override.
     ////////////////////////////////////////////////////////////////
     /**
-     * Returns the admin address of the local domain. Note that this method
-     * should be called only when you own the domain that is available on
-     * an accessible file system.
+     * Returns the admin address of the local domain. Note that this method should
+     * be called only when you own the domain that is available on an accessible
+     * file system.
      *
      * @return HostAndPort object with admin server address
      * @throws CommandException in case of parsing errors
      */
     protected final HostAndPort getAdminAddress() throws CommandException {
-        // default:  DAS which always has the name "server"
+        // default: DAS which always has the name "server"
         return getAdminAddress("server");
     }
 
     /**
-     * Returns the admin address of a particular server.
-     * Note that this method should be called only when you own the server that is available on an accessible
-     * file system.
+     * Returns the admin address of a particular server. Note that this method
+     * should be called only when you own the server that is available on an
+     * accessible file system.
      *
      * @param serverName the server name
      * @return HostAndPort object with admin server address
      * @throws CommandException in case of parsing errors
      */
-    protected final HostAndPort getAdminAddress(String serverName)
-            throws CommandException {
+    protected final HostAndPort getAdminAddress(String serverName) throws CommandException {
 
         try {
             MiniXmlParser parser = new MiniXmlParser(getDomainXml(), serverName);
@@ -155,8 +166,7 @@ public abstract class LocalServerCommand extends CLICommand {
             } else {
                 throw new CommandException(STRINGS.get("NoAdminPort"));
             }
-        }
-        catch (MiniXmlParserException ex) {
+        } catch (MiniXmlParserException ex) {
             throw new CommandException(STRINGS.get("NoAdminPortEx", ex), ex);
         }
     }
@@ -178,26 +188,23 @@ public abstract class LocalServerCommand extends CLICommand {
         setLocalPassword();
     }
 
-
     protected final void setLocalPassword() {
         String pw = serverDirs == null ? null : serverDirs.getLocalPassword();
 
         if (ok(pw)) {
-            programOpts.setPassword(pw!= null ? pw.toCharArray() : null,
+            programOpts.setPassword(pw != null ? pw.toCharArray() : null,
                     ProgramOptions.PasswordLocation.LOCAL_PASSWORD);
             logger.finer("Using local password");
-        }
-        else
+        } else
             logger.finer("Not using local password");
     }
 
     protected final void unsetLocalPassword() {
-        programOpts.setPassword(null,
-                ProgramOptions.PasswordLocation.LOCAL_PASSWORD);
+        programOpts.setPassword(null, ProgramOptions.PasswordLocation.LOCAL_PASSWORD);
     }
 
     protected final void resetServerDirs() throws IOException {
-        if(serverDirs == null)
+        if (serverDirs == null)
             throw new RuntimeException(Strings.get("NoServerDirs"));
 
         serverDirs = serverDirs.refresh();
@@ -208,72 +215,68 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     protected final File getDomainXml() {
-        if(serverDirs == null)
+        if (serverDirs == null)
             throw new RuntimeException(Strings.get("NoServerDirs"));
 
         return serverDirs.getDomainXml();
     }
 
     /**
-     * Checks if the create-domain was created using --savemasterpassword flag
-     * which obtains security by obfuscation! Returns null in case of failure
-     * of any kind.
+     * Checks if the create-domain was created using --savemasterpassword flag which
+     * obtains security by obfuscation! Returns null in case of failure of any kind.
+     * 
      * @return String representing the password from the JCEKS store named
-     *          master-password in domain folder
+     *         master-password in domain folder
      */
     protected final String readFromMasterPasswordFile() {
         File mpf = getMasterPasswordFile();
         if (mpf == null)
-            return null;   // no master password  saved
+            return null; // no master password saved
         try {
-            PasswordAdapter pw = new PasswordAdapter(mpf.getAbsolutePath(),
-                    MASTERPASSWORD_FILE.toCharArray()); // fixed key
+            PasswordAdapter pw = new PasswordAdapter(mpf.getAbsolutePath(), MASTERPASSWORD_FILE.toCharArray()); // fixed
+                                                                                                                // key
             return pw.getPasswordForAlias(MASTERPASSWORD_FILE);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             logger.log(Level.FINER, "master password file reading error: {0}", e.getMessage());
             return null;
         }
     }
 
     protected final boolean verifyMasterPassword(String mpv) {
-        //issue : 14971, should ideally use javax.net.ssl.keyStore and
-        //javax.net.ssl.keyStoreType system props here but they are
-        //unavailable to asadmin start-domain hence falling back to
-        //cacerts.jks instead of keystore.jks. Since the truststore
-        //is less-likely to be Non-JKS
+        // issue : 14971, should ideally use javax.net.ssl.keyStore and
+        // javax.net.ssl.keyStoreType system props here but they are
+        // unavailable to asadmin start-domain hence falling back to
+        // cacerts.jks instead of keystore.jks. Since the truststore
+        // is less-likely to be Non-JKS
 
-        return loadAndVerifyKeystore(getJKS(),mpv);
+        return loadAndVerifyKeystore(getJKS(), mpv);
     }
 
-    protected boolean loadAndVerifyKeystore(File jks,String mpv) {
+    protected boolean loadAndVerifyKeystore(File jks, String mpv) {
         FileInputStream fis = null;
         try {
             fis = new FileInputStream(jks);
             KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
             ks.load(fis, mpv.toCharArray());
             return true;
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             if (logger.isLoggable(Level.FINER))
                 logger.finer(e.getMessage());
             return false;
-        }
-        finally {
+        } finally {
             try {
                 if (fis != null)
                     fis.close();
-            }
-            catch (IOException ioe) {
+            } catch (IOException ioe) {
                 // ignore, I know ...
             }
         }
     }
 
     /**
-     * Get the master password, either from a password file or
-     * by asking the user.
-     * @return the actual master password 
+     * Get the master password, either from a password file or by asking the user.
+     * 
+     * @return the actual master password
      */
     protected final String getMasterPassword() throws CommandException {
         // Sets the password into the launcher info.
@@ -281,16 +284,15 @@ public abstract class LocalServerCommand extends CLICommand {
         final int RETRIES = 3;
         long t0 = now();
         String mpv = passwords.get(CLIConstants.MASTER_PASSWORD);
-        if (mpv == null) { //not specified in the password file
-            mpv = DEFAULT_MASTER_PASSWORD;  //optimization for the default case -- see 9592
+        if (mpv == null) { // not specified in the password file
+            mpv = DEFAULT_MASTER_PASSWORD; // optimization for the default case -- see 9592
             if (!verifyMasterPassword(mpv)) {
                 mpv = readFromMasterPasswordFile();
                 if (!verifyMasterPassword(mpv)) {
                     mpv = retry(RETRIES);
                 }
             }
-        }
-        else { // the passwordfile contains AS_ADMIN_MASTERPASSWORD, use it
+        } else { // the passwordfile contains AS_ADMIN_MASTERPASSWORD, use it
             if (!verifyMasterPassword(mpv))
                 mpv = retry(RETRIES);
         }
@@ -302,7 +304,7 @@ public abstract class LocalServerCommand extends CLICommand {
     /**
      * See if the server is alive and is the one at the specified directory.
      *
-     * @param ourDir the directory to check if the server is alive agains
+     * @param ourDir       the directory to check if the server is alive agains
      * @param directoryKey the key for the directory
      * @return true if it's the DAS at this domain directory
      */
@@ -325,20 +327,16 @@ public abstract class LocalServerCommand extends CLICommand {
                 return theirDir.equals(ourDir);
             }
             return false;
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             return false;
         }
     }
 
     protected final int getServerPid() {
         try {
-            return Integer.parseInt(
-                    new RemoteCLICommand("__locations", programOpts, env)
-                    .executeAndReturnActionReport("__locations")
-                    .findProperty("Pid"));
-        }
-        catch (Exception e) {
+            return Integer.parseInt(new RemoteCLICommand("__locations", programOpts, env)
+                    .executeAndReturnActionReport("__locations").findProperty("Pid"));
+        } catch (Exception e) {
             return -1;
         }
     }
@@ -346,11 +344,11 @@ public abstract class LocalServerCommand extends CLICommand {
     /**
      * There is sometimes a need for subclasses to know if a
      * <code> local domain </code> is running.An example of such a command is
-     * change-master-password command.The stop-domain command also needs to
-     * know if a domain is running <i> without </i> having to provide user
-     * name and password on command line (this is the case when I own a domain
-     * that has non-default admin user and password) and want to stop it
-     * without providing it.<p>
+     * change-master-password command.The stop-domain command also needs to know if
+     * a domain is running <i> without </i> having to provide user name and password
+     * on command line (this is the case when I own a domain that has non-default
+     * admin user and password) and want to stop it without providing it.
+     * <p>
      * In such cases, we need to know if the domain is running and this method
      * provides a way to do that.
      *
@@ -359,36 +357,36 @@ public abstract class LocalServerCommand extends CLICommand {
      * @return boolean indicating whether the server is running
      */
     protected final boolean isRunning(String host, int port) {
-        
-        try(Socket server = new Socket()) {
+
+        try (Socket server = new Socket()) {
             if (host == null) {
                 host = InetAddress.getByName(null).getHostName();
             }
-            
-            server.connect( new InetSocketAddress(host, port), IS_RUNNING_DEFAULT_TIMEOUT);
+
+            server.connect(new InetSocketAddress(host, port), IS_RUNNING_DEFAULT_TIMEOUT);
             return true;
-        }catch  (Exception ex) {
+        } catch (Exception ex) {
             logger.log(Level.FINER, "\nisRunning got exception: {0}", ex);
             return false;
         }
     }
 
     /**
-     * Is the server still running?
-     * This is only called when we're hanging around waiting for the server to die.
-     * Byron Nevins, Nov 7, 2010 - Check to see if the process itself is still running
-     * We use OS tools to figure this out.  See ProcessUtils for details.
-     * Failover to the JPS check if necessary
+     * Is the server still running? This is only called when we're hanging around
+     * waiting for the server to die. Byron Nevins, Nov 7, 2010 - Check to see if
+     * the process itself is still running We use OS tools to figure this out. See
+     * ProcessUtils for details. Failover to the JPS check if necessary
      *
      * bnevins, May 2013
      * http://serverfault.com/questions/181015/how-do-you-free-up-a-port-being-held-open-by-dead-process
      * In WIndows the admin port may be held open for a while -- if there happens to
-     * be an attached running child process.  This is the key message from the url:
+     * be an attached running child process. This is the key message from the url:
      *
      * If your program spawned any processes while it was running, try killing them.
      * That should cause its process record to be freed and the TCP port to be
-     * cleaned up. Apparently windows does this when the record is released not
-     * when the process exits as I would have expected.
+     * cleaned up. Apparently windows does this when the record is released not when
+     * the process exits as I would have expected.
+     * 
      * @return
      */
     protected boolean isRunning() {
@@ -408,17 +406,16 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     /**
-     * Byron Nevins Says: We have quite a historical assortment of ways to
-     * determine if a server has restarted. There are little teeny timing issues
-     * with all of them. I'm confident that this new technique will clear them
-     * all up. Here we are just monitoring the PID of the new server and
-     * comparing it to the pid of the old server. The oldServerPid is guaranteed
-     * to be either the PID of the "old" server or -1 if we couldn't get it --
-     * or it isn't running. If it is -1 then we make the assumption that once we
-     * DO get a valid pid that the server has started. If the old pid is valid
-     * we simply poll until we get a different pid. Notice that we will never
-     * get a valid pid back unless the server is officially up and running and
-     * "STARTED" Created April 2013
+     * Byron Nevins Says: We have quite a historical assortment of ways to determine
+     * if a server has restarted. There are little teeny timing issues with all of
+     * them. I'm confident that this new technique will clear them all up. Here we
+     * are just monitoring the PID of the new server and comparing it to the pid of
+     * the old server. The oldServerPid is guaranteed to be either the PID of the
+     * "old" server or -1 if we couldn't get it -- or it isn't running. If it is -1
+     * then we make the assumption that once we DO get a valid pid that the server
+     * has started. If the old pid is valid we simply poll until we get a different
+     * pid. Notice that we will never get a valid pid back unless the server is
+     * officially up and running and "STARTED" Created April 2013
      *
      * @param oldServerPid The pid of the server which is being restarted.
      * @throws CommandException if we time out.
@@ -428,19 +425,18 @@ public abstract class LocalServerCommand extends CLICommand {
 
         while (now() < end) {
             try {
-                if(isLocal())
+                if (isLocal())
                     resetLocalPassword();
 
                 int newServerPid = getServerPid();
 
                 if (newServerPid > 0 && newServerPid != oldServerPid) {
                     logger.log(Level.FINER, "oldserver-pid, newserver-pid = {0} --- {1}",
-                            new Object[]{oldServerPid, newServerPid});
+                            new Object[] { oldServerPid, newServerPid });
                     return;
                 }
                 Thread.sleep(CLIConstants.RESTART_CHECK_INTERVAL_MSEC);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 // continue
             }
         }
@@ -458,19 +454,17 @@ public abstract class LocalServerCommand extends CLICommand {
 
             String pids = FileUtils.readSmallFile(prevPidFile).trim();
             return Integer.parseInt(pids);
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             return -1;
         }
     }
 
     /**
-     * Is the server still running?
-     * This is only called when we're hanging around waiting for the server to die.
-     * Byron Nevins, Nov 7, 2010 - Check to see if the process itself is still running
-     * We use jps to check
-     * If there are any problems fall back to the previous implementation of
-     * isRunning() which looks for the pidfile to get deleted
+     * Is the server still running? This is only called when we're hanging around
+     * waiting for the server to die. Byron Nevins, Nov 7, 2010 - Check to see if
+     * the process itself is still running We use jps to check If there are any
+     * problems fall back to the previous implementation of isRunning() which looks
+     * for the pidfile to get deleted
      */
     private boolean isRunningUsingJps() {
         int pp = getPrevPid();
@@ -482,22 +476,22 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     /**
-     * Is the server still running?
-     * This is only called when we're hanging around waiting for the server to die.
+     * Is the server still running? This is only called when we're hanging around
+     * waiting for the server to die.
      */
     private boolean isRunningByCheckingForPidFile() {
         File pf = getServerDirs().getPidFile();
 
         if (pf != null) {
             return pf.exists();
-        }
-        else
+        } else
             return isRunning(programOpts.getHost(), // remote case
                     programOpts.getPort());
     }
 
     /**
      * Get uptime from the server.
+     * 
      * @return uptime in milliseconds
      * @throws CommandException if the server is not running
      */
@@ -513,11 +507,12 @@ public abstract class LocalServerCommand extends CLICommand {
         logger.log(Level.FINER, "server uptime: {0}", uptimeMillis);
         return uptimeMillis;
     }
+
     /**
-     * See if the server is restartable
-     * As of March 2011 -- this only returns false if a passwordfile argument was given
-     * when the server started -- but it is no longer available - i.e.the user
-     * deleted it or made it unreadable.
+     * See if the server is restartable As of March 2011 -- this only returns false
+     * if a passwordfile argument was given when the server started -- but it is no
+     * longer available - i.e.the user deleted it or made it unreadable.
+     * 
      * @return true if the server is restartable
      * @throws CommandException
      */
@@ -537,19 +532,17 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     ////////////////////////////////////////////////////////////////
-    /// Section:  private methods
+    /// Section: private methods
     ////////////////////////////////////////////////////////////////
     /**
-     * The remote uptime command returns a string like:
-     * Uptime: 10 minutes, 53 seconds, Total milliseconds: 653859\n
-     * We find that last number and extract it.
-     * XXX - this is pretty gross, and fragile
+     * The remote uptime command returns a string like: Uptime: 10 minutes, 53
+     * seconds, Total milliseconds: 653859\n We find that last number and extract
+     * it. XXX - this is pretty gross, and fragile
      */
     private long parseUptime(String up) {
         try {
             return Long.parseLong(up);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             return 0;
         }
     }
@@ -592,7 +585,7 @@ public abstract class LocalServerCommand extends CLICommand {
             if (i < (times - 1))
                 logger.info(STRINGS.get("retry.mp"));
             // make them pay for typos?
-            //Thread.currentThread().sleep((i+1)*10000);
+            // Thread.currentThread().sleep((i+1)*10000);
         }
         throw new CommandException(STRINGS.get("mp.giveup", times));
     }
@@ -600,8 +593,7 @@ public abstract class LocalServerCommand extends CLICommand {
     private File getUniquePath(File f) {
         try {
             f = f.getCanonicalFile();
-        }
-        catch (IOException ioex) {
+        } catch (IOException ioex) {
             f = SmartFile.sanitize(f);
         }
         return f;
@@ -619,15 +611,19 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     protected boolean dataGridEncryptionEnabled() throws IOException, XMLStreamException {
-        // We can't access config beans from this invocation due to it being CLI vs. ASAdmin command - it's not
-        // executing against a running server. This means we need to read directly from the domain.xml.
-        XMLEventReader xmlReader = XMLInputFactory.newInstance().createXMLEventReader(new FileInputStream(getDomainXml()));
+        // We can't access config beans from this invocation due to it being CLI vs.
+        // ASAdmin command - it's not
+        // executing against a running server. This means we need to read directly from
+        // the domain.xml.
+        XMLEventReader xmlReader = XMLInputFactory.newInstance()
+                .createXMLEventReader(new FileInputStream(getDomainXml()));
         while (xmlReader.hasNext()) {
             XMLEvent event = xmlReader.nextEvent();
 
             if (event.isStartElement()
                     && event.asStartElement().getName().getLocalPart().equals("hazelcast-runtime-configuration")) {
-                Attribute attribute = event.asStartElement().getAttributeByName(new QName("datagrid-encryption-enabled"));
+                Attribute attribute = event.asStartElement()
+                        .getAttributeByName(new QName("datagrid-encryption-enabled"));
                 if (attribute == null) {
                     return false;
                 }
@@ -635,14 +631,15 @@ public abstract class LocalServerCommand extends CLICommand {
             }
         }
 
-        logger.warning("Could not determine if data grid encryption is enabled - " +
-                "you will need to regenerate the encryption key if it is");
+        logger.warning("Could not determine if data grid encryption is enabled - "
+                + "you will need to regenerate the encryption key if it is");
         return false;
     }
 
     /**
-     * Gets the GlassFish installation root (using property com.sun.aas.installRoot),
-     * first from asenv.conf.  If that's not available, then from java.lang.System.
+     * Gets the GlassFish installation root (using property
+     * com.sun.aas.installRoot), first from asenv.conf. If that's not available,
+     * then from java.lang.System.
      *
      * @return path of GlassFish install root
      * @throws CommandException if the GlassFish install root is not found
@@ -658,5 +655,37 @@ public abstract class LocalServerCommand extends CLICommand {
             throw new CommandException("noInstallDirPath");
         }
         return installRootPath;
+    }
+
+    protected HashMap<String, String> getAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
+        HashMap<String,String> additionalTrustandKeyStores = new HashMap<>();
+        try {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(getDomainXml());
+            NodeList jvmOptionsNodes = document.getElementsByTagName("jvm-options");
+    
+            for(int i = 0; i < jvmOptionsNodes.getLength(); i++){
+                if (additionalTrustandKeyStores.containsKey("additionalKeyStores")
+                        && additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
+                    break;
+                }
+                String jvmOption = jvmOptionsNodes.item(i).getTextContent();
+                if(jvmOption.startsWith("-Dfish.payara.ssl.additionalKeyStores")){
+                    String additionalKeyStores = jvmOption.split("=")[1];
+                    additionalTrustandKeyStores.put("additionalKeyStores", additionalKeyStores);
+                    continue;
+                }
+                if(jvmOption.startsWith("-Dfish.payara.ssl.additionalTrustStores")){
+                    String additionalTrustStores = jvmOption.split("=")[1];
+                    additionalTrustandKeyStores.put("additionalTrustStores", additionalTrustStores);
+                    continue;
+                }
+            }
+            
+        } catch (ParserConfigurationException | SAXException exception) {
+            logger.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
+        }
+        return additionalTrustandKeyStores; 
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -661,7 +661,7 @@ public abstract class LocalServerCommand extends CLICommand {
         return installRootPath;
     }
 
-    protected void getAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
+    protected void checkAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
         HashMap<String, String> additionalTrustandKeyStores = new HashMap<>();
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2021`] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -673,32 +673,24 @@ public abstract class LocalServerCommand extends CLICommand {
                 String jvmOption = jvmOptionsNodes.item(i).getTextContent();
                 if (jvmOption.startsWith("-Dfish.payara.ssl.additionalKeyStores")) {
                     String additionalKeyStores = jvmOption.split("=")[1];
-                    if (!additionalTrustandKeyStores.containsKey("additionalKeyStores")) {
-                        additionalTrustandKeyStores.put("additionalKeyStores", additionalKeyStores);
-                    } else {
-                        additionalTrustandKeyStores.computeIfPresent("additionalKeyStores", (key, value) -> value.concat(", " + additionalKeyStores));
-                    }
+                    additionalTrustandKeyStores.compute("additionalKeyStores", (key, value) -> value == null ? additionalKeyStores : value.concat(", " + additionalKeyStores));
                     continue;
                 }
                 if (jvmOption.startsWith("-Dfish.payara.ssl.additionalTrustStores")) {
                     String additionalTrustStores = jvmOption.split("=")[1];
-                    if (!additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
-                        additionalTrustandKeyStores.put("additionalTrustStores", additionalTrustStores);
-                    } else {
-                        additionalTrustandKeyStores.computeIfPresent("additionalTrustStores", (key, value) -> value.concat(", " + additionalTrustStores));
-                    }
+                    additionalTrustandKeyStores.compute("additionalTrustStores", (key, value) -> value == null ? additionalTrustStores : value.concat(", " + additionalTrustStores));
                     continue;
                 }
             }
             if (additionalTrustandKeyStores.containsKey("additionalKeyStores")) {
                 logger.log(Level.INFO,
                         "The passwords of additional KeyStores {0} have not been changed - please update these manually to continue using them.",
-                        Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(":")));
+                        Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(":(?!\)")));
             }
             if (additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
                 logger.log(Level.INFO,
                         "The passwords of additional TrustStores {0} have not been changed - please update these manually to continue using them.",
-                        Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":")));
+                        Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":(?!\)")));
             }
         } catch (ParserConfigurationException | SAXException | IOException exception) {
             logger.warning(

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2021`] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -658,34 +658,35 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     protected HashMap<String, String> getAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
-        HashMap<String,String> additionalTrustandKeyStores = new HashMap<>();
+        HashMap<String, String> additionalTrustandKeyStores = new HashMap<>();
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
             Document document = documentBuilder.parse(getDomainXml());
             NodeList jvmOptionsNodes = document.getElementsByTagName("jvm-options");
-    
-            for(int i = 0; i < jvmOptionsNodes.getLength(); i++){
+
+            for (int i = 0; i < jvmOptionsNodes.getLength(); i++) {
                 if (additionalTrustandKeyStores.containsKey("additionalKeyStores")
                         && additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
                     break;
                 }
                 String jvmOption = jvmOptionsNodes.item(i).getTextContent();
-                if(jvmOption.startsWith("-Dfish.payara.ssl.additionalKeyStores")){
+                if (jvmOption.startsWith("-Dfish.payara.ssl.additionalKeyStores")) {
                     String additionalKeyStores = jvmOption.split("=")[1];
                     additionalTrustandKeyStores.put("additionalKeyStores", additionalKeyStores);
                     continue;
                 }
-                if(jvmOption.startsWith("-Dfish.payara.ssl.additionalTrustStores")){
+                if (jvmOption.startsWith("-Dfish.payara.ssl.additionalTrustStores")) {
                     String additionalTrustStores = jvmOption.split("=")[1];
                     additionalTrustandKeyStores.put("additionalTrustStores", additionalTrustStores);
                     continue;
                 }
             }
-            
+
         } catch (ParserConfigurationException | SAXException exception) {
-            logger.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
+            logger.warning(
+                    "Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
         }
-        return additionalTrustandKeyStores; 
+        return additionalTrustandKeyStores;
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -661,7 +661,7 @@ public abstract class LocalServerCommand extends CLICommand {
         return installRootPath;
     }
 
-    protected void checkAdditionalTrustandKeyStores() throws IOException, XMLStreamException {
+    protected void checkAdditionalTrustAndKeyStores() throws IOException, XMLStreamException {
         HashMap<String, String> additionalTrustandKeyStores = new HashMap<>();
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -685,12 +685,12 @@ public abstract class LocalServerCommand extends CLICommand {
             if (additionalTrustandKeyStores.containsKey("additionalKeyStores")) {
                 logger.log(Level.INFO,
                         "The passwords of additional KeyStores {0} have not been changed - please update these manually to continue using them.",
-                        Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(":(?!\)")));
+                        Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(":(?!\\\\)")));
             }
             if (additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
                 logger.log(Level.INFO,
                         "The passwords of additional TrustStores {0} have not been changed - please update these manually to continue using them.",
-                        Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":(?!\)")));
+                        Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":(?!\\\\)")));
             }
         } catch (ParserConfigurationException | SAXException | IOException exception) {
             logger.warning(

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.cli.cluster;
 
@@ -141,7 +141,7 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
             LOGGER.warning("Could not determine if data grid encryption is enabled - "
                     + "you will need to regenerate the encryption key if it is");
         }
-        
+
         try {
             HashMap<String, String> additionalTrustandKeyStores = getAdditionalTrustandKeyStores();
             if (additionalTrustandKeyStores.containsKey("additionalKeyStores")) {

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -143,7 +143,7 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
         }
 
         try {
-            getAdditionalTrustandKeyStores();
+            checkAdditionalTrustandKeyStores();
         } catch (IOException | XMLStreamException exception) {
             LOGGER.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
         }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -143,7 +143,7 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
         }
 
         try {
-            checkAdditionalTrustandKeyStores();
+            checkAdditionalTrustAndKeyStores();
         } catch (IOException | XMLStreamException exception) {
             LOGGER.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
         }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ChangeNodeMasterPasswordCommand.java
@@ -143,20 +143,9 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
         }
 
         try {
-            HashMap<String, String> additionalTrustandKeyStores = getAdditionalTrustandKeyStores();
-            if (additionalTrustandKeyStores.containsKey("additionalKeyStores")) {
-                logger.log(Level.INFO,
-                        "The passwords of additional KeyStores {0} have not been changed - please update these manually to continue using them.",
-                        additionalTrustandKeyStores.get("additionalKeyStores").split(":"));
-            }
-            if (additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
-                logger.log(Level.INFO,
-                        "The passwords of additional TrustStores {0} have not been changed - please update these manually to continue using them.",
-                        additionalTrustandKeyStores.get("additionalTrustStores").split(":"));
-            }
+            getAdditionalTrustandKeyStores();
         } catch (IOException | XMLStreamException exception) {
-            logger.warning(
-                    "Could not fetch additional Trust and Keystores - if there are additional Trust Stores or Key Stores, the passwords need to be updated in order to continue using them.");
+            LOGGER.warning("Could not determine if there were additional Key Stores or Trust stores, if the master-password has been updated, the password for the additional stores need updating in order to continue using them.");
         }
 
     }
@@ -187,7 +176,7 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
     /**
      * Find the old password from the property in the password file with the name
      * {@link #OLD_PASSWORD_ALIAS} if it exists, or by prompting the user otherwise.
-     * 
+     *
      * @throws CommandException if the password is null
      */
     protected String findOldPassword() throws CommandException {
@@ -217,7 +206,7 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
      * Set the {@link #newPassword} field from the property in the password file
      * with the name {@link #OLD_PASSWORD_ALIAS} if it exists, or by prompting the
      * user twice otherwise.
-     * 
+     *
      * @throws CommandException if the passwords don't match or are null
      */
     protected void setNewPassword() throws CommandException {
@@ -236,7 +225,7 @@ public class ChangeNodeMasterPasswordCommand extends LocalInstanceCommand {
 
     /**
      * This will get the directory of all instances for the selected node.
-     * 
+     *
      * @return The list of instances for the selected node
      * @throws CommandException if there are no instances
      */


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Added warning message to change-master-password command to warn about additional trust and key stores not being re-encrypted 
![Message when there are no additional trust and keystores](https://user-images.githubusercontent.com/73829904/129345132-8457eac4-4dff-4d71-a265-6e54b1312b35.png)
![Message when there are additional stores](https://user-images.githubusercontent.com/73829904/129345137-896f993a-8b69-4da8-b2db-03f5594f91a5.png)

![warningmessage2](https://user-images.githubusercontent.com/73829904/129895863-9e7b902f-3207-4b09-9385-83b70e9e5a63.png)

## Testing
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Ran command to see if warning message appeared.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
openjdk version "1.8.0_292" 
ubuntu 20.04 
maven 3.6.3