### PR TITLE
FISH-966 Updated asadmin stop-domain help to be accurate with behaviour

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/stop-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/stop-domain.1
@@ -17,11 +17,13 @@ DESCRIPTION
        specified.
 
        This subcommand is supported in local or remote mode. If you specify a
-       host name, the subcommand assumes you are operating in remote mode,
-       which means you must correctly authenticate to the remote server. In
-       local mode, you normally do not need to authenticate to the server as
-       long as you are running the subcommand as the same user who started the
-       server.
+       host name and it references a remote host, the subcommand assumes you
+       are operating in remote mode, which means you must correctly authenticate
+       to the remote server. If the host name points to localhost, then the
+       subcommand assumes you are operating in local mode as if the host name
+       wasn't specified at all. In local mode, you normally do not need to
+       authenticate to the server as long as you are running the subcommand as
+       the same user who started the server.
 
 OPTIONS
        --help, -?


### PR DESCRIPTION
## Description
Currently the help text from running _asadmin stop-domain --help_  does not accurately reflect the behaviour of the subcommand. This updates it to be accurate.

## Important Info

## Testing

### Testing Performed
Manually tested running _asadmin stop-domain --help_ to ensure the updated text is displayed and keeps to the original formatting.

### Testing Environment
Windows 10 Pro, Maven 3.6.3, JDK8