### PR TITLE
FISH-5678 Fixed Jakarta named properties in persistence.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <monitoring-console-process.version>1.7</monitoring-console-process.version>
         <monitoring-console-webapp.version>1.7</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
-        <payara.transformer>0.2.5</payara.transformer>
+        <payara.transformer>0.2.6</payara.transformer>
     </properties>
 
     <profiles>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Jakarta named properties in a Jakarta EE9 application persistence.xml were not recognised. I added the changes to the payara transformer and upgraded the version. PR [here ](https://github.com/payara/transformer/pull/21)
I believe this PR will also solve the issue #5404 

## Testing
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Deployed an Jakarta EE9 application and checked if the persistence.xml properties were working as intended.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04 maven version 3.6.3  openjdk version "1.8.0_292"
