### PR TITLE
FISH-1323 Upgrade Docker Images

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -15,8 +15,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk8.tag>8u302</docker.jdk8.tag>
-        <docker.jdk11.tag>11.0.12</docker.jdk11.tag>
+        <docker.jdk8.tag>8u312</docker.jdk8.tag>
+        <docker.jdk11.tag>11.0.13</docker.jdk11.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
Update to https://github.com/payara/Payara/pull/5460 to use the just released images.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built and ran the docker tests.

### Testing Environment
Windows 10, JDK 8.

## Documentation
N/A

## Notes for Reviewers
None extra on top of https://github.com/payara/Payara/pull/5460 - TLS 1.0 and 1.1 removed.
