### PR TITLE
FISH-5736 Fix Unknown Exclude Field Provided Warning on Startup

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/ExcludeFieldsSupport.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/ExcludeFieldsSupport.java
@@ -67,6 +67,8 @@ public class ExcludeFieldsSupport {
             String[] fields = excludeFields.split(",");
             for (String field : fields) {
                 switch (field) {
+                    case "":
+                        break;
                     case "tid":
                         excludeSuppAttrsBits.set(SupplementalAttribute.TID.ordinal());
                         break;


### PR DESCRIPTION
## Description
Title.

Handle the empty string which is default so that the log message doesn't get thrown on startup.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started server - no error.
Added an exclude field - no error and field excluded.

### Testing Environment
Windows 10, JDK8

## Documentation
N/A

## Notes for Reviewers
None
