### PR TITLE
FISH-5802 Exclude .gitkeep File From Payara Micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -52,8 +52,8 @@
     <property name="deploydir" value="${microdir}/deploy"/>
     <property name="libdir" value="${microdir}/lib"/>
     <property name="domaindir" value="${microdir}/domain"/>
-    <property name="tempdir" value="${rootdir}/temp" />
-    
+    <property name="tempdir" value="${rootdir}/temp"/>
+
     <target name="new.create">
         <antcall target="makeDirs"/>
         <antcall target="dumpRuntime"/>
@@ -66,19 +66,19 @@
         <antcall target="buildFinalJar"/>
         <attachArtifact file="${finaljar}"/>
     </target>
-         
-     <target name="makeDirs">
-         <mkdir dir="${rootdir}/stage/META-INF"/>
-         <mkdir dir="${microdir}"/>
-         <mkdir dir="${domaindir}"/>
-         <mkdir dir="${libdir}"/>
-         <mkdir dir="${runtimedir}"/>
-         <mkdir dir="${classesdir}"/>
-         <mkdir dir="${deploydir}"/>
-     </target>
-     
-     <target name="dumpRuntime">
-         <echo message="Dumping Dependencies into the runtime directory" />
+
+    <target name="makeDirs">
+        <mkdir dir="${rootdir}/stage/META-INF"/>
+        <mkdir dir="${microdir}"/>
+        <mkdir dir="${domaindir}"/>
+        <mkdir dir="${libdir}"/>
+        <mkdir dir="${runtimedir}"/>
+        <mkdir dir="${classesdir}"/>
+        <mkdir dir="${deploydir}"/>
+    </target>
+
+    <target name="dumpRuntime">
+        <echo message="Dumping Dependencies into the runtime directory"/>
         <copy todir="${runtimedir}">
             <fileset dir="${zipdir}">
                 <include name="*.jar"/>
@@ -90,52 +90,54 @@
                 <exclude name="mq**.zip"/>
             </fileset>
         </unzip>
-     </target>
+    </target>
 
-     <target name="tidyRuntimeJars">
-         <move todir="${runtimedir}" flatten="true">
-             <fileset dir="${runtimedir}/">
-                 <include name="**/*.jar"/>
-             </fileset>
-         </move>
-	<delete file="${runtimedir}/javahelp.jar"/>
-	<delete file="${runtimedir}/upgrade-tool.jar"/>
-	<delete file="${runtimedir}/web-gui-plugin-common.jar"/>
-	<delete file="${runtimedir}/ha-file-store.jar"/>
-	<delete file="${runtimedir}/payara-console-extras.jar"/>
-	<delete file="${runtimedir}/load-balancer-admin.jar"/>
-	<delete file="${runtimedir}/gf-load-balancer-connector.jar"/>
-	<delete file="${runtimedir}/backup.jar"/>
-	<delete file="${runtimedir}/ant.jar" failonerror="false"/>
-	<delete verbose="true" failonerror="false">
-	  <fileset dir="${runtimedir}" includes="**console-plugin.jar"/>
-	  <fileset dir="${runtimedir}" includes="console-**-help.jar"/>
-	  <fileset dir="${runtimedir}" includes="console-**-plugin.jar"/>
-	  <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
-	  <fileset dir="${runtimedir}" includes="**/appserver-domain*.jar"/>
-	  <fileset dir="${runtimedir}" includes="**/nucleus-domain.jar"/>
-	  <fileset dir="${runtimedir}" includes="**/weld-se-shaded.jar"/>
-	  <fileset dir="${runtimedir}" includes="**/weld-environment-common.jar"/>
-	</delete>
-	<delete file="${runtimedir}/autostart/osgi-cdi.jar" failonerror="false"/>
-     </target>
-     
-     <target name="sortOutBootClasses">
+    <target name="tidyRuntimeJars">
+        <move todir="${runtimedir}" flatten="true">
+            <fileset dir="${runtimedir}/">
+                <include name="**/*.jar"/>
+            </fileset>
+        </move>
+        <delete file="${runtimedir}/javahelp.jar"/>
+        <delete file="${runtimedir}/upgrade-tool.jar"/>
+        <delete file="${runtimedir}/web-gui-plugin-common.jar"/>
+        <delete file="${runtimedir}/ha-file-store.jar"/>
+        <delete file="${runtimedir}/payara-console-extras.jar"/>
+        <delete file="${runtimedir}/load-balancer-admin.jar"/>
+        <delete file="${runtimedir}/gf-load-balancer-connector.jar"/>
+        <delete file="${runtimedir}/backup.jar"/>
+        <delete file="${runtimedir}/ant.jar" failonerror="false"/>
+        <delete verbose="true" failonerror="false">
+            <fileset dir="${runtimedir}" includes="**console-plugin.jar"/>
+            <fileset dir="${runtimedir}" includes="console-**-help.jar"/>
+            <fileset dir="${runtimedir}" includes="console-**-plugin.jar"/>
+            <!-- skip the domain creation template jar files viz., nucleus-domain.jar, appserver-domain.jar -->
+            <fileset dir="${runtimedir}" includes="**/appserver-domain*.jar"/>
+            <fileset dir="${runtimedir}" includes="**/nucleus-domain.jar"/>
+            <fileset dir="${runtimedir}" includes="**/weld-se-shaded.jar"/>
+            <fileset dir="${runtimedir}" includes="**/weld-environment-common.jar"/>
+        </delete>
+        <delete file="${runtimedir}/autostart/osgi-cdi.jar" failonerror="false"/>
+    </target>
+
+    <target name="sortOutBootClasses">
         <unzip dest="${stagedir}">
             <fileset dir="${runtimedir}">
