### PR TITLE
FISH-26 Skip Init on Servlets Annotated with '@RegisterRestClient'

### DIFF
--- a/appserver/packager/microprofile-package/pom.xml
+++ b/appserver/packager/microprofile-package/pom.xml
@@ -2,7 +2,7 @@
 <!--
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 *
-* Copyright (c) [2016-2020] Payara Foundation and/or its affiliates. All rights reserved.
+* Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
 *
 * The contents of this file are subject to the terms of either the GNU
 * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/packager/microprofile-package/pom.xml
+++ b/appserver/packager/microprofile-package/pom.xml
@@ -240,7 +240,12 @@
             <version>${jersey.version}</version>
         </dependency>
 
-        <!-- MicroProfile Rest Client ssl-->
+        <!-- MicroProfile Rest Client Extensions-->
+        <dependency>
+            <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
+            <artifactId>microprofile-rest-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
             <artifactId>rest-client-ssl</artifactId>

--- a/appserver/payara-appserver-modules/microprofile/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/pom.xml
@@ -2,7 +2,7 @@
 <!--
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
+Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
 
 The contents of this file are subject to the terms of either the GNU
 General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/rest-client/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/rest-client/pom.xml
@@ -2,7 +2,7 @@
 <!--
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
 
 The contents of this file are subject to the terms of either the GNU
 General Public License Version 2 only ("GPL") or the Common Development
@@ -38,33 +38,30 @@ and therefore, elected the GPL Version 2 license, then the option applies
 only if the new code is made subject to such option by the copyright
 holder.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-    
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
-        <artifactId>payara-appserver-modules</artifactId>
+        <artifactId>microprofile</artifactId>
         <version>5.2021.10-SNAPSHOT</version>
     </parent>
