### PR TITLE
FISH-5835 ClassFileWriter 1.2.5

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -61,7 +61,7 @@
     <properties>
         <jakarta.faces-spec.version>2.3.1</jakarta.faces-spec.version>
         <jsftemplating.version>2.1.4</jsftemplating.version>
-        <jboss.classfilewriter.version>1.2.4.Final</jboss.classfilewriter.version>
+        <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
         <apache.bcel.version>6.2</apache.bcel.version>
         <!-- Java EE Security API -->
         <javax.security.enterprise-spec.version>1.0</javax.security.enterprise-spec.version>


### PR DESCRIPTION
## Description
Fixes the issue with Weld creating proxies with Java 5 style signatures, which lead to `Signature Parse error: Expected Field Type Signature` when parsing annotations with enum parameters with non-default values.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran Payara Samples on JDK 8, 11, and 17 - no issues.
Ran Java EE 7 Samples on JDK 8, 11, and 17 - no issues.


### Testing Environment
WSL OpenSUSE 15.3, Zulu JDK 8u312, 11.0.13, 17.0.1

## Documentation
N/A

## Notes for Reviewers
None.
