### PR TITLE
FISH-376 Allow finer configuration details of HTTP GZIP compression

### DIFF
--- a/appserver/admingui/web/src/main/resources/grizzly/httpAttr.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/httpAttr.inc
@@ -40,7 +40,7 @@
 
 -->
 
-<!-- Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates.] -->
+<!-- Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates.] -->
 
 <!-- grizzly/httpAttr.inc -->
 
@@ -165,6 +165,14 @@
 
         <sun:property id="Compression"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.Compression}" helpText="$resource{i18n_web.http.CompressionHelp}">
             <sun:dropDown id="Compression" selected="#{pageSession.httpMap['compression']}" labels={"on","off","force"} />
+        </sun:property>
+
+        <sun:property id="CompressionLevel"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.CompressionLevel}" helpText="$resource{i18n_web.http.CompressionLevelHelp}">
+            <sun:dropDown id="CompressionLevel" selected="#{pageSession.httpMap['compressionLevel']}" labels={"-1","0","1","2","3","4","5","6","7","8","9"} />
+        </sun:property>
+
+        <sun:property id="CompressionStrategy"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.CompressionStrategy}" helpText="$resource{i18n_web.http.CompressionStrategyHelp}">
+            <sun:dropDown id="compressionStrategy" selected="#{pageSession.httpMap['compressionStrategy']}" labels={"Default","Filtered","Huffman Only"} />
         </sun:property>
 
         <sun:property id="CompressableMimeType"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.CompressableMimeType}" helpText="$resource{i18n_web.http.CompressableMimeTypeHelp}" >

--- a/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
+++ b/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates.]
+# Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates.]
 
 button.GetStatistics=Get Statistics
 
@@ -316,6 +316,10 @@ http.Trace=Trace:
 http.TraceHelp=Enable TRACE operation
 http.Compression=Compression:
 http.CompressionHelp=Enable HTTP/1.1 GZIP compression to save server bandwidth
+http.CompressionLevel=Compression Level:
+http.CompressionLevelHelp=-1 corresponds to the default level, 0 is no compression, 1 is best speed and 9 is best compression
+http.CompressionStrategy=Compression Strategy:
+http.CompressionStrategyHelp=Compression encoding strategy to be used
 http.AuthPassThrough=Auth Pass Through:
 http.AuthPassThroughHelp=Indicate that the network listener receives traffic from an SSL-terminating proxy server
 http.Chunking=Chunking:

