### PR TITLE
FISH-5800 Jaspic Uses Unexported Package in 'java.base' Module

### DIFF
--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jaspic/config/ConfigDomainParser.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jaspic/config/ConfigDomainParser.java
@@ -94,9 +94,7 @@ public class ConfigDomainParser implements ConfigParser {
 
         if (service instanceof SecurityService) {
             processServerConfig((SecurityService) service, configMap);
-        } /*
-         * else { throw new IOException("invalid configBean type passed to parser"); }
-         */
+        }
     }
 
     private void processServerConfig(SecurityService service, Map<String, GFServerConfigProvider.InterceptEntry> newConfig) throws IOException {


### PR DESCRIPTION
## Description
When using JDK 17 Payara Micro would throw an exception about java.base not exporting the `sun.security.util` package.
This PR brings in the changes made upstream in GlassFish, and adjusts it to fit in our code base: https://github.com/eclipse-ee4j/glassfish/pull/23339

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Build the server (JDK 8)
Started Payara Micro and deployed reproducer app from Jira and poked the endpoint (JDK 17) - no error
Started Payara Micro and deployed reproducer app from Jira and poked the endpoint (JDK 8) - no error
Started Payara Micro and deployed reproducer app from Jira and poked the endpoint (JDK 11) - no error

### Testing Environment
Windows 10.
Zulu JDK 8.0.312, 11.0.13, and 17.0.1

## Documentation
N/A

## Notes for Reviewers
Haven't poked the server past just loading the admin console, but no purple dancing elephants as to why this would break anything.
