### PR TITLE
Yasson 1.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <tyrus.version>1.17.payara-p1</tyrus.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <json.bind-api.version>1.0.2</json.bind-api.version>
-        <yasson.version>1.0.6</yasson.version>
+        <yasson.version>1.0.9</yasson.version>
         <jakarta-persistence-api.version>2.2.3</jakarta-persistence-api.version>
         <eclipselink.version>2.7.7.payara-p3</eclipselink.version>
         <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>


### PR DESCRIPTION
Please consider updating Yasson 1.0.6 to 1.0.9 in next release of Payara Community 5.x

Yasson 1.0.6 contains several serialization failures which are fixed in 1.0.9 and it took me days to work around them, so to prevent others to run in the same troubles, this update should get adopted. As it is a pure bug fix it should not imply any new bugs.