### PR TITLE
FISH-1654: Log To Console and Verbose mode.

### DIFF
--- a/appserver/admin/cli/src/main/java/org/glassfish/admin/cli/AsadminMain.java
+++ b/appserver/admin/cli/src/main/java/org/glassfish/admin/cli/AsadminMain.java
@@ -37,11 +37,14 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2021] Payara Foundation and/or affiliates
 package org.glassfish.admin.cli;
 
 import com.sun.enterprise.admin.cli.AdminMain;
 import com.sun.enterprise.admin.cli.Environment;
 import com.sun.enterprise.admin.remote.Metrix;
+
+import java.util.Arrays;
 
 /**
  * The asadmin main program.
@@ -53,7 +56,9 @@ public class AsadminMain extends AdminMain {
 //        Metrix.event("START");
         Environment.setPrefix("AS_ADMIN_");
         Environment.setShortPrefix("AS_");
-        int code = new AsadminMain().doMain(args);
+        // forceVerbose so that asadmin always runs with output to console
+        // (re-)start-instance can set --logToConsole which means forceVerbose should not be set
+        int code = new AsadminMain().doMain(args, !Arrays.asList(args).contains("--logToConsole"));
 //        Metrix.event("DONE");
 //        System.out.println("METRIX:");
 //        System.out.println(Metrix.getInstance().toString());

--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/startInForeground.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/startInForeground.sh
@@ -46,7 +46,7 @@ if [ -z $DOMAIN_NAME ]; then echo "Variable DOMAIN_NAME is not set."; exit 1; fi
 touch $PREBOOT_COMMANDS_FINAL
 touch $POSTBOOT_COMMANDS_FINAL
 
-OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --vebose --dry-run --prebootcommandfile=${PREBOOT_COMMANDS_FINAL} --postbootcommandfile=${POSTBOOT_COMMANDS_FINAL} $@ $DOMAIN_NAME`
+OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --verbose --dry-run --prebootcommandfile=${PREBOOT_COMMANDS_FINAL} --postbootcommandfile=${POSTBOOT_COMMANDS_FINAL} $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then

--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/startInForeground.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/startInForeground.sh
@@ -46,7 +46,7 @@ if [ -z $DOMAIN_NAME ]; then echo "Variable DOMAIN_NAME is not set."; exit 1; fi
 touch $PREBOOT_COMMANDS_FINAL
 touch $POSTBOOT_COMMANDS_FINAL
 
-OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --dry-run --prebootcommandfile=${PREBOOT_COMMANDS_FINAL} --postbootcommandfile=${POSTBOOT_COMMANDS_FINAL} $@ $DOMAIN_NAME`
+OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --vebose --dry-run --prebootcommandfile=${PREBOOT_COMMANDS_FINAL} --postbootcommandfile=${POSTBOOT_COMMANDS_FINAL} $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then

--- a/appserver/extras/docker-images/server-web/src/main/docker/bin/startInForeground.sh
+++ b/appserver/extras/docker-images/server-web/src/main/docker/bin/startInForeground.sh
@@ -46,7 +46,7 @@ if [ -z $DOMAIN_NAME ]; then echo "Variable DOMAIN_NAME is not set."; exit 1; fi
 touch $PREBOOT_COMMANDS_FINAL
 touch $POSTBOOT_COMMANDS_FINAL
 
-OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --dry-run --prebootcommandfile=${PREBOOT_COMMANDS_FINAL} --postbootcommandfile=${POSTBOOT_COMMANDS_FINAL} $@ $DOMAIN_NAME`
+OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --verbose --dry-run --prebootcommandfile=${PREBOOT_COMMANDS_FINAL} --postbootcommandfile=${POSTBOOT_COMMANDS_FINAL} $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
 package com.sun.enterprise.admin.cli;
 
 import com.sun.enterprise.admin.remote.reader.ProprietaryReaderFactory;
@@ -54,6 +54,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
+import fish.payara.logging.LoggingUtil;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
 import org.glassfish.api.admin.InvalidCommandException;
@@ -199,11 +200,20 @@ public class AdminMain {
 
     public static void main(String[] args) {
         AdminMain adminMain = new AdminMain();
-        int code = adminMain.doMain(args);
+        int code = adminMain.doMain(args, false);
         System.exit(code);
     }
 
-    protected int doMain(String[] args) {
+    protected int doMain(String[] args, boolean forceVerbose) {
+        // since this method is called to start an instance or the asadmin command
+        // we can force verbose mode for asadmin.
+        boolean verbose = false;
+        if (forceVerbose || Arrays.asList(args).contains("--verbose")
+                || Arrays.asList(args).contains("--logToConsole")) {
+            verbose = true;
+            System.setProperty(LoggingUtil.SYSTEM_PROPERTY_PAYARA_LOGGING_VERBOSE, "true");
+        }
+
         int minor = JDK.getMinor();
         int major = JDK.getMajor();
         //In case of JDK1 to JDK8 the major version would be 1 always.Starting from
@@ -234,17 +244,20 @@ public class AdminMain {
             logger.setLevel(Level.FINE);
         }
         logger.setUseParentHandlers(false);
-        Handler h = new CLILoggerHandler();
-        h.setLevel(logger.getLevel());
-        logger.addHandler(h);
+        if (verbose) {
+            // Only when in verbose mode we have console that is visible.
+            Handler h = new CLILoggerHandler();
+            h.setLevel(logger.getLevel());
+            logger.addHandler(h);
 
-        // make sure the root logger uses our handler as well
-        Logger rlogger = Logger.getLogger("");
-        rlogger.setUseParentHandlers(false);
-        for (Handler lh : rlogger.getHandlers()) {
-            rlogger.removeHandler(lh);
+            // make sure the root logger uses our handler as well
+            Logger rlogger = Logger.getLogger("");
+            rlogger.setUseParentHandlers(false);
+            for (Handler lh : rlogger.getHandlers()) {
+                rlogger.removeHandler(lh);
+            }
+            rlogger.addHandler(h);
         }
-        rlogger.addHandler(h);
 
         if (debug) {
             System.setProperty(CLIConstants.WALL_CLOCK_START_PROP, "" + System.currentTimeMillis());

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  * 
- * Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+ * Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
  */
 package com.sun.enterprise.v3.admin.cluster;
 
