### PR TITLE
FISH-5687/FISH-1467 Integrate HotSwap Agent in Payara Platform

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -42,7 +42,7 @@
 
 -->
 
-<!-- Portions Copyright [2017-2020] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates] -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
     <hazelcast-runtime-configuration start-port="%%%HAZELCAST_START_PORT%%%" das-port="%%%HAZELCAST_DAS_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>
@@ -273,6 +273,9 @@
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
                 <!-- allow asadmin command enable-monitoring for JDK 9+ -->
                 <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
+                <!-- Hotswap Agent -->
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />
@@ -503,6 +506,9 @@
                 <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
                 <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
                 <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+                <!-- Hotswap Agent -->
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
             </java-config>
             <availability-service>
                 <web-container-availability />

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -3,7 +3,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -267,7 +267,10 @@
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
         <!-- allow asadmin command enable-monitoring for JDK 9+ -->
-        <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
+        <jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>                
+        <!-- Hotswap Agent -->
+        <jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
+        <jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />
@@ -494,6 +497,9 @@
         <jvm-options>[1.8.0u191|1.8.0u250]-Xbootclasspath/p:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap-1.8.1.jar</jvm-options>
         <jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
+        <!-- Hotswap Agent -->
+        <jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
+        <jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
       </java-config>
       <availability-service>
         <web-container-availability />

--- a/appserver/common/annotation-framework/src/main/java/org/glassfish/apf/impl/AnnotationProcessorImpl.java
+++ b/appserver/common/annotation-framework/src/main/java/org/glassfish/apf/impl/AnnotationProcessorImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or affiliates]
 
 package org.glassfish.apf.impl;
 
@@ -57,7 +57,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Member;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -73,10 +72,6 @@ import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.apf.ProcessingResult;
 import org.glassfish.apf.Scanner;
 import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import org.glassfish.api.deployment.DeployCommandParameters;
