### PR TITLE
Fixes EJB scheduler bug described in #4650

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
@@ -328,10 +328,9 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
                 cmpDeployer.clean(dc);
             }
 
-            Properties appProps = dc.getAppProps();
-            String uniqueAppId = appProps.getProperty(APP_UNIQUE_ID_PROP);
+            long uniqueAppId = getApplicationFromApplicationInfo(params.name()).getUniqueId();
             try {
-                if (getTimeoutStatusFromApplicationInfo(params.name()) && uniqueAppId != null) {
+                if (getTimeoutStatusFromApplicationInfo(params.name())) {
                     EJBTimerService persistentTimerService = null;
                     EJBTimerService nonPersistentTimerService = null;
                     boolean tsInitialized = false;
@@ -360,7 +359,7 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
                             if (getKeepStateFromApplicationInfo(params.name())) {
                                 _logger.log(Level.INFO, "Persistent Timers will not be destroyed since keepstate is true for application {0}", params.name());
                             } else {
-                                persistentTimerService.destroyAllTimers(Long.parseLong(uniqueAppId));
+                                persistentTimerService.destroyAllTimers(uniqueAppId);
                             }
                         }
                         if (nonPersistentTimerService == null) {
@@ -368,7 +367,7 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
                                     "EJB Non-Persistent Timer Service is not available. Non-Persistent Timers for application with id {0} will not be deleted",
                                     uniqueAppId);
                         } else {
-                            nonPersistentTimerService.destroyAllTimers(Long.parseLong(uniqueAppId));
+                            nonPersistentTimerService.destroyAllTimers(uniqueAppId);
                         }
                     }
                 }

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraInstanceImpl.java
@@ -116,6 +116,8 @@ public class PayaraInstanceImpl implements EventListener, MessageReceiver, Payar
 
     public static final String APPLICATIONS_STORE_NAME = "payara.micro.applications.store";
 
+    private static final String APP_UNIQUE_ID_PROP = "org.glassfish.ejb.container.application_unique_id";
+
     private static final Logger logger = Logger.getLogger(PayaraInstanceImpl.class.getName());
 
     @Inject
@@ -277,8 +279,10 @@ public class PayaraInstanceImpl implements EventListener, MessageReceiver, Payar
                     Long appID = (Long) cluster.getClusteredStore().get(APPLICATIONS_STORE_NAME, app.getName());
                     if (appID != null) {
                         app.setUniqueId(appID);
+                        deploymentContext.getAppProps().setProperty(APP_UNIQUE_ID_PROP, String.valueOf(appID));
                     } else {
                         cluster.getClusteredStore().set(APPLICATIONS_STORE_NAME, app.getName(), app.getUniqueId());
+                        deploymentContext.getAppProps().setProperty(APP_UNIQUE_ID_PROP, String.valueOf(app.getUniqueId()));
                     }
                 }
             }


### PR DESCRIPTION
## Description
Fixed the EJB timer bug introduced in #3b2dd29. We've manually patched the 'ejb-container' and 'payara-micro-service' module since Payara version 5.201 and it seems to be working very well.

## Testing
### Testing Performed
Manually deployed a sample application using persistent EJB timers. Performed multiple redeployments to see if the application id is preserved and the timers get removed. 

### 1st redeploy

```
[2021-09-10T14:47:38.596+0200] [Payara 5.2021.8-SNAPSHOT] [INFORMATION] [] [javax.enterprise.system.container.ejb.com.sun.ejb.containers] [tid: _ThreadID=122 _ThreadName=admin-thread-pool::admin-listener(1)] [timeMillis: 1631278058596] [levelValue: 800] [[
  [1] timers deleted for id: 106907436383141888]]
```

### 2nd redeploy

```
[2021-09-10T14:47:49.658+0200] [Payara 5.2021.8-SNAPSHOT] [INFORMATION] [] [javax.enterprise.system.container.ejb.com.sun.ejb.containers] [tid: _ThreadID=133 _ThreadName=admin-thread-pool::admin-listener(2)] [timeMillis: 1631278069658] [levelValue: 800] [[
  [1] timers deleted for id: 106907436383141888]]
```

### Testing Environment
Zulu JDK 1.8.0_302 on Windows 10 with Maven 3.8.1
