### PR TITLE
FISH-5711 Fix Method not Found Error on boot of Payara Micro

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/AnsiColorFormatter.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/AnsiColorFormatter.java
@@ -52,7 +52,12 @@ public abstract class AnsiColorFormatter extends CommonFormatter {
     private boolean ansiColor;
     private HashMap<Level,AnsiColor> colors;
     private AnsiColor loggerColor;
-    
+
+    // Account for instances of (Formatter) Class.forName(formatter).newInstance();
+    public AnsiColorFormatter() {
+        this(null);
+    }
+
     public AnsiColorFormatter(String excludeFields) {
         super(excludeFields);
         LogManager manager = LogManager.getLogManager();

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/CommonFormatter.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/CommonFormatter.java
@@ -56,6 +56,11 @@ public abstract class CommonFormatter extends Formatter {
     private final ServiceLocator habitat;
     private String productId = "";
 
+    // Account for instances of (Formatter) Class.forName(formatter).newInstance();
+    protected CommonFormatter() {
+        this(null);
+    }
+
     protected CommonFormatter(String excludeFields) {
         super();
         habitat = Globals.getDefaultBaseServiceLocator();

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/ODLLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/ODLLogFormatter.java
@@ -118,6 +118,11 @@ public class ODLLogFormatter extends AnsiColorFormatter implements LogEventBroad
 
     private static final String INDENT = "  ";
 
+    // Account for instances of (Formatter) Class.forName(formatter).newInstance();
+    public ODLLogFormatter() {
+        this(null);
+    }
+
     public ODLLogFormatter(String excludeFields) {
         super(excludeFields);
         loggerResourceBundleTable = new HashMap<String,ResourceBundle>();

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/UniformLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/UniformLogFormatter.java
@@ -131,6 +131,11 @@ public class UniformLogFormatter extends AnsiColorFormatter implements LogEventB
 
     private static final String INDENT = "  ";
 
+    // Account for instances of (Formatter) Class.forName(formatter).newInstance();
+    public UniformLogFormatter() {
+        this(null);
+    }
+
     public UniformLogFormatter(String excludeFields) {
         super(excludeFields);
         loggerResourceBundleTable = new HashMap();

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/JSONLogFormatter.java
@@ -130,6 +130,11 @@ public class JSONLogFormatter extends CommonFormatter implements LogEventBroadca
     @Deprecated
     private static final String PAYARA_JSONLOGFORMATTER_UNDERSCORE="fish.payara.deprecated.jsonlogformatter.underscoreprefix";
 
+    // Account for instances of (Formatter) Class.forName(formatter).newInstance();
+    public JSONLogFormatter() {
+        this(null);
+    }
+
     public JSONLogFormatter(String excludeFields) {
         super(excludeFields);
         loggerResourceBundleTable = new HashMap<>();


### PR DESCRIPTION
## Description
Title. Bug fix.

When starting Payara Micro an error would get thrown due to the no-arg constructor no longer existing.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started Payara Micro - no error

### Testing Environment
Windows, JDK 8

## Documentation
None

## Notes for Reviewers
None
