### PR TITLE
FISH-5693 Updated multiple keystore delimiter to be OS dependent

### DIFF
--- a/appserver/tests/payara-samples/test-domain-setup/src/test/java/fish/payara/samples/setuptests/MultipleKeystoresConfigurationTest.java
+++ b/appserver/tests/payara-samples/test-domain-setup/src/test/java/fish/payara/samples/setuptests/MultipleKeystoresConfigurationTest.java
@@ -46,7 +46,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 
@@ -58,16 +57,20 @@ import java.security.cert.X509Certificate;
 public class MultipleKeystoresConfigurationTest {
 
     @Test
-    public void createAdditionalKeystore() throws IOException {
+    public void createAdditionalKeystore() {
         KeyPair clientKeyPair = SecurityUtils.generateRandomRSAKeys();
         X509Certificate clientCertificate = SecurityUtils.createSelfSignedCertificate(clientKeyPair);
         String path = SecurityUtils.createTempJKSKeyStore(clientKeyPair.getPrivate(), clientCertificate);
+
+        //Used so the path is correct when run in the cli command
+        path = path.replace("\\", "\\\\");
+        path = path.replace(":", "\\:");
 
         CliCommands.payaraGlassFish("create-jvm-options", "\"-Dfish.payara.ssl.additionalKeyStores="+path+"\"");
     }
 
     @Test
-    public void createNewNetworkListener(){
+    public void createNewNetworkListener() {
         CliCommands.payaraGlassFish("create-protocol", "--securityenabled=true", "--target=server-config", "wibbles-protocol");
         CliCommands.payaraGlassFish("create-http", "--defaultVirtualServer=server", "--target=server-config", "wibbles-protocol");
         CliCommands.payaraGlassFish("create-network-listener", "--address=0.0.0.0", "--listenerport=8282", "--protocol=wibbles-protocol", "wibbles");

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -685,12 +685,12 @@ public abstract class LocalServerCommand extends CLICommand {
             if (additionalTrustandKeyStores.containsKey("additionalKeyStores")) {
                 logger.log(Level.INFO,
                         "The passwords of additional KeyStores {0} have not been changed - please update these manually to continue using them.",
-                        Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(":(?!\\\\)")));
+                        Arrays.toString(additionalTrustandKeyStores.get("additionalKeyStores").split(File.pathSeparator)));
             }
             if (additionalTrustandKeyStores.containsKey("additionalTrustStores")) {
                 logger.log(Level.INFO,
                         "The passwords of additional TrustStores {0} have not been changed - please update these manually to continue using them.",
-                        Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(":(?!\\\\)")));
+                        Arrays.toString(additionalTrustandKeyStores.get("additionalTrustStores").split(File.pathSeparator)));
             }
         } catch (ParserConfigurationException | SAXException exception) {
             logger.warning(

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/JSSESocketFactory.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/JSSESocketFactory.java
@@ -255,7 +255,7 @@ public abstract class JSSESocketFactory extends ServerSocketFactory {
         String keystoreFile = (String) attributes.get("keystore");
         String[] additionalKeyStoreFileNames = null;
         if(attributes.get(ADDITIONAL_KEY_STORES_ATTR) != null){
-            additionalKeyStoreFileNames = ((String) attributes.get(ADDITIONAL_KEY_STORES_ATTR)).split(":");
+            additionalKeyStoreFileNames = ((String) attributes.get(ADDITIONAL_KEY_STORES_ATTR)).split(File.pathSeparator);
         }
 
         if (logger.isLoggable(Level.FINE)) {
@@ -299,7 +299,7 @@ public abstract class JSSESocketFactory extends ServerSocketFactory {
 
         String[] additionalTrustStoreFileNames = null;
         if(attributes.get(ADDITIONAL_TRUST_STORES_ATTR) != null){
-            additionalTrustStoreFileNames = ((String) attributes.get(ADDITIONAL_TRUST_STORES_ATTR)).split(":");
+            additionalTrustStoreFileNames = ((String) attributes.get(ADDITIONAL_TRUST_STORES_ATTR)).split(File.pathSeparator);
         }
         if (logger.isLoggable(Level.FINE)) {
             logger.log(Level.FINE, "Truststore file= {0}", truststore);

--- a/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/impl/SecuritySupportImpl.java
+++ b/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/impl/SecuritySupportImpl.java
@@ -47,6 +47,7 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
+import java.io.File;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -409,10 +410,10 @@ public class SecuritySupportImpl extends SecuritySupport {
         String[] additionalKeyStoreFileNames = null;
         String[] additionalTrustStoreFileNames = null;
         if(additionalKeyStoreFileName != null){
-            additionalKeyStoreFileNames = additionalKeyStoreFileName.split(":");
+            additionalKeyStoreFileNames = additionalKeyStoreFileName.split(File.pathSeparator);
         }
         if(additionalTrustStoreFileName != null){
-            additionalTrustStoreFileNames = additionalTrustStoreFileName.split(":");
+            additionalTrustStoreFileNames = additionalTrustStoreFileName.split(File.pathSeparator);
         }
 
         initStores(keyStoreFileName, keyStorePass, trustStoreFileName, trustStorePass, additionalKeyStoreFileNames, additionalTrustStoreFileNames);


### PR DESCRIPTION
## Description
This is a bugfix for [FISH-1342](https://github.com/payara/Payara/pull/5324) which introduced the ability to specify multiple keystores, however this didn't work on Windows due to the delimiter being ':'. 

This has been changed to use File.pathSeparator which is OS dependent meaning the delimiter is still ':' for Linux but ';' for Windows, allowing this feature to work. Changes have also been made to the keystore path for MultipleKeystoresConfigurationTest meaning SecureCustomHttpListenerTest now passes on Windows.

The same delimiter changes have been made to [FISH-5639](https://github.com/payara/Payara/pull/5370) so this displays the keystores correctly on Windows.

## Important Info

## Testing

### Testing Performed
Manually tested the feature works on windows. Tested the Multiple Keystores test in Payara Samples ensuring it passes and works correctly on windows. Manually tested FISH-5639 produces the expected behaviour with these changes.

Ensured multiple keystores still works on Linux.

### Testing Environment
Windows 10 Pro, Maven 3.6.3, JDK8

## Documentation
Documentation PR: https://github.com/payara/Payara-Community-Documentation/pull/241