-import org.glassfish.hk2.classmodel.reflect.Type;
-
 
 /**
  *
@@ -160,7 +155,7 @@ public class AnnotationProcessorImpl implements AnnotationProcessor {
             processorState.ifPresent(s -> s.setProcessingResult(result));
         } else {
             result = processorState.get().getProcessingResult(ProcessingResultImpl.class);
-            for (Class modifiedClass : scanner.getElements(state.getClassesChanged())) {
+            for (Class modifiedClass : scanner.getElements(state.getClassesChanged().keySet())) {
                 result.add(process(ctx, modifiedClass));
             }
         }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/archivist/Archivist.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/archivist/Archivist.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2020] [Payara Foundation and/or its affiliates.]
+// Portions Copyright [2020-2021] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.deployment.archivist;
 
@@ -105,7 +105,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
     // attributes of this archive
     protected Manifest manifest;
-    
+
     // standard DD file associated with this archivist
     protected DeploymentDescriptorFile<T> standardDD;
 
@@ -120,9 +120,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
     private ConfigurationDeploymentDescriptorFile confDD;
 
     // resources...
-    private static final LocalStringManagerImpl localStrings =
-	    new LocalStringManagerImpl(Archivist.class);    
-    
+    private static final LocalStringManagerImpl localStrings
+            = new LocalStringManagerImpl(Archivist.class);
+
     // class loader to use when validating the DOL
     protected ClassLoader classLoader = null;
 
@@ -144,7 +144,6 @@ public abstract class Archivist<T extends BundleDescriptor> {
     private static final String WSDL = ".wsdl";
     private static final String XML = ".xml";
     private static final String XSD = ".xsd";
-
 
     protected static final String APPLICATION_EXTENSION = ".ear";
     protected static final String APPCLIENT_EXTENSION = ".jar";
@@ -185,9 +184,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * initializes this instance from another archivist, this is used
-     * to transfer contextual information between archivists, for
-     * example whether we should handle runtime information and such
+     * initializes this instance from another archivist, this is used to
+     * transfer contextual information between archivists, for example whether
+     * we should handle runtime information and such
      */
     protected void initializeContext(Archivist other) {
         handleRuntimeInfo = other.isHandlingRuntimeInfo();
@@ -198,7 +197,6 @@ public abstract class Archivist<T extends BundleDescriptor> {
         annotationErrorHandler = other.annotationErrorHandler;
     }
 
-    
     /**
      * Set the applicable extension archivists for this archivist
      *
@@ -213,9 +211,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Archivist read XML deployment descriptors and keep the
-     * parsed result in the DOL descriptor instances. Sets the descriptor
-     * for a particular Archivist type
+     * Archivist read XML deployment descriptors and keep the parsed result in
+     * the DOL descriptor instances. Sets the descriptor for a particular
+     * Archivist type
      *
      * @param descriptor for this archivist instnace
      */
@@ -231,7 +229,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Open a new archive file, read the deployment descriptors and annotations      *  and set the constructed DOL descriptor instance
+     * Open a new archive file, read the deployment descriptors and annotations
+     * and set the constructed DOL descriptor instance
      *
      * @param archive the archive file path
      * @return the deployment descriptor for this archive
@@ -245,20 +244,21 @@ public abstract class Archivist<T extends BundleDescriptor> {
             final ReadableArchive contentArchive) throws IOException, SAXParseException {
         return open(descriptorArchive, contentArchive, null);
     }
+
     /**
      * Creates the DOL object graph for an app for which the descriptor(s)
      * reside in one archive and the content resides in another.
      * <p>
-     * This allows the app client container to use both the generated JAR
-     * which contains the descriptors that are filled in during deployment and
-     * also the developer's original JAR which contains the classes that
-     * might be subject to annotation processing.
+     * This allows the app client container to use both the generated JAR which
+     * contains the descriptors that are filled in during deployment and also
+     * the developer's original JAR which contains the classes that might be
+     * subject to annotation processing.
      *
      * @param descriptorArchive archive containing the descriptor(s)
      * @param contentArchive archive containing the classes, etc.
      * @param app owning DOL application (if any)
      * @return DOL object graph for the application
-     * 
+     *
      * @throws IOException
      * @throws SAXParseException
      */
@@ -289,7 +289,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
         // application archivist will override this method
         if (app.isVirtual()) {
-            T descriptor = readRestDeploymentDescriptors((T)app.getStandaloneBundleDescriptor(), archive, archive, app);
+            T descriptor = readRestDeploymentDescriptors((T) app.getStandaloneBundleDescriptor(), archive, archive, app);
             if (descriptor != null) {
                 postOpen(descriptor, archive);
                 descriptor.setApplication(app);
@@ -298,9 +298,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
         return app;
     }
 
-
     /**
-     * Open a new archive file, read the XML descriptor and set the  constructed
+     * Open a new archive file, read the XML descriptor and set the constructed
      * DOL descriptor instance
      *
      * @param path the archive file path
@@ -333,7 +332,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
         // attempt validation
         validate(null);
 
-        return descriptor;    
+        return descriptor;
     }
 
     /**
@@ -344,8 +343,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
      * @param extensions map of extension archivists
      */
     protected void postStandardDDsRead(T descriptor, ReadableArchive archive,
-                Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions)
-                throws IOException {
+            Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions)
+            throws IOException {
     }
 
     /**
@@ -365,7 +364,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
      * @param archive the module archive
      */
     public void postRuntimeDDsRead(T descriptor,
-                                      ReadableArchive archive) throws IOException {
+            ReadableArchive archive) throws IOException {
     }
 
     /**
@@ -396,13 +395,13 @@ public abstract class Archivist<T extends BundleDescriptor> {
         return readRestDeploymentDescriptors(descriptor, descriptorArchive, contentArchive, app);
     }
 
-    private T readRestDeploymentDescriptors (T descriptor,
-        ReadableArchive descriptorArchive, ReadableArchive contentArchive, 
-        Application app) throws IOException, SAXParseException {
+    private T readRestDeploymentDescriptors(T descriptor,
+            ReadableArchive descriptorArchive, ReadableArchive contentArchive,
+            Application app) throws IOException, SAXParseException {
 
         ApplicationState state = descriptorArchive.getExtraData(ApplicationState.class);
         Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions = new HashMap<>();
-        if (extensionsArchivists!=null) {
+        if (extensionsArchivists != null) {
             for (ExtensionsArchivist extension : extensionsArchivists) {
                 Object extDescriptor = null;
                 if (state != null && state.isActive()
@@ -429,8 +428,10 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
         readAnnotations(contentArchive, descriptor, extensions);
         postStandardDDsRead(descriptor, contentArchive, extensions);
-        postAnnotationProcess(descriptor, contentArchive);
-
+        ApplicationState appState = contentArchive.getExtraData(ApplicationState.class);
+        if (appState == null || !appState.isHotswap()) {
+            postAnnotationProcess(descriptor, contentArchive);
+        }
         // now read the runtime deployment descriptors
         readRuntimeDeploymentDescriptor(descriptorArchive, descriptor);
 
@@ -452,20 +453,20 @@ public abstract class Archivist<T extends BundleDescriptor> {
      * Read all Java EE annotations
      */
     protected void readAnnotations(ReadableArchive archive, T descriptor,
-                                 Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions)
+            Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions)
             throws IOException {
 
         readAnnotations(archive, descriptor, extensions, null);
     }
 
     protected void readAnnotations(ReadableArchive archive, T descriptor,
-                                 Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions,
-                                 ModuleScanner scanner)
+            Map<ExtensionsArchivist, RootDeploymentDescriptor> extensions,
+            ModuleScanner scanner)
             throws IOException {
-        
+
         try {
             boolean processAnnotationForMainDescriptor = isProcessAnnotation(descriptor);
-            ProcessingResult result = null; 
+            ProcessingResult result = null;
 
             if (processAnnotationForMainDescriptor) {
                 if (scanner == null) {
@@ -483,7 +484,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
                         // whether to process annotations
                         if (processAnnotationForMainDescriptor) {
                             RootDeploymentDescriptor o = extension.getKey().getDefaultDescriptor();
-                            if( o != null ) {
+                            if (o != null) {
                                 o.setModuleDescriptor(descriptor.getModuleDescriptor());
                                 // for the case of extension descriptor not 
                                 // present, set the metadata-complete attribute 
@@ -491,36 +492,36 @@ public abstract class Archivist<T extends BundleDescriptor> {
                                 // metadata-complete value of main descriptor
                                 if (o instanceof BundleDescriptor) {
                                     boolean isFullMain = descriptor.isFullAttribute();
-                                    ((BundleDescriptor)o).setFullAttribute(String.valueOf(isFullMain));
+                                    ((BundleDescriptor) o).setFullAttribute(String.valueOf(isFullMain));
                                 }
                             }
                             processAnnotations(o, extension.getKey().getScanner(), archive);
-                            if (o!=null && !o.isEmpty()) {
+                            if (o != null && !o.isEmpty()) {
                                 extension.getKey().addExtension(descriptor, o);
                                 extensions.put(extension.getKey(), (RootDeploymentDescriptor) o);
                             }
                         }
-                    } else{
+                    } else {
                         // extension deployment descriptor is present
                         // use the extension descriptor information to decide
                         // whether to process annotations
                         BundleDescriptor extBundle;
                         if (extension.getValue() instanceof BundleDescriptor) {
-                            extBundle = (BundleDescriptor)extension.getValue();
+                            extBundle = (BundleDescriptor) extension.getValue();
                             if (isProcessAnnotation(extBundle)) {
                                 processAnnotations(extBundle, extension.getKey().getScanner(), archive);
                             }
                         }
                     }
-                 } catch (AnnotationProcessorException ex) {
+                } catch (AnnotationProcessorException ex) {
                     DOLUtils.getDefaultLogger().severe(ex.getMessage());
                     DOLUtils.getDefaultLogger().log(Level.FINE, ex.getMessage(), ex);
                     throw new IllegalStateException(ex);
                 }
             }
 
-            if (result != null &&
-                    ResultType.FAILED.equals(result.getOverallResult())) {
+            if (result != null
+                    && ResultType.FAILED.equals(result.getOverallResult())) {
                 DOLUtils.getDefaultLogger().severe(localStrings.getLocalString(
                         "enterprise.deployment.archivist.annotationprocessingfailed",
                         "Annotations processing failed for {0}",
@@ -529,8 +530,11 @@ public abstract class Archivist<T extends BundleDescriptor> {
             //XXX for backward compatible in case of having cci impl in EJB
         } catch (NoClassDefFoundError err) {
             if (DOLUtils.getDefaultLogger().isLoggable(Level.WARNING)) {
-                DOLUtils.getDefaultLogger().warning(
-                        "Error in annotation processing: " + err);
+                DOLUtils.getDefaultLogger().log(
+                        Level.WARNING,
+                        "Error in annotation processing: {0}",
+                        err
+                );
             }
         } catch (AnnotationProcessorException ex) {
             DOLUtils.getDefaultLogger().severe(ex.getMessage());
@@ -540,45 +544,45 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Returns the scanner for this archivist, usually it is the scanner regitered
-     * with the same module type as this archivist, but subclasses can return a
-     * different version
+     * Returns the scanner for this archivist, usually it is the scanner
+     * registered with the same module type as this archivist, but subclasses can
+     * return a different version
      *
      */
     public ModuleScanner getScanner() {
-        
+
         Scanner scanner = null;
         try {
             scanner = habitat.getService(Scanner.class, getModuleType().toString());
-            if (scanner==null || !(scanner instanceof ModuleScanner)) {
+            if (scanner == null || !(scanner instanceof ModuleScanner)) {
                 logger.log(Level.SEVERE, "Cannot find module scanner for " + this.getManifest());
             }
         } catch (MultiException e) {
             // XXX To do
             logger.log(Level.SEVERE, "Cannot find scanner for " + this.getModuleType(), e);
         }
-        return (ModuleScanner)scanner;
+        return (ModuleScanner) scanner;
     }
 
     /**
-     * Process annotations in a bundle descriptor, the annoation processing
-     * is dependent on the type of descriptor being passed.
+     * Process annotations in a bundle descriptor, the annotation processing is
+     * dependent on the type of descriptor being passed.
      */
     public ProcessingResult processAnnotations(T bundleDesc,
-                                               ReadableArchive archive)
+            ReadableArchive archive)
             throws AnnotationProcessorException, IOException {
-        
+
         return processAnnotations(bundleDesc, getScanner(), archive);
 
     }
-    
+
     /**
-     * Process annotations in a bundle descriptor, the annotation processing
-     * is dependent on the type of descriptor being passed.
+     * Process annotations in a bundle descriptor, the annotation processing is
+     * dependent on the type of descriptor being passed.
      */
     protected ProcessingResult processAnnotations(RootDeploymentDescriptor bundleDesc,
-                                               ModuleScanner scanner,
-                                               ReadableArchive archive)
+            ModuleScanner scanner,
+            ReadableArchive archive)
             throws AnnotationProcessorException, IOException {
 
         if (scanner == null) {
@@ -603,7 +607,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
         scanner.process(archive, bundleDesc, classLoader, parser);
 
         if (!scanner.getElements().isEmpty()) {
-            if (((BundleDescriptor)bundleDesc).isDDWithNoAnnotationAllowed()) {
+            if (((BundleDescriptor) bundleDesc).isDDWithNoAnnotationAllowed()) {
                 // if we come into this block, it means an old version
                 // of deployment descriptor has annotation which is not correct
                 // throw exception in this case
@@ -621,7 +625,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
             }
             boolean isFullAttribute = false;
             if (bundleDesc instanceof BundleDescriptor) {
-                isFullAttribute = ((BundleDescriptor)bundleDesc).isFullAttribute();
+                isFullAttribute = ((BundleDescriptor) bundleDesc).isFullAttribute();
             }
 
             AnnotationProcessor ap = annotationFactory.getAnnotationProcessor(isFullAttribute);
@@ -678,10 +682,10 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Read the standard deployment descriptors (can contained in one or
-     * many file) and return the corresponding initialized descriptor instance.
-     * By default, the standard deployment descriptors are all contained in
-     * the xml file characterized with the path returned by
+     * Read the standard deployment descriptors (can contained in one or many
+     * file) and return the corresponding initialized descriptor instance. By
+     * default, the standard deployment descriptors are all contained in the xml
+     * file characterized with the path returned by
      *
      * @return the initialized descriptor
      * @link getDeploymentDescriptorPath
@@ -694,9 +698,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
         try {
             getStandardDDFile().setArchiveType(getModuleType());
             File altDDFile = archive.getArchiveMetaData(
-                DeploymentProperties.ALT_DD, File.class);
+                    DeploymentProperties.ALT_DD, File.class);
             if (altDDFile != null && altDDFile.exists() && altDDFile.isFile()) {
-                is = new FileInputStream(altDDFile); 
+                is = new FileInputStream(altDDFile);
             } else {
                 is = archive.getEntry(standardDD.getDeploymentDescriptorPath());
             }
@@ -707,7 +711,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
                     standardDD.setErrorReportingString(archive.getURI().getSchemeSpecificPart());
                 }
                 T result = standardDD.read(is);
-                ((RootDeploymentDescriptor)result).setClassLoader(classLoader);
+                ((RootDeploymentDescriptor) result).setClassLoader(classLoader);
                 return result;
             } else {
                 /*
@@ -725,10 +729,10 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Read the runtime deployment descriptors (can contained in one or
-     * many file) set the corresponding information in the passed descriptor.
-     * By default, the runtime deployment descriptors are all contained in
-     * the xml file characterized with the path returned by
+     * Read the runtime deployment descriptors (can contained in one or many
+     * file) set the corresponding information in the passed descriptor. By
+     * default, the runtime deployment descriptors are all contained in the xml
+     * file characterized with the path returned by
      *
      * @param archive the archive
      * @param descriptor the initialized deployment descriptor
@@ -740,14 +744,15 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Read the runtime deployment descriptors (can contained in one or
-     * many file) set the corresponding information in the passed descriptor.
-     * By default, the runtime deployment descriptors are all contained in
-     * the xml file characterized with the path returned by
+     * Read the runtime deployment descriptors (can contained in one or many
+     * file) set the corresponding information in the passed descriptor. By
+     * default, the runtime deployment descriptors are all contained in the xml
+     * file characterized with the path returned by
      *
      * @param archive the archive
      * @param descriptor the initialized deployment descriptor
-     * @param warnIfMultipleDDs whether to log warnings if both the GlassFish and the legacy Sun descriptors are present
+     * @param warnIfMultipleDDs whether to log warnings if both the GlassFish
+     * and the legacy Sun descriptors are present
      * @link getRuntimeDeploymentDescriptorPath
      */
     public void readRuntimeDeploymentDescriptor(ReadableArchive archive, T descriptor,
@@ -801,9 +806,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
         WritableArchive out = null;
         BufferedOutputStream bos = null;
         try {
-            File outputFile=null;
-            if (oldArchive != null && oldArchive.exists() &&
-                    !(oldArchive instanceof WritableArchive)) {
+            File outputFile = null;
+            if (oldArchive != null && oldArchive.exists()
+                    && !(oldArchive instanceof WritableArchive)) {
                 // this is a rewrite, get a temp file name...
                 // I am creating a tmp file just to get a name
                 outputFile = getTempFile(outPath);
@@ -857,7 +862,6 @@ public abstract class Archivist<T extends BundleDescriptor> {
         in.close();
     }
 
-
     /**
      * writes the content of an archive to another archive
      *
@@ -869,11 +873,10 @@ public abstract class Archivist<T extends BundleDescriptor> {
         writeContents(in, out, null);
     }
 
-
     /**
      * writes the content of an archive to a JarFile
      *
-     * @param in input  archive
+     * @param in  input archive
      * @param out archive output stream to write to
      * @param entriesToSkip files to not write from the original archive
      */
@@ -902,8 +905,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * writes the deployment descriptors (standard and runtime)
-     * to a JarFile using the right deployment descriptor path
+     * writes the deployment descriptors (standard and runtime) to a JarFile
+     * using the right deployment descriptor path
      *
      * @param in the input archive
      * @param out the abstract archive file to write to
@@ -949,14 +952,14 @@ public abstract class Archivist<T extends BundleDescriptor> {
         // files out (revisit this to see what is the desired behavior 
         // here, write out all, or write out the highest precedence one, 
         // or not write out)
-        List<ConfigurationDeploymentDescriptorFile> confDDFilesToWrite = getSortedConfigurationDDFiles(in); 
+        List<ConfigurationDeploymentDescriptorFile> confDDFilesToWrite = getSortedConfigurationDDFiles(in);
         if (confDDFilesToWrite.isEmpty()) {
             confDDFilesToWrite = getConfigurationDDFiles();
         }
         for (ConfigurationDeploymentDescriptorFile ddFile : confDDFilesToWrite) {
             ddFile.setArchiveType(getModuleType());
             OutputStream os = out.putNextEntry(
-                ddFile.getDeploymentDescriptorPath());
+                    ddFile.getDeploymentDescriptorPath());
             ddFile.write(desc, os);
             out.closeEntry();
         }
@@ -964,6 +967,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
     /**
      * Write extension descriptors
+     *
      * @param in the input archive
      * @param out the output archive
      */
@@ -990,16 +994,16 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * @return the location of the DeploymentDescriptor file for a
-     *         particular type of J2EE Archive
+     * @return the location of the DeploymentDescriptor file for a particular
+     * type of J2EE Archive
      */
     public String getDeploymentDescriptorPath() {
         return getStandardDDFile().getDeploymentDescriptorPath();
     }
 
     /**
-     * @return the location of the runtime deployment descriptor file
-     *         for a particular type of J2EE Archive
+     * @return the location of the runtime deployment descriptor file for a
+     * particular type of J2EE Archive
      */
     public String getRuntimeDeploymentDescriptorPath(ReadableArchive archive) throws IOException {
         DeploymentDescriptorFile ddFile = getConfigurationDDFile(archive);
@@ -1011,9 +1015,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Archivists can be associated with a module descriptor once the
-     * XML deployment descriptors have been read and the DOL tree
-     * is initialized.
+     * Archivists can be associated with a module descriptor once the XML
+     * deployment descriptors have been read and the DOL tree is initialized.
      */
     public void setModuleDescriptor(ModuleDescriptor<T> module) {
         setDescriptor(module.getDescriptor());
@@ -1034,18 +1037,13 @@ public abstract class Archivist<T extends BundleDescriptor> {
         Vector<String> libs = getLibraries(archive);
         if (libs != null) {
             for (String libUri : libs) {
-                JarInputStream jis = null;
-                try {
-                    jis = new JarInputStream(archive.getEntry(libUri));
+                try (JarInputStream jis = new JarInputStream(archive.getEntry(libUri))) {
                     m = jis.getManifest();
                     if (m != null) {
                         if (!InstalledLibrariesResolver.resolveDependencies(m, libUri)) {
                             dependenciesSatisfied = false;
                         }
                     }
-                } finally {
-                    if (jis != null)
-                        jis.close();
                 }
             }
         }
@@ -1053,32 +1051,32 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * @return the  module type handled by this archivist
-     *         as defined in the application DTD/Schema
-     */              
+     * @return the module type handled by this archivist as defined in the
+     * application DTD/Schema
+     */
     public abstract ArchiveType getModuleType();
 
     /**
-     * @return the DeploymentDescriptorFile responsible for handling
-     *         standard deployment descriptor
+     * @return the DeploymentDescriptorFile responsible for handling standard
+     * deployment descriptor
      */
     public abstract DeploymentDescriptorFile<T> getStandardDDFile();
 
     /**
-     * @return the list of the DeploymentDescriptorFile responsible for
-     *         handling the configuration deployment descriptors
+     * @return the list of the DeploymentDescriptorFile responsible for handling
+     * the configuration deployment descriptors
      */
     public abstract List<ConfigurationDeploymentDescriptorFile> getConfigurationDDFiles();
 
     /**
-     * @return if exists the DeploymentDescriptorFile responsible for
-     *         handling the configuration deployment descriptors
+     * @return if exists the DeploymentDescriptorFile responsible for handling
+     * the configuration deployment descriptors
      */
     private ConfigurationDeploymentDescriptorFile getConfigurationDDFile(ReadableArchive archive) throws IOException {
         if (confDD == null) {
             getSortedConfigurationDDFiles(archive);
             if (sortedConfDDFiles != null && !sortedConfDDFiles.isEmpty()) {
-               confDD = sortedConfDDFiles.get(0);
+                confDD = sortedConfDDFiles.get(0);
             }
         }
         return confDD;
@@ -1096,7 +1094,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
     /**
      * Returns true if this archivist is capable of handling the archive type
-     *  Here we check for the existence of the deployment descriptors
+     * Here we check for the existence of the deployment descriptors
+     *
      * @return true if the archivist is handling the provided archive
      */
     protected abstract boolean postHandles(ReadableArchive archive) throws IOException;
@@ -1115,7 +1114,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
             throws IOException {
 
         //check null: since .par archive does not have runtime dds
-        getConfigurationDDFile(archive); 
+        getConfigurationDDFile(archive);
 
         if (confDD != null) {
             return true;
@@ -1134,8 +1133,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     public boolean handles(ReadableArchive archive) {
         try {
             //first, check the existence of any deployment descriptors
-            if (hasStandardDeploymentDescriptor(archive) ||
-                    hasRuntimeDeploymentDescriptor(archive)) {
+            if (hasStandardDeploymentDescriptor(archive)
+                    || hasRuntimeDeploymentDescriptor(archive)) {
                 return true;
             }
 
@@ -1171,7 +1170,6 @@ public abstract class Archivist<T extends BundleDescriptor> {
         setDescriptor(descriptor);
         return newModule;
     }
-
 
     /**
      * print the current descriptor associated with this archivist
@@ -1265,8 +1263,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * @return the class-path as set in the manifest associated
-     *         with the archive
+     * @return the class-path as set in the manifest associated with the archive
      */
     public String getClassPath() {
 
@@ -1284,8 +1281,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
     public Vector getLibraries(Archive archive) {
 
         Enumeration<String> entries = archive.entries();
-        if (entries == null)
+        if (entries == null) {
             return null;
+        }
 
         Vector libs = new Vector();
         while (entries.hasMoreElements()) {
@@ -1302,7 +1300,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * @returns an entry name unique amongst names in this archive based on the triel name.
+     * @returns an entry name unique amongst names in this archive based on the
+     * trial name.
      */
     protected String getUniqueEntryFilenameFor(Archive archive, String trialName) throws IOException {
         Vector entriesNames = new Vector();
@@ -1314,11 +1313,11 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * utility method to get a tmp file in the current user directory of the provided
-     * directory
+     * utility method to get a tmp file in the current user directory of the
+     * provided directory
      *
-     * @param fileOrDirPath path to a file or directory to use as temp location (use parent directory
-     *             if a file is provided)
+     * @param fileOrDirPath path to a file or directory to use as temp location
+     * (use parent directory if a file is provided)
      */
     protected static File getTempFile(String fileOrDirPath) throws IOException {
         if (fileOrDirPath != null) {
@@ -1330,7 +1329,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
     /**
      * @return the list of files that should not be copied from the old archive
-     *         when a save is performed.
+     * when a save is performed.
      */
     public Vector getListOfFilesToSkip(ReadableArchive archive) throws IOException {
 
@@ -1352,15 +1351,15 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * utility method to get a tmp file in the current user directory of the provided
-     * directory
+     * Utility method to get a tmp file in the current user directory of the
+     * provided directory
      *
-     * @param fileOrDir file or directory to use as temp location (use parent directory
-     *             if a file is provided)
+     * @param fileOrDir file or directory to use as temp location (use parent
+     * directory if a file is provided)
      */
     protected static File getTempFile(File fileOrDir) throws IOException {
 
-        File dir = null;
+        File dir;
         if (fileOrDir == null) {
             dir = new File(System.getProperty("user.dir"));
         } else {
@@ -1382,20 +1381,22 @@ public abstract class Archivist<T extends BundleDescriptor> {
      * @param archive abstraction to use when adding the file
      * @param filePath to the file to add
      * @param entryName the entry name in the archive
+     * @throws java.io.IOException
      */
     protected static void addFileToArchive(WritableArchive archive, String filePath, String entryName)
             throws IOException {
 
         FileInputStream is = null;
         try {
-            is =  new FileInputStream(new File(filePath));
+            is = new FileInputStream(new File(filePath));
             OutputStream os = archive.putNextEntry(entryName);
             ArchivistUtils.copyWithoutClose(is, os);
         } finally {
             try {
-                if (is!=null)
+                if (is != null) {
                     is.close();
-            } catch(IOException e) {
+                }
+            } catch (IOException e) {
                 archive.closeEntry();
                 throw e;
             }
@@ -1404,8 +1405,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * copy all contents of a jar file to a new jar file except
-     * for all the deployment descriptors files
+     * copy all contents of a jar file to a new jar file except for all the
+     * deployment descriptors files
      *
      * @param in  jar file
      * @param out jar file
@@ -1421,9 +1422,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
                 if (ignoreList == null || !ignoreList.contains(anEntry)) {
                     InputStream is = in.getEntry(anEntry);
                     if (is != null) {
-                      OutputStream os = out.putNextEntry(anEntry);
-                      ArchivistUtils.copyWithoutClose(is, os);
-                      is.close();
+                        OutputStream os = out.putNextEntry(anEntry);
+                        ArchivistUtils.copyWithoutClose(is, os);
+                        is.close();
                     }
                     out.closeEntry();
                 }
@@ -1482,8 +1483,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Turn on or off the XML Validation for all standard deployment
-     * descriptors loading
+     * Turn on or off the XML Validation for all standard deployment descriptors
+     * loading
      *
      * @param validate set to true to turn on XML validation
      */
@@ -1492,8 +1493,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * @return true if the Deployment Descriptors XML will be validated
-     *         while reading.
+     * @return true if the Deployment Descriptors XML will be validated while
+     * reading.
      */
     public boolean getXMLValidation() {
         return isValidatingXML;
@@ -1510,8 +1511,7 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * @return true if the runtime XML will be validated
-     *         while reading.
+     * @return true if the runtime XML will be validated while reading.
      */
     public boolean getRuntimeXMLValidation() {
         return isValidatingRuntimeXML;
@@ -1569,11 +1569,11 @@ public abstract class Archivist<T extends BundleDescriptor> {
         bundleDesc.visit(postVisitor);
     }
 
-
     /**
      * Copy this archivist to a new abstract archive
      *
      * @param target the new archive to use to copy our contents into
+     * @throws java.io.IOException
      */
     public void copyInto(WritableArchive target) throws IOException {
         ReadableArchive source = archiveFactory.openArchive(new File(path));
@@ -1581,9 +1581,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Copy source archivist to a target abstract archive.  By default,
-     * every entry in source archive will be copied to the target archive,
-     * including the manifest of the source archive.
+     * Copy source archivist to a target abstract archive. By default, every
+     * entry in source archive will be copied to the target archive, including
+     * the manifest of the source archive.
      *
      * @param source        the source archive to copy from
      * @param target        the target archive to copy to
@@ -1606,12 +1606,13 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     /**
-     * Copy source archivist to a target abstract archive.  By default, the manifest
-     * in source archive overwrites the one in target archive.
+     * Copy source archivist to a target abstract archive. By default, the
+     * manifest in source archive overwrites the one in target archive.
      *
      * @param source        the source archive to copy from
      * @param target        the target archive to copy to
      * @param entriesToSkip the entries that will be skipped by target archive
+     * @throws              java.io.IOException
      */
     public void copyInto(ReadableArchive source, WritableArchive target, Vector entriesToSkip)
             throws IOException {
@@ -1626,9 +1627,10 @@ public abstract class Archivist<T extends BundleDescriptor> {
      * @param entriesToSkip     the entries that will be skipped by target archive
      * @param overwriteManifest if true, the manifest in source archive
      *                          overwrites the one in target archive
+     * @throws                  java.io.IOException
      */
     public void copyInto(ReadableArchive source, WritableArchive target,
-                         Vector entriesToSkip, boolean overwriteManifest)
+            Vector entriesToSkip, boolean overwriteManifest)
             throws IOException {
 
         copyJarElements(source, target, entriesToSkip);
@@ -1644,8 +1646,8 @@ public abstract class Archivist<T extends BundleDescriptor> {
 
     // only copy the entry if the destination archive does not have this entry
     public void copyAnEntry(ReadableArchive in,
-                                   WritableArchive out, String entryName) 
-        throws IOException {
+            WritableArchive out, String entryName)
+            throws IOException {
         InputStream is = null;
         InputStream is2 = null;
         ReadableArchive in2 = archiveFactory.openArchive(out.getURI());
@@ -1672,14 +1674,14 @@ public abstract class Archivist<T extends BundleDescriptor> {
     }
 
     public void copyStandardDeploymentDescriptors(ReadableArchive in,
-                                                  WritableArchive out) throws IOException {
+            WritableArchive out) throws IOException {
         String entryName = getDeploymentDescriptorPath();
         copyAnEntry(in, out, entryName);
     }
 
     // copy wsdl and mapping files etc 
     public void copyExtraElements(ReadableArchive in,
-                                         WritableArchive out) throws IOException {
+            WritableArchive out) throws IOException {
         Enumeration entries = in.entries();
         if (entries != null) {
             for (; entries.hasMoreElements();) {
@@ -1691,9 +1693,9 @@ public abstract class Archivist<T extends BundleDescriptor> {
                     // see Integration Notice #80587
                     continue;
                 }
-                if (anEntry.indexOf(WSDL) != -1 ||
-                        anEntry.indexOf(XML) != -1 ||
-                        anEntry.indexOf(XSD) != -1) {
+                if (anEntry.contains(WSDL)
+                        || anEntry.contains(XML)
+                        || anEntry.contains(XSD)) {
                     copyAnEntry(in, out, anEntry);
                 }
             }

--- a/appserver/web/war-util/pom.xml
+++ b/appserver/web/war-util/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -118,6 +118,11 @@
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.core</groupId>
+            <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>
    </dependencies>

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -598,7 +598,7 @@ public class WebappClassLoader
     }
 
     @Override
-    public Class addResourceEntry(String name, ResourceEntry entry) {
+    public Class addResourceEntry(String name, String path, ResourceEntry entry) {
         Class clazz = null;
         if (!this.resourceEntries.containsKey(name)) {
             definePackage(name, entry);
@@ -616,6 +616,37 @@ public class WebappClassLoader
             }
         }
         return clazz;
+    }
+
+    @Override
+    public Class reloadResourceEntry(String name, String path, ResourceEntry entry) {
+        try {
+            InputStream binaryStream = null;
+            Resource resource = null;
+            Object lookupResult = resources.lookup(path);
+            if (lookupResult instanceof Resource) {
+                resource = (Resource) lookupResult;
+            }
+
+            ResourceAttributes attributes
+                    = (ResourceAttributes) resources.getAttributes(path);
+            int contentLength = (int) attributes.getContentLength();
+            entry.lastModified = attributes.getLastModified();
+
+            if (resource != null) {
+                try {
+                    binaryStream = resource.streamContent();
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+            readEntryData(entry, name, binaryStream, contentLength, null);
+
+            return loadClass(name);
+        } catch (NamingException | ClassNotFoundException ex) {
+            logger.log(Level.SEVERE, null, ex);
+        }
+        return null;
     }
 
     @Override

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -64,6 +64,7 @@ import com.sun.appserv.ClassLoaderUtil;
 import com.sun.appserv.server.util.PreprocessorUtil;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.util.DOLUtils;
+import com.sun.enterprise.glassfish.bootstrap.MainHelper.HotSwapHelper;
 import com.sun.enterprise.security.integration.DDPermissionsLoader;
 import com.sun.enterprise.security.integration.PermsHolder;
 import com.sun.enterprise.util.JDK;
@@ -2049,6 +2050,8 @@ public class WebappClassLoader
             }
 
             DirContextURLStreamHandler.unbind(this);
+
+            HotSwapHelper.closeClassLoader(this);
         }
     }
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/TomcatDeploymentConfig.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/TomcatDeploymentConfig.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -373,75 +374,10 @@ public class TomcatDeploymentConfig {
      */
     protected static void configureStandardContext(WebModule webModule,
                                                    WebBundleDescriptorImpl wmd) {
-        StandardWrapper wrapper;    
-        Enumeration enumeration;
-        SecurityRoleReference securityRoleReference;
-       
+
         for (WebComponentDescriptor webComponentDesc :
                 wmd.getWebComponentDescriptors()) {
-
-            if (!webComponentDesc.isEnabled()) {
-                continue;
-            }
-
-            wrapper = (StandardWrapper)webModule.createWrapper();
-            wrapper.setName(webComponentDesc.getCanonicalName());
-
-            String impl = webComponentDesc.getWebComponentImplementation();
-            if (impl != null && !impl.isEmpty()) {
-                if (webComponentDesc.isServlet()){
-                    wrapper.setServletClassName(impl);
-                } else {
-                    wrapper.setJspFile(impl);
-                }
-            }
-
-            /*
-             * Add the wrapper only after we have set its 
-             * servletClassName, so we know whether we're dealing with
-             * a JSF app
-             */
-            webModule.addChild(wrapper);
-
-            enumeration = webComponentDesc.getInitializationParameters();
-            InitializationParameter initP = null;
-            while (enumeration.hasMoreElements()) {
-                initP = (InitializationParameter)enumeration.nextElement();
-                wrapper.addInitParameter(initP.getName(), initP.getValue());
-            }
-
-            if (webComponentDesc.getLoadOnStartUp() != null) {
-                wrapper.setLoadOnStartup(webComponentDesc.getLoadOnStartUp());
-            }
-            if (webComponentDesc.isAsyncSupported() != null) {
-                wrapper.setIsAsyncSupported(webComponentDesc.isAsyncSupported());
-            }
-
-            if (webComponentDesc.getRunAsIdentity() != null) {
-                wrapper.setRunAs(webComponentDesc.getRunAsIdentity().getRoleName());
-            }
-
-            for (String pattern : webComponentDesc.getUrlPatternsSet()) {
-                webModule.addServletMapping(pattern,
-                    webComponentDesc.getCanonicalName());
-            }
-
-            enumeration = webComponentDesc.getSecurityRoleReferences();
-            while (enumeration.hasMoreElements()){
-                securityRoleReference = (SecurityRoleReference)
-                    enumeration.nextElement();
-                wrapper.addSecurityReference(
-                    securityRoleReference.getRoleName(),
-                    securityRoleReference.getSecurityRoleLink().getName());
-            }
-
-            MultipartConfig mpConfig = webComponentDesc.getMultipartConfig();
-            if (mpConfig != null) {
-                wrapper.setMultipartLocation(mpConfig.getLocation());
-                wrapper.setMultipartMaxFileSize(mpConfig.getMaxFileSize());
-                wrapper.setMultipartMaxRequestSize(mpConfig.getMaxRequestSize());
-                wrapper.setMultipartFileSizeThreshold(mpConfig.getFileSizeThreshold());
-            }
+            addWebComponentDescriptor(webModule, webComponentDesc);
         }
        
         SessionConfig sessionConfig = wmd.getSessionConfig();
@@ -514,7 +450,7 @@ public class TomcatDeploymentConfig {
             }
         }
 
-        enumeration = wmd.getWelcomeFiles();
+        Enumeration enumeration = wmd.getWelcomeFiles();
         while (enumeration.hasMoreElements()){
             webModule.addWelcomeFile((String)enumeration.nextElement());
         }
@@ -541,7 +477,74 @@ public class TomcatDeploymentConfig {
             Integer.parseInt(majorMinorVersions[1]));
     }
 
-    
+    private static StandardWrapper addWebComponentDescriptor(
+            WebModule webModule,
+            WebComponentDescriptor webComponentDesc) {
+
+        if (!webComponentDesc.isEnabled()) {
+            return null;
+        }
+
+        StandardWrapper wrapper = (StandardWrapper) webModule.createWrapper();
+        wrapper.setName(webComponentDesc.getCanonicalName());
+
+        String impl = webComponentDesc.getWebComponentImplementation();
+        if (impl != null && !impl.isEmpty()) {
+            if (webComponentDesc.isServlet()) {
+                wrapper.setServletClassName(impl);
+            } else {
+                wrapper.setJspFile(impl);
+            }
+        }
+
+        /*
+             * Add the wrapper only after we have set its 
+             * servletClassName, so we know whether we're dealing with
+             * a JSF app
+         */
+        webModule.addChild(wrapper);
+
+        Enumeration enumeration = webComponentDesc.getInitializationParameters();
+        InitializationParameter initP = null;
+        while (enumeration.hasMoreElements()) {
+            initP = (InitializationParameter) enumeration.nextElement();
+            wrapper.addInitParameter(initP.getName(), initP.getValue());
+        }
+
+        if (webComponentDesc.getLoadOnStartUp() != null) {
+            wrapper.setLoadOnStartup(webComponentDesc.getLoadOnStartUp());
+        }
+        if (webComponentDesc.isAsyncSupported() != null) {
+            wrapper.setIsAsyncSupported(webComponentDesc.isAsyncSupported());
+        }
+
+        if (webComponentDesc.getRunAsIdentity() != null) {
+            wrapper.setRunAs(webComponentDesc.getRunAsIdentity().getRoleName());
+        }
+        
+        for (String pattern : webComponentDesc.getUrlPatternsSet()) {
+            webModule.addServletMapping(pattern,
+                    webComponentDesc.getCanonicalName());
+        }
+
+        enumeration = webComponentDesc.getSecurityRoleReferences();
+        while (enumeration.hasMoreElements()) {
+            SecurityRoleReference securityRoleReference = (SecurityRoleReference) enumeration.nextElement();
+            wrapper.addSecurityReference(
+                    securityRoleReference.getRoleName(),
+                    securityRoleReference.getSecurityRoleLink().getName());
+        }
+
+        MultipartConfig mpConfig = webComponentDesc.getMultipartConfig();
+        if (mpConfig != null) {
+            wrapper.setMultipartLocation(mpConfig.getLocation());
+            wrapper.setMultipartMaxFileSize(mpConfig.getMaxFileSize());
+            wrapper.setMultipartMaxRequestSize(mpConfig.getMaxRequestSize());
+            wrapper.setMultipartFileSizeThreshold(mpConfig.getFileSizeThreshold());
+        }
+        return wrapper;
+    }
+
     /**
      * Configure security constraint element for a web application,
      * as represented by a <code>&lt;security-constraint&gt;</code> element in 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebApplication.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebApplication.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2020-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -61,7 +61,6 @@ import org.glassfish.web.deployment.descriptor.WebBundleDescriptorImpl;
 import org.glassfish.web.deployment.runtime.SessionManager;
 import org.glassfish.web.deployment.runtime.SunWebAppImpl;
 
-import java.lang.String;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.*;
@@ -76,7 +75,7 @@ public class WebApplication implements ApplicationContainer<WebBundleDescriptorI
 
     private final WebContainer container;
     private final WebModuleConfig wmInfo;
-    private Set<WebModule> webModules = new HashSet<WebModule>();
+    private final Set<WebModule> webModules = new HashSet<WebModule>();
     private final org.glassfish.web.config.serverbeans.WebModuleConfig appConfigCustomizations;
 
     public WebApplication(WebContainer container, WebModuleConfig config, 
@@ -171,6 +170,12 @@ public class WebApplication implements ApplicationContainer<WebBundleDescriptorI
 
         stopCoherenceWeb();
 
+        return true;
+    }
+
+    @Override
+    public boolean reload(ApplicationContext context) throws Exception {
+        webModules.forEach(WebModule::reload);
         return true;
     }
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebDeployer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -45,7 +45,6 @@ import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.ServerTags;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.util.StringUtils;
-import fish.payara.nucleus.hotdeploy.HotDeployService;
 import org.glassfish.api.container.RequestDispatcher;
 import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
@@ -67,7 +66,6 @@ import java.text.MessageFormat;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.glassfish.deployment.common.DeploymentProperties;
 
 /**
  * Web module deployer.
@@ -90,9 +88,6 @@ public class WebDeployer extends JavaEEDeployer<WebContainer, WebApplication>{
 
     @Inject
     RequestDispatcher dispatcher;
-
-    @Inject
-    private HotDeployService hotDeployService;
 
     /**
      * Constructor

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModuleContextConfig.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModuleContextConfig.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -222,7 +223,7 @@ public class WebModuleContextConfig extends ContextConfig {
 
                 // If .war contains EJBs, .war-defined dependencies have already been bound by
                 // EjbDeployer, so just add the dependencies from outside the .war
-                if( webBundleContainsEjbs ) {
+                if( webBundleContainsEjbs && !((WebModule) context).getPaused()) {
                     namingMgr.addToComponentNamespace(webBundleDescriptor, envProps, resRefs);
                 } else {
                     namingMgr.bindToComponentNamespace(webBundleDescriptor);

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -883,7 +883,7 @@ public abstract class GFLauncher {
         Optional<JDK.Version> jdkVersion = getConfiguredJdkVersion(javaExe);
         List<String> rawJvmOptions = parser.getJvmOptions()
                 .stream()
-                .filter(fullOption -> JDK.isCorrectJDK(jdkVersion, fullOption.vendor, fullOption.minVersion, fullOption.maxVersion))
+                .filter(fullOption -> JDK.isCorrectJDK(jdkVersion, fullOption.vendorOrVM, fullOption.minVersion, fullOption.maxVersion))
                 .map(option -> option.option)
                 .collect(Collectors.toList());
         rawJvmOptions.addAll(getSpecialSystemProperties());

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
@@ -263,8 +263,8 @@ public abstract class CollectionLeafResource extends AbstractResource {
     
     private Map<String, String> optionToMap(JvmOption option){
         Map<String, String> baseMap = new HashMap<>();        
-        if (option.vendor.isPresent()) {
-            baseMap.put(MIN_VERSION, option.vendor.get() + "-" + option.minVersion.map(JDK.Version::toString).orElse(""));
+        if (option.vendorOrVM.isPresent()) {
+            baseMap.put(MIN_VERSION, option.vendorOrVM.get() + "-" + option.minVersion.map(JDK.Version::toString).orElse(""));
         } else {
             baseMap.put(MIN_VERSION, option.minVersion.map(JDK.Version::toString).orElse(""));
         }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/xml/MiniXmlParser.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/xml/MiniXmlParser.java
@@ -250,7 +250,7 @@ public class MiniXmlParser {
 
     public static class JvmOption {
         public final String option;
-        public final Optional<String> vendor;
+        public final Optional<String> vendorOrVM;
         public final Optional<JDK.Version> minVersion;
         public final Optional<JDK.Version> maxVersion;
 
@@ -269,10 +269,10 @@ public class MiniXmlParser {
             if (matcher.matches()) {
                 if (matcher.group(1).contains("-")) {
                     String[] parts = matcher.group(1).split("-");
-                    this.vendor = Optional.ofNullable(parts[0]);
+                    this.vendorOrVM = Optional.ofNullable(parts[0]);
                     this.minVersion = Optional.ofNullable(JDK.getVersion(parts[1]));
                 } else {
-                    this.vendor = Optional.empty();
+                    this.vendorOrVM = Optional.empty();
                     this.minVersion = Optional.ofNullable(JDK.getVersion(matcher.group(1)));
                 }
 
@@ -280,7 +280,7 @@ public class MiniXmlParser {
                 this.option = matcher.group(3);
             } else {
                 this.option = option;
-                this.vendor = Optional.empty();
+                this.vendorOrVM = Optional.empty();
                 this.minVersion = Optional.empty();
                 this.maxVersion = Optional.empty();
             }
@@ -290,10 +290,10 @@ public class MiniXmlParser {
             this.option = option;
             if (minVersion != null && minVersion.contains("-")) {
                 String[] parts = minVersion.split("-");
-                this.vendor = Optional.ofNullable(parts[0]);
+                this.vendorOrVM = Optional.ofNullable(parts[0]);
                 this.minVersion = Optional.ofNullable(JDK.getVersion(parts[1]));
             } else {
-                this.vendor = Optional.empty();
+                this.vendorOrVM = Optional.empty();
                 this.minVersion = Optional.ofNullable(JDK.getVersion(minVersion));
             }
             this.maxVersion = Optional.ofNullable(JDK.getVersion(maxVersion));
@@ -330,7 +330,7 @@ public class MiniXmlParser {
             if (!minVersion.isPresent() && !maxVersion.isPresent()) {
                 return option;
             }
-            return String.format("[%s%s|%s]%s", vendor.isPresent() ? vendor.get() + "-" : "" ,minVersion.isPresent() ? minVersion.get() : "",
+            return String.format("[%s%s|%s]%s", vendorOrVM.isPresent() ? vendorOrVM.get() + "-" : "" ,minVersion.isPresent() ? minVersion.get() : "",
                     maxVersion.isPresent() ? maxVersion.get() : "", option);
         }
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
@@ -110,7 +110,6 @@ public final class JDK {
     }
 
     public static class Version {
-        private final Optional<String> vendorOrVM;
         private final int major;
         private final Optional<Integer> minor;
         private final Optional<Integer> subminor;
@@ -124,10 +123,7 @@ public final class JDK {
 
             if (version.contains("-")) {
                 String[] versionSplit = version.split("-");
-                vendorOrVM = versionSplit.length > 0 ? Optional.of(versionSplit[0]) : Optional.empty();
                 version = versionSplit.length > 1 ? versionSplit[1] : "";
-            } else {
-                vendorOrVM = Optional.empty();
             }
             String[] split = version.split("[\\._u\\-]+");
 
@@ -138,7 +134,6 @@ public final class JDK {
         }
 
         private Version() {
-            vendorOrVM = Optional.of(JDK.vendor + JDK.vm);
             major = JDK.major;
             minor = Optional.of(JDK.minor);
             subminor = Optional.of(JDK.subminor);

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.util;
 
@@ -105,8 +105,12 @@ public final class JDK {
         return vendor;
     }
 
+    public static String getVm() {
+        return vm;
+    }
+
     public static class Version {
-        private final Optional<String> vendor;
+        private final Optional<String> vendorOrVM;
         private final int major;
         private final Optional<Integer> minor;
         private final Optional<Integer> subminor;
@@ -120,10 +124,10 @@ public final class JDK {
 
             if (version.contains("-")) {
                 String[] versionSplit = version.split("-");
-                vendor = versionSplit.length > 0 ? Optional.of(versionSplit[0]) : Optional.empty();
+                vendorOrVM = versionSplit.length > 0 ? Optional.of(versionSplit[0]) : Optional.empty();
                 version = versionSplit.length > 1 ? versionSplit[1] : "";
             } else {
-                vendor = Optional.empty();
+                vendorOrVM = Optional.empty();
             }
             String[] split = version.split("[\\._u\\-]+");
 
@@ -134,7 +138,7 @@ public final class JDK {
         }
 
         private Version() {
-            vendor = Optional.of(JDK.vendor);
+            vendorOrVM = Optional.of(JDK.vendor + JDK.vm);
             major = JDK.major;
             minor = Optional.of(JDK.minor);
             subminor = Optional.of(JDK.subminor);
@@ -291,17 +295,17 @@ public final class JDK {
      * Check if the reference version falls between the minVersion and maxVersion.
      *
      * @param reference The version to compare; falls back to the current JDK version if empty.
-     * @param vendor The inclusive JDK vendor.
+     * @param vendorOrVM The inclusive JDK vendor or VM name.
      * @param minVersion The inclusive minimum version.
      * @param maxVersion The inclusive maximum version.
      * @return true if within the version range, false otherwise
      */
-    public static boolean isCorrectJDK(Optional<Version> reference, Optional<String> vendor, Optional<Version> minVersion, Optional<Version> maxVersion) {
+    public static boolean isCorrectJDK(Optional<Version> reference, Optional<String> vendorOrVM, Optional<Version> minVersion, Optional<Version> maxVersion) {
         Version version = reference.orElse(JDK_VERSION);
         boolean correctJDK = true;
 
-        if (vendor.isPresent()) {
-            correctJDK = JDK.vendor.contains(vendor.get());
+        if (vendorOrVM.isPresent()) {
+            correctJDK = JDK.vendor.contains(vendorOrVM.get()) || JDK.vm.contains(vendorOrVM.get());
         }
 
         if (correctJDK && minVersion.isPresent()) {
@@ -337,6 +341,7 @@ public final class JDK {
     private static int subminor;
     private static int update;
     private static String vendor;
+    private static String vm;
     private static Version JDK_VERSION;
 
     // silently fall back to ridiculous defaults if something is crazily wrong...
@@ -346,6 +351,8 @@ public final class JDK {
         try {
             String javaVersion = System.getProperty("java.version");
             vendor = System.getProperty("java.vendor");
+            vm = System.getProperty("java.vm.name");
+
             /*In JEP 223 java.specification.version will be a single number versioning , not a dotted versioning . So if we get a single
             integer as versioning we know that the JDK is post JEP 223
             For JDK 8:

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/ApplicationContainer.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/ApplicationContainer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.api.deployment;
 
@@ -77,6 +77,17 @@ public interface ApplicationContainer<T> {
     public boolean start(ApplicationContext startupContext) throws Exception;
     
     /**
+     * Reloads an application container. 
+     * @param context the context 
+     * @return true if the container reload was successful.
+     *
+     * @throws Exception if this application container could not be reloaded
+     */
+    default boolean reload(ApplicationContext context) throws Exception {
+        return true;
+    }
+
+    /*
      * Stop the application container
      * @return true if stopping was successful.
      * @param stopContext

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/ResourceClassLoader.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/ResourceClassLoader.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -56,7 +56,9 @@ public interface ResourceClassLoader {
 
     ConcurrentHashMap<String, ResourceEntry> getResourceEntries();
 
-    Class addResourceEntry(String name, ResourceEntry entry);
+    Class addResourceEntry(String name, String path, ResourceEntry entry);
+    
+    Class reloadResourceEntry(String name, String path, ResourceEntry entry);
 
     Class addGeneratedResourceEntry(
             String mainClass,

--- a/nucleus/common/internal-api/pom.xml
+++ b/nucleus/common/internal-api/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -149,6 +149,11 @@
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.core</groupId>
+            <artifactId>glassfish</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/common/internal-api/src/main/java/fish/payara/nucleus/hotdeploy/ApplicationState.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/nucleus/hotdeploy/ApplicationState.java
@@ -54,7 +54,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -128,19 +127,14 @@ public class ApplicationState {
     private static final String JAVA_EXT = ".java";
     private static final String WEB_INF_CLASSES = "WEB-INF/classes";
 
-    private final static String HOTSWAP_PLUGIN_MANAGER = "org.hotswap.agent.config.PluginManager";
-    private final static String HOTSWAP_VM_KEY = "java.vm.name";
-    private final static String HOTSWAP_VM_VALUE = "Dynamic Code Evolution";
-
     private static final Logger LOG = Logger.getLogger(ApplicationState.class.getName());
     private static final ServiceLocator habitat = Globals.getDefaultHabitat();
-    private Object hotswapManager = null;
 
     public ApplicationState(String name, File path, ExtendedDeploymentContext deploymentContext) {
         this.name = name;
         this.path = path;
         this.deploymentContext = deploymentContext;
-        hotswap = System.getProperty(HOTSWAP_VM_KEY).contains(HOTSWAP_VM_VALUE);
+        hotswap = HotSwapHelper.isHotswapEnabled();
     }
 
     public File getPath() {

--- a/nucleus/common/internal-api/src/main/java/fish/payara/nucleus/hotdeploy/ApplicationState.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/nucleus/hotdeploy/ApplicationState.java
@@ -127,7 +127,6 @@ public class ApplicationState {
     private static final String JAVA_EXT = ".java";
     private static final String WEB_INF_CLASSES = "WEB-INF/classes";
 
-    private static final Logger LOG = Logger.getLogger(ApplicationState.class.getName());
     private static final ServiceLocator habitat = Globals.getDefaultHabitat();
 
     public ApplicationState(String name, File path, ExtendedDeploymentContext deploymentContext) {

--- a/nucleus/common/internal-api/src/main/java/fish/payara/nucleus/hotdeploy/HotDeployService.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/nucleus/hotdeploy/HotDeployService.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.WeakHashMap;
 import javax.inject.Singleton;
+import org.glassfish.api.deployment.ApplicationContext;
 import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.jvnet.hk2.annotations.Service;
@@ -70,6 +71,14 @@ public class HotDeployService {
     public Optional<ApplicationState> getApplicationState(boolean hotdeploy, File path) {
         if (hotdeploy) {
             return getApplicationState(path);
+        } else {
+            return Optional.empty();
+        }
+    }
+    
+    public Optional<ApplicationState> getApplicationState(ApplicationContext context) {
+        if (context instanceof DeploymentContext) {
+            return getApplicationState((DeploymentContext) context);
         } else {
             return Optional.empty();
         }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationInfo.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationInfo.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.data;
 
@@ -45,7 +45,6 @@ import com.sun.enterprise.config.serverbeans.Application;
 import com.sun.enterprise.config.serverbeans.Engine;
 import com.sun.enterprise.config.serverbeans.Module;
 import java.beans.PropertyVetoException;
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
@@ -62,7 +61,6 @@ import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.bootstrap.DescriptorFileFinder;
 import org.glassfish.hk2.bootstrap.HK2Populator;
 import org.glassfish.hk2.bootstrap.PopulatorPostProcessor;
-import org.glassfish.hk2.classmodel.reflect.Types;
 import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.internal.deployment.DeploymentTracing;
 import org.glassfish.internal.deployment.ExtendedDeploymentContext;
@@ -370,6 +368,24 @@ public class ApplicationInfo extends ModuleInfo {
             events.send(new Event<ApplicationInfo>(Deployment.APPLICATION_STARTED, this), false);
             innerSpan.close();
         }
+    }
+
+    public void reload(
+            ExtendedDeploymentContext context,
+            ProgressTracker tracker) throws Exception {
+
+        StructuredDeploymentTracing tracing = StructuredDeploymentTracing.load(context);
+        DeploymentSpan span = tracing.startSpan(DeploymentTracing.AppStage.RELOAD);
+
+        super.reload(context, tracker);
+        // registers all deployed items.
+        for (ModuleInfo module : getModuleInfos()) {
+            DeploymentSpan innerSpan = tracing.startSpan(TraceContext.Level.MODULE, module.getName(), DeploymentTracing.AppStage.RELOAD);
+
+            module.reload(getSubContext(module, context), tracker);
+            innerSpan.close();
+        }
+
     }
 
     public void initialize() {

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/EngineRef.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/EngineRef.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.data;
 
@@ -125,6 +125,20 @@ public class EngineRef {
         }
 
         tracker.add("started", EngineRef.class, this);
+        return true;
+    }
+
+    public boolean reload(ApplicationContext context, ProgressTracker tracker)
+            throws Exception {
+
+        if (appCtr == null) {
+            return true;
+        }
+        if (!appCtr.reload(context)) {
+            return false;
+        }
+
+        tracker.add("reloaded", EngineRef.class, this);
         return true;
     }
 

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ModuleInfo.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ModuleInfo.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.data;
 
@@ -58,7 +58,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
@@ -314,7 +313,7 @@ public class ModuleInfo {
             Thread.currentThread().setContextClassLoader(currentClassLoader);
         }
     }
- 
+
     public synchronized void stop(ExtendedDeploymentContext context, Logger logger) {
 
         if (!started)
@@ -336,6 +335,42 @@ public class ModuleInfo {
             loaded = false;
             if (events!=null) {
                 events.send(new Event<ModuleInfo>(Deployment.MODULE_STOPPED, this), false);
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(currentClassLoader);
+        }
+    }
+
+    public synchronized void reload(
+        DeploymentContext context,
+        ProgressTracker tracker) throws Exception {
+
+        Logger logger = context.getLogger();
+
+        ClassLoader currentClassLoader  = 
+            Thread.currentThread().getContextClassLoader();
+        StructuredDeploymentTracing tracing = StructuredDeploymentTracing.load(context);
+        try (DeploymentSpan span = tracing.startSpan(TraceContext.Level.MODULE, getName(), DeploymentTracing.AppStage.START)) {
+            Thread.currentThread().setContextClassLoader(context.getClassLoader());
+            for (EngineRef engine : _getEngineRefs()) {
+                if (logger.isLoggable(FINE)) {
+                    logger.log(FINE, "Reloading {0}", engine.getContainerInfo().getSniffer().getModuleType());
+                }
+
+                try (DeploymentSpan innerSpan = tracing.startSpan(TraceContext.Level.CONTAINER,  engine.getContainerInfo().getSniffer().getModuleType(), DeploymentTracing.AppStage.START)){
+                    if (!engine.reload( context, tracker)) {
+                        logger.log(SEVERE, "Module not reloaded {0}", engine.getApplicationContainer().toString());
+                        throw new Exception( "Module not reloaded " +  engine.getApplicationContainer().toString());
+                    }
+                } catch(Exception e) { 
+                    DeployCommandParameters dcp = context.getCommandParameters(DeployCommandParameters.class);
+                    if(dcp.isSkipDSFailure() && ExceptionUtil.isDSFailure(e)){
+                        logger.log(WARNING, "Resource communication failure exception skipped while invoking " + engine.getApplicationContainer().getClass() + " start method", e);
+                    } else {
+                        logger.log(SEVERE, "Exception while invoking " + engine.getApplicationContainer().getClass() + " reload method", e);
+                        throw e;
+                    }
+                }
             }
         } finally {
             Thread.currentThread().setContextClassLoader(currentClassLoader);

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
@@ -173,7 +173,7 @@ public interface Deployment {
     EventTypes<ApplicationInfo> DISABLE_START = EventTypes.create("Disable_Start", ApplicationInfo.class);
 
 
-    public interface DeploymentContextBuilder {
+    interface DeploymentContextBuilder {
 
         DeploymentContextBuilder source(File source);
         DeploymentContextBuilder source(ReadableArchive archive);
@@ -193,7 +193,7 @@ public interface Deployment {
 
     }
 
-    static class ApplicationDeployment {
+    class ApplicationDeployment {
         public ApplicationDeployment(ApplicationInfo appInfo, ExtendedDeploymentContext context) {
             this.appInfo = appInfo;
             this.context = context;

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.deployment;
 
@@ -66,7 +66,9 @@ import java.io.IOException;
 import java.io.File;
 import java.util.List;
 import java.util.Collection;
+import java.util.Map;
 import java.util.logging.Logger;
+import org.glassfish.api.deployment.ApplicationMetaDataProvider;
 
 /**
  * Deployment facility
@@ -78,82 +80,82 @@ public interface Deployment {
     /**
      * This synchronous event is sent right after initial deployment context is created
      */
-    public final EventTypes<DeploymentContext> INITIAL_CONTEXT_CREATED = EventTypes.create("Initial_Context_Created", DeploymentContext.class);
+    EventTypes<DeploymentContext> INITIAL_CONTEXT_CREATED = EventTypes.create("Initial_Context_Created", DeploymentContext.class);
     /**
      * This synchronous event is sent when a new deployment or loading of an already deployed application start. It is invoked
      * once before any sniffer is invoked.
      */
-    public final EventTypes<DeploymentContext> DEPLOYMENT_START = EventTypes.create("Deployment_Start", DeploymentContext.class);
+    EventTypes<DeploymentContext> DEPLOYMENT_START = EventTypes.create("Deployment_Start", DeploymentContext.class);
     
     /**
      * The name of the Deployment Failure event
      */
-    public static final String DEPLOYMENT_FAILURE_NAME = "Deployment_Failed";
+    String DEPLOYMENT_FAILURE_NAME = "Deployment_Failed";
     /**
      * This asynchronous event is sent when a deployment activity (first time deploy or loading of an already deployed application)
      * failed.
      */
-    public final EventTypes<DeploymentContext> DEPLOYMENT_FAILURE = EventTypes.create(DEPLOYMENT_FAILURE_NAME, DeploymentContext.class);
+    EventTypes<DeploymentContext> DEPLOYMENT_FAILURE = EventTypes.create(DEPLOYMENT_FAILURE_NAME, DeploymentContext.class);
     /**
      * This synchronous event is sent after creation of deployment classloader. 
      */
-    public final EventTypes<DeploymentContext> AFTER_DEPLOYMENT_CLASSLOADER_CREATION =
+    EventTypes<DeploymentContext> AFTER_DEPLOYMENT_CLASSLOADER_CREATION =
             EventTypes.create("After_Deployment_ClassLoader_Creation", DeploymentContext.class);
     /**
      * This synchronous event is sent before prepare phase of deployment. 
      */
-    public final EventTypes<DeploymentContext> DEPLOYMENT_BEFORE_CLASSLOADER_CREATION =
+    EventTypes<DeploymentContext> DEPLOYMENT_BEFORE_CLASSLOADER_CREATION =
             EventTypes.create("Deployment_ClassLoader_Creation", DeploymentContext.class);
     /**
      * This synchronous event is sent after creation of application classloader. 
      */
-    public final EventTypes<DeploymentContext> AFTER_APPLICATION_CLASSLOADER_CREATION =
+    EventTypes<DeploymentContext> AFTER_APPLICATION_CLASSLOADER_CREATION =
             EventTypes.create("After_Application_ClassLoader_Creation", DeploymentContext.class);
 
     /**
      * This asynchronous event is sent when a deployment activity (first time deploy or loading of an already deployed application)
      * succeeded.
      */
-    public final EventTypes<ApplicationInfo> DEPLOYMENT_SUCCESS = EventTypes.create("Deployment_Success", ApplicationInfo.class);
+    EventTypes<ApplicationInfo> DEPLOYMENT_SUCCESS = EventTypes.create("Deployment_Success", ApplicationInfo.class);
 
     /**
      * This asynchronous event is sent when a new deployment or loading of an already deployed application start. It is invoked
      * once before any sniffer is invoked.
      */
-    public final EventTypes<ApplicationInfo> UNDEPLOYMENT_START = EventTypes.create("Undeployment_Start", ApplicationInfo.class);
+    EventTypes<ApplicationInfo> UNDEPLOYMENT_START = EventTypes.create("Undeployment_Start", ApplicationInfo.class);
     /**
      * This asynchronous event is sent when a deployment activity (first time deploy or loading of an already deployed application)
      * failed.
      */
-    public final EventTypes<DeploymentContext> UNDEPLOYMENT_FAILURE = EventTypes.create("Undeployment_Failed", DeploymentContext.class);
+    EventTypes<DeploymentContext> UNDEPLOYMENT_FAILURE = EventTypes.create("Undeployment_Failed", DeploymentContext.class);
 
     /**
      * This asynchronous event is sent when a deployment activity (first time deploy or loading of an already deployed application)
      * succeeded.
      */
-    public final EventTypes<DeploymentContext> UNDEPLOYMENT_SUCCESS = EventTypes.create("Undeployment_Success", DeploymentContext.class);
+    EventTypes<DeploymentContext> UNDEPLOYMENT_SUCCESS = EventTypes.create("Undeployment_Success", DeploymentContext.class);
 
     /**
      * The following synchronous events are sent after each change in a module state.
      */
-    public final EventTypes<DeploymentContext> MODULE_PREPARED = EventTypes.create("Module_Prepared", DeploymentContext.class);
-    public final EventTypes<ModuleInfo> MODULE_LOADED = EventTypes.create("Module_Loaded", ModuleInfo.class);
-    public final EventTypes<ModuleInfo> MODULE_STARTED = EventTypes.create("Module_Running", ModuleInfo.class);
-    public final EventTypes<ModuleInfo> MODULE_STOPPED = EventTypes.create("Module_Stopped", ModuleInfo.class);
-    public final EventTypes<ModuleInfo> MODULE_UNLOADED = EventTypes.create("Module_Unloaded", ModuleInfo.class);
-    public final EventTypes<DeploymentContext> MODULE_CLEANED= EventTypes.create("Module_Cleaned", DeploymentContext.class);
+    EventTypes<DeploymentContext> MODULE_PREPARED = EventTypes.create("Module_Prepared", DeploymentContext.class);
+    EventTypes<ModuleInfo> MODULE_LOADED = EventTypes.create("Module_Loaded", ModuleInfo.class);
+    EventTypes<ModuleInfo> MODULE_STARTED = EventTypes.create("Module_Running", ModuleInfo.class);
+    EventTypes<ModuleInfo> MODULE_STOPPED = EventTypes.create("Module_Stopped", ModuleInfo.class);
+    EventTypes<ModuleInfo> MODULE_UNLOADED = EventTypes.create("Module_Unloaded", ModuleInfo.class);
+    EventTypes<DeploymentContext> MODULE_CLEANED= EventTypes.create("Module_Cleaned", DeploymentContext.class);
 
     /**
      * The following synchronous events are sent after each change in an application stated (An application contains
      * 1 to many modules)
      */
-    public final EventTypes<DeploymentContext> APPLICATION_PREPARED = EventTypes.create("Application_Prepared", DeploymentContext.class);
-    public final EventTypes<ApplicationInfo> APPLICATION_LOADED = EventTypes.create("Application_Loaded", ApplicationInfo.class);
-    public final EventTypes<ApplicationInfo> APPLICATION_STARTED = EventTypes.create("Application_Running", ApplicationInfo.class);
-    public final EventTypes<ApplicationInfo> APPLICATION_STOPPED = EventTypes.create("Application_Stopped", ApplicationInfo.class);
-    public final EventTypes<ApplicationInfo> APPLICATION_UNLOADED = EventTypes.create("Application_Unloaded", ApplicationInfo.class);
-    public final EventTypes<DeploymentContext> APPLICATION_CLEANED= EventTypes.create("Application_Cleaned", DeploymentContext.class);
-    public final EventTypes<ApplicationInfo> APPLICATION_DISABLED = EventTypes.create("Application_Disabled", ApplicationInfo.class);
+    EventTypes<DeploymentContext> APPLICATION_PREPARED = EventTypes.create("Application_Prepared", DeploymentContext.class);
+    EventTypes<ApplicationInfo> APPLICATION_LOADED = EventTypes.create("Application_Loaded", ApplicationInfo.class);
+    EventTypes<ApplicationInfo> APPLICATION_STARTED = EventTypes.create("Application_Running", ApplicationInfo.class);
+    EventTypes<ApplicationInfo> APPLICATION_STOPPED = EventTypes.create("Application_Stopped", ApplicationInfo.class);
+    EventTypes<ApplicationInfo> APPLICATION_UNLOADED = EventTypes.create("Application_Unloaded", ApplicationInfo.class);
+    EventTypes<DeploymentContext> APPLICATION_CLEANED= EventTypes.create("Application_Cleaned", DeploymentContext.class);
+    EventTypes<ApplicationInfo> APPLICATION_DISABLED = EventTypes.create("Application_Disabled", ApplicationInfo.class);
 
 
     /**
@@ -161,7 +163,7 @@ public interface Deployment {
      * undeployed so various listeners could validate the undeploy operation
      * and decide whether to abort undeployment
      */
-    public final EventTypes<DeploymentContext> UNDEPLOYMENT_VALIDATION = EventTypes.create("Undeployment_Validation", DeploymentContext.class);
+    EventTypes<DeploymentContext> UNDEPLOYMENT_VALIDATION = EventTypes.create("Undeployment_Validation", DeploymentContext.class);
 
     /**
      * This event is thrown before the STOP deployment phase, notably from the disable and undeploy asadmin commands.
@@ -173,20 +175,20 @@ public interface Deployment {
 
     public interface DeploymentContextBuilder {
 
-        public DeploymentContextBuilder source(File source);
-        public DeploymentContextBuilder source(ReadableArchive archive);
-        public File sourceAsFile();
-        public ReadableArchive sourceAsArchive();
-        public ArchiveHandler archiveHandler();
-        public DeploymentContextBuilder archiveHandler(ArchiveHandler handler);
+        DeploymentContextBuilder source(File source);
+        DeploymentContextBuilder source(ReadableArchive archive);
+        File sourceAsFile();
+        ReadableArchive sourceAsArchive();
+        ArchiveHandler archiveHandler();
+        DeploymentContextBuilder archiveHandler(ArchiveHandler handler);
 
-        public Logger logger();
-        public ActionReport report();
-        public OpsParams params();
+        Logger logger();
+        ActionReport report();
+        OpsParams params();
         
-        public ExtendedDeploymentContext build() throws IOException;
+        ExtendedDeploymentContext build() throws IOException;
 
-        public abstract ExtendedDeploymentContext build(ExtendedDeploymentContext initialContext)
+        ExtendedDeploymentContext build(ExtendedDeploymentContext initialContext)
                 throws IOException;
 
     }
@@ -205,97 +207,99 @@ public interface Deployment {
      * triggered when all applications are loaded, but not yet initialized
      * Useful to find out when all classes are available in the class loader
      */
-    public final EventTypes<DeploymentContext> ALL_APPLICATIONS_LOADED = EventTypes.create("All_Applications_Loaded", DeploymentContext.class);
+    EventTypes<DeploymentContext> ALL_APPLICATIONS_LOADED = EventTypes.create("All_Applications_Loaded", DeploymentContext.class);
 
     /**
      * The following asynchronous event is sent after all applications are 
      * started in server start up.
      */
-    public final EventTypes<DeploymentContext> ALL_APPLICATIONS_PROCESSED= EventTypes.create("All_Applications_Processed", DeploymentContext.class);
+    EventTypes<DeploymentContext> ALL_APPLICATIONS_PROCESSED= EventTypes.create("All_Applications_Processed", DeploymentContext.class);
 
     /**
      * All applications are now stopped / unloaded in the process of server shutdown
      */
-    public final EventTypes<DeploymentContext> ALL_APPLICATIONS_STOPPED = EventTypes.create("All_Applications_Stopped", DeploymentContext.class);
+    EventTypes<DeploymentContext> ALL_APPLICATIONS_STOPPED = EventTypes.create("All_Applications_Stopped", DeploymentContext.class);
 
-    public DeploymentContextBuilder getBuilder(Logger loggger, OpsParams params, ActionReport report);
+    DeploymentContextBuilder getBuilder(Logger loggger, OpsParams params, ActionReport report);
 
-    public ArchiveHandler getArchiveHandler(ReadableArchive archive) throws IOException;
+    ArchiveHandler getArchiveHandler(ReadableArchive archive) throws IOException;
 
-    public ArchiveHandler getArchiveHandler(ReadableArchive archive, String type) throws IOException;
+    ArchiveHandler getArchiveHandler(ReadableArchive archive, String type) throws IOException;
 
-    public ModuleInfo prepareModule(
+    ModuleInfo prepareModule(
         List<EngineInfo> sortedEngineInfos, String moduleName,
         DeploymentContext context,
         ProgressTracker tracker) throws Exception;
 
-    public ApplicationDeployment prepare(final Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context);
-    public void initialize(ApplicationInfo appInfo, final Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context);
+    ApplicationDeployment prepare(final Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context);
+    void initialize(ApplicationInfo appInfo, final Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context);
 
-    public ApplicationInfo deploy(final ExtendedDeploymentContext context);
-    public ApplicationInfo deploy(final Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context);
+    ApplicationInfo deploy(final ExtendedDeploymentContext context);
+    ApplicationInfo deploy(final Collection<? extends Sniffer> sniffers, final ExtendedDeploymentContext context);
 
-    public void undeploy(String appName, ExtendedDeploymentContext context);
+    void undeploy(String appName, ExtendedDeploymentContext context);
 
-    public Transaction prepareAppConfigChanges(final DeploymentContext context)
+    Transaction prepareAppConfigChanges(final DeploymentContext context)
         throws TransactionFailure;
 
-    public void registerAppInDomainXML(final ApplicationInfo
+    void registerAppInDomainXML(final ApplicationInfo
         applicationInfo, final DeploymentContext context, Transaction t) 
         throws TransactionFailure;
 
-    public void unregisterAppFromDomainXML(final String appName, 
+    void unregisterAppFromDomainXML(final String appName, 
         final String target)
         throws TransactionFailure;
 
-    public void registerAppInDomainXML(final ApplicationInfo
+    void registerAppInDomainXML(final ApplicationInfo
         applicationInfo, final DeploymentContext context, Transaction t,
         boolean appRefOnly)
         throws TransactionFailure;
 
-    public void unregisterAppFromDomainXML(final String appName,
+    void unregisterAppFromDomainXML(final String appName,
         final String target, boolean appRefOnly)
         throws TransactionFailure;
 
-    public void registerTenantWithAppInDomainXML(final String appName, final ExtendedDeploymentContext context)
+    void registerTenantWithAppInDomainXML(final String appName, final ExtendedDeploymentContext context)
             throws TransactionFailure;
 
-    public void unregisterTenantWithAppInDomainXML(final String appName, final String tenantName)
+    void unregisterTenantWithAppInDomainXML(final String appName, final String tenantName)
             throws TransactionFailure, RetryableException;
 
-    public void updateAppEnabledAttributeInDomainXML(final String appName,
+    void updateAppEnabledAttributeInDomainXML(final String appName,
         final String target, final boolean enabled) throws TransactionFailure;
 
-    public List<EngineInfo> setupContainerInfos(
+    List<EngineInfo> setupContainerInfos(
             DeploymentContext context) throws Exception;
 
-    public List<EngineInfo> setupContainerInfos(final ArchiveHandler handler,
+    List<EngineInfo> setupContainerInfos(final ArchiveHandler handler,
             Collection<? extends Sniffer> sniffers, DeploymentContext context)
              throws Exception;
+    
+    Map<Class, ApplicationMetaDataProvider> getTypeByProvider();
 
-    public boolean isRegistered(String appName);
+    boolean isRegistered(String appName);
 
-    public ApplicationInfo get(String appName);
+    ApplicationInfo get(String appName);
 
-    public ParameterMap prepareInstanceDeployParamMap(DeploymentContext dc) throws Exception;
+    ParameterMap prepareInstanceDeployParamMap(DeploymentContext dc) throws Exception;
 
-    public void validateDeploymentTarget(String target, String name,
+    void validateDeploymentTarget(String target, String name,
         boolean isRedeploy);
 
-    public void validateUndeploymentTarget(String target, String name);
+    void validateUndeploymentTarget(String target, String name);
 
-    public void validateSpecifiedTarget(String target);
+    void validateSpecifiedTarget(String target);
 
-    public boolean isAppEnabled(Application app);
+    boolean isAppEnabled(Application app);
 
-    public ApplicationInfo unload(ApplicationInfo appInfo,
+    ApplicationInfo unload(ApplicationInfo appInfo,
         ExtendedDeploymentContext context);
 
-    public DeploymentContext disable(UndeployCommandParameters commandParams, 
+    DeploymentContext disable(UndeployCommandParameters commandParams, 
         Application app, ApplicationInfo appInfo, ActionReport report, 
         Logger logger) throws Exception;
 
-    public DeploymentContext enable(String target, Application app, ApplicationRef appRef,
+    DeploymentContext enable(String target, Application app, ApplicationRef appRef,
         ActionReport report, Logger logger) throws Exception;
 
     /**
@@ -307,17 +311,17 @@ public interface Deployment {
      * @return the types information from the deployment artifacts
      * @throws IOException if the scanning fails due to an I/O exception
      */
-    public Types getDeployableTypes(DeploymentContext context) throws IOException;
+    Types getDeployableTypes(DeploymentContext context) throws IOException;
 
-    public List<Sniffer> getSniffersFromApp(Application app);
+    List<Sniffer> getSniffersFromApp(Application app);
 
-    public Collection<? extends Sniffer> getSniffers(ArchiveHandler archiveHandler, Collection<? extends Sniffer> sniffers, DeploymentContext context);
+    Collection<? extends Sniffer> getSniffers(ArchiveHandler archiveHandler, Collection<? extends Sniffer> sniffers, DeploymentContext context);
 
     // sets the default target when the target is not specified
-    public String getDefaultTarget(String appName, OpsParams.Origin origin, Boolean isClassicStyle);
+    String getDefaultTarget(String appName, OpsParams.Origin origin, Boolean isClassicStyle);
 
     // gets the default target when no target is specified for non-paas case
-    public String getDefaultTarget(Boolean isClassicStyle);
+    String getDefaultTarget(Boolean isClassicStyle);
 
     /**
      * Returns thread-local deployment, which is the currently-executing deployment context,
@@ -325,5 +329,5 @@ public interface Deployment {
      * 
      * @return Currently-executing deployment context
      */
-    public ExtendedDeploymentContext getCurrentDeploymentContext();
+    ExtendedDeploymentContext getCurrentDeploymentContext();
 }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/DeploymentTracing.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/DeploymentTracing.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or its affiliates
+// Portions Copyright [2019-2021] Payara Foundation and/or its affiliates
 package org.glassfish.internal.deployment;
 
 import com.sun.enterprise.module.HK2Module;
@@ -184,6 +184,12 @@ public class DeploymentTracing {
          * Load the application code and prepare runtime structures.
          */
         LOAD,
+        
+        /**
+         *
+         * Reload the application code.
+         */
+        RELOAD,
     }
 
     public enum ModuleMark {

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -84,12 +84,14 @@ public class GlassFishMain {
 
     public static void main(final String args[]) throws Exception {
         MainHelper.checkJdkVersion();
-
+        
         final Properties argsAsProps = argsToMap(args);
 
         String platform = MainHelper.whichPlatform();
 
         System.out.println("Launching Payara Server on " + platform + " platform");
+        
+        MainHelper.HotSwapHelper.updateHotSwapClassLoaderConfig();
 
         // Set the system property if downstream code wants to know about it
         System.setProperty(Constants.PLATFORM_PROPERTY_KEY, platform); // TODO(Sahoo): Why is this a system property?

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.glassfish.bootstrap;
 
@@ -47,6 +47,7 @@ import com.sun.enterprise.module.bootstrap.StartupContext;
 import com.sun.enterprise.module.bootstrap.Which;
 import com.sun.enterprise.util.JDK;
 import java.io.*;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
@@ -54,6 +55,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.glassfish.hk2.api.ServiceLocator;
 
 /**
  * Utility class used by bootstrap module.
@@ -853,6 +855,99 @@ public class MainHelper {
         protected File getFrameworkConfigFile() {
             return null;  // no config file for this platform.
         }
+    }
+    
+    public static class HotSwapHelper {
+
+        private final static String HOTSWAP_TRANSFORMER = "org.hotswap.agent.util.HotswapTransformer";
+
+        private final static String BUNDLE_CLASSLOADER = "org.apache.felix.framework.BundleWiringImpl$BundleClassLoader";
+        private final static String PROVIDER_GENERATOR_CLASSLOADER = "org.glassfish.flashlight.impl.core.ProviderSubClassImplGenerator$SubClassLoader";
+        private final static String JDK_PLATFORM_CLASSLOADER = "jdk.internal.loader.ClassLoaders$PlatformClassLoader";
+        private final static String JDK_APP_CLASSLOADER = "jdk.internal.loader.ClassLoaders$AppClassLoader";
+        private final static String BOOTSTRAP_CLASSLOADER = "null";
+        private final static String METHODUTIL_CLASSLOADER = "sun.reflect.misc.MethodUtil";
+        private final static String HK2_DELEGATING_CLASSLOADER = "org.jvnet.hk2.internal.DelegatingClassLoader";
+        private final static String CURRENT_BEFORE_PARENT_CLASSLOADER = "com.sun.enterprise.loader.CurrentBeforeParentClassLoader";
+
+        private final static String HOTSWAP_VM_KEY = "java.vm.name";
+        private final static String HOTSWAP_VM_VALUE = "Dynamic Code Evolution";
+
+        private final static String HOTSWAP_PLUGIN_MANAGER = "org.hotswap.agent.config.PluginManager";
+
+        private static Object hotswapManager = null;
+
+        public static void updateHotSwapClassLoaderConfig() {
+            try {
+                if (System.getProperty(HOTSWAP_VM_KEY).contains(HOTSWAP_VM_VALUE)) {
+                    Class clazz = ClassLoader.getSystemClassLoader()
+                            .loadClass(HOTSWAP_TRANSFORMER);
+                    if (clazz == null) {
+                        logger.log(Level.INFO, "HotSwap Agent not enabled.");
+                        return;
+                    }
+                    Field fld = clazz.getDeclaredField("skippedClassLoaders");
+                    fld.setAccessible(true);
+                    Set<String> skippedClassLoaders = (Set<String>) fld.get(null);
+                    skippedClassLoaders.add(BUNDLE_CLASSLOADER);
+                    skippedClassLoaders.add(PROVIDER_GENERATOR_CLASSLOADER);
+                    skippedClassLoaders.add(JDK_PLATFORM_CLASSLOADER);
+                    skippedClassLoaders.add(JDK_APP_CLASSLOADER);
+                    skippedClassLoaders.add(BOOTSTRAP_CLASSLOADER);
+                    skippedClassLoaders.add(METHODUTIL_CLASSLOADER);
+                    skippedClassLoaders.add(HK2_DELEGATING_CLASSLOADER);
+                    skippedClassLoaders.add(CURRENT_BEFORE_PARENT_CLASSLOADER);
+                }
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, null, ex);
+            }
+        }
+
+        /**
+         * Redefine the set of classes using the supplied bytecode.
+         *
+         * @param reloadMap class and bytecode pairs
+         */
+        public static void hotswap(Map<Class<?>, byte[]> reloadMap) {
+            try {
+                getPluginManager()
+                        .getClass()
+                        .getMethod("hotswap", Map.class)
+                        .invoke(getPluginManager(), reloadMap);
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, null, ex);
+            }
+        }
+
+        /**
+         * Free all ClassLoader references and close any associated plugin
+         * instance.
+         *
+         * @param classLoader to free
+         */
+        public static void closeClassLoader(ClassLoader classLoader) {
+            try {
+                if (System.getProperty(HOTSWAP_VM_KEY).contains(HOTSWAP_VM_VALUE)) {
+                    getPluginManager()
+                            .getClass()
+                            .getMethod("closeClassLoader", ClassLoader.class)
+                            .invoke(getPluginManager(), classLoader);
+                }
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, null, ex);
+            }
+        }
+
+        private static Object getPluginManager() throws Exception {
+            if (hotswapManager == null) {
+                ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+                hotswapManager = classLoader.loadClass(HOTSWAP_PLUGIN_MANAGER)
+                        .getMethod("getInstance")
+                        .invoke(null);
+            }
+            return hotswapManager;
+        }
+ 
     }
 }
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
@@ -55,7 +55,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.glassfish.hk2.api.ServiceLocator;
 
 /**
  * Utility class used by bootstrap module.
@@ -879,7 +878,7 @@ public class MainHelper {
 
         public static void updateHotSwapClassLoaderConfig() {
             try {
-                if (System.getProperty(HOTSWAP_VM_KEY).contains(HOTSWAP_VM_VALUE)) {
+                if (isHotswapEnabled()) {
                     Class clazz = ClassLoader.getSystemClassLoader()
                             .loadClass(HOTSWAP_TRANSFORMER);
                     if (clazz == null) {
@@ -927,7 +926,7 @@ public class MainHelper {
          */
         public static void closeClassLoader(ClassLoader classLoader) {
             try {
-                if (System.getProperty(HOTSWAP_VM_KEY).contains(HOTSWAP_VM_VALUE)) {
+                if (isHotswapEnabled()) {
                     getPluginManager()
                             .getClass()
                             .getMethod("closeClassLoader", ClassLoader.class)
@@ -936,6 +935,10 @@ public class MainHelper {
             } catch (Exception ex) {
                 logger.log(Level.SEVERE, null, ex);
             }
+        }
+        
+        public static boolean isHotswapEnabled() {
+            return System.getProperty(HOTSWAP_VM_KEY).contains(HOTSWAP_VM_VALUE);
         }
 
         private static Object getPluginManager() throws Exception {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/ListJvmOptions.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/ListJvmOptions.java
@@ -129,8 +129,8 @@ public final class ListJvmOptions implements AdminCommand, AdminCommandSecurity.
                 }
                 option.minVersion.ifPresent(minVersion -> {
                     sb.append("min(");
-                    option.vendor.ifPresent(vendor -> {
-                        sb.append(vendor).append("-");
+                    option.vendorOrVM.ifPresent(vendorOrVM -> {
+                        sb.append(vendorOrVM).append("-");
                     });
                     sb.append(minVersion);
                     sb.append(")");

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates.]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates.]
 
 package com.sun.enterprise.v3.server;
 
@@ -985,7 +985,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         }
     }
 
-    private Map<Class, ApplicationMetaDataProvider> getTypeByProvider() {
+    public Map<Class, ApplicationMetaDataProvider> getTypeByProvider() {
         // in reality, there is single implementation of ApplicationMetadataProvider at this point.
         final Map<Class, ApplicationMetaDataProvider> typeByProvider = new HashMap<>();
         final List<ApplicationMetaDataProvider> providers = habitat.<ApplicationMetaDataProvider>getAllServices(ApplicationMetaDataProvider.class);

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
@@ -364,16 +364,12 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
 
     @Override
     public Collection<Object> getModuleMetadata() {
-        List<Object> copy = new ArrayList<>();
-        copy.addAll(modulesMetaData.values());
-        return copy;
+        return Collections.unmodifiableCollection(modulesMetaData.values());
     }
 
     @Override
     public Map<String, Object> getTransientAppMetadata() {
-        HashMap<String, Object> copy = new HashMap<>();
-        copy.putAll(transientAppMetaData);
-        return copy;
+        return Collections.unmodifiableMap(transientAppMetaData);
     }
 
     @Override

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
@@ -76,6 +76,7 @@ import java.util.logging.Level;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
 import org.glassfish.api.deployment.DeployCommandParameters;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.classmodel.reflect.Parser;
 import org.glassfish.hk2.classmodel.reflect.Types;
 import org.glassfish.internal.api.Globals;
@@ -711,10 +712,14 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
 
     @Override
     public void postDeployClean(boolean isFinalClean) {
-        HotDeployService deployService = Globals.getDefaultHabitat().getService(HotDeployService.class);
-        boolean hotSwap = deployService.getApplicationState(this)
-                .map(ApplicationState::isHotswap)
-                .orElse(false);
+        boolean hotSwap = false;
+        ServiceLocator serviceLocator = Globals.getDefaultHabitat();
+        if (serviceLocator != null) {
+            hotSwap = serviceLocator.getService(HotDeployService.class)
+                    .getApplicationState(this)
+                    .map(ApplicationState::isHotswap)
+                    .orElse(false);
+        }
         if (transientAppMetaData != null && !hotSwap) {
             if (isFinalClean) {
                 transientAppMetaData.clear();

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/RootDeploymentDescriptor.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/RootDeploymentDescriptor.java
@@ -333,11 +333,13 @@ public abstract class RootDeploymentDescriptor extends Descriptor {
         if (extensions.containsKey(type)) {
             values = extensions.get(type);
         } else {
-            values = new ArrayList<RootDeploymentDescriptor>();
+            values = new ArrayList<>();
             extensions.put(type, values);
         }
         ((RootDeploymentDescriptor)instance).index = index;
-        values.add(instance);
+        if (!values.contains(instance)) {
+            values.add(instance);
+        }
 
     }
 


### PR DESCRIPTION
## Description
This is an experimental feature PR to integrate the Payara Platform with the HotSwap Agent.
HotSwap Agent is enabled by jvm-option `-XX:HotswapAgent` where VM name `Dynamic Code Evolution` is added to the option to skip this option for JDK with Hotspot vm.


## Important Info
### Todo

1. Currently, the HotSwap agent instrumenting all classloaders and loaded classes that need to be filtered and activate to the application classloader.
2. Modifying annotation or descriptor data is currently not supported and should be fixed under the following tickets:
      - FISH-1467 - Web Container
      -  FISH-5650 - EJB Container
      - FISH-5706 - JPA Container
      - FISH-5707 - Resources Container
      - FISH-5708 - CDI Container
      - FISH-5709 - Security Container
      - FISH-5710 - Connectors Container


## Testing
### Testing Performed
Manual tested on JDK11

### Step to test the feature
- To test this feature,  download the [Patched JDK](https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases).
- Add the Payara Server to the Apache NetBeans IDE.
- Enable the Hot Deploy from the Properties of the registered server
- Start the Payara Server from command-line  (starting the Payara Server from IDE is not recommended currently as `VM name` support need to be added to the domain.xml parser in the IDE tools)
- Deploy the application from the IDE
- Change the Source code e.g Servlet
- You should see the similar following message in the server.log file.
```
HOTSWAP AGENT: 18:27:33.362 RELOAD (org.hotswap.agent.config.PluginManager) - Reloading classes [com.mycompany.mavenproject.NewServlet] (autoHotswap)]]
```
- And on refreshing the browser, changes should be reflected instantly.







