### PR TITLE
FISH-5879 The 'stop-deployment-group --kill=true' command does not work with custom Node Directory

### DIFF
--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopInstanceCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2022] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.v3.admin.cluster;
 
@@ -314,13 +314,21 @@ public class StopInstanceCommand extends StopServer implements AdminCommand, Pos
 
         String nodeName = instance.getNodeRef();
         Node node = nodes.getNode(nodeName);
+        String nodeDir = node.getNodeDirUnixStyle();
         NodeUtils nodeUtils = new NodeUtils(habitat, logger);
 
         // asadmin command to run on instances node
         ArrayList<String> command = new ArrayList<String>();
         command.add("stop-local-instance");
         command.add("--kill");
+        if (nodeDir != null) {
+            command.add("--nodedir");
+            command.add(nodeDir);
+        }
+        command.add("--node");
+        command.add(nodeName);
         command.add(instanceName);
+
         String humanCommand = makeCommandHuman(command);
         String firstErrorMessage = Strings.get("stop.local.instance.kill",
                 instanceName, nodeName, humanCommand);


### PR DESCRIPTION
## Description
A bug fix where using a custom node directory would result in `Node directory ... does not exist or is not a valid node directory` as it would always look at the default directory when executing `asadmin stop-local-instance` as part of the `asadmin stop-deployment-group` command.

## Important Info

## Testing
### Testing Performed
Manually tested with reproducer on the ticket using: New node in custom directory, default node and New node in default directory.

### Testing Environment
Windows 10, JDK 8, Maven 3.6.3

## Documentation
None.

## Notes for Reviewers
None.