-                <include name="*payara-micro-boot*.jar"/>      
+                <include name="*payara-micro-boot*.jar"/>
             </fileset>
         </unzip>
         <delete>
             <fileset dir="${runtimedir}">
-                <include name="*payara-micro-boot*.jar"/>      
+                <include name="*payara-micro-boot*.jar"/>
             </fileset>
         </delete>
-	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@PRODUCT@@@" value="${product.name}"/>
-	<replace file="${domaindir}/branding/glassfish-version.properties" token="@@@BUILD_NUMBER@@@" value="${build.number}"/>
-     </target>
-     
-    <target name="addSchemas" >
+        <replace file="${domaindir}/branding/glassfish-version.properties" token="@@@PRODUCT@@@"
+                 value="${product.name}"/>
+        <replace file="${domaindir}/branding/glassfish-version.properties" token="@@@BUILD_NUMBER@@@"
+                 value="${build.number}"/>
+    </target>
+
+    <target name="addSchemas">
         <echo message="adding schemas"/>
         <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas/920"/>
         <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas/1.0"/>
@@ -168,21 +170,27 @@
         <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas/weblogic-wsee-databinding"/>
         <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas/weblogic-wsee-standaloneclient"/>
         <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas/webservice-policy-ref"/>
-        <jar jarfile="${runtimedir}/dtds.jar" basedir="${runtimedir}/${install.dir.name}/glassfish/lib" includes="dtds/**/*"/>
-	<jar jarfile="${runtimedir}/schemas.jar" basedir="${runtimedir}/${install.dir.name}/glassfish/lib" includes="schemas/**/*"/>
-        <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/dtds" />
-        <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas" />
+        <jar jarfile="${runtimedir}/dtds.jar" basedir="${runtimedir}/${install.dir.name}/glassfish/lib"
+             includes="dtds/**/*"/>
+        <jar jarfile="${runtimedir}/schemas.jar" basedir="${runtimedir}/${install.dir.name}/glassfish/lib"
+             includes="schemas/**/*"/>
+        <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/dtds"/>
+        <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/schemas"/>
     </target>
 
     <target name="addRARs">
         <echo message="adding rars"/>
