### PR TITLE
FISH-5836 FISH-5837 Refactor EJB Security to Use Public APIs and Fix Improper Formatting in GSSUtils

### DIFF
--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUPToken.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUPToken.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2011 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2021 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.iiop.security;
 
 /**
@@ -52,11 +52,11 @@ import com.sun.corba.ee.org.omg.GSSUP.InitialContextTokenHelper;
 import com.sun.enterprise.security.auth.login.common.PasswordCredential;
 import com.sun.enterprise.util.Utility;
 import com.sun.logging.LogDomains;
+import org.ietf.jgss.GSSException;
 import org.omg.CORBA.Any;
 import org.omg.CORBA.ORB;
 import org.omg.IOP.Codec;
 
-import java.io.IOException;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 
@@ -329,7 +329,7 @@ public class GSSUPToken {
             if (target_name != null && target_name.length != 0) {
                 targetNameRealm = new String(GSSUtils.importName(GSSUtils.GSSUP_MECH_OID, target_name));
             }
-        } catch (IOException ex) {
+        } catch (GSSException ex) {
             _logger.log(Level.FINE, null, ex);
         }
         if (targetNameRealm != null && !DEFAULT_REALM_NAME.equals(targetNameRealm)) {
@@ -346,7 +346,7 @@ public class GSSUPToken {
      *
      * @return byte[] the byte array representation of the GSSToken
      */
