### PR TITLE
FISH-5658 instance in custom metrics

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricsServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricsServiceImpl.java
@@ -271,7 +271,7 @@ public class MetricsServiceImpl implements MetricsService, ConfigListener, Monit
                         }
                     }
                 } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, "Failing retrieving metric: " + metricID, ex);;
+                    LOGGER.log(Level.SEVERE, "Failed to retrieve metric: " + metricID);;
                 }
             }
         }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricsServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricsServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -95,6 +95,7 @@ import fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper;
 import fish.payara.monitoring.collect.MonitoringDataCollector;
 import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
+import java.util.logging.Level;
 
 @Service(name = "microprofile-metrics-service")
 @RunLevel(StartupRunLevel.VAL)
@@ -251,22 +252,26 @@ public class MetricsServiceImpl implements MetricsService, ConfigListener, Monit
             for (Entry<MetricID, Metric> entry : ((MetricRegistryImpl) registry).getMetrics(name).entrySet()) {
                 MetricID metricID = entry.getKey();
                 Metric metric = entry.getValue();
-                MonitoringDataCollector metricCollector = tagCollector(contextName, metricID, collector);
-                if (metric instanceof Counting) {
-                    metricCollector.collect(toName(metricID, "Count"), ((Counting) metric).getCount());
-                }
-                if (metric instanceof SimpleTimer) {
-                    metricCollector.collect(toName(metricID, "Duration"), ((SimpleTimer) metric).getElapsedTime().toMillis());
-                }
-                if (metric instanceof Timer) {
-                    metricCollector.collect(toName(metricID, "MaxDuration"), ((Timer) metric).getSnapshot().getMax());
-                }
-                if (metric instanceof Gauge) {
-                    Object value = ((Gauge<?>) metric).getValue();
-                    if (value instanceof Number) {
-                        metricCollector.collect(toName(metricID,
-                                getMetricUnitSuffix(registry.getMetadata(name).unit())), ((Number) value));
+                try {
+                    MonitoringDataCollector metricCollector = tagCollector(contextName, metricID, collector);
+                    if (metric instanceof Counting) {
+                        metricCollector.collect(toName(metricID, "Count"), ((Counting) metric).getCount());
                     }
+                    if (metric instanceof SimpleTimer) {
+                        metricCollector.collect(toName(metricID, "Duration"), ((SimpleTimer) metric).getElapsedTime().toMillis());
+                    }
+                    if (metric instanceof Timer) {
+                        metricCollector.collect(toName(metricID, "MaxDuration"), ((Timer) metric).getSnapshot().getMax());
+                    }
+                    if (metric instanceof Gauge) {
+                        Object value = ((Gauge<?>) metric).getValue();
+                        if (value instanceof Number) {
+                            metricCollector.collect(toName(metricID,
+                                    getMetricUnitSuffix(registry.getMetadata(name).unit())), ((Number) value));
+                        }
+                    }
+                } catch (Exception ex) {
+                    LOGGER.log(Level.SEVERE, "Failing retrieving metric: " + metricID, ex);;
                 }
             }
         }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
@@ -136,7 +136,7 @@ public class MBeanExpression {
                 CompositeData compositeData = (CompositeData) attribute;
                 return (Number) compositeData.get(getSubAttributeName());
             } else {
-                throw new IllegalArgumentException("The MBean expression is neither a number nor CompositeData: " + getMBean() + ", attribute " + attributeName + ", the value type is " + attribute.getClass());
+                throw new IllegalArgumentException("The MBean expression is neither a number nor CompositeData: " + getMBean() + ", attribute " + attributeName + ", type " + attribute.getClass());
             }
         } catch (InstanceNotFoundException ex) {
             throw new IllegalStateException("MBean instance not found: " + ex.getMessage(), ex);

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -48,7 +48,6 @@ import static java.util.Collections.emptyList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import javax.management.AttributeNotFoundException;
@@ -137,11 +136,12 @@ public class MBeanExpression {
                 CompositeData compositeData = (CompositeData) attribute;
                 return (Number) compositeData.get(getSubAttributeName());
             } else {
-                throw new IllegalArgumentException(getMBean());
+                throw new IllegalArgumentException("The MBean expression is neither a number nor CompositeData: " + getMBean() + ", attribute " + attributeName + ", the value type is " + attribute.getClass());
             }
+        } catch (InstanceNotFoundException ex) {
+            throw new IllegalStateException("MBean instance not found: " + ex.getMessage(), ex);
         } catch (Exception ex) {
-            LOGGER.log(Level.WARNING, ex.getMessage());
-            throw new IllegalStateException(ex);
+            throw new IllegalStateException("Unable to get numeric value of MBean: " + ex.getMessage(), ex);
         }
     }
 

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -98,21 +98,21 @@ public class MBeanMetadata implements Metadata {
 
 
     public MBeanMetadata() {
+        tags = new ArrayList<>();
     }
 
     public MBeanMetadata(Metadata metadata) {
         this(null, metadata.getName(), metadata.getDisplayName(), metadata.description().orElse(null), metadata.getTypeRaw(), metadata.unit().orElse(null));
-
     }
 
     public MBeanMetadata(String mBean, String name, String displayName, String description, MetricType typeRaw, String unit) {
+        this();
         this.mBean = mBean;
         this.name = name;
         this.displayName = displayName;
         this.description = description;
         this.type = typeRaw.toString();
         this.unit = unit;
-        tags = new ArrayList<>();
     }
 
     public String getMBean() {
@@ -139,9 +139,6 @@ public class MBeanMetadata implements Metadata {
     }
 
     List<XmlTag> getTags() {
-        if (tags == null) {
-            tags = new ArrayList<>();
-        }
         return tags;
     }
 
@@ -243,13 +240,13 @@ public class MBeanMetadata implements Metadata {
     }
 
     public void setTags(List<XmlTag> tags) {
+        if (tags == null) {
+            throw new IllegalArgumentException("tags must not be null");
+        }
         this.tags = tags;
     }
 
     public void addTags(List<XmlTag> tags) {
-        if (this.tags == null) {
-            this.tags = new ArrayList<>();
-        }
         this.tags.addAll(tags);
     }
 


### PR DESCRIPTION
## Description
Improvement of templating (https://docs.payara.fish/community/docs/documentation/microprofile/metrics/vendor-metrics.html#advanced-templating), adding `${instance}` to `metrics.xml`, which is replaced with the name of the current instance.

## Testing
### Testing Performed
- copy `metrics.xml` from `Payara/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources` to `payara5/glassfish/domains/domain1/config`
- add this part before `</vendor>`:
```
    <metadata>
      <name>requestcount.${instance}</name>
      <mbean>amx:type=web-request-mon,pp=/mon/server-mon[${instance}],name=clusterjsp/server/requestcount#count</mbean>
      <type>gauge</type>
      <unit>none</unit>
      <displayName>XXXFINDMEXXX</displayName>
      <description>XXXFINDMEXXX</description>
    </metadata>
```

- setup monitoring on server

```
set-monitoring-level --level=HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH --module=jvm:transactionService:connectorService:jmsService:security:webContainer:jersey:webServicesContainer:jpa:jdbcConnectionPool:threadPool:ejbContainer:orb:connectorConnectionPool:deployment:httpService --target=server-config
set-monitoring-service-configuration --mbeanEnabled=true --monitoringEnabled=true --dtraceEnabled=false --target=server-config
set-jmx-monitoring-configuration --setNotifiers=log-notifier --logfrequency=15 --logfrequencyunit=SECONDS --dynamic=true --enabled=false --target=server-config
set-amx-enabled --dynamic=true --enabled=true --target=server-config
```

- create instance and deployment group
```
create-instance --node=localhost-domain1 i1
create-deployment-group dg
add-instance-to-deployment-group --instance=i1 --deploymentGroup=dg
start-deployment-group dg
```

- deploy a test application
```
deploy --keepState=false --precompilejsp=false --availabilityEnabled=true --name=clusterjsp --verify=false --force=false --enabled=true --properties=implicitCdiEnabled=true:preserveAppScopedResources=false:cdiDevModeEnabled=false --target=dg /tmp/clusterjsp.war
create-application-ref --target=server clusterjsp
```

- setup monitoring on instance
```
set-jmx-monitoring-configuration --setNotifiers=log-notifier --logfrequency=15 --logfrequencyunit=SECONDS --dynamic=true --enabled=false --target=i1-config
set-amx-enabled --dynamic=true --enabled=true --target=i1-config
set-monitoring-level --level=HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH:HIGH --module=jvm:transactionService:connectorService:jmsService:security:webContainer:jersey:webServicesContainer:jpa:jdbcConnectionPool:threadPool:ejbContainer:orb:connectorConnectionPool:deployment:httpService --target=i1-config
set-monitoring-service-configuration --mbeanEnabled=true --monitoringEnabled=true --dtraceEnabled=false --target=i1-config
set-jmx-monitoring-configuration --setNotifiers=log-notifier --logfrequency=15 --logfrequencyunit=SECONDS --dynamic=true --enabled=false --target=i1-config
set-amx-enabled --dynamic=true --enabled=true --target=i1-config
```

- touch the app, so monitor mbean appears in the tree
```
curl http://localhost:28080/clusterjsp/
```

- verfify metrics on the instance: http://localhost:28080/metrics

It should show
```
# TYPE vendor_requestcount_i1 gauge
# HELP vendor_requestcount_i1 XXXFINDMEXXX
vendor_requestcount_i1 1
```

- verify the same on DAS (server): http://localhost:8080/metrics
Expected output:
```
vendor_requestcount_server 3
```

## Documentation
https://github.com/payara/Payara-Community-Documentation/pull/245


