### PR TITLE
FISH-5883 Security Exception When a Remote EJB Is Called While Authenticated Using The OIDC Security Connector

### DIFF
--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecClientRequestInterceptor.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecClientRequestInterceptor.java
@@ -54,6 +54,7 @@ import com.sun.corba.ee.org.omg.CSIIOP.CompoundSecMech;
 import com.sun.enterprise.common.iiop.security.AnonCredential;
 import com.sun.enterprise.common.iiop.security.GSSUPName;
 import com.sun.enterprise.common.iiop.security.SecurityContext;
+import com.sun.enterprise.security.auth.login.DistinguishedPrincipalCredential;
 import com.sun.enterprise.security.auth.login.common.PasswordCredential;
 import com.sun.enterprise.security.auth.login.common.X509CertificateCredential;
 import com.sun.enterprise.util.LocalStringManagerImpl;
@@ -237,6 +238,14 @@ public class SecClientRequestInterceptor extends org.omg.CORBA.LocalObject imple
             GSS_NT_ExportedNameHelper.insert(any, expname);
 
             /* IdentityToken with CDR encoded GSSUPName */
+            idtok.principal_name(codec.encode_value(any));
+        } else if (DistinguishedPrincipalCredential.class.isAssignableFrom(cls)) {
+            _logger.log(Level.FINE,
+                    "Constructing a GSS Exported Name Identity Token from DistinguishedPrincipalCredential");
+            DistinguishedPrincipalCredential distinguishedPrincipalCredential = (DistinguishedPrincipalCredential) cred;
+            GSSUPName gssupName = new GSSUPName(distinguishedPrincipalCredential.getPrincipal().getName(), "");
+            byte[] expname = gssupName.getExportedName();
+            GSS_NT_ExportedNameHelper.insert(any, expname);
             idtok.principal_name(codec.encode_value(any));
         }
         

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecClientRequestInterceptor.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecClientRequestInterceptor.java
@@ -240,12 +240,17 @@ public class SecClientRequestInterceptor extends org.omg.CORBA.LocalObject imple
             /* IdentityToken with CDR encoded GSSUPName */
             idtok.principal_name(codec.encode_value(any));
         } else if (DistinguishedPrincipalCredential.class.isAssignableFrom(cls)) {
+            // If authenticated via OIDC rather than any of the above we'll have a DistinguishedPrincipalCredential
             _logger.log(Level.FINE,
                     "Constructing a GSS Exported Name Identity Token from DistinguishedPrincipalCredential");
             DistinguishedPrincipalCredential distinguishedPrincipalCredential = (DistinguishedPrincipalCredential) cred;
+
+            // Create a DER encoding of the principal name as a GSSUPName - realm is not currently factored into the
+            // parsing of the principal name from the IdentityToken so is left blank.
             GSSUPName gssupName = new GSSUPName(distinguishedPrincipalCredential.getPrincipal().getName(), "");
             byte[] expname = gssupName.getExportedName();
             GSS_NT_ExportedNameHelper.insert(any, expname);
+
             idtok.principal_name(codec.encode_value(any));
         }
         

--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecurityMechanismSelector.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/SecurityMechanismSelector.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2018-2021 Payara Foundation and/or its affiliates
 package com.sun.enterprise.iiop.security;
 
 import com.sun.corba.ee.org.omg.CSI.ITTAnonymous;
@@ -55,6 +55,7 @@ import com.sun.enterprise.common.iiop.security.SecurityContext;
 import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.deployment.EjbIORConfigurationDescriptor;
 import com.sun.enterprise.security.SecurityServicesUtil;
+import com.sun.enterprise.security.auth.login.DistinguishedPrincipalCredential;
 import com.sun.enterprise.security.auth.login.LoginContextDriver;
 import com.sun.enterprise.security.auth.login.common.LoginException;
 import com.sun.enterprise.security.auth.login.common.PasswordCredential;
@@ -771,6 +772,8 @@ public final class SecurityMechanismSelector implements PostConstruct {
                     ctx.identcls = GSSUPName.class;
                 } else if (o instanceof X500Principal) {
                     ctx.identcls = X500Principal.class;
+                } else if (o instanceof DistinguishedPrincipalCredential) {
+                    ctx.identcls = DistinguishedPrincipalCredential.class;
                 } else {
                     ctx.identcls = X509CertificateCredential.class;
                 }


### PR DESCRIPTION
## Description
Bug Fix.

Payara expects to be able to propagate a CSIV2 IdentityToken to the remote EJB, and so needs to map the `CallerPrincipal` (wrapped within a `DistinguishedPrincipalCredential`) it has gained from the OIDC provider to a Distinguished Name, Principal Name, or Certificate Chain (or simply pass an anoynmous token).

This PR makes the server now map `DistinguishedPrincipalCredential`s as a GSSAPI principal name (Generic Security Service Application Program Interface).

## Important Info
### Blockers
None

## Testing
### New tests
None - this is a tricky test to automate (multiple instances, applications deployed to one and not the other etc.).

### Testing Performed
Executed the reproducer attached to the issue.

### Testing Environment
Windows 11, JDK 11.0.13

## Documentation
N/A

## Notes for Reviewers
Slight variation on this solution available here, which tries to avoid the creation of a GSSUPName class [here](https://github.com/Pandrex247/Payara/commit/fb7daa039621c82bfe0ebdc0205f19ab4967cfd3)
