### PR TITLE
FISH-5752 Update Command Security Plugin to 1.0.13

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -189,7 +189,7 @@
         <glassfishbuild.version>3.2.20.payara-p2</glassfishbuild.version>
         <source-annotation-processor.version>1.0</source-annotation-processor.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
-        <command-security-plugin.version>1.0.10.payara-p1</command-security-plugin.version>
+        <command-security-plugin.version>1.0.13</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
         <copyright-plugin.version>1.39</copyright-plugin.version>
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>


### PR DESCRIPTION
## Description
Updates the GlassFish Command Security Plugin to 1.0.13.
No patched-project needed, as upstream has either included or fixes or made them redundant.

## Important Info
### Blockers
None.

## Testing
### New tests
None.

### Testing Performed
Start Payara server (JDK 8), no errors. Execute `list-commands` command, no errors.
Start Payara server (JDK 11), no errors. Execute `list-commands` command, no errors.

### Testing Environment
Windows 10, Zulu JDK 8 & Zulu JDK 11.

## Documentation
N/A

## Notes for Reviewers
None
