### PR TITLE
FISH-5660 Micro fails to deploy WAR with "ServletConfig has not been initialized"

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/init/OpenApiServletContainerInitializer.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/init/OpenApiServletContainerInitializer.java
@@ -87,8 +87,6 @@ public class OpenApiServletContainerInitializer implements ServletContainerIniti
         }
 
         // Start the OpenAPI application
-        new JerseyServletContainerInitializer().onStartup(new HashSet<>(asList(OpenApiApplication.class)), ctx);
-
         ServletContainer servletContainer = new ServletContainer(new OpenApiApplication());
         ServletRegistration.Dynamic reg = ctx.addServlet("microprofile-openapi-servlet", servletContainer);
         reg.setLoadOnStartup(1);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/init/OpenApiServletContainerInitializer.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/init/OpenApiServletContainerInitializer.java
@@ -91,6 +91,7 @@ public class OpenApiServletContainerInitializer implements ServletContainerIniti
 
         ServletContainer servletContainer = new ServletContainer(new OpenApiApplication());
         ServletRegistration.Dynamic reg = ctx.addServlet("microprofile-openapi-servlet", servletContainer);
+        reg.setLoadOnStartup(1);
         reg.addMapping("/" + configuration.getEndpoint()  + "/*");
         if (Boolean.parseBoolean(configuration.getSecurityEnabled())) {
             String[] roles = configuration.getRoles().split(",");


### PR DESCRIPTION
## Description
This PR fixes the dynamic registration of the Open API endpoint via prioritizing initialization of OpenApiApplication's `org.glassfish.jersey.servlet.ServletContainer` on application deployment.

A bug fix addressing community bug report: #5363.

## Important Info
OpenAPI document processing is done on the first call to `/openapi` endpoint.