### PR TITLE
FISH-5916 Update Enforcer Plugin

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -108,7 +108,7 @@
     <properties>
         <!-- on Hudson and RE, ${build.number} gets replaced by real build ID -->
         <build.id>${build.number}</build.id>
-        <jdk.version>1.8.0</jdk.version>
+        <jdk.version>11</jdk.version>
         <javadoc.skip>false</javadoc.skip>
 
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
@@ -470,7 +470,7 @@
                             <rules>
                                 <requireJavaVersion>
                                     <version>[${jdk.version},18.9)</version>
-                                    <message>You need JDK8 (${jdk.version}) or JDK11</message>
+                                    <message>You need at least JDK11 (${jdk.version})</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.0.3,3.2.1],[3.2.3,)</version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -470,7 +470,7 @@
                             <rules>
                                 <requireJavaVersion>
                                     <version>[${jdk.version},18.9)</version>
-                                    <message>You need at least JDK11 (${jdk.version})</message>
+                                    <message>You need at least JDK11</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.0.3,3.2.1],[3.2.3,)</version>


### PR DESCRIPTION
## Description
Title.
Make Enforcer plugin require JDK 11

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Attempted to build with JDK 8 -> got warning and build exits.
Attempted to build with JDK 11 -> build starts.

### Testing Environment
Windows 11, Zulu JDK 8 & 11

## Documentation
N/A

## Notes for Reviewers
None
