### PR TITLE
FISH-5636 Remote EJB Tracing Improvements

### DIFF
--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopClientInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopClientInterceptor.java
@@ -53,7 +53,6 @@ import org.omg.PortableInterceptor.ForwardRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopInterceptorFactory.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopInterceptorFactory.java
@@ -50,6 +50,8 @@ import org.omg.PortableInterceptor.ORBInitInfo;
 import org.omg.PortableInterceptor.ServerRequestInterceptor;
 
 import javax.inject.Singleton;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Factory for creating IIOP client and server interceptors that propagate OpenTracing SpanContext.
@@ -59,6 +61,8 @@ import javax.inject.Singleton;
 @Service(name = "OpenTracingIiopInterceptorFactory")
 @Singleton
 public class OpenTracingIiopInterceptorFactory implements IIOPInterceptorFactory {
+
+    private static final Logger logger = Logger.getLogger(OpenTracingIiopInterceptorFactory.class.getName());
 
     public static final int OPENTRACING_IIOP_ID = 3226428;
     public static final long OPENTRACING_IIOP_SERIAL_VERSION_UID = 20200731171822L;
@@ -74,7 +78,12 @@ public class OpenTracingIiopInterceptorFactory implements IIOPInterceptorFactory
     public ClientRequestInterceptor createClientRequestInterceptor(ORBInitInfo info, Codec codec) {
         if (clientRequestInterceptor == null) {
             if (attemptCreation()) {
-                clientRequestInterceptor = new OpenTracingIiopClientInterceptor(openTracingService);
+                try {
+                    clientRequestInterceptor = new OpenTracingIiopClientInterceptor(openTracingService);
+                } catch (NullPointerException nullPointerException) {
+                    logger.log(Level.WARNING, "Could not create OpenTracing IIOP Client Interceptor - Remote EJBs will not be traced");
+                    return null;
+                }
             }
         }
 

--- a/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
+++ b/appserver/ejb/ejb-opentracing/src/main/java/fish/payara/ejb/opentracing/OpenTracingIiopServerInterceptor.java
@@ -73,7 +73,8 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
     public OpenTracingIiopServerInterceptor(OpenTracingService openTracingService) {
         this.openTracingService = openTracingService;
 
-        if (openTracingService != null && openTracingService.isEnabled()) {
+        // Null check for opentracing should have been done by factory
+        if (openTracingService.isEnabled()) {
             this.tracer = openTracingService.getTracer(PAYARA_CORBA_RMI_TRACER_NAME);
         }
     }
@@ -154,9 +155,7 @@ public class OpenTracingIiopServerInterceptor extends LocalObject implements Ser
 
     private boolean tracerAvailable() {
         if (tracer == null) {
-            if (openTracingService == null) {
-                return false;
-            }
+            // Null check for opentracing should have been done by factory
             if (!openTracingService.isEnabled()) {
                 return false;
             }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardWrapper.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardWrapper.java
@@ -133,6 +133,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import io.opentracing.Tracer;
 import org.apache.catalina.Container;
 import org.apache.catalina.ContainerServlet;
 import org.apache.catalina.Context;
@@ -1639,12 +1640,13 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
                         String applicationName = openTracing.getApplicationName(
                                 Globals.getDefaultBaseServiceLocator().getService(InvocationManager.class));
 
-                        if (openTracing.getTracer(applicationName).activeSpan() != null) {
+                        Tracer tracer = openTracing.getTracer(applicationName);
+                        if (tracer != null && tracer.activeSpan() != null) {
                             // Presumably held open by return being handled by another thread
-                            openTracing.getTracer(applicationName).activeSpan().setTag(
+                            tracer.activeSpan().setTag(
                                     Tags.HTTP_STATUS.getKey(),
                                     Integer.toString(((HttpServletResponse) response).getStatus()));
-                            openTracing.getTracer(applicationName).activeSpan().finish();
+                            tracer.activeSpan().finish();
                         }
 
                         if (requestTracing.isRequestTracingEnabled() && span != null) {

--- a/nucleus/packager/external/opentracing-repackaged/pom.xml
+++ b/nucleus/packager/external/opentracing-repackaged/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.opentracing,io.opentracing.propagation,io.opentracing.tag,io.opentracing.mock,io.opentracing.util</Export-Package>
+                        <Export-Package>io.opentracing,io.opentracing.propagation,io.opentracing.tag,io.opentracing.log,io.opentracing.util</Export-Package>
                         <Private-Package>*</Private-Package>
                         <Include-Resource>META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/</Include-Resource>
                     </instructions>
@@ -93,12 +93,6 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-mock</artifactId>
-            <version>${opentracing.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -74,12 +74,6 @@
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-mock</artifactId>
-            <version>${opentracing.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -99,7 +99,7 @@ public class OpenTracingService implements EventListener {
         // registered to that application (if there is one)
         if (event.is(Deployment.APPLICATION_LOADED)) {
             ApplicationInfo info = (ApplicationInfo) event.hook();
-            createAndReturnTracer(info.getName());
+            createTracer(info.getName());
         }
 
         if (event.is(Deployment.APPLICATION_UNLOADED)) {
@@ -124,13 +124,13 @@ public class OpenTracingService implements EventListener {
 
         // If there isn't a tracer for the application, create one
         if (tracer == null) {
-            tracer = createAndReturnTracer(applicationName);
+            tracer = createTracer(applicationName);
         }
 
         return tracer;
     }
 
-    private synchronized Tracer createAndReturnTracer(String applicationName) {
+    private synchronized Tracer createTracer(String applicationName) {
         // Does this NEED to be synchronised? Tracers don't store state, and Scopes are ThreadLocal
 
         // Double-checked locking - potentially naughty

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -177,7 +177,11 @@ public class OpenTracingService implements EventListener {
         return false;
     }
 
-    public RequestTracingService getRequestTracingService() {
+    /**
+     * Gets the {@link RequestTracingService}, looking up the active service from HK2 if necessary.
+     * @return The {@link RequestTracingService}, or null.
+     */
+    private RequestTracingService getRequestTracingService() {
         if (requestTracingService == null) {
             requestTracingService = getFromServiceHandle(Globals.getDefaultBaseServiceLocator(),
                     RequestTracingService.class);

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -41,20 +41,6 @@ package fish.payara.opentracing;
 
 import fish.payara.nucleus.requesttracing.RequestTracingService;
 import io.opentracing.Tracer;
-import io.opentracing.mock.MockTracer;
-import io.opentracing.util.ThreadLocalScopeManager;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.PostConstruct;
-import javax.interceptor.InvocationContext;
-
 import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.Events;
 import org.glassfish.api.invocation.ComponentInvocation;
@@ -66,6 +52,17 @@ import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.data.ApplicationRegistry;
 import org.glassfish.internal.deployment.Deployment;
 import org.jvnet.hk2.annotations.Service;
+
+import javax.annotation.PostConstruct;
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Service class for the OpenTracing integration.
@@ -135,9 +132,7 @@ public class OpenTracingService implements EventListener {
                 logger.log(Level.SEVERE, "Unable to find Tracer implementation", ex);
             }
 
-            if (Boolean.getBoolean("USE_OPENTRACING_MOCK_TRACER")) {
-                tracer = new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
-            } else if (tracer == null) {
+            if (tracer == null) {
                 tracer = new fish.payara.opentracing.tracer.Tracer(applicationName, scopeManager);
             }
 

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -100,13 +100,16 @@ public class OpenTracingService implements EventListener {
 
     @Override
     public void event(Event<?> event) {
-        // Listen for application unloaded events (happens during undeployment), so that we remove the tracer instance
-        // registered to that application (if there is one)
+        // Eagerly create tracer if request tracing is enabled
         if (event.is(Deployment.APPLICATION_LOADED)) {
-            ApplicationInfo info = (ApplicationInfo) event.hook();
-            createTracer(info.getName());
+            if (getRequestTracingService() != null && requestTracingService.isRequestTracingEnabled()) {
+                ApplicationInfo info = (ApplicationInfo) event.hook();
+                createTracer(info.getName());
+            }
         }
 
+        // Listen for application unloaded events (happens during undeployment), so that we remove the tracer instance
+        // registered to that application (if there is one)
         if (event.is(Deployment.APPLICATION_UNLOADED)) {
             ApplicationInfo info = (ApplicationInfo) event.hook();
             tracers.remove(info.getName());

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/tracer/Tracer.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/tracer/Tracer.java
@@ -92,6 +92,15 @@ public class Tracer implements io.opentracing.Tracer {
     private static final String SPANID_KEY = "spanid";
 
     /**
+     * Constructor that registers this Tracer to an application using a thread-local ScopeManager
+     *
+     * @param applicationName The application to register this tracer to
+     */
+    public Tracer(String applicationName) {
+        this(applicationName, new ScopeManager());
+    }
+
+    /**
      * Constructor that registers this Tracer to an application.
      *
      * @param applicationName The application to register this tracer to

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTracingService.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/RequestTracingService.java
@@ -127,7 +127,6 @@ public class RequestTracingService implements EventListener, ConfigListener, Mon
     private static final int SECOND = 1;
     private static final int MINUTE = 60 * SECOND;
     private static final int HOUR = 60 * MINUTE;
-    private static final int DAY = 24 * HOUR;
 
     @Inject
     @Named(ServerEnvironment.DEFAULT_INSTANCE_NAME)
@@ -258,7 +257,7 @@ public class RequestTracingService implements EventListener, ConfigListener, Mon
 
             // Set up the historic request trace store if enabled
             if (executionOptions.isHistoricTraceStoreEnabled()) {
-                historicRequestTraceStore = RequestTraceStoreFactory.getStore(events, executionOptions.getReservoirSamplingEnabled(), true);
+                historicRequestTraceStore = RequestTraceStoreFactory.getStore(executionOptions.getReservoirSamplingEnabled(), true);
                 initStoreSize(historicRequestTraceStore, executionOptions::getHistoricTraceStoreSize, "historicRequestTraceStoreSize");
 
 
@@ -277,7 +276,7 @@ public class RequestTracingService implements EventListener, ConfigListener, Mon
             }
 
             // Set up the general request trace store
-            requestTraceStore = RequestTraceStoreFactory.getStore(events, executionOptions.getReservoirSamplingEnabled(), false);
+            requestTraceStore = RequestTraceStoreFactory.getStore(executionOptions.getReservoirSamplingEnabled(), false);
             initStoreSize(requestTraceStore, executionOptions::getTraceStoreSize, "requestTraceStoreSize");
 
             // Disable cleanup task if it's null, less than 0, or reservoir sampling is enabled

--- a/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/store/RequestTraceStoreFactory.java
+++ b/nucleus/payara-modules/requesttracing-core/src/main/java/fish/payara/nucleus/requesttracing/store/RequestTraceStoreFactory.java
@@ -44,7 +44,6 @@ import fish.payara.nucleus.requesttracing.store.strategy.LongestTraceStorageStra
 import fish.payara.nucleus.requesttracing.store.strategy.ReservoirTraceStorageStrategy;
 import fish.payara.nucleus.requesttracing.store.strategy.TraceStorageStrategy;
 import fish.payara.nucleus.store.ClusteredStore;
-import org.glassfish.api.event.Events;
 import org.glassfish.hk2.api.ServiceHandle;
 import org.glassfish.internal.api.Globals;
 
@@ -68,7 +67,7 @@ public class RequestTraceStoreFactory {
      * @param historic whether the store is a historic store or not.
      * @return a request trace store.
      */
-    public static RequestTraceStoreInterface getStore(Events events, boolean reservoirSamplingEnabled, boolean historic) {
+    public static RequestTraceStoreInterface getStore(boolean reservoirSamplingEnabled, boolean historic) {
 
         // Get the hazelcast store name for if it's a clustered store.
         String storeName;


### PR DESCRIPTION
## Description

An attempt to improve the throughput of the OpenTracing service, particularly with regards to remote EJBs.
The main change is the un-synchronising of the `getTracer` method - creation of tracers is still synchronised but is now split off into another method and utilises double-checked locking to prevent conflicts. While double-checked locking can be naughty, in this case it's being done on a map itself, so the issue of partially constructed references not returning null Shouldn't™ occur.

My results from performance testing were largely inconclusive since the realm of variance is pretty large - this is working at the micro and millisecond timeframe, any slight deviation outside of my control (e.g. OS runs a background process) will affect the result. In any case, I shall list the reasoning of how each change should help below.

* `getTracer` split into two methods: `getTracer` and `createTracer`
  * `getTracer` is now unsynchronised, meaning there should be less contention waiting for locks in normal operation since only `createTracer` is synchronised (tracers only get created once)
* `StandardWrapper` no longer does two calls for `getTracer` back-to-back (less of an impact now that `getTracer` is no longer synced but still saves performing the get operation on a ConcurrentHashMap twice)
* Lookup of `RequestTracingService` moved from `SpanBuilder` constructor to `OpenTracingService` (and then passed to `Tracer` as a constructor parameter). The intent here is to make it so an HK2 lookup doesn't need to be performed each time a span is created, and is instead done once.  

This PR also includes some cleanup of deprecated or ugly code:
* MockTracer removed from code base - this is now handled using service loader
  * Supplemental - I noticed the export for `log` was missing and so I added it in
* `GlobalTracer.register(Tracer)` is deprecated, so has been replaced with `GlobalTracer.registerIfAbsent(Callable)`
  * A lot of the null checks being done here were redundant, since they are handled by the factory. In any case, a try-catch has been added to the factory around the create method since that can (but Shouldn't™) be thrown by `GlobalTracer.registerIfAbsent(Callable)`
* Removed `Events` from constructor of `RequestTraceStoreFactory` - not used.
* `DAY` variable removed from `RequestTracingService` - not used.
* Static `ScopeManager` moved from `OpenTracingService` to `Tracer` - it isn't used anywhere else, and our `Tracer` impl doesn't use any other kind of `ScopeManager`

## Important Info

### Dependant PRs
MicroProfile OpenTracing TCK Runner update: https://github.com/payara/MicroProfile-TCK-Runners/pull/153

### Blockers
None

## Testing

### New tests
None - with the level of sensitivity being worked on here (milliseconds) performance tests are not suitable for day-to-day testing.

### Testing Performed
Ran my own test using JMeter numerous times against various points on the branch and compared against master - results largely inconclusive. Added my own logging around every call to `getTracer` to try and get a sense of the response time of synchronised vs. un-synchronised (inconclusive). 

Ran a test created by @fturizo and inspected using JProfiler numerous times against various points on the branch and compared against master to see if any discernible difference could be gained (inconclusive).

Ran MicroProfile OpenTracing TCK to check everything still works.

### Test suites executed
MicroProfile OpenTracing

### Testing Environment
Windows 10, JDK8.

## Documentation
N/A

## Notes for Reviewers
Please keep performance in mind when reviewing, pointing out stuff I've missed or things I may have misunderstood.