-    
-    <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
-    <artifactId>microprofile</artifactId>
-    <description>Parent POM for all Microprofile related modules</description>
-    <packaging>pom</packaging>
-    
-    <modules>
-        <module>config</module>
-        <module>config-extensions</module>
-        <module>fault-tolerance</module>
-        <module>healthcheck</module>
-        <module>jwt-auth</module>
-        <module>metrics</module>
-        <module>openapi</module>
-        <module>opentracing</module>
-        <!-- Extension of opentracing for Jax-ws, split out due to web distribution not having Jax-ws -->
-        <module>opentracing-jaxws</module>
-        <module>microprofile-common</module>
-        <module>microprofile-connector</module>
-        <module>rest-client-ssl</module>
-        <module>rest-client</module>
-    </modules>
+
+    <artifactId>microprofile-rest-client</artifactId>
+    <packaging>glassfish-jar</packaging>
+    <name>MicroProfile Rest Client</name>
+    <description>Module containing additional integrations for Rest Client into Payara Platform</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.web</groupId>
+            <artifactId>war-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/rest-client/src/main/java/fish/payara/microprofile/restclient/RestClientServletContainerInitializerBlacklist.java
+++ b/appserver/payara-appserver-modules/microprofile/rest-client/src/main/java/fish/payara/microprofile/restclient/RestClientServletContainerInitializerBlacklist.java
@@ -63,15 +63,15 @@ public class RestClientServletContainerInitializerBlacklist implements ServletCo
 
     @Override
     public void removeServletContainerInitializers(Map<Class<? extends ServletContainerInitializer>,
-            Set<Class<?>>> initializerList) {
+            Set<Class<?>>> initializerMap) {
 
-        for (Map.Entry<Class<? extends ServletContainerInitializer>, Set<Class<?>>> e : initializerList.entrySet()) {
+        for (Map.Entry<Class<? extends ServletContainerInitializer>, Set<Class<?>>> e : initializerMap.entrySet()) {
             Class<? extends ServletContainerInitializer> initializer = e.getKey();
 
             if (e.getValue() != null) {
                 // Don't try to initialise MicroProfile Rest Client interfaces as servlets
-                initializerList.put(initializer,
-                        initializerList.get(initializer).stream()
+                initializerMap.put(initializer,
+                        initializerMap.get(initializer).stream()
                                 .filter(clazz -> !clazz.isAnnotationPresent(RegisterRestClient.class))
                                 .collect(Collectors.toSet()));
             }

--- a/appserver/payara-appserver-modules/microprofile/rest-client/src/main/java/fish/payara/microprofile/restclient/RestClientServletContainerInitializerBlacklist.java
+++ b/appserver/payara-appserver-modules/microprofile/rest-client/src/main/java/fish/payara/microprofile/restclient/RestClientServletContainerInitializerBlacklist.java
@@ -48,6 +48,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Extension point that omits {@link ServletContainerInitializer ServletContainerInitializers} annotated with
+ * {@link RegisterRestClient}. If we try and initialise these interfaces Jersey will fail them on validation (correctly)
+ * since you will end up with a duplicate mapping (the interface itself against the actual endpoint implementation).
+ *
+ * Using an extension mechanism rather than having this check directly in
+ * {@link org.glassfish.web.loader.ServletContainerInitializerUtil} allows us to avoid pulling MicroProfile APIs into
+ * the core server as a dependency.
+ *
+ * @author Andrew Pielage
+ */
 public class RestClientServletContainerInitializerBlacklist implements ServletContainerInitializerBlacklist {
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/rest-client/src/main/java/fish/payara/microprofile/restclient/RestClientServletContainerInitializerBlacklist.java
+++ b/appserver/payara-appserver-modules/microprofile/rest-client/src/main/java/fish/payara/microprofile/restclient/RestClientServletContainerInitializerBlacklist.java
@@ -1,0 +1,69 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.microprofile.restclient;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import fish.payara.web.loader.ServletContainerInitializerBlacklist;
+
+import javax.servlet.ServletContainerInitializer;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RestClientServletContainerInitializerBlacklist implements ServletContainerInitializerBlacklist {
+
+    @Override
+    public void removeServletContainerInitializers(Map<Class<? extends ServletContainerInitializer>,
+            Set<Class<?>>> initializerList) {
+
+        for (Map.Entry<Class<? extends ServletContainerInitializer>, Set<Class<?>>> e : initializerList.entrySet()) {
+            Class<? extends ServletContainerInitializer> initializer = e.getKey();
+
+            if (e.getValue() != null) {
+                // Don't try to initialise MicroProfile Rest Client interfaces as servlets
+                initializerList.put(initializer,
+                        initializerList.get(initializer).stream()
+                                .filter(clazz -> !clazz.isAnnotationPresent(RegisterRestClient.class))
+                                .collect(Collectors.toSet()));
+            }
+        }
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/rest-client/src/main/resources/META-INF/services/fish.payara.web.loader.ServletContainerInitializerBlacklist
+++ b/appserver/payara-appserver-modules/microprofile/rest-client/src/main/resources/META-INF/services/fish.payara.web.loader.ServletContainerInitializerBlacklist
@@ -1,23 +1,23 @@
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # The contents of this file are subject to the terms of either the GNU
 # General Public License Version 2 only ("GPL") or the Common Development
 # and Distribution License("CDDL") (collectively, the "License").  You
 # may not use this file except in compliance with the License.  You can
 # obtain a copy of the License at
-# https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-# or packager/legal/LICENSE.txt.  See the License for the specific
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
 # language governing permissions and limitations under the License.
 #
 # When distributing the software, include this License Header Notice in each
-# file and include the License file at packager/legal/LICENSE.txt.
+# file and include the License file at glassfish/legal/LICENSE.txt.
 #
 # GPL Classpath Exception:
-# Oracle designates this particular file as subject to the "Classpath"
-# exception as provided by Oracle in the GPL Version 2 section of the License
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
 # file that accompanied this code.
 #
 # Modifications:
@@ -38,18 +38,4 @@
 # holder.
 #
 
--exportcontents: \
-                        com.sun.enterprise.glassfish.web; \
-                        org.glassfish.web.loader; \
-                        org.glassfish.web.util; \
-                        fish.payara.web.loader; \
-                        com.sun.logging.enterprise.system.container.web; version=${project.osgi.version}
-
-# Normally Import-Package is not required, as the default value of *
-# is enough to find all static dependencies. But, when a module is
-# doing Class.forName, there is no foolproof way to find out the
-# desired package name, hence we need to add those packages explicitly.
-# In this case, sun.rmi.transport is one such package which is used
-# during classloader cleanup. Since it is only presence for Oracle JDK,
-# the import has been marked as optional.
-Import-Package: sun.rmi.transport; resolution:=optional, org.jboss.weld.interceptor.proxy,*
+fish.payara.microprofile.restclient.RestClientServletContainerInitializerBlacklist

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <groupId>fish.payara.samples</groupId>
+        <version>5.2021.10-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>microprofile-rest-client</artifactId>
+
+    <name>Payara Samples - Payara - Microprofile Rest Client</name>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/pom.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/master/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at glassfish/legal/LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/java/fish/payara/sample/microprofile/restclient/JAXRSConfiguration.java
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/java/fish/payara/sample/microprofile/restclient/JAXRSConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.sample.microprofile.restclient;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Configures JAX-RS for the application.
+ * @author Juneau
+ */
+@ApplicationPath("resources")
+public class JAXRSConfiguration extends Application {
+    
+}

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/java/fish/payara/sample/microprofile/restclient/JavaEE8Resource.java
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/java/fish/payara/sample/microprofile/restclient/JavaEE8Resource.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.sample.microprofile.restclient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ *
+ * @author Ondrej Mihalyi
+ */
+@Path("javaee8")
+public class JavaEE8Resource {
+    
+    @GET
+    public Response ping(){
+        return Response.ok("ping").build();
+    }
+}

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/java/fish/payara/sample/microprofile/restclient/JavaEE8ResourceClient.java
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/java/fish/payara/sample/microprofile/restclient/JavaEE8ResourceClient.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.sample.microprofile.restclient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ *
+ * @author Ondrej Mihalyi
+ */
+@Path("javaee8")
+@RegisterRestClient
+public interface JavaEE8ResourceClient {
+    
+    @GET
+    Response ping();
+}

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/resources/META-INF/beans.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/resources/META-INF/beans.xml
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/src/main/resources/META-INF/beans.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/master/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at glassfish/legal/LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"

--- a/appserver/tests/payara-samples/samples/microprofile-rest-client/src/test/java/fish/payara/samples/microprofile/restclient/MicroProfileRestClientIT.java
+++ b/appserver/tests/payara-samples/samples/microprofile-rest-client/src/test/java/fish/payara/samples/microprofile/restclient/MicroProfileRestClientIT.java
@@ -1,0 +1,87 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.samples.microprofile.restclient;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import fish.payara.sample.microprofile.restclient.JAXRSConfiguration;
+import fish.payara.sample.microprofile.restclient.JavaEE8Resource;
+import fish.payara.sample.microprofile.restclient.JavaEE8ResourceClient;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.servlet.http.HttpServletResponse;
+import java.net.URL;
+
+@RunWith(PayaraArquillianTestRunner.class)
+@NotMicroCompatible
+public class MicroProfileRestClientIT {
+
+    @ArquillianResource
+    private URL baseUrl;
+
+    // The test is that the app deploys - if Jersey attempts to initialise both the MicroProfile Rest Client interface
+    // and the actual JAX-RS endpoints as servlets then an ambiguous endpoint validation error will occur (since they
+    // both map to the same endpoint)
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "microprofile-rest-client.war")
+                .addClass(JAXRSConfiguration.class)
+                .addClass(JavaEE8Resource.class)
+                .addClass(JavaEE8ResourceClient.class)
+                .addAsManifestResource(JAXRSConfiguration.class.getResource("/META-INF/beans.xml"), "beans.xml");
+    }
+
+    @Test
+    public void testRetry() throws Exception {
+        Page page = new WebClient().getPage(baseUrl + "/resources/javaee8");
+        Assert.assertEquals(HttpServletResponse.SC_OK, page.getWebResponse().getStatusCode());
+    }
+
+
+}

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/master/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at glassfish/legal/LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -44,6 +44,7 @@
         <module>client-certificate-validator</module>
         <!-- Skip - this test needs to be run repeatedly for around 60 minutes to be effective -->
         <!--<module>corba-read-timeout</module>-->
+        <module>microprofile-rest-client</module>
     </modules>
 
     <dependencies>

--- a/appserver/web/war-util/osgi.bundle
+++ b/appserver/web/war-util/osgi.bundle
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright 2021 Payara Foundation and/or its affiliates
 
 -exportcontents: \
                         com.sun.enterprise.glassfish.web; \

--- a/appserver/web/war-util/src/main/java/fish/payara/web/loader/ServletContainerInitializerBlacklist.java
+++ b/appserver/web/war-util/src/main/java/fish/payara/web/loader/ServletContainerInitializerBlacklist.java
@@ -1,0 +1,64 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.web.loader;
+
+import javax.servlet.ServletContainerInitializer;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Service Loader interface extension point for filtering out
+ * {@link ServletContainerInitializer ServletContainerInitializers} that would otherwise be picked up and loaded by
+ * the blanket interest list.
+ */
+public interface ServletContainerInitializerBlacklist {
+
+    /**
+     * Removes {@link ServletContainerInitializer ServletContainerInitializers} from the list of initializers to be
+     * invoked.
+     *
+     * @param initializerList The list of {@link ServletContainerInitializer} to remove the initializers we don't want
+     *                        to be run from
+     */
+    void removeServletContainerInitializers(Map<Class<? extends ServletContainerInitializer>,
+            Set<Class<?>>> initializerList);
+
+}

--- a/appserver/web/war-util/src/main/java/fish/payara/web/loader/ServletContainerInitializerBlacklist.java
+++ b/appserver/web/war-util/src/main/java/fish/payara/web/loader/ServletContainerInitializerBlacklist.java
@@ -47,7 +47,9 @@ import java.util.Set;
 /**
  * Service Loader interface extension point for filtering out
  * {@link ServletContainerInitializer ServletContainerInitializers} that would otherwise be picked up and loaded by
- * the blanket interest list.
+ * the blanket interest list. Allows us to omit initializers based on criteria without having to pull in extra
+ * dependencies into core server (e.g. MicroProfile).
+ *
  */
 public interface ServletContainerInitializerBlacklist {
 

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
@@ -37,10 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2021 Payara Foundation and/or its affiliates
 
 package org.glassfish.web.loader;
 
+import fish.payara.web.loader.ServletContainerInitializerBlacklist;
 import org.glassfish.deployment.common.ClassDependencyBuilder;
 import org.glassfish.hk2.classmodel.reflect.*;
 
@@ -365,6 +366,9 @@ public class ServletContainerInitializerUtil {
             }
         }
 
+        // Remove initializers we aren't interested in
+        initializerList = checkAgainstBlacklist(initializerList);
+
         return initializerList;
     }
 
@@ -560,6 +564,19 @@ public class ServletContainerInitializerUtil {
             }
         }
         return initializerList;
+    }
+
+    private static Map<Class<? extends ServletContainerInitializer>, Set<Class<?>>> checkAgainstBlacklist(
+            Map<Class<? extends ServletContainerInitializer>, Set<Class<?>>> initializersList) {
+
+
+        Iterable<ServletContainerInitializerBlacklist> blacklistServices = ServiceLoader.load(
+                ServletContainerInitializerBlacklist.class);
+
+        blacklistServices.forEach(blacklistService -> blacklistService.removeServletContainerInitializers(
+                initializersList));
+
+        return initializersList;
     }
 
     

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
@@ -568,8 +568,6 @@ public class ServletContainerInitializerUtil {
 
     private static Map<Class<? extends ServletContainerInitializer>, Set<Class<?>>> checkAgainstBlacklist(
             Map<Class<? extends ServletContainerInitializer>, Set<Class<?>>> initializersList) {
-
-
         Iterable<ServletContainerInitializerBlacklist> blacklistServices = ServiceLoader.load(
                 ServletContainerInitializerBlacklist.class);
 

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -188,5 +188,11 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${microprofile-rest-client.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -188,11 +188,5 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-            <version>${microprofile-rest-client.version}</version>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -208,9 +208,6 @@ import org.glassfish.web.valve.GlassFishValve;
  * @author Remy Maucherat
  * @version $Revision: 1.48 $ $Date: 2007/07/25 00:52:04 $
  */
-
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
-
 public class StandardContext
     extends ContainerBase
     implements Context, ServletContext

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -98,7 +98,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import javax.management.MBeanRegistrationException;
 import javax.management.MalformedObjectNameException;
@@ -190,7 +189,6 @@ import org.apache.naming.resources.ProxyDirContext;
 import org.apache.naming.resources.Resource;
 import org.apache.naming.resources.WARDirContext;
 import org.apache.naming.resources.WebDirContext;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.glassfish.grizzly.http.server.util.AlternateDocBase;
 import org.glassfish.grizzly.http.server.util.Mapper;
 import org.glassfish.grizzly.http.server.util.MappingData;
@@ -5854,18 +5852,7 @@ public class StandardContext
 
                     fireContainerEvent(BEFORE_CONTEXT_INITIALIZER_ON_STARTUP, iniInstance);
 
-                    if (e.getValue() == null) {
-                        iniInstance.onStartup(initializerList.get(initializer), ctxt);
-                    } else {
-                        // Don't try to initialise MicroProfile Rest Client interfaces as servlets
-                        // TODO Ideally we wouldn't have a hard dependency like this.
-                        //  Possibly rewrite with a new blacklist/whitelist serviceloader or equivalent extension
-                        //  pattern to cull the initialisers we want to skip
-                        iniInstance.onStartup(initializerList.get(initializer).stream()
-                                .filter(clazz -> !clazz.isAnnotationPresent(RegisterRestClient.class))
-                                .collect(Collectors.toSet()),
-                                ctxt);
-                    }
+                    iniInstance.onStartup(initializerList.get(initializer), ctxt);
 
                     fireContainerEvent(AFTER_CONTEXT_INITIALIZER_ON_STARTUP, iniInstance);
                 } catch (Throwable t) {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -5858,6 +5858,9 @@ public class StandardContext
                         iniInstance.onStartup(initializerList.get(initializer), ctxt);
                     } else {
                         // Don't try to initialise MicroProfile Rest Client interfaces as servlets
+                        // TODO Ideally we wouldn't have a hard dependency like this.
+                        //  Possibly rewrite with a new blacklist/whitelist serviceloader or equivalent extension
+                        //  pattern to cull the initialisers we want to skip
                         iniInstance.onStartup(initializerList.get(initializer).stream()
                                 .filter(clazz -> !clazz.isAnnotationPresent(RegisterRestClient.class))
                                 .collect(Collectors.toSet()),

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -98,6 +98,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import javax.management.MBeanRegistrationException;
 import javax.management.MalformedObjectNameException;
@@ -189,6 +190,7 @@ import org.apache.naming.resources.ProxyDirContext;
 import org.apache.naming.resources.Resource;
 import org.apache.naming.resources.WARDirContext;
 import org.apache.naming.resources.WebDirContext;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.glassfish.grizzly.http.server.util.AlternateDocBase;
 import org.glassfish.grizzly.http.server.util.Mapper;
 import org.glassfish.grizzly.http.server.util.MappingData;
@@ -5852,7 +5854,14 @@ public class StandardContext
 
                     fireContainerEvent(BEFORE_CONTEXT_INITIALIZER_ON_STARTUP, iniInstance);
 
-                    iniInstance.onStartup(initializerList.get(initializer), ctxt);
+                    if (e.getValue() == null) {
+                        iniInstance.onStartup(initializerList.get(initializer), ctxt);
+                    } else {
+                        iniInstance.onStartup(initializerList.get(initializer).stream()
+                                .filter(clazz -> !clazz.isAnnotationPresent(RegisterRestClient.class))
+                                .collect(Collectors.toSet()),
+                                ctxt);
+                    }
 
                     fireContainerEvent(AFTER_CONTEXT_INITIALIZER_ON_STARTUP, iniInstance);
                 } catch (Throwable t) {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.apache.catalina.core;
 
@@ -5857,6 +5857,7 @@ public class StandardContext
                     if (e.getValue() == null) {
                         iniInstance.onStartup(initializerList.get(initializer), ctxt);
                     } else {
+                        // Don't try to initialise MicroProfile Rest Client interfaces as servlets
                         iniInstance.onStartup(initializerList.get(initializer).stream()
                                 .filter(clazz -> !clazz.isAnnotationPresent(RegisterRestClient.class))
                                 .collect(Collectors.toSet()),


### PR DESCRIPTION
## Description
Bug fix.

If we don't skip trying to initialise Rest Client "servlets" a knock-on effect will occur during validation where a clash will be detected with the implementation endpoint (as in the endpoint that the Rest Client interface actually maps to).

Retry of https://github.com/payara/Payara/pull/5514 following on from comments made on that (can't reopen original since I rebased onto latest master). I've now added a "blacklist" extension point using _ServiceLoader_ pattern to the usual flow of gathering the initializers from an "interest" list, allowing us to remove the dependency on MicroProfile from web-core.

## Important Info
### Blockers
None

## Testing
### New tests
New sample added that checks that an app with both actual endpoint and Rest Client interface bundled within it can deploy successfully.

### Testing Performed
Ran new sample.
Ran MicroProfile Rest Client TCK.
Deployed and poked Rest Client Example: https://github.com/payara/Payara-Examples/tree/master/microprofile/rest-client

### Testing Environment
Windows 11, Zulu 8u312

## Documentation
N/A

## Notes for Reviewers
None
