### PR TITLE
FISH-1058 FISH-5690 FISH-5691 Deploy applications via Micro API outside Application Invocation and fix surrounding trouble

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -337,6 +337,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
     private ComponentInvocation createComponentInvocation(ComponentInvocation currInv) {
         ComponentInvocation newInv = currInv.clone();
         newInv.setResourceTableKey(null);
+        newInv.clearRegistry();
         newInv.instance = currInv.getInstance();
         if (!naming) {
             newInv.setJNDIEnvironment(null);

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -324,9 +324,9 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
                 // if app is null then it is likely that appId is still deploying
                 // and its enabled status has not been written to the domain.xml yet
                 // this can happen for example with a Startup EJB submitting something
-                // it its startup method. Reference Payara GitHub issue 204
+                // it its startup method, and since Aug 2021 CDI deployment in general. Reference Payara GitHub issue 204
                 if(applicationRegistry.get(appId) != null){
-                    logger.log(Level.INFO, "Job submitted for {0} likely during deployment. Continuing...", appId);
+                    logger.log(Level.FINE, "Job submitted for {0} likely during deployment. Continuing...", appId);
                     result = true;
                 }
             }

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -53,6 +53,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
@@ -265,8 +266,13 @@ public class InvocationManagerImpl implements InvocationManager {
 
     @Override
     public List<? extends ComponentInvocation> popAllInvocations() {
-        List<? extends ComponentInvocation> result = getAllInvocations();
-        framesByThread.set(null);
+        InvocationFrames frames = framesByThread.get();
+        if (frames == null) {
+            return Collections.emptyList();
+        }
+        frames.state = UN_INITIALIZED;
+        List<? extends ComponentInvocation> result = new ArrayList<>(frames);
+        frames.clear();
         return result;
     }
 

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -139,6 +139,7 @@ public class InvocationManagerImpl implements InvocationManager {
         InvocationFrames frames = framesByThread.get();
         if (invocation.getInvocationType() == SERVICE_STARTUP) {
             frames.setState(SERVICE_STARTUP);
+            LOGGER.finest(() -> "Not storing service startup invocation on the stack:" + invocation);
             return;
         }
 
@@ -156,6 +157,7 @@ public class InvocationManagerImpl implements InvocationManager {
         } finally {
             // Push this invocation on the stack
             frames.addLast(invocation);
+            LOGGER.finest(() -> "Added invocation "+frames.size()+" on the stack:\n" + invocation);
 
             if (allTypesHandler != null) {
                 allTypesHandler.afterPreInvoke(type, prev, invocation);
@@ -171,6 +173,7 @@ public class InvocationManagerImpl implements InvocationManager {
         InvocationFrames frames = framesByThread.get();
         if (invocation.getInvocationType() == SERVICE_STARTUP) {
             frames.setState(UN_INITIALIZED);
+            LOGGER.finest(() -> "Skipping SERVICE_STARTUP invocation :" + invocation);
             return;
         }
 
@@ -199,7 +202,8 @@ public class InvocationManagerImpl implements InvocationManager {
             }
         } finally {
             // pop the stack
-            frames.removeLast();
+            ComponentInvocation removed = frames.removeLast();
+            LOGGER.finest(() -> "Removed\n"+removed+ "\nafter postInvoke of\n"+invocation);
 
             if (allTypesHandler != null) {
                 allTypesHandler.afterPostInvoke(type, prev, current);
@@ -217,7 +221,7 @@ public class InvocationManagerImpl implements InvocationManager {
         if (a.getClass() != b.getClass()) {
             return true;
         }
-        return a != b && !a.getClass().getSimpleName().equals("WebComponentInvocation"); // Effectively we ignore WebComponentInvocations for now
+        return a.getClass().getSimpleName().equals("WebComponentInvocation") ? a.instance != b.instance : a != b; // Effectively we ignore WebComponentInvocations for now
     }
 
     /**
@@ -273,11 +277,13 @@ public class InvocationManagerImpl implements InvocationManager {
         frames.state = UN_INITIALIZED;
         List<? extends ComponentInvocation> result = new ArrayList<>(frames);
         frames.clear();
+        LOGGER.finest(() -> "Removed invocations of a thread: " + result);
         return result;
     }
 
     @Override
     public void putAllInvocations(List<? extends ComponentInvocation> invocations) {
+        LOGGER.fine(() -> "Forcefully set invocations of a thread to\n"+invocations);
         framesByThread.set(InvocationFrames.valueOf(invocations));
     }
 
@@ -320,7 +326,7 @@ public class InvocationManagerImpl implements InvocationManager {
                         parentFrame.getTransaction()));
             }
         }
-
+        LOGGER.finest(() -> "Computed new invocation stack for child thread: " + childFrames);
         return childFrames;
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
When `PayaraMicroRuntime.deploy` is used to deploy an application in a service call (like JAX-RS call in `payara-micro-deployer`) the call retained Component Invocation context of deploying application.

With changes to MP Config earlier this year this caused MP Config properties from classpath not being properly discovered.

At the core the PR "pauses" invocation context by putting it aside and restoring it after deployment.

In my testing this uncovered other problems:

Two component invocations were taken from invocation stack when exception was thrown in `postInvoke` (FISH-5690)
The invocation in this case was EntityManager incorrectly propagated to managed thread executor resulting in duplicate closes of it.

## Testing
It would be great to run Concurrency, Servlet, JPA and EJB TCKs on this one as it touches parts that we rarely change.

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Payara Cloud test suites now pass.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
```
Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)
Maven home: C:\ProgramData\chocolatey\lib\maven\apache-maven-3.8.1\bin\..
Java version: 1.8.0_302, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-8\jre
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
