### PR TITLE
FISH-5854 Error Related to the RolesPermittedInterceptor During Deployment

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -449,6 +449,10 @@ public class DeploymentImpl implements CDI11Deployment {
                            new Object[]{beanClass, newBda});
             }
             beanDeploymentArchives.add(newBda);
+
+            // Make the extension BDA visible to all previously found extensions
+            newBda.getBeanDeploymentArchives().addAll(extensionBDAMap.values());
+
             idToBeanDeploymentArchive.put(newBda.getId(), newBda);
             extensionBDAMap.put( beanClass.getClassLoader(), newBda);
             return newBda;

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -450,7 +450,7 @@ public class DeploymentImpl implements CDI11Deployment {
             }
             beanDeploymentArchives.add(newBda);
 
-            // Make the extension BDA visible to all previously found extensions
+            // Make all previously found extension BDAs visible to this extension BDA
             newBda.getBeanDeploymentArchives().addAll(extensionBDAMap.values());
 
             idToBeanDeploymentArchive.put(newBda.getId(), newBda);


### PR DESCRIPTION
## Description
Bug fix.
In certain situations applications would _sometimes_ fail to deploy due to a failure to validate the injection points of CDI Extensions (e.g. the RolesPermittedInterceptor).

This was eventually tracked down to whether certain bean managers were accessible to the extension, which was determined by the order in which they were resolved/loaded. This eventually led (all credit to @pdudits) to a discovery that the bean deployment archive graph was being created incorrectly.

## Important Info
### Blockers
None

## Testing
### New tests
None - tricky to reproduce and the reproducer we have is a customer app

### Testing Performed
Deployed and undeployed customer app > 20 times without error.

### Testing Environment
Windows 11, JDK 8

## Documentation
N/A

## Notes for Reviewers
None.
