### PR TITLE
FISH-5914 Resolve Ambiguous Reference

### DIFF
--- a/nucleus/payara-modules/healthcheck-cpool/src/main/java/fish/payara/nucleus/healthcheck/cpool/ConnectionPoolHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-cpool/src/main/java/fish/payara/nucleus/healthcheck/cpool/ConnectionPoolHealthCheck.java
@@ -40,6 +40,7 @@
 package fish.payara.nucleus.healthcheck.cpool;
 
 import com.sun.enterprise.config.serverbeans.*;
+import com.sun.enterprise.config.serverbeans.Module;
 import com.sun.enterprise.connectors.util.ResourcesUtil;
 import com.sun.enterprise.resource.pool.PoolManager;
 import com.sun.enterprise.resource.pool.PoolStatus;


### PR DESCRIPTION
## Description
Title.
JDK 11 has a class named `Module`, so the wildcard import needs being made explicit. 

## Important Info
### Blockers
None.

## Testing
### New tests
None.

### Testing Performed
Compiled module on JDK 11.

### Testing Environment
Windows 11, Zulu JDK 11

## Documentation
N/A

## Notes for Reviewers
None.
