### PR TITLE
PAYARA-5496  fixing RwLockDatastructure locking bug (also FISH-985)

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructureFactory.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructureFactory.java
@@ -67,13 +67,13 @@ public class DataStructureFactory {
             if(className.equals(ListDataStructure.class.getName())){
                 ds = new ListDataStructure(parameters, maxPoolSize, handler, strategyClass);
             }else if(className.equals(RWLockDataStructure.class.getName())){
-                ds = new RWLockDataStructure(parameters, maxPoolSize, handler, strategyClass);
+                ds = new RWLockDataStructure(maxPoolSize, handler);
             }else{
                 ds = initializeCustomDataStructureInPrivilegedMode(className, parameters, maxPoolSize, handler, strategyClass);
             }
         } else {
             debug("Initializing RWLock DataStructure");
-            ds = new RWLockDataStructure(parameters, maxPoolSize, handler, strategyClass);
+            ds = new RWLockDataStructure(maxPoolSize, handler);
         }
         return ds;
     }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -172,13 +172,9 @@ public class RWLockDataStructure implements DataStructure {
     public void removeAll() {
         final List<ResourceHandle> removedResources = new ArrayList<>();
         doLockSecured(() -> {
-            Iterator<ResourceHandle> it = allResources.iterator();
-            while (it.hasNext()) {
-                final ResourceHandle resource = it.next();
-                it.remove();
-                removedResources.add(resource);
-                freeResources.remove(resource);
-            }
+            removedResources.addAll(allResources);
+            allResources.clear();
+            freeResources.clear();
         }, writeLock);
         for(ResourceHandle resourceHandle : removedResources) {
             handler.deleteResource(resourceHandle);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -47,7 +47,10 @@ import com.sun.enterprise.resource.allocator.ResourceAllocator;
 import com.sun.enterprise.resource.pool.ResourceHandler;
 import com.sun.logging.LogDomains;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -113,29 +113,29 @@ public class RWLockDataStructure implements DataStructure {
      * {@inheritDoc}
      */
     public ResourceHandle getResource() {
+        ResourceHandle result = null;
         readLock.lock();
-        for(int i=0; i<resources.size(); i++){
-            ResourceHandle h = resources.get(i);
-            if (!h.isBusy()) {
-                readLock.unlock();
-                writeLock.lock();
-                try {
-                    if (!h.isBusy()) {
-                        h.setBusy(true);
-                        return h;
-                    } else {
+        try {
+            for(int i = 0; result == null && i < resources.size(); i++){
+                ResourceHandle h = resources.get(i);
+                if (!h.isBusy()) {
+                    readLock.unlock();
+                    writeLock.lock();
+                    try {
+                        if (!h.isBusy()) {
+                            h.setBusy(true);
+                            result = h;
+                        }
                         readLock.lock();
-                        continue;
+                    } finally {
+                        writeLock.unlock();
                     }
-                }finally {
-                    writeLock.unlock();
                 }
-            } else {
-                continue;
             }
+        } finally {
+            readLock.unlock();
         }
-        readLock.unlock();
-        return null;
+        return result;
     }
 
     /**

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -193,15 +193,14 @@ public class RWLockDataStructure implements DataStructure {
     public void removeAll() {
         writeLock.lock();
         try {
-            Iterator it = resources.iterator();
+            Iterator<ResourceHandle> it = resources.iterator();
             while (it.hasNext()) {
-                handler.deleteResource((ResourceHandle) it.next());
+                handler.deleteResource(it.next());
                 it.remove();
             }
         } finally {
             writeLock.unlock();
         }
-        resources.clear();
     }
 
     /**
@@ -212,9 +211,9 @@ public class RWLockDataStructure implements DataStructure {
     }
 
     /**
-     * Set maxSize based on the new max pool size set on the connection pool 
-     * during a reconfiguration. 
-     * 
+     * Set maxSize based on the new max pool size set on the connection pool
+     * during a reconfiguration.
+     *
      * @param maxSize
      */
     public void setMaxSize(int maxSize) {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -97,12 +97,12 @@ public class RWLockDataStructure implements DataStructure {
                         resources.add(handle);
                         numResAdded++;
                     }
-                    readLock.lock();
                 } catch (Exception e) {
                     PoolingException pe = new PoolingException(e.getMessage());
                     pe.initCause(e);
                     throw pe;
                 } finally {
+                    readLock.lock();
                     writeLock.unlock();
                 }
             }
@@ -129,8 +129,8 @@ public class RWLockDataStructure implements DataStructure {
                             h.setBusy(true);
                             result = h;
                         }
-                        readLock.lock();
                     } finally {
+                        readLock.lock();
                         writeLock.unlock();
                     }
                 }


### PR DESCRIPTION
## Description
This fixes a lost read lock in RWLockDataStructure in case removeAll() is called while other threads call getResource().
fixes #5496

## Testing
### New tests
No new tests created

### Testing Performed
Testing could be done by simulation heavy db access load.

## Notes for Reviewers
There were notes about some coarse lock handling in method addResource(...) which as been adapted according to lock handling in getResource() method