--- a/appserver/tests/payara-samples/samples/http/src/test/java/fish/payara/samples/http/CompressionTest.java
+++ b/appserver/tests/payara-samples/samples/http/src/test/java/fish/payara/samples/http/CompressionTest.java
@@ -1,0 +1,139 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.samples.http;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.samples.CliCommands;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author James Hillyard
+ */
+
+@RunWith(PayaraArquillianTestRunner.class)
+public class CompressionTest {
+    private static long uncompressedSize;
+    private long compressionLevelNegativeOne;
+    private long compressionLevelOne;
+    private long compressionLevelNine;
+
+    private static WebClient WEB_CLIENT;
+    private static final String URL = "http://localhost:8080";
+
+    private static final String CONFIG_COMPRESSION_STRATEGY =
+            "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.compression-strategy=";
+    private static final String CONFIG_COMPRESSION_LEVEL =
+            "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.compression-level=";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        WEB_CLIENT = new WebClient();
+        WEB_CLIENT.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        uncompressedSize = WEB_CLIENT.getPage(URL).getWebResponse().getContentLength();
+
+        CliCommands.payaraGlassFish("set",
+                "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.http2-enabled=false");
+        CliCommands.payaraGlassFish("set",
+                "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.compression=on");
+        WEB_CLIENT.addRequestHeader("Accept-Encoding", "gzip,deflate");
+    }
+
+    //Resets http-listener-1 back to its original state
+    @AfterClass
+    public static void afterClass() {
+        CliCommands.payaraGlassFish("set",
+                "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.http2-enabled=true");
+        CliCommands.payaraGlassFish("set",
+                "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.compression=off");
+    }
+
+    @Test
+    public void defaultCompressionStrategyLevelsTest() throws IOException {
+        CliCommands.payaraGlassFish("set", "'" + CONFIG_COMPRESSION_STRATEGY + "Default'");
+        getCompressionLevelValues();
+        //Check default compression is smaller than uncompressed
+        assertTrue(compressionLevelNegativeOne < uncompressedSize);
+        //Check fastest compression is bigger than default compression
+        assertTrue(compressionLevelOne > compressionLevelNegativeOne);
+        //Check fastest compression is bigger than best compression
+        assertTrue(compressionLevelOne > compressionLevelNine);
+    }
+
+    @Test
+    public void filteredCompressionStrategyLevelsTest() throws IOException {
+        CliCommands.payaraGlassFish("set", "'" + CONFIG_COMPRESSION_STRATEGY + "Filtered'");
+        getCompressionLevelValues();
+        //Check default compression is smaller than uncompressed
+        assertTrue(compressionLevelNegativeOne < uncompressedSize);
+        //Check fastest compression is bigger than default compression
+        assertTrue(compressionLevelOne > compressionLevelNegativeOne);
+        //Check fastest compression is bigger than best compression
+        assertTrue(compressionLevelOne > compressionLevelNine);
+    }
+
+    @Test
+    public void huffmanCompressionStrategyLevelsTest() throws IOException {
+        CliCommands.payaraGlassFish("set", "'" + CONFIG_COMPRESSION_STRATEGY + "Huffman Only'");
+        getCompressionLevelValues();
+        //Check default compression is smaller than uncompressed
+        assertTrue(compressionLevelNegativeOne < uncompressedSize);
+        //Huffman Only is not affected by compression level in this test case.
+    }
+
+    private void getCompressionLevelValues() throws IOException {
+        CliCommands.payaraGlassFish("set", "'" + CONFIG_COMPRESSION_LEVEL + "1'");
+        compressionLevelOne = WEB_CLIENT.getPage(URL).getWebResponse().getContentLength();
+
+        CliCommands.payaraGlassFish("set", "'" + CONFIG_COMPRESSION_LEVEL + "9'");
+        compressionLevelNine = WEB_CLIENT.getPage(URL).getWebResponse().getContentLength();
+
+        CliCommands.payaraGlassFish("set", "'" + CONFIG_COMPRESSION_LEVEL + "-1'");
+        compressionLevelNegativeOne = WEB_CLIENT.getPage(URL).getWebResponse().getContentLength();
+    }
+}

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web.connector.coyote;
 