@@ -57,6 +57,7 @@ import java.util.logging.Logger;
 import javax.inject.Inject;
 import javax.validation.constraints.Min;
 
+import fish.payara.logging.LoggingUtil;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
@@ -279,6 +280,18 @@ public class StartInstanceCommand implements AdminCommand {
       
         if (debug) {
             command.add("--debug");
+        }
+
+        boolean verbose = LoggingUtil.isVerboseMode();
+        if (verbose && node != null) {
+
+            if (node.isLocal()) {
+                // Do not use --verbose as the start-instance does not return,
+                // and it hangs the Admin console for example. (see StartLocalInstanceCommand.executeCommand)
+                command.add("--logToConsole");
+            } else {
+                command.add("--verbose");
+            }
         }
 
         command.add(instanceName);

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
@@ -82,6 +82,10 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
     @Param(optional = true, shortName = "v", defaultValue = "false")
     private boolean verbose;
 
+    @Param(optional = true, defaultValue = "false")
+    // To avoid the start-instance command to never return with --verbose
+    private boolean logToConsole;
+
     @Param(optional = true, shortName = "w", defaultValue = "false")
     private boolean watchdog;
 
@@ -246,6 +250,7 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
         // now the start-local-instance specific arguments
         args.add(getName()); // the command name
         args.add("--verbose=" + verbose);
+        args.add("--logToConsole=" + logToConsole);
         args.add("--watchdog=" + watchdog);
         args.add("--debug=" + debug);
 

--- a/nucleus/common/common-util/osgi.bundle
+++ b/nucleus/common/common-util/osgi.bundle
@@ -69,6 +69,7 @@ Bundle-Activator: org.glassfish.common.util.CommonUtilsActivator
                         com.sun.enterprise.util.uuid; \
                         com.sun.enterprise.util.zip; \
                         com.sun.logging; \
+                        fish.payara.logging; \
                         org.glassfish.admin.payload; \
                         org.glassfish.common.util.admin; \
                         org.glassfish.common.util; \

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -43,6 +43,7 @@
 package com.sun.enterprise.glassfish.bootstrap;
 
 import fish.payara.boot.runtime.BootCommands;
+import fish.payara.logging.LoggingUtil;
 import fish.payara.logging.PayaraLogManager;
 import org.glassfish.embeddable.*;
 
@@ -70,22 +71,27 @@ public class GlassFishMain {
 
     private static final Pattern COMMAND_PATTERN = Pattern.compile("([^\"']\\S*|\".*?\"|'.*?')\\s*");
     private static final String[] COMMAND_TYPE = new String[0];
-    private static final Logger LOGGER;
+    private static Logger LOGGER;
 
     // TODO(Sahoo): Move the code to ASMain once we are ready to phase out ASMain
 
     static {
         // This is not a JVM parameter in the domain as users should not have the possibility to not use the Payara Log Manager.
         System.setProperty("java.util.logging.manager", PayaraLogManager.class.getName());
-
-        // Do not use as variable initialization as that will trigger LogManager before System property is set.
-        LOGGER = Logger.getLogger(GlassFishMain.class.getName());
     }
 
     public static void main(final String args[]) throws Exception {
-        MainHelper.checkJdkVersion();
 
+        // Avoid triggering logging for the moment
         final Properties argsAsProps = argsToMap(args);
+        boolean verbose = Boolean.parseBoolean(argsAsProps.getProperty("-verbose"));
+        System.setProperty(LoggingUtil.SYSTEM_PROPERTY_PAYARA_LOGGING_VERBOSE, Boolean.toString(verbose));
+
+        // Do not use as variable initialization as that will trigger LogManager before System property is set.
+        // And only after we have determined if we use verbose logging so that ConsoleHandler usage is correct.
+        LOGGER = Logger.getLogger(GlassFishMain.class.getName());
+
+        MainHelper.checkJdkVersion();
 
         String platform = MainHelper.whichPlatform();
 

--- a/nucleus/core/logging/osgi.bundle
+++ b/nucleus/core/logging/osgi.bundle
@@ -49,5 +49,6 @@ DynamicImport-Package: \
 					com.trilead.ssh2, \
 					com.sun.enterprise.util.cluster.windows.io, \
 					com.sun.enterprise.util.cluster.windows.process, \
-					org.glassfish.cluster.ssh.util
+					org.glassfish.cluster.ssh.util, \
+					fish.payara.logging
 

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -51,7 +51,7 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.logging.AgentFormatterDelegate;
 import fish.payara.enterprise.server.logging.JSONLogFormatter;
-import fish.payara.enterprise.server.logging.PayaraNotificationLogRotationTimer;;
+import fish.payara.enterprise.server.logging.PayaraNotificationLogRotationTimer;
 import java.io.*;
 import java.security.PrivilegedAction;
 import java.text.FieldPosition;
@@ -71,6 +71,7 @@ import java.util.logging.StreamHandler;
 import java.util.zip.GZIPOutputStream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
 import org.glassfish.api.logging.Task;
 import org.glassfish.config.support.TranslatedConfigView;
 import org.glassfish.hk2.api.PostConstruct;
@@ -1066,6 +1067,7 @@ public class GFFileHandler extends StreamHandler implements
     }
 
     private void logStandardStreams() {
+
         // redirect stderr and stdout, a better way to do this
         //http://blogs.sun.com/nickstephen/entry/java_redirecting_system_out_and
 
@@ -1150,7 +1152,7 @@ public class GFFileHandler extends StreamHandler implements
         this.compressionOnRotation = compressionOnRotation;
     }
 
-    public synchronized void setLogStandardStreams(boolean logStandardStreams) {
+    synchronized void setLogStandardStreams(boolean logStandardStreams) {
         this.logStandardStreams = logStandardStreams;
 
         if (logStandardStreams) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/ListLogAttributes.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/ListLogAttributes.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging.commands;
 
@@ -52,6 +52,7 @@ import java.util.Properties;
 
 import javax.inject.Inject;
 
+import fish.payara.logging.LoggingUtil;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
@@ -115,7 +116,7 @@ public class ListLogAttributes implements AdminCommand {
         final ActionReport report = context.getActionReport();
         
         try {
-            HashMap<String, String> props = null;
+            HashMap<String, String> props;
             
             TargetInfo targetInfo = new TargetInfo(domain, target);
             String targetConfigName = targetInfo.getConfigName();
@@ -133,17 +134,18 @@ public class ListLogAttributes implements AdminCommand {
                 return;
             }
 
-            List<String> keys = new ArrayList<String>();
-            keys.addAll(props.keySet());
+            LoggingUtil.handleConsoleHandlerLogic(props);
+
+            List<String> keys = new ArrayList<>(props.keySet());
             Collections.sort(keys);
             Iterator<String> it2 = keys.iterator();
 
             // The following Map is used to hold the REST data
-            Map<String, String> logAttributes = new HashMap<String, String>();
+            Map<String, String> logAttributes = new HashMap<>();
 
             while (it2.hasNext()) {
                 String name = it2.next();
-                if (!name.endsWith(".level") && !name.equals(".level")) {
+                if (!name.endsWith(".level")) {
                     final ActionReport.MessagePart part = report.getTopMessagePart()
                             .addChild();
                     part.setMessage(name + "\t" + "<" + props.get(name) + ">");


### PR DESCRIPTION
new PR based on https://github.com/payara/Payara/pull/5327 and https://github.com/payara/Payara/pull/5382       

## Description
ConsoleHandler is always active but unless domain is started with --verbose option, there is no console to write the output to. Since ConsoleHandler.publish() is synchronized, it is a bottleneck in performance when multiple threads perform logging.

This PR also fixes the .logtoConsole logging property but it only has effect when running in verbose mode

There is no impact/change on Payara Micro and Payara Embedded.

**Important**

`./asadmin list-log-attributes` returns the 'active' state of the handlers attributes (so ConsoleHandler is not reported when not active)

When custom Docker Images are used, make sure the domain is started in verbose mode to have the output with `docker logs`.

## Important Info

## Testing
 
### Testing Performed

- Running in verbose mode and non-verbose mode and tested logging from within application
- Verified ConsoleHandler is indeed not active in non-verbose mode
- Tested output of `list-log-attributes``
- Tested Docker image
- Adding local instance in verbose mode.


### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.4 with Maven 3.6.3

## Documentation

https://github.com/payara/Payara-Community-Documentation/pull/185
