### PR TITLE
FISH-5768 Clustered CDI Events not Received if Sender Application Deployed on Receiver Instance

### DIFF
--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
@@ -170,7 +170,7 @@ public class ClusteredCDIEventBusImpl implements CDIEventListener, ClusteredCDIE
                     bm.fireEvent(eventPayload,annotations);
                 } catch (IOException | ClassNotFoundException ex) {
                     Logger.getLogger(ClusteredCDIEventBusImpl.class.getName())
-                            .log(ex.getCause() instanceof IllegalStateException? Level.FINE : Level.INFO,
+                            .log(ex.getCause() instanceof IllegalStateException ? Level.FINE : Level.INFO,
                                     "Received Event but could not process it", ex);
                 }
             });

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraClusteredCDIEventImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraClusteredCDIEventImpl.java
@@ -175,7 +175,7 @@ public class PayaraClusteredCDIEventImpl implements PayaraClusteredCDIEvent {
                             Logger.getLogger(PayaraClusteredCDIEventImpl.class.getName()).log(
                                     ex instanceof IllegalArgumentException &&
                                             ex.getMessage().contains("is not visible from class loader") ? Level.FINE : Level.INFO,
-                                    "Problem determining the qualifier type of an Event ignoring", ex);
+                                    "Problem determining the qualifier type of an Event, ignoring", ex);
                         }
                     }
                 }

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraClusteredCDIEventImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/PayaraClusteredCDIEventImpl.java
@@ -41,7 +41,7 @@ package fish.payara.appserver.micro.services;
 
 import com.sun.enterprise.util.Utility;
 import fish.payara.micro.event.PayaraClusteredCDIEvent;
-import fish.payara.cdi.jsr107.implementation.PayaraValueHolder;
+import fish.payara.appserver.micro.services.data.PayaraValueHolder;
 import fish.payara.micro.data.InstanceDescriptor;
 import java.io.IOException;
 import java.io.Serializable;
@@ -172,7 +172,10 @@ public class PayaraClusteredCDIEventImpl implements PayaraClusteredCDIEvent {
                             // then create a proxy for the annotation type from the serialized Invocation Handler
                             result.add((Annotation) Proxy.newProxyInstance(Utility.getClassLoader(), new Class[]{annotationClazz}, qualifier));
                         } catch (Throwable ex) {
-                            Logger.getLogger(PayaraClusteredCDIEventImpl.class.getName()).log(Level.INFO, "Problem determining the qualifier type of an Event ignoring", ex);
+                            Logger.getLogger(PayaraClusteredCDIEventImpl.class.getName()).log(
+                                    ex instanceof IllegalArgumentException &&
+                                            ex.getMessage().contains("is not visible from class loader") ? Level.FINE : Level.INFO,
+                                    "Problem determining the qualifier type of an Event ignoring", ex);
                         }
                     }
                 }

--- a/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/data/PayaraValueHolder.java
+++ b/appserver/payara-appserver-modules/payara-micro-service/src/main/java/fish/payara/appserver/micro/services/data/PayaraValueHolder.java
@@ -37,7 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.cdi.jsr107.implementation;
+package fish.payara.appserver.micro.services.data;
+
+import fish.payara.cdi.jsr107.implementation.PayaraTCCLObjectInputStream;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.api.JavaEEContextUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,10 +50,6 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
-import java.util.Optional;
-import org.glassfish.internal.api.Globals;
-import org.glassfish.internal.api.JavaEEContextUtil;
-import org.glassfish.internal.api.JavaEEContextUtil.Context;
 
 /**
  * Packages up an object into a Serializable value
@@ -79,12 +79,8 @@ public class PayaraValueHolder<T> implements Externalizable {
         String componentId = null;
         try (ByteArrayInputStream bais = new ByteArrayInputStream(data); PayaraTCCLObjectInputStream ois = new PayaraTCCLObjectInputStream(bais)) {
             componentId = (String)ois.readObject();
-            JavaEEContextUtil ctxUtil = Globals.getDefaultHabitat().getService(JavaEEContextUtil.class);
-            JavaEEContextUtil.Instance inst = Optional.ofNullable(componentId)
-                    .map(ctxUtil::fromComponentId).orElse(ctxUtil.empty());
-            try (Context ctx = inst.setApplicationClassLoader()) {
-                return (T) ois.readObject();
-            }
+            Object result = ois.readObject();
+            return (T)result;
         }
         catch (ClassNotFoundException ex) {
             String invocationComponentId = Globals.getDefaultHabitat().getService(JavaEEContextUtil.class).getInvocationComponentId();


### PR DESCRIPTION
## Description
Bug Fix.

Clustered CDI Events do not get resolved correctly if both the sender application and receiver application are deployed to the same instance. The cause is our old favourite: class loaders.

When Weld comes to resolve the observer methods for the event, it fails to do a `.equals` comparison on the event class due to it having been loaded by the sender class loader rather than the receiver.

The fix here partially reverts https://github.com/payara/Payara/pull/5010 - notably the bit in `PayaraValueHolder` where the error was tracked down to.
This does seem to have a knock-on effect when resolving qualifiers - where _Sometimes_ it seems to not have the correct class loader set and will hit `java.lang.IllegalArgumentException: interface xyz is not visible from class loader`. The behaviour here however is to just ignore the error and move on, and from my testing this doesn't seem to negatively impact the expected behaviour (the correct number of events are still received and their observing methods invoked whether the error appears or not). Given this, I've added an extra clause to the log statement to use Fine rather than Info, similar to https://github.com/payara/Payara/blob/master/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java#L173 (which likely gets hit afterwards on this particular thread anyway)

## Important Info
### Blockers
None

## Testing
### New tests
Pending...

### Testing Performed
Pending...

Start two instances, and deploy the receiver and sender applications (Payara-Examples/payara-micro/clustered-cdi-events) to both instances. 

### Testing Environment
Windows 10 - JDK 8

## Documentation
N/A

## Notes for Reviewers
Pending...
