### PR TITLE
FISH-5801: Custom Vendor MP Metrics Using Placeholders Require 'tags'

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
@@ -93,7 +93,7 @@ public class MBeanMetadata implements Metadata {
     private Boolean valid;
 
     @XmlElementWrapper(name = "tags", nillable = true)
-    @XmlElement(name="tag")
+    @XmlElement(name = "tag")
     private List<XmlTag> tags;
 
 
@@ -215,9 +215,12 @@ public class MBeanMetadata implements Metadata {
                     validationResult = false;
                 } else if (metadata.getMBean().contains(keyword)) {
                     boolean tagSpecifier = false;
-                    for (XmlTag tag: tags) {
-                        if (tag.getValue().contains(keyword)) {
-                            tagSpecifier = true;
+                    if (tags != null) {
+                        for (XmlTag tag : tags) {
+                            if (tag.getValue() != null && tag.getValue().contains(keyword)) {
+                                tagSpecifier = true;
+                                break;
+                            }
                         }
                     }
                     if (!(metadata.getName().contains(keyword) || tagSpecifier)) {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanMetadata.java
@@ -215,12 +215,10 @@ public class MBeanMetadata implements Metadata {
                     validationResult = false;
                 } else if (metadata.getMBean().contains(keyword)) {
                     boolean tagSpecifier = false;
-                    if (tags != null) {
-                        for (XmlTag tag : tags) {
-                            if (tag.getValue() != null && tag.getValue().contains(keyword)) {
-                                tagSpecifier = true;
-                                break;
-                            }
+                    for (XmlTag tag : tags) {
+                        if (tag.getValue() != null && tag.getValue().contains(keyword)) {
+                            tagSpecifier = true;
+                            break;
                         }
                     }
                     if (!(metadata.getName().contains(keyword) || tagSpecifier)) {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MBeanMetadataTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MBeanMetadataTest.java
@@ -1,0 +1,125 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.microprofile.metrics.jmx;
+
+import org.eclipse.microprofile.metrics.MetricType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MBeanMetadataTest {
+
+    @Test
+    public void isValid_basic() {
+        MBeanMetadata metadata = new MBeanMetadata("m", "name"
+                , "Display", "description", MetricType.COUNTER, "none");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("test", "JUnit"));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
+    @Test
+    public void isValid_EmptyTag() {
+        MBeanMetadata metadata = new MBeanMetadata("m", "name", "Display", "description"
+                , MetricType.COUNTER, "none");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("test", "JUnit"));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
+    @Test
+    public void isValid_PlaceHolder() {
+        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+                , "jdbc.connection.pool.%s.pool.instance.free.connections"
+                , "Free Connections (Instance)"
+                , "The total number of free connections in the pool as of the last sampling"
+                , MetricType.GAUGE, "none");
+        List<XmlTag> tags = new ArrayList<>();
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
+    @Test
+    public void isValid_PlaceHolderSomeTag() {
+        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+                , "jdbc.connection.pool.%s.pool.instance.free.connections"
+                , "Free Connections (Instance)"
+                , "The total number of free connections in the pool as of the last sampling"
+                , MetricType.GAUGE, "none");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("test", "JUnit"));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
+    @Test
+    public void isValid_PlaceHolderPlaceHolderTag() {
+        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+                , "jdbc.connection.pool.instance.free.connections"
+                , "Free Connections (Instance)"
+                , "The total number of free connections in the pool as of the last sampling"
+                , MetricType.GAUGE, "none");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("pool", "%s"));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
+    @Test
+    public void isValid_PlaceHolderEmptyTag() {
+        // FISH-5801
+        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+                , "jdbc.connection.pool.%s.pool.instance.free.connections"
+                , "Free Connections (Instance)"
+                , "The total number of free connections in the pool as of the last sampling"
+                , MetricType.GAUGE, "none");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("test", null));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+}


### PR DESCRIPTION
## Description
Fixes Exception when not using tags in custom Vendor metrics having a Placeholder.

## Important Info

## Testing

### New tests
new Unit test MBeanMetadataTest

### Testing Environment
Zulu 8.52.0.23-CA-macosx (build 1.8.0_282-b08) on Mac 11.8 with Maven 3.8.2

## Documentation
Not needed, Bugfix

