### PR TITLE
FISH-5769 RFC2253 format with Certificate HAM, fix role verification

### DIFF
--- a/appserver/security/core-ee/pom.xml
+++ b/appserver/security/core-ee/pom.xml
@@ -41,7 +41,7 @@
 
 -->
 
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -236,6 +236,11 @@
         <dependency>
             <groupId>jakarta.security.jacc</groupId>
             <artifactId>jakarta.security.jacc-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
         </dependency>
          <dependency>
             <groupId>fish.payara.server.internal.security</groupId>

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccWebAuthorizationManager.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccWebAuthorizationManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.security.jacc;
 
@@ -99,8 +99,10 @@ import org.glassfish.security.common.PrincipalImpl;
 import org.glassfish.security.common.Role;
 
 import static com.sun.enterprise.security.common.AppservAccessController.privilegedException;
+import java.util.HashSet;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
+import javax.security.enterprise.CallerPrincipal;
 import static org.glassfish.api.web.Constants.ADMIN_VS;
 
 /**
@@ -118,6 +120,7 @@ import static org.glassfish.api.web.Constants.ADMIN_VS;
  *
  * @author Jean-Francois Arcand
  * @author Harpreet Singh.
+ * @author Ondro Mihalyi
  * @todo introduce a new class called AbstractSecurityManager. Move functionality from this class and EJBSecurityManager
  * class and extend this class from AbstractSecurityManager
  */
@@ -344,13 +347,39 @@ public class JaccWebAuthorizationManager {
     public boolean hasRoleRefPermission(String servletName, String role, Principal principal) {
         WebRoleRefPermission requestedPermission = new WebRoleRefPermission(servletName, role);
 
-        boolean isGranted = checkPermission(requestedPermission, getSecurityContext(principal).getPrincipalSet());
-
+        Set<Principal> principalSetFromSecurityContext = getSecurityContext(principal).getPrincipalSet();
+        boolean isGranted = checkPermission(requestedPermission, principalSetFromSecurityContext);
+        if (!isGranted) {
+            isGranted = checkPermissionForModifiedPrincipalSet(principalSetFromSecurityContext, isGranted, requestedPermission);
+        }
+        
         if (logger.isLoggable(Level.FINE)) {
             logger.log(FINE, "[Web-Security] hasRoleRef perm: {0}", requestedPermission);
             logger.log(FINE, "[Web-Security] hasRoleRef isGranted: {0}", isGranted);
         }
 
+        return isGranted;
+    }
+
+    /* If the principal set contains CallerPrincipal, replace it with PrincipalImpl. 
+       This is because CallerPrincipal isn't equal to PrincipalImpl and doesn't imply it.
+       CallerPrincipal doesn't even implement equals method, so 2 CallerPrincipals with the same name are not equal. 
+       Because CallerPrincipal is from Jakarta EE, we can't change it.
+    */
+    private boolean checkPermissionForModifiedPrincipalSet(Set<Principal> principalSetFromSecurityContext, boolean isGranted, WebRoleRefPermission requestedPermission) {
+        boolean principalSetContainsCallerPrincipal = false;
+        Set<Principal> modifiedPrincipalSet = new HashSet<Principal>(principalSetFromSecurityContext.size());
+        for (Principal p : principalSetFromSecurityContext) {
+            if (p instanceof CallerPrincipal) {
+                principalSetContainsCallerPrincipal = true;
+                modifiedPrincipalSet.add(new PrincipalImpl(p.getName()));
+            } else {
+                modifiedPrincipalSet.add(p);
+            }
+        }
+        if (principalSetContainsCallerPrincipal) {
+            isGranted = checkPermission(requestedPermission, modifiedPrincipalSet);
+        }
         return isGranted;
     }
 
@@ -800,3 +829,4 @@ public class JaccWebAuthorizationManager {
     }
 
 }
+        

--- a/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/CertificateCredentialImpl.java
+++ b/appserver/security/realm-stores/src/main/java/fish/payara/security/realm/CertificateCredentialImpl.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2019-2021] Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -41,12 +41,14 @@ package fish.payara.security.realm;
 
 import fish.payara.security.api.CertificateCredential;
 import java.security.cert.X509Certificate;
+import javax.security.auth.x500.X500Principal;
 import javax.security.enterprise.CallerPrincipal;
 import javax.security.enterprise.credential.AbstractClearableCredential;
 
 /**
  *
  * @author Gaurav Gupta
+ * @author Ondro Mihalyi
  */
 public class CertificateCredentialImpl extends AbstractClearableCredential implements CertificateCredential {
 
@@ -66,7 +68,7 @@ public class CertificateCredentialImpl extends AbstractClearableCredential imple
 
     @Override
     public CallerPrincipal getPrincipal() {
-        return new CallerPrincipal(certificates[0].getIssuerDN().getName());
+        return new CallerPrincipal(certificates[0].getIssuerX500Principal().getName(X500Principal.RFC2253));
     }
 
     @Override


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This is a bug fix.

The problem: When authenticated using @CertificateAuthenticationMechanismDefinition and IdentityStore @CertificateIdentityStoreDefinition, and when a role is mapped to a particular certificate principal in payara-web.xml, the role isn't assigned to the authenticated user. The role is applied if CLIENT_CERT login config mechanism is defined in web.xml.

Proposed solution in this PR:

* in `JaccWebAuthorizationManager`, if the role isn’t granted (potentially because of the mismatch between `PrincipalImpl` and `CallerPrincipal`), check if the current principal class is `CallerPrincipal`. If that's true, convert it to `PrincipalImpl` and check for the role again
* In `CertificateCredentialImpl`, change how the `CallerPrincipal` is created so that it contains the name in the same `RFC2253` that `PrincipalImpl` uses so that it’s equal with the one in the policy. This will ensure that the `PrincipalImpl` created from `CallerPrincipal` is equal to the one in the policy


## Important Info

## Testing

Manually tested with the reproducer attached to FISH-5769

### Testing Environment

Ubuntu

## Notes for Reviewers

The policy in `JaccWebAuthorizationManager` contains the same role policies as in the working case (when using Servlet authentication). These are stored in the file `generated/policy/payara-certificate-realm/payara-certificate-realm/granted.policy`. These policies are for principal class `PrincipalImpl` but, if Jakarta Security authentication is used, the passed `ProtectionDomain` with the authenticated user contains a principal of type `CallerPrincipal` from Jakarta Security API. The `policy` object then refuses to add a policy for the role because it doesn’t match the authenticated user principal.

There are more observations:

* Jakarta Security `CallerPrincipal` class doesn’t override `hashCode` and `equals` methods, therefore even 2 instances with the same principal name are not equal. So it doesn’t help if an additional role policy for `CallerPrincipal` is added to the `granted.policy` file
* The `CallerPrincipal` has a slightly different name than the `PrincipalImpl`. Both contain the certificate's distinguished name but it's in `RFC2253` format for `PrincipalImpl` and in `RFC1779` format for `CallerPrincipal`. For this reason, even if we somehow converted `CallerPrincipal` to `PrincipalImpl`, they wouldn't be equal unless we also convert the format of the principal's name. The `RFC1779` format contains more spaces between attributes and is obsolete. 

