### PR TITLE
FISH-5802: exclude .gitkeep file from unpacking

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExplodedURLClassloader.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExplodedURLClassloader.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -142,7 +142,7 @@ public class ExplodedURLClassloader extends OpenURLClassLoader {
                             fileName = entry.getName().substring(LIB_DOMAIN_DIR.length());
                         }
 
-                        if (fileName != null) {
+                        if (fileName != null && !fileName.contains("gitkeep")) {
                             File outputFile = new File(runtimeDir, fileName);
                             registerForDeletion(outputFile);
                             super.addURL(outputFile.getAbsoluteFile().toURI().toURL());


### PR DESCRIPTION
## Description
The file `.gitkeep` is not required in the unpacked runtime directory of  the Payara Micro instance and its presence prevents using the CDS capabilities fully on JDK17.

## Testing

### Testing Performed
Testing the creation of the outputlauncher and using it to run an application.

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.8 with Maven 3.8.2

