### PR TITLE
FISH-5866 MicroProfile OpenAPI version upgrade to 3.0 

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -39,17 +39,16 @@
  */
 package fish.payara.microprofile.openapi.impl.model;
 
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createList;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
-
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.info.InfoImpl;
 import fish.payara.microprofile.openapi.impl.model.security.SecurityRequirementImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createList;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
 import java.util.List;
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
@@ -147,17 +146,14 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
 
         final String serverUrl = server.getUrl();
 
-        if (serverUrl == null) {
-            return this;
-        }
-
         if (servers == null) {
             servers = createList();
         }
 
         for (Server existingServer : getServers()) {
-            // If a server with the same URL is found, merge them
-            if (serverUrl.equals(existingServer.getUrl())) {
+            // If a server with the same URL is found, merge them.
+            // Consider two servers without url as different in order to pass TCK.
+            if (serverUrl != null && serverUrl.equals(existingServer.getUrl())) {
                 ModelUtils.merge(server, existingServer, true);
                 return this;
             }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
@@ -159,6 +159,13 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
         return hash;
     }
 
+    /**
+     * Two tags are equal, if they have the same non-null name.
+     *
+     * @param obj the reference tag with which to compare.
+     * @return {@code true} if this tag has the same non-null name,
+     * {@code false} otherwise.
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -171,7 +178,7 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
             return false;
         }
         final TagImpl other = (TagImpl) obj;
-        return Objects.equals(this.name, other.name);
+        return this.name != null && Objects.equals(this.name, other.name);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -669,7 +669,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             property.setType(ModelUtils.getSchemaType(typeName, context));
         }
 
-        SchemaImpl.merge(schema, property, true, context);
+        SchemaImpl.merge(schema, property, false, context);
     }
 
     private static void visitSchemaParameter(AnnotationModel schemaAnnotation, org.glassfish.hk2.classmodel.reflect.Parameter parameter, ApiContext context) {

--- a/pom.xml
+++ b/pom.xml
@@ -202,14 +202,14 @@
         <jbi.version>1.0</jbi.version>
         <jakarta-platform.version>9.1.0-RC1</jakarta-platform.version>
         <microprofile-release.version>5.0</microprofile-release.version>
-        <microprofile-opentracing.version>2.0.payara-p2</microprofile-opentracing.version>
+        <microprofile-opentracing.version>3.0</microprofile-opentracing.version>
         <microprofile-config.version>3.0</microprofile-config.version>
         <microprofile-fault-tolerance.version>3.0.payara-p1</microprofile-fault-tolerance.version>
         <microprofile-jwt-auth.version>1.2.payara-p1</microprofile-jwt-auth.version>
         <microprofile-healthcheck.version>4.0</microprofile-healthcheck.version>
         <microprofile-metrics.version>4.0</microprofile-metrics.version>
         <microprofile-rest-client.version>3.0</microprofile-rest-client.version>
-        <microprofile-openapi.version>2.0</microprofile-openapi.version>
+        <microprofile-openapi.version>3.0</microprofile-openapi.version>
         <payara-arquillian-container.version>3.0.alpha1</payara-arquillian-container.version>
         <opentracing.version>0.33.0</opentracing.version>
         <h2db.version>1.4.196</h2db.version>


### PR DESCRIPTION
## Description
This is a component upgrade PR of MicroProfile OpenAPI to v3.0

## Testing
### Testing Performed
MicroProfile OpenAPI TCK 3.0
`Tests run: 244, Failures: 0, Errors: 0, Skipped: 0`

MicroProfile OpenAPI Unit tests
`Tests run: 118, Failures: 0, Errors: 0, Skipped: 0`

### Testing Environment
Windows 11, JDK 1.8.0_172, Apache Maven 3.6.3

### Related PRs
https://github.com/payara/MicroProfile-TCK-Runners/pull/164
