### PR TITLE
FISH-5703 Option to Improve Logging Speed

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/LoggingHandlers.java
@@ -209,6 +209,7 @@ public class LoggingHandlers {
                         key.equals("com.sun.enterprise.server.logging.GFFileHandler.rotationOnDateChange") ||
                         key.equals("com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation") ||
                         key.equals("com.sun.enterprise.server.logging.GFFileHandler.logStandardStreams") ||
+                        key.equals("com.sun.enterprise.server.logging.GFFileHandler.fastLogging") ||
                         key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.logtoFile") ||
                         key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.rotationOnDateChange") ||
                         key.equals("fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.compressOnRotation"))

--- a/appserver/admingui/common/src/main/resources/configuration/loggerGeneral.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/loggerGeneral.jsf
@@ -129,6 +129,10 @@
                 <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.multiLineMode']}"  selectedValue="true" />
            </sun:property>
 
+          <sun:property id="fastLogging"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.fastLogging}" helpText="$resource{i18nc.log.fastLoggingHelp}">
+              <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.fastLogging']}"  selectedValue="true" />
+          </sun:property>
+
            <sun:property id="consoleFormat"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.ConsoleLogFormat}" helpText="$resource{i18nc.log.ConsoleLogFormatHelp}">
                 <sun:dropDown id="consoleFormat" selected="#{pageSession.logAttributes['java.util.logging.ConsoleHandler.formatter']}"
                     labels={ "ULF","ODL","JSON"}

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 ## 'server' is the name of the server instance. No Not Translate it.
 tree.adminServer=server (Admin Server)
@@ -393,6 +393,8 @@ log.MaxHistoryFiles=Maximum History Files:
 log.MaxHistoryFilesHelp=Maximum number of log files to keep. Enter 0 to keep all rotated log files.
 log.multiLineMode=Multiline Mode:
 log.multiLineModeHelp=Start the log message body on a new line after the message header
