### PR TITLE
FISH-5701 fix automated deployment, put command to the right file

### DIFF
--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/init_1_generate_deploy_commands.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/init_1_generate_deploy_commands.sh
@@ -57,7 +57,7 @@ deploy() {
     echo "post boot commands already deploys $1";
   else
     echo "Adding deployment target $1 to post boot commands";
-    echo $DEPLOY_STATEMENT >> $POSTBOOT_COMMANDS;
+    echo $DEPLOY_STATEMENT >> $POSTBOOT_COMMANDS_FINAL;
   fi
 }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Fix for https://github.com/payara/Payara/issues/5391, application added to $DEPLOY_DIR in docker image is not deployed. 
Actually, the fixed file is exactly the same as the related file Payara/appserver/extras/docker-images/server-web/src/main/docker/bin/init_1_generate_deploy_commands.sh, which was OK.


## Testing
### Testing Performed
In Payara/appserver/extras/docker-images, build docker image:
mvn -pl :server-full-docker-image -am -PBuildExtras -PBuildDockerImages install

Then create directory with clusterjsp.war (or any war), Dockerfile:
FROM payara/server-full
COPY clusterjsp.war $DEPLOY_DIR

Run the docker:
docker run -i --rm --name bwbportal -p 54848:4848 -p 58080:8080 -p 58181:8181 bwbportal

Correct output:
In log:
clusterjsp was successfully deployed in ...
Accessible app:
http://localhost:58080/clusterjsp/

