### PR TITLE
FISH-5832 FISH-5833 Weld 3.1.8 and Weld SPI 3.1.SP4

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/WeldProxyException.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/WeldProxyException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.weld.services;
+
+
+/**
+ * Runtime exception meaning that the operation failed to finish the desired operation.
+ *
+ * @author David Matějček
+ */
+public class WeldProxyException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public WeldProxyException(final String message, final Exception cause) {
+        super(message, cause);
+    }
+
+
+    public WeldProxyException(final String message) {
+        super(message);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@
         <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
         <jakarta.inject.version>1.0</jakarta.inject.version>
         <cdi-api.version>2.0.2</cdi-api.version>
-        <weld.version>3.1.4.Final</weld.version>
-        <weld-api.version>3.1.Final</weld-api.version>
+        <weld.version>3.1.8.Final</weld.version>
+        <weld-api.version>3.1.SP4</weld-api.version>
         <jakarta.security.enterprise-api.version>1.0.2</jakarta.security.enterprise-api.version>
         <jakarta.security.enterprise.version>1.1-b01.payara-p4</jakarta.security.enterprise.version>
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>


### PR DESCRIPTION
## Description
Title.
Updates Weld to a version that works with JDK 17.

PR does not constitute support for CDI under JDK 17 - there are failures in Payara Samples that indicate an issue in Weld with the resolution of the `RolesPermitted` annotation. Java reflect can't parse the signature of the `semantics` enum, specifically when it's the Weld Proxy being parsed (it's using JDK 1.5 type signatures which support for was removed in JDK 17):
`fish.payara.cdi.auth.roles.LogicalOperator -- Signature Parse error: Expected Field Type Signature`

This does however only occur when the server is running under JDK 17 since it's a change in the JDK itself that breaks things.

## Important Info
### Blockers
None.

## Testing
### New tests
None

### Testing Performed
Started the server and ran Payara Samples without issue - JDK 8
Started the server and ran Payara Samples without issue - JDK 11

### Testing Environment
WSL OpenSUSE 15.3, Zulu JDK 8u312 and 11.0.13

## Documentation
N/A

## Notes for Reviewers
None
