### PR TITLE
Fish 28 fixing issue when starting openmq with invalid jre path

### DIFF
--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.connectors.jms.system;
 
@@ -1166,19 +1166,20 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
     /**
      * This method evaluate the current JDK and return true if the version is greater than 8 as an indicator
      * to include the start-args attribute for the broker configuration with the correct jrehome path
+     *
      * @return boolean indicator to create the start-args attribute for the jrehome
      */
     private boolean availableJDKForStartArgs() {
-        int major = JDK.getMajor();
-        if(major > 8) {
+        if (JDK.getMajor() > 8) {
             return true;
         }
         return false;
     }
 
     /**
-     * This method build the start args attribute with the value -jrehome to override the default value added
-     * on the configuration of the jms broker
+     * This method build the start-args attribute with the value -jrehome to override the default used when configuring
+     * the jms broker
+     *
      * @param javaHome String with the path to use for the -jrehome attribute
      * @return String with the formed start-args value for the jms broker configuration
      */

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -1164,10 +1164,10 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
     }
 
     /**
-     * This method evaluate the current JDK and return true if the version is greater than 8 as an indicator
-     * to include the start-args attribute for the broker configuration with the correct jrehome path
+     * This method evaluate the current JDK and return true if the version is greater than 8. This indicator
+     * is used to include the start-args attribute for the broker configuration with the jrehome path attribute
      *
-     * @return boolean indicator to create the start-args attribute for the jrehome
+     * @return boolean indicator to create the start-args attribute for the broker
      */
     private boolean availableJDKForStartArgs() {
         if (JDK.getMajor() > 8) {
@@ -1177,11 +1177,10 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
     }
 
     /**
-     * This method build the start-args attribute with the value -jrehome to override the default used when configuring
-     * the jms broker
+     * This method build the start-args attribute with the value -jrehome for the jms broker configuration
      *
      * @param javaHome String with the path to use for the -jrehome attribute
-     * @return String with the formed start-args value for the jms broker configuration
+     * @return String with the formed start-args attribute
      */
     private String buildStartArgsForJREHome(String javaHome) {
         StringBuilder buildStartArgs = new StringBuilder("-jrehome ");

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -1180,7 +1180,7 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
      * @return String with the formed start-args attribute
      */
     private String buildStartArgsForJREHome(String javaHome) {
-        return " -jrehome "+javaHome;
+        return " -jrehome "+"\""+javaHome+"\"";
     }
 
    private Properties listToProperties(List<Property> props){

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -77,6 +77,7 @@ import com.sun.enterprise.deployment.JMSDestinationDefinitionDescriptor;
 import com.sun.enterprise.deployment.MessageDestinationDescriptor;
 import com.sun.enterprise.deployment.WebBundleDescriptor;
 import com.sun.enterprise.deployment.runtime.BeanPoolDescriptor;
+import com.sun.enterprise.util.JDK;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.Result;
 import com.sun.enterprise.util.SystemPropertyConstants;
@@ -1043,9 +1044,13 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
             if (tmpString == null) {
                 tmpString = "";
             }
-
             String brokerArgs = tmpString;
 
+            //condition to evaluate the JDK and if version greater than 8 then omit the jre folder
+            //by adding the start-args for the broker configuration
+            if (availableJDKForStartArgs()) {
+                brokerArgs = buildStartArgsForJREHome(java_home);
+            }
 
             //XX: Extract the information from the optional properties.
        List jmsProperties =    getJmsService().getProperty();
@@ -1156,6 +1161,31 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
         }
         //Optional
         //BrokerBindAddress, RmiRegistryPort
+    }
+
+    /**
+     * This method evaluate the current JDK and return true if the version is greater than 8 as an indicator
+     * to include the start-args attribute for the broker configuration with the correct jrehome path
+     * @return boolean indicator to create the start-args attribute for the jrehome
+     */
+    private boolean availableJDKForStartArgs() {
+        int major = JDK.getMajor();
+        if(major > 8) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * This method build the start args attribute with the value -jrehome to override the default value added
+     * on the configuration of the jms broker
+     * @param javaHome String with the path to use for the -jrehome attribute
+     * @return String with the formed start-args value for the jms broker configuration
+     */
+    private String buildStartArgsForJREHome(String javaHome) {
+        StringBuilder buildStartArgs = new StringBuilder("-jrehome ");
+        buildStartArgs.append(javaHome);
+        return buildStartArgs.toString();
     }
 
    private Properties listToProperties(List<Property> props){

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -1048,8 +1048,8 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
 
             //condition to evaluate the JDK and if version greater than 8 then omit the jre folder
             //by adding the start-args for the broker configuration
-            if (availableJDKForStartArgs()) {
-                brokerArgs = buildStartArgsForJREHome(java_home);
+            if (!tmpString.contains("-jrehome") && availableJDKForStartArgs()) {
+                brokerArgs = brokerArgs + buildStartArgsForJREHome(java_home);
             }
 
             //XX: Extract the information from the optional properties.
@@ -1170,10 +1170,7 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
      * @return boolean indicator to create the start-args attribute for the broker
      */
     private boolean availableJDKForStartArgs() {
-        if (JDK.getMajor() > 8) {
-            return true;
-        }
-        return false;
+        return JDK.getMajor() > 8;
     }
 
     /**
@@ -1183,9 +1180,7 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
      * @return String with the formed start-args attribute
      */
     private String buildStartArgsForJREHome(String javaHome) {
-        StringBuilder buildStartArgs = new StringBuilder("-jrehome ");
-        buildStartArgs.append(javaHome);
-        return buildStartArgs.toString();
+        return " -jrehome "+javaHome;
     }
 
    private Properties listToProperties(List<Property> props){


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Fix for the issue when starting the local jms broker using jdk 11
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
I didn't add new unit test because of the complexity to deal with statics when starting the ActiveJmsResourceAdapter class
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
please verify the following comment on jira ticket with the result of manual test that I did on my local environment:
https://payara.atlassian.net/browse/FISH-28?focusedCommentId=57690
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 10 with JDK 11(zulu), JDK 10(openjdk) and JDK 9(openjdk)
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