-    byte[] getGSSToken() throws IOException {
+    byte[] getGSSToken() throws GSSException {
         if (_logger.isLoggable(Level.FINER)) {
             _logger.log(Level.FINER, "IIOP:GSSUP mech token : " + GSSUtils.dumpHex(cdr_encoded_token));
         }

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtils.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtils.java
@@ -1,7 +1,6 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- *
- * Copyright (c) 1997-2011 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,7 +36,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.iiop.security;
 
@@ -45,15 +44,11 @@ import com.sun.corba.ee.org.omg.CSI.GSS_NT_Export_Name_OID;
 import com.sun.corba.ee.org.omg.CSI.GSS_NT_Scoped_Username_OID;
 import com.sun.corba.ee.org.omg.GSSUP.GSSUPMechOID;
 import com.sun.logging.LogDomains;
-import sun.security.util.DerInputStream;
-import sun.security.util.DerOutputStream;
-import sun.security.util.ObjectIdentifier;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.Oid;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.logging.Level;
-
-;
 
 /**
  * @author Sekhar Vajjhala (Almost complete rewrite of an old version)
@@ -62,29 +57,29 @@ import java.util.logging.Level;
 public class GSSUtils {
     private static final java.util.logging.Logger _logger = LogDomains.getLogger(GSSUtils.class, LogDomains.CORBA_LOGGER, false);
 
-    public static final ObjectIdentifier GSSUP_MECH_OID;
+    public static final Oid GSSUP_MECH_OID;
 
-    public static final ObjectIdentifier GSS_NT_EXPORT_NAME_OID;
+    public static final Oid GSS_NT_EXPORT_NAME_OID;
 
     /*
      * GSS_NT_SCOPED_USERNAME_OID is currently not used by this class. It is defined here for the sake
      * of completeness.
      */
-    public static final ObjectIdentifier GSS_NT_SCOPED_USERNAME_OID;
+    public static final Oid GSS_NT_SCOPED_USERNAME_OID;
 
     private static byte[] mech;
 
     static {
 
         int i; // index
-        ObjectIdentifier x = null;
+        Oid x = null;
 
         /* Construct an ObjectIdentifer by extracting each OID */
 
         try {
             i = GSSUPMechOID.value.indexOf(':');
-            x = new ObjectIdentifier(GSSUPMechOID.value.substring(i + 1));
-        } catch (IOException e) {
+            x = new Oid(GSSUPMechOID.value.substring(i + 1));
+        } catch (GSSException e) {
             x = null;
             _logger.log(Level.SEVERE, "Cannot construct the ObjectIdentifier for " + GSSUPMechOID.value, e);
         }
@@ -92,8 +87,8 @@ public class GSSUtils {
 
         try {
             i = GSS_NT_Export_Name_OID.value.indexOf(':');
-            x = new ObjectIdentifier(GSS_NT_Export_Name_OID.value.substring(i + 1));
-        } catch (IOException e) {
+            x = new Oid(GSS_NT_Export_Name_OID.value.substring(i + 1));
+        } catch (GSSException e) {
             x = null;
             _logger.log(Level.SEVERE, "Cannot construct the ObjectIdentifier for " + GSS_NT_Export_Name_OID.value, e);
         }
@@ -101,8 +96,8 @@ public class GSSUtils {
 
         try {
             i = GSS_NT_Scoped_Username_OID.value.indexOf(':');
-            x = new ObjectIdentifier(GSS_NT_Scoped_Username_OID.value.substring(i + 1));
-        } catch (IOException e) {
+            x = new Oid(GSS_NT_Scoped_Username_OID.value.substring(i + 1));
+        } catch (GSSException e) {
             x = null;
             _logger.log(Level.SEVERE, "Cannot construct the ObjectIdentifier for " + GSS_NT_Scoped_Username_OID.value, e);
         }
@@ -114,13 +109,13 @@ public class GSSUtils {
                 _logger.log(Level.FINE, "GSS_NT_EXPORT_NAME_OID: " + dumpHex(getDER(GSS_NT_EXPORT_NAME_OID)));
                 _logger.log(Level.FINE, "GSS_NT_SCOPED_USERNAME_OID: " + dumpHex(getDER(GSS_NT_SCOPED_USERNAME_OID)));
             }
-        } catch (IOException e) {
+        } catch (GSSException e) {
             _logger.log(Level.SEVERE, "getDER failed", e);
         }
 
         try {
             mech = GSSUtils.getDER(GSSUtils.GSSUP_MECH_OID);
-        } catch (IOException io) {
+        } catch (GSSException io) {
             mech = null;
         }
     }
@@ -148,13 +143,13 @@ public class GSSUtils {
      * Import the exported name from the mechanism independent exported name.
      */
 
-    public static byte[] importName(ObjectIdentifier oid, byte[] externalName) throws IOException {
+    public static byte[] importName(Oid oid, byte[] externalName) throws GSSException {
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "Attempting to import mechanism independent name");
             _logger.log(Level.FINE, dumpHex(externalName));
         }
 
-        IOException e = new IOException("Invalid Name");
+        GSSException e = new GSSException(GSSException.BAD_NAME);
 
         if (externalName[0] != 0x04)
             throw e;
@@ -175,7 +170,7 @@ public class GSSUtils {
 
         byte[] deroid = new byte[mechoidlen];
         System.arraycopy(externalName, 4, deroid, 0, mechoidlen);
-        ObjectIdentifier oid1 = getOID(deroid);
+        Oid oid1 = getOID(deroid);
         if (!oid1.equals((Object) oid))
             throw e;
 
@@ -201,13 +196,13 @@ public class GSSUtils {
 
     /* verify if exportedName is of object ObjectIdentifier. */
 
-    public static boolean verifyMechOID(ObjectIdentifier oid, byte[] externalName) throws IOException {
+    public static boolean verifyMechOID(Oid oid, byte[] externalName) throws GSSException {
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "Attempting to verify mechanism independent name");
             _logger.log(Level.FINE, dumpHex(externalName));
         }
 
-        IOException e = new IOException("Invalid Name");
+        GSSException e = new GSSException(GSSException.BAD_NAME);
 
         if (externalName[0] != 0x04)
             throw e;
@@ -229,7 +224,7 @@ public class GSSUtils {
 
         byte[] deroid = new byte[mechoidlen];
         System.arraycopy(externalName, 4, deroid, 0, mechoidlen);
-        ObjectIdentifier oid1 = getOID(deroid);
+        Oid oid1 = getOID(deroid);
         return oid1.equals((Object) oid);
     }
 
@@ -239,8 +234,7 @@ public class GSSUtils {
      * name is reproduced here from [RFC2743] : Format: Bytes 2 0x04 0x01 2 mech OID length (len) len
      * mech OID's DER value 4 exported name len name len exported name
      */
-
-    public static byte[] createExportedName(ObjectIdentifier oid, byte[] extName) throws IOException {
+    public static byte[] createExportedName(Oid oid, byte[] extName) throws GSSException {
         byte[] oidDER = getDER(oid);
         int tokensize = 2 + 2 + oidDER.length + 4 + extName.length;
 
@@ -276,17 +270,17 @@ public class GSSUtils {
      * as specified byte the DER representation for an ObjectIdentifier.
      */
 
-    public static byte[] getDER(ObjectIdentifier id) throws IOException {
+    public static byte[] getDER(Oid id) throws GSSException {
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "Returning OID in DER format");
             _logger.log(Level.FINE, "    OID = " + id.toString());
         }
-        DerOutputStream dos = new DerOutputStream();
-        dos.putOID(id);
-        byte[] oid = dos.toByteArray();
+        
+        byte[] oid = id.getDER();
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "    DER OID: " + dumpHex(oid));
         }
+        
         return oid;
     }
 
@@ -296,14 +290,8 @@ public class GSSUtils {
      * specified byte the DER representation for an ObjectIdentifier.
      */
 
-    public static ObjectIdentifier getOID(byte[] derOID) throws IOException {
-        DerInputStream dis = new DerInputStream(derOID);
-        ObjectIdentifier oid = dis.getOID();
-
-        /*
-         * Note: getOID() method call generates an IOException if derOID contains any malformed data
-         */
-        return oid;
+    public static Oid getOID(byte[] derOID) throws GSSException {
+        return new Oid(derOID);
     }
 
     /*
@@ -315,7 +303,7 @@ public class GSSUtils {
      * format defined by the mechanism itself outside of RFC 2743.
      */
 
-    public static byte[] createMechIndToken(ObjectIdentifier mechoid, byte mechtok[]) throws IOException {
+    public static byte[] createMechIndToken(Oid mechoid, byte mechtok[]) throws GSSException {
         byte[] deroid = getDER(mechoid);
 
         byte[] token = new byte[1 // for 0x60
@@ -338,6 +326,7 @@ public class GSSUtils {
             _logger.log(Level.FINE, "Mechanism independent token created: ");
             _logger.log(Level.FINE, dumpHex(token));
         }
+        
         return token;
     }
 
@@ -346,8 +335,7 @@ public class GSSUtils {
      * independent token is specified in section 3.1, [RFC 2743].
      */
 
-    public static byte[] getMechToken(ObjectIdentifier oid, byte[] token) {
-
+    public static byte[] getMechToken(Oid oid, byte[] token) {
         byte[] mechtoken = null;
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "Received mechanism independent token: ");
@@ -363,7 +351,7 @@ public class GSSUtils {
                 _logger.log(Level.FINE, "Mechanism specific token : ");
                 _logger.log(Level.FINE, dumpHex(mechtoken));
             }
-        } catch (IOException e) {
+        } catch (GSSException e) {
             _logger.log(Level.SEVERE, "Cannot verify token header", e);
         }
         return mechtoken;
@@ -376,14 +364,13 @@ public class GSSUtils {
      * token is returned. If the header is mal formed, then an exception is thrown.
      */
 
-    private static int verifyTokenHeader(ObjectIdentifier oid, byte[] token) throws IOException {
+    private static int verifyTokenHeader(Oid oid, byte[] token) throws GSSException {
         int index = 0;
-        if (_logger.isLoggable(Level.FINE)) {
-            _logger.log(Level.FINE, "Attempting to verify tokenheader in the mechanism independent token.");
-        }
+        _logger.log(Level.FINE, "Attempting to verify tokenheader in the mechanism independent token.");
+        
         // verify header
         if (token[index++] != 0x60)
-            throw new IOException("Defective Token");
+            throw new GSSException(GSSException.DEFECTIVE_TOKEN);
 
         int toklen = readDERLength(token, index); // derOID length + token length
 
@@ -396,13 +383,13 @@ public class GSSUtils {
         }
 
         if (token[index] != 0x06)
-            throw new IOException("Defective Token");
+            throw new GSSException(GSSException.DEFECTIVE_TOKEN);
 
         byte[] buf = new byte[token.length - index];
 
         System.arraycopy(token, index, buf, 0, token.length - index);
 
-        ObjectIdentifier mechoid = getOID(buf);
+        Oid mechoid = getOID(buf);
 
         if (_logger.isLoggable(Level.FINE)) {
             _logger.log(Level.FINE, "Comparing mech OID in token with the expected mech OID");
@@ -414,7 +401,7 @@ public class GSSUtils {
             if (_logger.isLoggable(Level.FINE)) {
                 _logger.log(Level.FINE, "mech OID in token does not match expected mech OID");
             }
-            throw new IOException("Defective token");
+            throw new GSSException(GSSException.DEFECTIVE_TOKEN);
         }
         int mechoidlen = getDER(oid).length;
 

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtils.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtils.java
@@ -385,9 +385,11 @@ public class GSSUtils {
         if (token[index] != 0x06)
             throw new GSSException(GSSException.DEFECTIVE_TOKEN);
 
-        byte[] buf = new byte[token.length - index];
+        // add first two bytes to the MECH_OID_LEN
+        int oidlen = token[index+1] + 2;
+        byte[] buf = new byte[oidlen];
 
-        System.arraycopy(token, index, buf, 0, token.length - index);
+        System.arraycopy(token, index, buf, 0, oidlen);
 
         Oid mechoid = getOID(buf);
 

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtilsService.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtilsService.java
@@ -37,15 +37,15 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.iiop.security;
 
 import com.sun.enterprise.common.iiop.security.GSSUtilsContract;
-import java.io.IOException;
-
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.Oid;
 import org.jvnet.hk2.annotations.Service;
+
 import javax.inject.Singleton;
-import sun.security.util.ObjectIdentifier;
 
 /**
  *
@@ -61,25 +61,17 @@ public class GSSUtilsService implements GSSUtilsContract {
     }
 
     @Override
-    public byte[] importName(ObjectIdentifier oid, byte[] externalName) throws IOException {
+    public byte[] importName(Oid oid, byte[] externalName) throws GSSException {
         return GSSUtils.importName(oid, externalName);
     }
 
     @Override
-    public byte[] createExportedName(ObjectIdentifier oid, byte[] extName) throws IOException {
+    public byte[] createExportedName(Oid oid, byte[] extName) throws GSSException {
         return GSSUtils.createExportedName(oid, extName);
     }
 
     @Override
-    public ObjectIdentifier GSSUP_MECH_OID() {
+    public Oid GSSUP_MECH_OID() {
         return GSSUtils.GSSUP_MECH_OID;
     }
-    /**
-     * TODO:V3 temporarily putting it inside this contract
-     * 
-     * @return the ORB public Object getORB() {
-     * 
-     * }
-     */
-
 }

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecClientRequestInterceptor.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecClientRequestInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2021 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,33 +37,51 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.iiop.security;
 
+import com.sun.corba.ee.org.omg.CSI.AuthorizationElement;
+import com.sun.corba.ee.org.omg.CSI.EstablishContext;
+import com.sun.corba.ee.org.omg.CSI.GSS_NT_ExportedNameHelper;
+import com.sun.corba.ee.org.omg.CSI.IdentityToken;
+import com.sun.corba.ee.org.omg.CSI.MTCompleteEstablishContext;
+import com.sun.corba.ee.org.omg.CSI.MTContextError;
+import com.sun.corba.ee.org.omg.CSI.SASContextBody;
+import com.sun.corba.ee.org.omg.CSI.SASContextBodyHelper;
+import com.sun.corba.ee.org.omg.CSI.X501DistinguishedNameHelper;
+import com.sun.corba.ee.org.omg.CSI.X509CertificateChainHelper;
+import com.sun.corba.ee.org.omg.CSIIOP.CompoundSecMech;
 import com.sun.enterprise.common.iiop.security.AnonCredential;
 import com.sun.enterprise.common.iiop.security.GSSUPName;
 import com.sun.enterprise.common.iiop.security.SecurityContext;
-
-import com.sun.corba.ee.org.omg.CSI.*;
-import com.sun.corba.ee.org.omg.CSIIOP.CompoundSecMech;
 import com.sun.enterprise.security.auth.login.common.PasswordCredential;
 import com.sun.enterprise.security.auth.login.common.X509CertificateCredential;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.logging.LogDomains;
+import org.glassfish.enterprise.iiop.api.GlassFishORBHelper;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.ORB;
+import org.omg.IOP.Codec;
+import org.omg.IOP.ServiceContext;
+import org.omg.PortableInterceptor.ClientRequestInfo;
+import org.omg.PortableInterceptor.ClientRequestInterceptor;
+import org.omg.PortableInterceptor.ForwardRequest;
+import org.omg.PortableInterceptor.LOCATION_FORWARD;
+import org.omg.PortableInterceptor.SUCCESSFUL;
+import org.omg.PortableInterceptor.SYSTEM_EXCEPTION;
+import org.omg.PortableInterceptor.TRANSPORT_RETRY;
+import org.omg.PortableInterceptor.USER_EXCEPTION;
 
-import java.util.*;
-import java.util.logging.Level;
+import javax.security.auth.x500.X500Principal;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.logging.Level;
 
-import org.glassfish.enterprise.iiop.api.GlassFishORBHelper;
-import org.omg.CORBA.*;
-import org.omg.PortableInterceptor.*;
-import org.omg.IOP.*;
-import sun.security.util.DerOutputStream;
-import sun.security.util.DerValue;
-import javax.security.auth.x500.X500Principal;
+import static java.util.Arrays.asList;
 
 /**
  * This class implements a client side security request interceptor for CSIV2. It is used to send
@@ -177,9 +195,7 @@ public class SecClientRequestInterceptor extends org.omg.CORBA.LocalObject imple
     private IdentityToken createIdToken(java.lang.Object cred, Class cls, ORB orb) throws Exception {
 
         IdentityToken idtok = null;
-
-        DerOutputStream dos = new DerOutputStream();
-        DerValue[] derval = null; // DER encoding buffer
+        
         // byte[] cdrval ; // CDR encoding buffer
         Any any = orb.create_any();
         idtok = new IdentityToken();
@@ -189,19 +205,21 @@ public class SecClientRequestInterceptor extends org.omg.CORBA.LocalObject imple
             X500Principal credname = (X500Principal) cred;
             X501DistinguishedNameHelper.insert(any, credname.getEncoded());
 
-            /* IdentityToken with CDR encoded X501 name */
+            /* IdentityToken with CDR encoded X500 principal */
             idtok.dn(codec.encode_value(any));
         } else if (X509CertificateCredential.class.isAssignableFrom(cls)) {
             _logger.log(Level.FINE, "Constructing an X509 Certificate Chain Identity Token");
+            
             /* create a DER encoding */
             X509CertificateCredential certcred = (X509CertificateCredential) cred;
             X509Certificate[] certchain = certcred.getX509CertificateChain();
             _logger.log(Level.FINE, "Certchain length = " + certchain.length);
-            derval = new DerValue[certchain.length];
-            for (int i = 0; i < certchain.length; i++)
-                derval[i] = new DerValue(certchain[i].getEncoded());
-            dos.putSequence(derval);
-            X509CertificateChainHelper.insert(any, dos.toByteArray());
+            
+            byte[] certBytes = CertificateFactory.getInstance("X.509")
+                    .generateCertPath(asList(certchain))
+                    .getEncoded();
+            
+            X509CertificateChainHelper.insert(any, certBytes);
 
             /* IdentityToken with CDR encoded certificate chain */
             idtok.certificate_chain(codec.encode_value(any));
@@ -221,6 +239,7 @@ public class SecClientRequestInterceptor extends org.omg.CORBA.LocalObject imple
             /* IdentityToken with CDR encoded GSSUPName */
             idtok.principal_name(codec.encode_value(any));
         }
+        
         return (idtok);
     }
 

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecServerRequestInterceptor.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecServerRequestInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2012 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2021 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,40 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.iiop.security;
 
-import static com.sun.enterprise.iiop.security.GSSUtils.GSSUP_MECH_OID;
-import static com.sun.enterprise.iiop.security.GSSUtils.verifyMechOID;
-import static com.sun.enterprise.iiop.security.SecurityContextUtil.STATUS_FAILED;
-import static java.security.AccessController.doPrivileged;
-import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.SEVERE;
-
-import java.net.Socket;
-import java.security.PrivilegedAction;
-import java.security.cert.X509Certificate;
-import java.util.Hashtable;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.security.auth.Subject;
-
-import com.sun.enterprise.security.auth.realm.certificate.OID;
-
-import org.glassfish.enterprise.iiop.api.GlassFishORBHelper;
-import org.omg.CORBA.Any;
-import org.omg.CORBA.BAD_PARAM;
-import org.omg.CORBA.NO_PERMISSION;
-import org.omg.CORBA.ORB;
-import org.omg.IOP.Codec;
-import org.omg.IOP.ServiceContext;
-import org.omg.PortableInterceptor.ForwardRequest;
-import org.omg.PortableInterceptor.ServerRequestInfo;
-import org.omg.PortableInterceptor.ServerRequestInterceptor;
-
-/* Import classes generated from CSIV2 idl files */
 import com.sun.corba.ee.org.omg.CSI.CompleteEstablishContext;
 import com.sun.corba.ee.org.omg.CSI.ContextError;
 import com.sun.corba.ee.org.omg.CSI.EstablishContext;
@@ -91,26 +61,42 @@ import com.sun.corba.ee.spi.legacy.connection.Connection;
 import com.sun.corba.ee.spi.legacy.interceptor.RequestInfoExt;
 import com.sun.enterprise.common.iiop.security.AnonCredential;
 import com.sun.enterprise.common.iiop.security.GSSUPName;
-
-/**
- * This class is a server side request interceptor for CSIV2.
- * It is used to send and receive the service context in a
- * a service context element in the service context list in
- * an IIOP header.
- *
- * @author: Nithya Subramanian
- */
-
 import com.sun.enterprise.common.iiop.security.SecurityContext;
 import com.sun.enterprise.security.auth.login.common.PasswordCredential;
 import com.sun.enterprise.security.auth.login.common.X509CertificateCredential;
+import com.sun.enterprise.security.auth.realm.certificate.OID;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.logging.LogDomains;
+import org.glassfish.enterprise.iiop.api.GlassFishORBHelper;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.BAD_PARAM;
+import org.omg.CORBA.NO_PERMISSION;
+import org.omg.CORBA.ORB;
+import org.omg.IOP.Codec;
+import org.omg.IOP.ServiceContext;
+import org.omg.PortableInterceptor.ForwardRequest;
+import org.omg.PortableInterceptor.ServerRequestInfo;
+import org.omg.PortableInterceptor.ServerRequestInterceptor;
 
-import sun.security.util.DerInputStream;
-import sun.security.util.DerValue;
+import javax.security.auth.Subject;
 import javax.security.auth.x500.X500Principal;
-import sun.security.x509.X509CertImpl;
+import java.io.ByteArrayInputStream;
+import java.net.Socket;
+import java.security.PrivilegedAction;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.sun.enterprise.iiop.security.GSSUtils.GSSUP_MECH_OID;
+import static com.sun.enterprise.iiop.security.GSSUtils.verifyMechOID;
+import static com.sun.enterprise.iiop.security.SecurityContextUtil.STATUS_FAILED;
+import static java.security.AccessController.doPrivileged;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.SEVERE;
 
 /**
  * Security server request interceptor
@@ -326,23 +312,18 @@ public class SecServerRequestInterceptor extends org.omg.CORBA.LocalObject imple
                 // Extract DER encoding
                 derEncoding = X509CertificateChainHelper.extract(any);
             }
+            
+            List<? extends Certificate> certificates = CertificateFactory.getInstance("X.509")
+                    .generateCertPath(new ByteArrayInputStream(derEncoding))
+                    .getCertificates();
 
-            DerInputStream din = new DerInputStream(derEncoding);
+            X509Certificate[] certchain = new X509Certificate[certificates.size()];
 
-            /**
-             * Size specified for getSequence() is 1 and is just used as a guess by the method getSequence().
-             */
-            DerValue[] derval = din.getSequence(1);
-            X509Certificate[] certchain = new X509CertImpl[derval.length];
-            /**
-             * X509Certificate does not have a constructor which can be used to instantiate objects from DER
-             * encodings. So use X509CertImpl extends X509Cerificate and also implements DerEncoder interface.
-             */
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Content of X509 Certificate chain:");
             }
             for (int i = 0; i < certchain.length; i++) {
-                certchain[i] = new X509CertImpl(derval[i]);
+                certchain[i] = (X509Certificate) certificates.get(i);
                 if (logger.isLoggable(FINE)) {
                     logger.log(FINE, "    " + certchain[i].getSubjectX500Principal()
                             .getName(X500Principal.RFC2253, OID.getOIDMap()));

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/common/iiop/security/GSSUtilsContract.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/common/iiop/security/GSSUtilsContract.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2021 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,14 +37,13 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2021 Payara Foundation and/or its affiliates.
 
 package com.sun.enterprise.common.iiop.security;
 
-import java.io.IOException;
-
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.Oid;
 import org.jvnet.hk2.annotations.Contract;
-
-import sun.security.util.ObjectIdentifier;
 
 /**
  *
@@ -55,10 +54,10 @@ public interface GSSUtilsContract {
 
     String dumpHex(byte[] octets);
 
-    byte[] importName(ObjectIdentifier oid, byte[] externalName) throws IOException;
+    byte[] importName(Oid oid, byte[] externalName) throws GSSException;
 
-    byte[] createExportedName(ObjectIdentifier oid, byte[] extName) throws IOException;
+    byte[] createExportedName(Oid oid, byte[] extName) throws GSSException;
 
-    ObjectIdentifier GSSUP_MECH_OID();
+    Oid GSSUP_MECH_OID();
 
 }


### PR DESCRIPTION
## Description
Cherry-pick from upstream of required changes for EJB security on JDK 17.

## Important Info
### Blockers
None.

## Testing
### New tests
None.

### Testing Performed
Ran the Payara - ejb-invoker Secure Endpoint test against JDK 8 - worked
Ran the Payara - ejb-invoker Secure Endpoint test against JDK 11 - worked
Ran the Payara - ejb-invoker Secure Endpoint test against JDK 17 - worked

### Testing Environment
WSL OpenSUSE 15.3, Zulu JDK 8u312, 11.0.13, 17.0.1

## Documentation
N/A

## Notes for Reviewers
None
