### PR TITLE
FISH-5660 - Application Deployment Failure on Payara Micro

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/init/OpenApiServletContainerInitializer.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/init/OpenApiServletContainerInitializer.java
@@ -54,7 +54,6 @@ import javax.servlet.ServletSecurityElement;
 import static javax.servlet.annotation.ServletSecurity.TransportGuarantee.CONFIDENTIAL;
 import static org.glassfish.common.util.StringHelper.isEmpty;
 import org.glassfish.internal.api.Globals;
-import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.servlet.init.JerseyServletContainerInitializer;
 
 /**
@@ -86,12 +85,11 @@ public class OpenApiServletContainerInitializer implements ServletContainerIniti
             return;
         }
 
+        ServletRegistration.Dynamic reg = ctx.addServlet(OpenApiApplication.class.getName(), OpenApiApplication.class.getName());
+        reg.addMapping("/" + configuration.getEndpoint()  + "/*");
+
         // Start the OpenAPI application
         new JerseyServletContainerInitializer().onStartup(new HashSet<>(asList(OpenApiApplication.class)), ctx);
-
-        ServletContainer servletContainer = new ServletContainer(new OpenApiApplication());
-        ServletRegistration.Dynamic reg = ctx.addServlet("microprofile-openapi-servlet", servletContainer);
-        reg.addMapping("/" + configuration.getEndpoint()  + "/*");
         if (Boolean.parseBoolean(configuration.getSecurityEnabled())) {
             String[] roles = configuration.getRoles().split(",");
             reg.setServletSecurity(new ServletSecurityElement(new HttpConstraintElement(CONFIDENTIAL, roles)));


### PR DESCRIPTION
## Description
A bug fix addressing community bug report: https://github.com/payara/Payara/issues/5363. Fixes applications failing to deploy on Payara Micro after versions 5.2021.4 if the application context root isn't "/".

## Important Info

## Testing

### Testing Performed
Manually tested with the reproducer given in the bug report. Manually tested with Payara Micro maven archetype. Ran relevant unit tests.

### Testing Environment
Windows 10 Pro, Maven 3.6.3. JDK8

## Documentation
No documentation required as this produced expected behaviour.