+log.fastLogging=Fast Logging:
+log.fastLoggingHelp=When enabled, the forced toString on parameters which may result in database access is skipped.
 log.ConsoleLogFormat=Console Logging Format:
 log.ConsoleLogFormatHelp=Format for logging to the console
 log.LogStandardStreams=Log Standard Streams:

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/LogService.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/LogService.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -202,6 +202,22 @@ public interface LogService extends ConfigBeanProxy  {
      * @throws PropertyVetoException
      */
     public void setLogToFile(String value) throws PropertyVetoException;
+
+    /**
+     * Gets the value of the fastLogging property.
+     *
+     * @return possible object is {@link String }
+     */
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    public String getFastLogging();
+
+    /**
+     * Sets the value of the fastLogging property.
+     *
+     * @param value allowed object is {@link String }
+     * @throws PropertyVetoException
+     */
+    public void setFastLogging(String value) throws PropertyVetoException;
     
      /**
      * Gets the value of the  Payara Notification logToFile property.

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/logging/UpgradeLogging.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/logging/UpgradeLogging.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.servermgmt.logging;
 
@@ -134,6 +134,7 @@ public class UpgradeLogging implements ConfigurationUpgrade, PostConstruct {
             logLevels.put("payara-notification-log-to-file", logService.getPayaraNotificationLogToFile());
             logLevels.put("log-to-console", logService.getLogToConsole());
             logLevels.put("log-rotation-limit-in-bytes", logService.getLogRotationLimitInBytes());
+            logLevels.put("fast-logging", logService.getFastLogging());
             logLevels.put("payara-notification-log-rotation-limit-in-bytes", logService.getPayaraNotificationLogRotationLimitInBytes());
             logLevels.put("log-rotation-timelimit-in-minutes", logService.getLogRotationTimelimitInMinutes());
             logLevels.put("payara-notification-log-rotation-timelimit-in-minutes", logService.getPayaraNotificationLogRotationTimelimitInMinutes());

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -52,6 +52,7 @@ java.util.logging.FileHandler.limit=50000
 java.util.logging.FileHandler.pattern=%h/java%u.log
 com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation=false
 com.sun.enterprise.server.logging.GFFileHandler.excludeFields=
+com.sun.enterprise.server.logging.GFFileHandler.fastLogging=false
 com.sun.enterprise.server.logging.GFFileHandler.file=${com.sun.aas.instanceRoot}/logs/server.log
 com.sun.enterprise.server.logging.GFFileHandler.flushFrequency=1
 com.sun.enterprise.server.logging.GFFileHandler.formatter=com.sun.enterprise.server.logging.ODLLogFormatter

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/LoggingImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/LoggingImpl.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admin.amx.impl.mbean;
 
@@ -233,6 +233,7 @@ public final class LoggingImpl extends AMXImplBase //implements /*Logging,*/ Log
             attributes.put(gfHandler + ".logtoConsole", props.get(gfHandler + ".logtoConsole"));
             attributes.put(gfHandler + ".flushFrequency", props.get(gfHandler + ".flushFrequency"));
             attributes.put(gfHandler + ".logStandardStreams", props.get(gfHandler + ".logStandardStreams"));
+            attributes.put(gfHandler + ".fastLogging", props.get(gfHandler + ".fastLogging"));
             attributes.put("handlers", props.get("handlers"));
             attributes.put(sysHandler + ".useSystemLogging", props.get(sysHandler + ".useSystemLogging"));
             return attributes;

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/GFLogRecord.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/GFLogRecord.java
@@ -42,16 +42,18 @@
 
 package com.sun.common.util.logging;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.logging.LogRecord;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
 
 /**
  * This class provides additional attributes not supported by JUL LogRecord
  * @author rinamdar
  */
 public class GFLogRecord extends LogRecord {
+
+    private static final String FAST_LOGGER_PROPERTY = "com.sun.enterprise.server.logging.GFFileHandler.fastLogging";
+    public static Boolean fastLogging = Boolean.parseBoolean(LogManager.getLogManager().getProperty(FAST_LOGGER_PROPERTY));
 
     /**
      * SVUID for serialization compatibility
@@ -129,7 +131,7 @@ public class GFLogRecord extends LogRecord {
         if (params == null) {
             return null;
         }
-        if (fastLoggingEnabled()) {
+        if (fastLogging) {
             return params;
         }
         Object[] result = new Object[params.length * 2];
@@ -143,20 +145,5 @@ public class GFLogRecord extends LogRecord {
             }
         }
         return result;
-    }
-
-    /**
-     * Reads the logging.properties file for fastLogging property dynamically so server restart is not needed
-     * @return true if fast logging is enabled
-     */
-    private static boolean fastLoggingEnabled() {
-        try {
-            //Gets the config directory of the Payara install. Using pathname "config" results in "config\config"
-            File configDir = new File("").getAbsoluteFile();
-            LoggingConfigImpl loggingConfig = new LoggingConfigImpl(configDir, configDir);
-            return Boolean.parseBoolean(loggingConfig.getLoggingProperty("com.sun.enterprise.server.logging.GFFileHandler.fastLogging"));
-        } catch (IOException ioException) {
-            return false;
-        }
     }
 }

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
@@ -96,6 +96,7 @@ public class LoggingConfigImpl implements LoggingConfig {
         DEFAULT_LOG_PROPERTIES.put(PY_FILE_HANDLER + ".compressOnRotation", "false");
         DEFAULT_LOG_PROPERTIES.put(GF_FILE_HANDLER + ".logStandardStreams", "true");
         DEFAULT_LOG_PROPERTIES.put(PY_FILE_HANDLER + ".formatter", "com.sun.enterprise.server.logging.ODLLogFormatter");
+        DEFAULT_LOG_PROPERTIES.put(GF_FILE_HANDLER + ".fastLogging", "false");
     }
 
     @Inject

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingPropertyNames.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingPropertyNames.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.common.util.logging;
 
@@ -79,6 +79,8 @@ public class LoggingPropertyNames {
     public static final String payaraNotificationLogToFile  = PYFileHandler + "logtoFile";
 
     public static final String logToConsole = GFFileHandler + "logtoConsole";
+
+    public static final String fastLogging = GFFileHandler + "fastLogging";
 
     public static final String alarms = GFFileHandler + "alarms";
 

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingXMLNames.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingXMLNames.java
@@ -72,6 +72,8 @@ public class LoggingXMLNames {
     public static final String logFilter = "log-filter";
     
     public static final String logToFile = "log-to-file";
+
+    public static final String fastLogging = "fast-logging";
     
     public static final String payaraNotificationLogToFile = "payara-notification-log-to-file";
 
@@ -137,6 +139,7 @@ public class LoggingXMLNames {
                 put(logToFile, LoggingPropertyNames.logToFile);
                 put(payaraNotificationLogToFile, LoggingPropertyNames.payaraNotificationLogToFile);
                 put(logToConsole, LoggingPropertyNames.logToConsole);
+                put(fastLogging, LoggingPropertyNames.fastLogging);
                 put(alarms, LoggingPropertyNames.alarms);
                 put(root, LogDomains.DOMAIN_ROOT + LEVEL);
                 put(server, LogDomains.SERVER_LOGGER + LEVEL);

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
@@ -41,6 +41,7 @@
 
 package com.sun.enterprise.server.logging;
 
+import com.sun.common.util.logging.GFLogRecord;
 import com.sun.common.util.logging.LoggingConfig;
 import com.sun.common.util.logging.LoggingConfigFactory;
 import com.sun.common.util.logging.LoggingXMLNames;
@@ -726,6 +727,11 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
                                                 break;
                                             }
                                         }
+                                    }
+                                } else if (a.equals(FAST_LOGGER_PROPERTY)) {
+                                    if (!val.equals(fastLoggingDetail)) {
+                                        fastLoggingDetail = val;
+                                        GFLogRecord.fastLogging = Boolean.parseBoolean(fastLoggingDetail);
                                     }
                                 } else if (a.equals(COMPRESS_ON_ROTATION_PROPERTY)) {
                                     if (!val.equals(compressOnRotationDetail)) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
@@ -160,6 +160,7 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
     String logFormatDateFormatDetail = "";
     String compressOnRotationDetail = "";
     String logStandardStreamsDetail = "";
+    String fastLoggingDetail = "";
     
     //Payara Notification Logging   
     String payaraNotificationLogFileDetail = "";
@@ -195,6 +196,7 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
     private static final String LOGFORMAT_DATEFORMAT_PROPERTY = "com.sun.enterprise.server.logging.GFFileHandler.logFormatDateFormat";
     private static final String COMPRESS_ON_ROTATION_PROPERTY = "com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation";
     private static final String LOG_STANDARD_STREAMS_PROPERTY = "com.sun.enterprise.server.logging.GFFileHandler.logStandardStreams";
+    private static final String FAST_LOGGER_PROPERTY = "com.sun.enterprise.server.logging.GFFileHandler.fastLogging";
     
     //Payara Notification Logging
     private static final String PAYARA_NOTIFICATION_LOG_FILE_PROPERTY = "fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.file";
@@ -983,6 +985,7 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
         logFormatDateFormatDetail = props.get(LOGFORMAT_DATEFORMAT_PROPERTY);
         compressOnRotationDetail = props.get(COMPRESS_ON_ROTATION_PROPERTY);
         logStandardStreamsDetail = props.get(LOG_STANDARD_STREAMS_PROPERTY);
+        fastLoggingDetail = props.get(FAST_LOGGER_PROPERTY);
 
         //Payara Notification Logging
         payaraNotificationLogFileDetail = props.get(PAYARA_NOTIFICATION_LOG_FILE_PROPERTY);

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/SetLogAttributes.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/SetLogAttributes.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.server.logging.commands;
 
 import com.sun.common.util.logging.LoggingConfigFactory;
@@ -140,6 +140,7 @@ public class SetLogAttributes implements AdminCommand {
         "com.sun.enterprise.server.logging.GFFileHandler.multiLineMode",
         "com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation",
         "com.sun.enterprise.server.logging.GFFileHandler.logStandardStreams",
+        "com.sun.enterprise.server.logging.GFFileHandler.fastLogging",
         "com.sun.enterprise.server.logging.UniformLogFormatter.ansiColor",
         "com.sun.enterprise.server.logging.UniformLogFormatter.infoColor",
         "com.sun.enterprise.server.logging.UniformLogFormatter.warnColor",


### PR DESCRIPTION
## Description
A new feature allowing users to skip the forced .toString() on all parameters when logging. The command to set this property has been added to set-log-attributes and the admin console. This property is updated dynamically and doesn't need a server restart for the logging changes to take affect.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Manually tested the toString is skipped appropriately and without the need for a server restart. Ran the logging tests already in place.

### Testing Environment
Windows 10, JDK 8, Maven 3.6.3

## Documentation
Community Documentation PR: https://github.com/payara/Payara-Community-Documentation/pull/276

## Notes for Reviewers
If you test this manually, fastLoggingEnabled() will return the old value while logging a logging property has been changed. Any logs after this will be using the new value. This doesn't impact the functionality but please keep it in mind if you manually test.