### PR TITLE
FISH-5750 Felix FileInstall 3.7.0.payara-p1

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -167,7 +167,7 @@
         <org.apache.felix.gogo.runtime.version>1.1.4</org.apache.felix.gogo.runtime.version>
         <org.apache.felix.gogo.shell.version>1.1.4</org.apache.felix.gogo.shell.version>
         <org.apache.felix.gogo.command.version>1.1.2</org.apache.felix.gogo.command.version>
-        <org.apache.felix.fileinstall.version>3.6.4.payara-p1</org.apache.felix.fileinstall.version>
+        <org.apache.felix.fileinstall.version>3.7.0.payara-p1</org.apache.felix.fileinstall.version>
         <org.apache.felix.configadmin.version>1.9.22</org.apache.felix.configadmin.version>
         <org.apache.felix.scr.version>2.1.28</org.apache.felix.scr.version>
         <org.apache.felix.bundlerepository.version>2.0.10</org.apache.felix.bundlerepository.version>


### PR DESCRIPTION
## Description
Missed in the original upgrade of all the Felix gubbins.
Applies our pre-existing patch to Felix FileInstall 3.7.0.
Our pre-existing patch makes Payara a bit better at cleaning up after itself in /tmp.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the server and loaded the admin console without issue on JDK 8 and 11.

### Testing Environment
WSL OpenSUSE 15.3.
Zulu JDK 8u312 and 11.0.13

## Documentation
N/A

## Notes for Reviewers
None
