### PR TITLE
Prevent NullPointerException in `com.sun.jts.CosTransactions.RecoveryManager`

### DIFF
--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/RecoveryManager.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/RecoveryManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation]
+// Portions Copyright [2016-2021] [Payara Foundation]
 //----------------------------------------------------------------------------
 //
 // Module:      RecoveryManager.java
@@ -692,8 +692,9 @@ public class RecoveryManager {
 
         // Post the resync in progress event semaphore.
 
-        if (resyncInProgress != null) {
-            resyncInProgress.post();
+        EventSemaphore tempResyncInProgress = resyncInProgress;
+        if (tempResyncInProgress != null) {
+            tempResyncInProgress.post();
             resyncInProgress = null;
         }
     }
@@ -763,9 +764,10 @@ public class RecoveryManager {
 
             // Otherwise ensure that resync has completed.
 
-            if (resyncInProgress != null) {
+            EventSemaphore tempResyncInProgress = resyncInProgress;
+            if (tempResyncInProgress != null) {
                 try {
-                    resyncInProgress.waitEvent();
+                    tempResyncInProgress.waitEvent();
                     if (resyncThread != null) {
                         resyncThread.join();
                     }
@@ -1455,14 +1457,15 @@ public class RecoveryManager {
      */
     public static void waitForResync() {
 
-        if (resyncInProgress != null) {
+        EventSemaphore tempResyncInProgress = resyncInProgress;
+        if (tempResyncInProgress != null) {
             try {
 
                 //
                 if (recoveryResynchTimeout == 0) {
-                    resyncInProgress.waitEvent();
+                    tempResyncInProgress.waitEvent();
                 } else {
-                    resyncInProgress.waitTimeoutEvent(recoveryResynchTimeout);
+                    tempResyncInProgress.waitTimeoutEvent(recoveryResynchTimeout);
                 }
             } catch (InterruptedException exc) {
 		_logger.log(Level.SEVERE,"jts.wait_for_resync_complete_interrupted");
@@ -1485,9 +1488,10 @@ public class RecoveryManager {
 
     public static void waitForResync(int cmtTimeOut) {
 
-        if (resyncInProgress != null) {
+        EventSemaphore tempResyncInProgress = resyncInProgress;
+        if (tempResyncInProgress != null) {
             try {
-                resyncInProgress.waitTimeoutEvent(cmtTimeOut);
+                tempResyncInProgress.waitTimeoutEvent(cmtTimeOut);
             } catch (InterruptedException exc) {
 		_logger.log(Level.SEVERE,"jts.wait_for_resync_complete_interrupted");
 		 String msg = LogFormatter.getLocalizedMessage(_logger,


### PR DESCRIPTION
Fixes #5491 

Make a copy of the EventSemaphore before accessing it.

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description

Prevents NPE in `com.sun.jts.CosTransactions.RecoveryManager` by making a copy of the `EventSemaphore`. This was suggested by @pdudits  in https://forum.payara.fish/t/nullpointerexception-in-com-sun-jts-costransactions-recoverymanager-when-restoring-ejb-timers/81

## Important Info

## Testing

This is a race condition which occurs very rarely. We only encountered this once in several years.
However, if anyone has an idea for a test I'd be happy to work on it.

### Testing Performed
n/a

### Testing Environment
n/a

## Documentation
n/a

## Notes for Reviewers
n/a