### PR TITLE
FISH-1654: Fix issue when starting local instance when using verbose mode

### DIFF
--- a/appserver/admin/cli/src/main/java/org/glassfish/admin/cli/AsadminMain.java
+++ b/appserver/admin/cli/src/main/java/org/glassfish/admin/cli/AsadminMain.java
@@ -44,6 +44,8 @@ import com.sun.enterprise.admin.cli.AdminMain;
 import com.sun.enterprise.admin.cli.Environment;
 import com.sun.enterprise.admin.remote.Metrix;
 
+import java.util.Arrays;
+
 /**
  * The asadmin main program.
  */
@@ -55,7 +57,8 @@ public class AsadminMain extends AdminMain {
         Environment.setPrefix("AS_ADMIN_");
         Environment.setShortPrefix("AS_");
         // forceVerbose so that asadmin always runs with output to console
-        int code = new AsadminMain().doMain(args, true);
+        // (re-)start-instance can set --logToConsole which means forceVerbose should not be set
+        int code = new AsadminMain().doMain(args, !Arrays.asList(args).contains("--logToConsole"));
 //        Metrix.event("DONE");
 //        System.out.println("METRIX:");
 //        System.out.println(Metrix.getInstance().toString());

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
@@ -208,7 +208,8 @@ public class AdminMain {
         // since this method is called to start an instance or the asadmin command
         // we can force verbose mode for asadmin.
         boolean verbose = false;
-        if (forceVerbose || Arrays.asList(args).contains("--logToConsole")) {
+        if (forceVerbose || Arrays.asList(args).contains("--verbose")
+                || Arrays.asList(args).contains("--logToConsole")) {
             verbose = true;
             System.setProperty(LoggingUtil.SYSTEM_PROPERTY_PAYARA_LOGGING_VERBOSE, "true");
         }

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
@@ -283,8 +283,15 @@ public class StartInstanceCommand implements AdminCommand {
         }
 
         boolean verbose = LoggingUtil.isVerboseMode();
-        if (verbose) {
-            command.add("--logToConsole");
+        if (verbose && node != null) {
+
+            if (node.isLocal()) {
+                // Do not use --verbose as the start-instance does not return,
+                // and it hangs the Admin console for example. (see StartLocalInstanceCommand.executeCommand)
+                command.add("--logToConsole");
+            } else {
+                command.add("--verbose");
+            }
         }
 
         command.add(instanceName);

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
@@ -82,6 +82,10 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
     @Param(optional = true, shortName = "v", defaultValue = "false")
     private boolean verbose;
 
+    @Param(optional = true, defaultValue = "false")
+    // To avoid the start-instance command to never return with --verbose
+    private boolean logToConsole;
+
     @Param(optional = true, shortName = "w", defaultValue = "false")
     private boolean watchdog;
 
@@ -246,6 +250,7 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
         // now the start-local-instance specific arguments
         args.add(getName()); // the command name
         args.add("--verbose=" + verbose);
+        args.add("--logToConsole=" + logToConsole);
         args.add("--watchdog=" + watchdog);
         args.add("--debug=" + debug);
 


### PR DESCRIPTION
## Description
ConsoleHandler is always active but unless domain is started with --verbose option, there is no console to write the output to. Since ConsoleHandler.publish() is synchronized, it is a bottleneck in performance when multiple threads perform logging.

This PR also fixes the .logtoConsole logging property but it only has effect when running in verbose mode

There is no impact/change on Payara Micro and Payara Embedded.

**Important**

`./asadmin list-log-attributes` returns the 'active' state of the handlers attributes (so ConsoleHandler is not reported when not active)

When custom Docker Images are used, make sure the domain is started in verbose mode to have the output with `docker logs`.

## Important Info

## Testing
 
### Testing Performed

- Running in verbose mode and non-verbose mode and tested logging from within application
- Verified ConsoleHandler is indeed not active in non-verbose mode
- Tested output of `list-log-attributes``
- Tested Docker image
- Adding local instance in verbose mode.


### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.4 with Maven 3.6.3

## Documentation

https://github.com/payara/Payara-Community-Documentation/pull/185