-        <jar jarfile="${runtimedir}/__cp_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish" includes="lib/install/applications/__cp_jdbc_ra/**/*"/>
-        <jar jarfile="${runtimedir}/__ds_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish" includes="lib/install/applications/__ds_jdbc_ra/**/*"/>
-        <jar jarfile="${runtimedir}/__dm_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish" includes="lib/install/applications/__dm_jdbc_ra/**/*"/>
-        <jar jarfile="${runtimedir}/__xa_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish" includes="lib/install/applications/__xa_jdbc_ra/**/*"/>
-        <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/install/applications" />
-    </target> 
-    
+        <jar jarfile="${runtimedir}/__cp_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish"
+             includes="lib/install/applications/__cp_jdbc_ra/**/*"/>
+        <jar jarfile="${runtimedir}/__ds_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish"
+             includes="lib/install/applications/__ds_jdbc_ra/**/*"/>
+        <jar jarfile="${runtimedir}/__dm_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish"
+             includes="lib/install/applications/__dm_jdbc_ra/**/*"/>
+        <jar jarfile="${runtimedir}/__xa_jdbc_ra.rar" basedir="${runtimedir}/${install.dir.name}/glassfish"
+             includes="lib/install/applications/__xa_jdbc_ra/**/*"/>
+        <delete dir="${runtimedir}/${install.dir.name}/glassfish/lib/install/applications"/>
+    </target>
+
     <target name="addKeystores">
         <unzip dest="${tempdir}">
             <fileset dir="${runtimedir}/${install.dir.name}/glassfish/common/templates/gf">
@@ -194,27 +202,28 @@
                 <include name="*.jks"/>
                 <include name="keyfile"/>
             </fileset>
-        </copy>       
+        </copy>
     </target>
-      
-    
+
+
     <target name="finalClean">
         <delete dir="${runtimedir}/${install.dir.name}"/>
         <delete file="${libdir}/.gitkeep"/>
         <delete file="${deploydir}/.gitkeep"/>
         <delete file="${classesdir}/.gitkeep"/>
-    </target>   
-     
+    </target>
+
     <target name="buildFinalJar">
         <jar basedir="${stagedir}" destfile="${finaljar}" compress="false">
-        <manifest>
+            <manifest>
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="fish.payara.micro.PayaraMicro"/>
                 <attribute name="Start-Class" value="fish.payara.micro.impl.PayaraMicroImpl"/>
                 <attribute name="Add-Exports" value="java.base/jdk.internal.ref"/>
-                <attribute name="Add-Opens" value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging"/>
-        </manifest>
-        </jar>    
-    </target> 
-     
+                <attribute name="Add-Opens"
+                           value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging"/>
+            </manifest>
+        </jar>
+    </target>
+
 </project>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -200,6 +200,9 @@
     
     <target name="finalClean">
         <delete dir="${runtimedir}/${install.dir.name}"/>
+        <delete file="${libdir}/.gitkeep"/>
+        <delete file="${deploydir}/.gitkeep"/>
+        <delete file="${classesdir}/.gitkeep"/>
     </target>   
      
     <target name="buildFinalJar">


### PR DESCRIPTION
## Description
Take two of https://github.com/payara/Payara/pull/5456

The file `.gitkeep` is not required in the unpacked runtime directory of the Payara Micro instance and its presence prevents using the CDS capabilities fully on JDK17.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built and checked manually - no .gitkeep present in any folder within Payara Micro

On JDK 17:
* java -jar payara-micro.jar --rootdir micro-root --outputlauncher
* java -XX:ArchiveClassesAtExit=payara.jsa -jar micro-root/launch-micro.jar --warmup --deploymentDir deployment --nocluster
* java -jar -XX:SharedArchiveFile=payara.jsa  micro-root/launch-micro.jar
* Should start with no errors

### Testing Environment
Windows 10, JDK 17.0.1

## Documentation
N/A

## Notes for Reviewers
I let IntelliJ do a formatting sweep because the indentation of the file made me cringe.
If you want to see the actual functionality change, just look at commit https://github.com/payara/Payara/pull/5488/commits/91f883e18d3914ab9e6f3d77e2a70344ee166eb5
