### PR TITLE
FISH-1323 upgrade docker jdk to 8u302 and 11.0.12

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -15,8 +15,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk8.tag>8u282</docker.jdk8.tag>
-        <docker.jdk11.tag>11.0.10</docker.jdk11.tag>
+        <docker.jdk8.tag>8u302</docker.jdk8.tag>
+        <docker.jdk11.tag>11.0.12</docker.jdk11.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
upgrade docker jdk to 8u302 and 11.0.12
Disable TLS 1.0 and 1.1

## Important Info
### Blockers
Is removal of TLS 1.0 and 1.1 blocker for anything?

## Testing
### Testing Performed
I ran all tests in project, Payara Samples

### Testing Environment
Zulu JDK 1.8_302 on Debian Linux
