### PR TITLE
FISH-5769 CertificateIdentityStoreDefinition Ignores Role Mappings Specified in payara-web.xml

### DIFF
--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/cdi/RealmExtension.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/cdi/RealmExtension.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -43,7 +43,6 @@ import com.sun.enterprise.config.serverbeans.AuthRealm;
 import com.sun.enterprise.config.serverbeans.SecurityService;
 import com.sun.enterprise.security.auth.realm.NoSuchRealmException;
 import com.sun.enterprise.security.auth.realm.Realm;
-import com.sun.enterprise.util.StringUtils;
 import fish.payara.security.annotations.CertificateAuthenticationMechanismDefinition;
 import fish.payara.security.annotations.CertificateIdentityStoreDefinition;
 import fish.payara.security.annotations.FileIdentityStoreDefinition;
@@ -311,7 +310,7 @@ public class RealmExtension implements Extension {
             authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                     .scope(ApplicationScoped.class)
                     .beanClass(HttpAuthenticationMechanism.class)
-                    .types(Object.class, HttpAuthenticationMechanism.class)
+                    .types(Object.class, CertificateAuthenticationMechanism.class)
                     .addToId(CertificateAuthenticationMechanism.class)
                     .create(e -> CDI.current().select(CertificateAuthenticationMechanism.class).get());
         });


### PR DESCRIPTION
## Description
This is a bug fix where using the @CertificateAuthenticationMechanismDefinition and @CertificateIdentityStoreDefinition annotations causes a 403 error where it should still return 200.

## Important Info
### Blockers
This fix cannot be fully implemented due to a limitation with Jakarta Security 2.0 where CLIENT-CERT auth-method wasn't converted into an annotation and so the servlet implementation is still needed. This issue is tracked here: https://github.com/eclipse-ee4j/security-api/issues/120

## Testing
### New tests
N/A

### Testing Performed
Manually tested with the reproducer on the ticket. Ran the related unit tests

### Testing Environment
Windows 10, JDK 8, Maven 3.6.3

## Documentation
Community PR: https://github.com/payara/Payara-Community-Documentation/pull/257

## Notes for Reviewers
N/A
