### PR TITLE
FISH-5812 HK2 Cannot Resolve OSGi on JDK 17

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
-  ~    Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+  ~    Copyright (c) [2019-2021] Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~    The contents of this file are subject to the terms of either the GNU
   ~    General Public License Version 2 only ("GPL") or the Common Development

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -430,26 +430,32 @@
 
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.compendium</artifactId>
-                <version>5.0.0</version>
+                <artifactId>osgi.cmpn</artifactId>
+                <version>${osgi.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.core</artifactId>
-                <version>6.0.0</version>
+                <artifactId>osgi.core</artifactId>
+                <version>${osgi.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.enterprise</artifactId>
-                <version>5.0.0</version>
+                <artifactId>osgi.enterprise</artifactId>
+                <version>${osgi.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi</groupId> <!-- OSGi Companion Code for org.osgi.dto Version 1.0.0. -->
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>${osgi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId> <!-- OSGi Companion Code for org.osgi.dto Version 1.1.0. -->
                 <artifactId>org.osgi.dto</artifactId>
-                <version>1.1.0</version>
+                <version>${osgi.dto.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>

--- a/appserver/extras/embedded/common/bootstrap/pom.xml
+++ b/appserver/extras/embedded/common/bootstrap/pom.xml
@@ -40,7 +40,7 @@
  * holder.
  */
 -->
-<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/appserver/extras/embedded/common/bootstrap/pom.xml
+++ b/appserver/extras/embedded/common/bootstrap/pom.xml
@@ -97,12 +97,12 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/extras/embedded/common/installroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/installroot-builder/pom.xml
@@ -39,7 +39,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
---> 
+-->
+<!-- Portions Copyright 2021 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/extras/embedded/common/installroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/installroot-builder/pom.xml
@@ -86,7 +86,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/extras/embedded/common/instanceroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/instanceroot-builder/pom.xml
@@ -87,7 +87,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/extras/embedded/common/instanceroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/instanceroot-builder/pom.xml
@@ -39,8 +39,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
---> 
-
+-->
+<!-- Portions Copyright 2021 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/extras/embedded/common/osgi-main/pom.xml
+++ b/appserver/extras/embedded/common/osgi-main/pom.xml
@@ -39,8 +39,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
---> 
-
+-->
+<!-- Portions Copyright 2021 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/extras/embedded/common/osgi-main/pom.xml
+++ b/appserver/extras/embedded/common/osgi-main/pom.xml
@@ -58,7 +58,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
+++ b/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
@@ -57,7 +57,7 @@ holder.
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
+++ b/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
@@ -39,7 +39,8 @@ and therefore, elected the GPL Version 2 license, then the option applies
 only if the new code is made subject to such option by the copyright
 holder.
 
---> 
+-->
+<!-- Portions Copyright 2021 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
+++ b/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
@@ -79,11 +79,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
+++ b/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-
+<!-- Portions Copyright 2021 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -150,7 +150,7 @@
         </dependency>
         <dependency> <!-- for FindBugs -->
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/web/web-naming/pom.xml
+++ b/appserver/web/web-naming/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/web/web-naming/pom.xml
+++ b/appserver/web/web-naming/pom.xml
@@ -89,13 +89,12 @@
         <dependency>
             <!-- Needed to register URLStreamHandler -->
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.annotation</artifactId>
-            <version>6.0.0</version>
+            <artifactId>osgi.annotation</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/DirContextURLStreamHandlerService.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/DirContextURLStreamHandlerService.java
@@ -46,6 +46,7 @@ import static org.osgi.service.url.URLConstants.URL_HANDLER_PROTOCOL;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Properties;
 
@@ -97,13 +98,13 @@ public class DirContextURLStreamHandlerService
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void start(BundleContext context) throws Exception {
         
-        Properties properties = new Properties();
+        Dictionary properties = new Properties();
         properties.put(URL_HANDLER_PROTOCOL, new String[] { "jndi" });
         
         context.registerService(
                 URLStreamHandlerService.class.getName(),
                 this,
-                (Hashtable) properties);
+                properties);
     }
 
     public void stop(BundleContext context) throws Exception {

--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/DirContextURLStreamHandlerService.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/DirContextURLStreamHandlerService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 
 package org.apache.naming.resources;
 

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -184,7 +184,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -148,7 +148,7 @@
         </dependency>
         <dependency> <!-- for FindBugs -->
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -113,13 +113,13 @@
         <dependency>
             <!-- Needed to have a bundle activator to set up a different serialization policy-->
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <!-- Needed to have a bundle activator to set up a different serialization policy-->
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
+            <artifactId>osgi.enterprise</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2014-2019] [Payara Foundation and/or its affiliates]" -->
+<!--"Portions Copyright [2014-2021] [Payara Foundation and/or its affiliates]" -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>

--- a/nucleus/core/bootstrap/pom.xml
+++ b/nucleus/core/bootstrap/pom.xml
@@ -132,12 +132,12 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/nucleus/core/bootstrap/pom.xml
+++ b/nucleus/core/bootstrap/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/BundleProvisioner.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/BundleProvisioner.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.glassfish.bootstrap.osgi;
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/BundleProvisioner.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/BundleProvisioner.java
@@ -754,8 +754,10 @@ public class BundleProvisioner {
         long t0 = System.currentTimeMillis();
 
         Framework framework = null;
+        Map<String, String> mm = new HashMap<>();
+        props.putAll(mm);
         for (FrameworkFactory frameworkFactory : ServiceLoader.load(FrameworkFactory.class)) {
-            framework = frameworkFactory.newFramework((Hashtable)props);
+            framework = frameworkFactory.newFramework(mm);
             System.out.println("framework = " + framework);
             break;
         }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntimeBuilder.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntimeBuilder.java
@@ -45,7 +45,9 @@ package com.sun.enterprise.glassfish.bootstrap.osgi;
 import static com.sun.enterprise.glassfish.bootstrap.Constants.BUILDER_NAME_PROPERTY;
 import static com.sun.enterprise.glassfish.bootstrap.Constants.PLATFORM_PROPERTY_KEY;
 
+import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.Properties;
 
 import org.glassfish.embeddable.BootstrapProperties;
 import org.glassfish.embeddable.GlassFishException;
@@ -81,11 +83,13 @@ public class EmbeddedOSGiGlassFishRuntimeBuilder implements RuntimeBuilder {
         provisionBundles(bootstrapProperties);
         
         GlassFishRuntime glassFishRuntime = new EmbeddedOSGiGlassFishRuntime(getBundleContext());
-        
-        getBundleContext().registerService(
-            GlassFishRuntime.class.getName(), 
-            glassFishRuntime, 
-            (Hashtable) bootstrapProperties.getProperties());
+
+        Properties props = bootstrapProperties.getProperties();
+        Dictionary properties = new Properties();
+        for (final String name: props.stringPropertyNames()) {
+            properties.put(name, props.getProperty(name));
+        }
+        getBundleContext().registerService(GlassFishRuntime.class.getName(), glassFishRuntime, properties);
         
         return glassFishRuntime;
     }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntimeBuilder.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntimeBuilder.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 
 
 package com.sun.enterprise.glassfish.bootstrap.osgi;

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiFrameworkLauncher.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiFrameworkLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.glassfish.bootstrap.osgi;
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiFrameworkLauncher.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiFrameworkLauncher.java
@@ -48,7 +48,9 @@ import org.osgi.framework.launch.Framework;
 import org.osgi.framework.launch.FrameworkFactory;
 import org.osgi.util.tracker.ServiceTracker;
 
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 
@@ -76,8 +78,12 @@ public class OSGiFrameworkLauncher {
             // Locate an OSGi framework and initialize it
             ServiceLoader<FrameworkFactory> frameworkFactories =
                     ServiceLoader.load(FrameworkFactory.class, getClass().getClassLoader());
+            Map<String, String> mm = new HashMap<>();
+            for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+                mm.put((String) entry.getKey(), (String) entry.getValue());
+            }
             for (FrameworkFactory frameworkFactory : frameworkFactories) {
-                framework = frameworkFactory.newFramework((Hashtable)properties);
+                framework = frameworkFactory.newFramework(mm);
                 break;
             }
             

--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]" -->
+<!--"Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]" -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -107,7 +107,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -346,6 +346,7 @@ jre-1.6=\
  javax.xml.datatype, \
  javax.xml.namespace, \
  javax.xml.parsers, \
+ javax.xml.soap, \
  javax.xml.stream; javax.xml.stream.events; javax.xml.stream.util, \
  javax.xml.transform, \
  javax.xml.transform.dom, \
@@ -394,7 +395,7 @@ jre-1.6=\
 # TODO: We still need to add appropriate SE packages for 7 & 8.
 jre-1.7=${jre-1.6},com.sun.tracing
 jre-1.8=${jre-1.7}
-jre-9=${jre-1.8}
+jre-9=${jre-1.8},jdk,jdk.security,jdk.security.jarsigner
 jre-10=${jre-9}
 jre-11=\
  javax.accessibility, \
@@ -498,6 +499,7 @@ jre-11=\
  javax.xml.transform.stream, \
  javax.xml.validation, \
  javax.xml.xpath, \
+ jdk, \
  jdk.jfr, \
  jdk.jfr.consumer, \
  jdk.jfr.events, \
@@ -511,6 +513,7 @@ jre-11=\
  jdk.net, \
  jdk.nio, \
  jdk.nio.zipfs, \
+ jdk.security, \
  jdk.security.jarsigner, \
  jdk.swing.interop, \
  jdk.tools.jimage, \
@@ -536,6 +539,16 @@ jre-11=\
  org.xml.sax.ext, \
  org.xml.sax.helpers, \
  com.sun.tracing
+jre-12=${jre-11}
+jre-13=${jre-11}
+jre-14=${jre-11}
+jre-15=${jre-11}
+jre-16=${jre-11}
+jre-17=${jre-11}
+jre-18=${jre-11}
+jre-19=${jre-11}
+jre-20=${jre-11}
+jre-21=${jre-11}
 
 # Bundle information optimization to improve performance
 felix.cache.singlebundlefile=true
@@ -564,7 +577,27 @@ gosh.args=--nointeractive
 #fix for GLASSFISH-21236
 org.osgi.framework.system.capabilities= \
  ${eecap-${java.specification.version}}
- #we are adding eecap entries upto 1.7 as GF is not supported for JDK<1.7
+#we are adding eecap entries upto 1.7 as GF is not supported for JDK<1.7
+eecap-21= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15,16,17,18,19,20,21"
+eecap-20= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15,16,17,18,19,20"
+eecap-19= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15,16,17,18,19"
+eecap-18= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15,16,17,18"
+eecap-17= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15,16,17"
+eecap-16= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15,16"
+eecap-15= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14,15"
+eecap-14= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13,14"
+eecap-13= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12,13"
+eecap-12= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11,12"
 eecap-11= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
  osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11"
 eecap-10= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -66,8 +66,8 @@
 # Unlike Equinox, Felix requires us to list all packages from felix.jar
 # while using org.osgi.framework.system.packages property.
 Felix.system.packages=\
- org.osgi.dto; version=1.0, \
- org.osgi.framework; version=1.8, \
+ org.osgi.dto; version=1.1, \
+ org.osgi.framework; version=1.9, \
  org.osgi.framework.dto; version=1.8, \
  org.osgi.framework.hooks.bundle; version=1.1, \
  org.osgi.framework.hooks.resolver; version=1.0, \
@@ -78,14 +78,14 @@ Felix.system.packages=\
  org.osgi.framework.startlevel; version=1.0, \
  org.osgi.framework.startlevel.dto; version=1.0, \
  org.osgi.framework.wiring; version=1.2, \
- org.osgi.framework.wiring.dto; version=1.2, \
+ org.osgi.framework.wiring.dto; version=1.3, \
  org.osgi.resource; version=1.0, \
  org.osgi.resource.dto; version=1.0, \
  org.osgi.service.packageadmin; version=1.2, \
- org.osgi.service.resolver; version=1.0, \
+ org.osgi.service.resolver; version=1.1, \
  org.osgi.service.startlevel; version=1.1, \
  org.osgi.service.url; version=1.0, \
- org.osgi.util.tracker; version=1.5.1, \
+ org.osgi.util.tracker; version=1.5.2, \
  ${extra-system-packages}
 
 

--- a/nucleus/osgi-platforms/osgi-cli-remote/osgi.bundle
+++ b/nucleus/osgi-platforms/osgi-cli-remote/osgi.bundle
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright 2021 Payara Foundation and/or its affiliates
 
 -exportcontents:
 

--- a/nucleus/osgi-platforms/osgi-cli-remote/osgi.bundle
+++ b/nucleus/osgi-platforms/osgi-cli-remote/osgi.bundle
@@ -43,4 +43,4 @@
 # shell packages resolved at runtime, whatever there is...
 DynamicImport-Package: \
     org.apache.felix.shell, \
-    org.apache.felix.service.command; status="provisional"
+    org.apache.felix.service.command;

--- a/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
@@ -64,7 +64,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/nucleus/osgi-platforms/osgi-container/pom.xml
+++ b/nucleus/osgi-platforms/osgi-container/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/nucleus/osgi-platforms/osgi-container/pom.xml
+++ b/nucleus/osgi-platforms/osgi-container/pom.xml
@@ -39,7 +39,7 @@
     holder.
 
 -->
-
+<!-- Portions Copyright 2021 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,8 @@
         <monitoring-console-webapp.version>1.7</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
         <payara.transformer>0.2.6</payara.transformer>
+        <osgi.version>7.0.0</osgi.version>
+        <osgi.dto.version>1.1.0</osgi.dto.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
## Description
OSGi changes to allow HK2 to resolve OSGi and for the server to boot.
Note that this does not constitute Payara supporting JDK 17 - it simply fixes this particular issue of the Felix and HK2 not even able to boot.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the domain and loaded admin console successfully on JDK 8 and 11 without error
Started the domain successfully in JDK 17 without error (loading the admin console is a separate can of worms)

### Testing Environment
Windows 10.
Zulu JDK 8u312, 11.0.13, and 17.0.1

## Documentation
N/A

## Notes for Reviewers
If you've started the admin console on JDK 8 and/or 11, you may need to clean the domain before attempting to start on JDK 17 since it may try to load the admin console automatically.