@@ -1108,6 +1108,8 @@ public class PECoyoteConnector extends Connector {
         setMaxSavePostSize(Integer.parseInt(http.getMaxSavePostSizeBytes()));
         setProperty("compression", http.getCompression());
         setProperty("compressableMimeType", http.getCompressableMimeType());
+        setProperty("compressionLevel", http.getCompressionLevel());
+        setProperty("compressionStrategy", http.getCompressionStrategy());
         if (http.getNoCompressionUserAgents() != null) {
             setProperty("noCompressionUserAgents", http.getNoCompressionUserAgents());
         }

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -1096,6 +1096,8 @@ public class GenericGrizzlyListener implements GrizzlyListener {
 
     protected Set<ContentEncoding> configureCompressionEncodings(Http http) {
         final String mode = http.getCompression();
+        final int compressionStrategy = getCompressionStrategyByInt(http.getCompressionStrategy());
+        final int compressionLevel = Integer.parseInt(http.getCompressionLevel());
         int compressionMinSize = Integer.parseInt(http.getCompressionMinSizeBytes());
         CompressionMode compressionMode;
         try {
@@ -1123,6 +1125,8 @@ public class GenericGrizzlyListener implements GrizzlyListener {
         final ContentEncoding gzipContentEncoding = new GZipContentEncoding(
             GZipContentEncoding.DEFAULT_IN_BUFFER_SIZE,
             GZipContentEncoding.DEFAULT_OUT_BUFFER_SIZE,
+            compressionLevel,
+            compressionStrategy,
             new CompressionEncodingFilter(compressionMode, compressionMinSize,
                 compressableMimeTypes,
                 noCompressionUserAgents,
@@ -1182,5 +1186,19 @@ public class GenericGrizzlyListener implements GrizzlyListener {
             }
         }
         return null;
+    }
+
+    private int getCompressionStrategyByInt(String compressionStrategy) {
+        switch (compressionStrategy) {
+            case "Default":
+                return 0;
+            case "Filtered":
+                return 1;
+            case "Huffman Only":
+                return 2;
+            default:
+                LOGGER.severe("Compression Strategy had an unexpected value.");
+                throw new IllegalStateException("Unexpected value: " + compressionStrategy);
+        }
     }
 }

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -1096,7 +1096,7 @@ public class GenericGrizzlyListener implements GrizzlyListener {
 
     protected Set<ContentEncoding> configureCompressionEncodings(Http http) {
         final String mode = http.getCompression();
-        final int compressionStrategy = getCompressionStrategyByInt(http.getCompressionStrategy());
+        final int compressionStrategy = getCompressionStrategyAsInt(http.getCompressionStrategy());
         final int compressionLevel = Integer.parseInt(http.getCompressionLevel());
         int compressionMinSize = Integer.parseInt(http.getCompressionMinSizeBytes());
         CompressionMode compressionMode;
@@ -1188,7 +1188,7 @@ public class GenericGrizzlyListener implements GrizzlyListener {
         return null;
     }
 
-    private int getCompressionStrategyByInt(String compressionStrategy) {
+    private int getCompressionStrategyAsInt(String compressionStrategy) {
         switch (compressionStrategy) {
             case "Default":
                 return 0;

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Http.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Http.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  * 
- * Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates] 
+ * Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
  */
 
 
@@ -78,6 +78,7 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     boolean ALLOW_PAYLOAD_FOR_UNDEFINED_HTTP_METHODS = false;
 
     int COMPRESSION_MIN_SIZE = 2048;
+    int COMPRESSION_LEVEL = -1;
     int CONNECTION_UPLOAD_TIMEOUT = 300000;
     int HEADER_BUFFER_LENGTH = 8192;
     int KEEP_ALIVE_TIMEOUT = 30;
@@ -95,6 +96,8 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     String COMPRESSABLE_MIME_TYPE = "text/html,text/xml,text/plain";
     String COMPRESSION = "off";
     String COMPRESSION_PATTERN = "on|off|force|\\d+";
+    String COMPRESSION_STRATEGY = "Default";
+    String COMPRESSION_STRATEGY_PATTERN = "Filtered|Default|Huffman Only|\\d+";
     String DEFAULT_ADAPTER = "org.glassfish.grizzly.http.server.StaticHttpHandler";
     String URI_ENCODING = "UTF-8";
     String SCHEME_PATTERN = "http|https";
@@ -149,6 +152,17 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     String getCompression();
 
     void setCompression(String compression);
+
+    @Attribute(defaultValue = "" + COMPRESSION_LEVEL, dataType = Integer.class)
+    String getCompressionLevel();
+
+    void setCompressionLevel(String level);
+
+    @Attribute(defaultValue = COMPRESSION_STRATEGY, dataType = String.class)
+    @Pattern(regexp = COMPRESSION_STRATEGY_PATTERN)
+    String getCompressionStrategy();
+
+    void setCompressionStrategy(String compressionStrategy);
 
     @Attribute(defaultValue = "" + COMPRESSION_MIN_SIZE, dataType = Integer.class)
     String getCompressionMinSizeBytes();

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
-        <grizzly.version>2.4.4.payara-p5</grizzly.version>
+        <grizzly.version>2.4.4.payara-p7</grizzly.version>
         <jax-rs-api.impl.version>2.1.6</jax-rs-api.impl.version>
         <jersey.version>2.34.payara-p1</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>


### PR DESCRIPTION
## Description
An improvement allowing finer configuration of HTTP GZip Compression. It allows the user to configure between three compression strategies: Default, Filtered and Huffman Only.
It also allows for setting the compression level, -1 is the default level, 0 is no compression, 1 is fastest speed and 9 is fastest compression.

Changes have also been made in patched-src-grizzly: https://github.com/payara/patched-src-grizzly/pull/31

## Important Info
### Blockers
Requires PR in patched-src-grizzly to be merged.

## Testing
### New tests
CompressionTest in Payara samples. Tests compression in all strategies and levels works.

### Testing Performed
Manually tested compression works with: 
_curl http://localhost:8080 --silent -H "Accept-Encoding: gzip,deflate" --write-out "%{size_download}\n" --output /dev/null_

Tested using the new test in Payara Samples.
### Testing Environment
Windows 10 Pro, Maven 3.6.3, JDK8

## Documentation
Documentation PR: https://github.com/payara/Payara-Community-Documentation/pull/246

## Notes for Reviewers
Changes have also been made in 
The new setting look like the following image under Network Config -> Network Listeners -> {Listener} -> HTTP
![image](https://user-images.githubusercontent.com/73830120/132871015-be7aecda-768e-4373-a0b3-85925c7aac20.png)
