### PR TITLE
FISH-5799: access docker instances logs via docker rest

### DIFF
--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Node.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Node.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiiates
+// Portions Copyright [2018-2021] Payara Foundation and/or affiiates
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -333,7 +333,9 @@ public interface Node extends ConfigBeanProxy, Named, ReferenceContainer, RefCon
                 return false;
             }
             // Although the Docker container may be local to this machine, it's not truly "local"
-            if (node.getType().equals("DOCKER")) {
+            // TEMP is a docker container as well.
+            if (node.getType().equals("DOCKER")
+                    || node.getType().equals("TEMP")) {
                 return false;
             }
             return NetUtils.isThisHostLocal(nodeHost);

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/TrivialTarInputStream.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/TrivialTarInputStream.java
@@ -1,0 +1,81 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.enterprise.server.logging;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Trivial implementation for TAR file downloaded from Docker, expecting regular file, ignoring filename.
+ *
+ * @author Petr Aubrecht <aubrecht@asoftware.cz>
+ */
+public class TrivialTarInputStream extends InputStream {
+
+    private final InputStream sourceStream;
+    private byte[] header = null;
+    private long size;
+    private long readSoFar = 0;
+
+    public TrivialTarInputStream(InputStream sourceStream) {
+        this.sourceStream = sourceStream;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (header == null) {
+            header = new byte[512];
+            sourceStream.read(header);
+            byte fileLinkType = header[156];
+            if (fileLinkType != 0 && fileLinkType != 48 /*'0'*/) {
+                throw new IOException("Tar file is not a normal file, type is " + fileLinkType);
+            }
+            String sizeStr = new String(header, 124, 11, "ASCII");
+            size = Integer.valueOf(sizeStr, 8);
+        }
+        if (readSoFar >= size) {
+            // we are at the end of file
+            return -1;
+        }
+        readSoFar++;
+        return sourceStream.read();
+    }
+
+}


### PR DESCRIPTION
## Description
Docker instance wasn't able to see logs from inside the docker. With this PR the log is available in the detail of the instance. Both View Log Files and View Raw Log work as well as http://localhost:4848/management/domain/view-log address.

## Important Info
### Blockers
Current version uses "guess" during information acquisition. This needs improvement.

## Testing
### Testing Performed
Create new Docker node with this settings:
Type `DOCKER`
Node Host: `localhost`
Node Directory: `/opt/payara/appserver/glassfish/nodes`
Installation Directory: `/opt/payara/appserver`

Docker Image: `payara/server-node:5.2021.9`
Docker Port: `2375`
(Payra wrongly enters 2376, although TLS if off)
Docker Password File:  your path to password file

The password file can look like this:
`AS_ADMIN_SSHPASSWORD='payara'`

Create new instance, select the new docker node.

Start the instance

Select the newly created instance, click View Log Files and View Raw Log buttons.

### Testing Environment
Linux, Docker version 20.10.11+

## Documentation
Probably not needed, this functionality was missing.
