### PR TITLE
FISH-5868 Upgrade MicroProfile RestClient to 3.0

### DIFF
--- a/appserver/packager/microprofile-package/pom.xml
+++ b/appserver/packager/microprofile-package/pom.xml
@@ -233,12 +233,12 @@
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-proxy-client</artifactId>
         </dependency>
-<!--        <dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.ext.microprofile</groupId>
             <artifactId>jersey-mp-rest-client</artifactId>
-             temporary add explicit version as bom artifact may be cached 
+             <!--temporary add explicit version as bom artifact may be cached--> 
             <version>${jersey.version}</version>
-        </dependency>-->
+        </dependency>
             
         <!-- OpenTracing -->
         <dependency>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -293,7 +293,7 @@
             <dependency>
                 <groupId>org.glassfish.jersey.ext.microprofile</groupId>
                 <artifactId>jersey-mp-rest-client</artifactId>
-                <version>2.33</version>
+                <version>${jersey.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <servlet-api.version>5.0.0</servlet-api.version>
         <grizzly.version>3.0.0</grizzly.version>
         <jax-rs-api.impl.version>3.0.0</jax-rs-api.impl.version>
-        <jersey.version>3.0.1</jersey.version>
+        <jersey.version>3.0.3.payara-p1</jersey.version>
         <jakarta.validation.version>3.0.0</jakarta.validation.version>
         <hibernate.validator.version>7.0.1.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>7.0.1.Final</hibernate.validator-cdi.version>
@@ -208,7 +208,7 @@
         <microprofile-jwt-auth.version>1.2.payara-p1</microprofile-jwt-auth.version>
         <microprofile-healthcheck.version>4.0</microprofile-healthcheck.version>
         <microprofile-metrics.version>4.0</microprofile-metrics.version>
-        <microprofile-rest-client.version>2.0.payara-p1</microprofile-rest-client.version>
+        <microprofile-rest-client.version>3.0</microprofile-rest-client.version>
         <microprofile-openapi.version>2.0</microprofile-openapi.version>
         <payara-arquillian-container.version>3.0.alpha1</payara-arquillian-container.version>
         <opentracing.version>0.33.0</opentracing.version>


### PR DESCRIPTION
## Description
This is a component upgrade PR of MicroProfile RestClient to v3.0

## Testing
### Testing Performed
MicroProfile RestClient TCK 3.0

### Testing Environment
Windows 11, JDK 1.8.0_172, Apache Maven 3.6.3

### Related PRs
https://github.com/payara/patched-src-jersey/pull/112
https://github.com/payara/MicroProfile-TCK-Runners/pull/162