### PR TITLE
FISH-5920 Update MicroProfile Metrics Schemagen for JDK 11

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -63,7 +63,7 @@
             <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>jaxb2-maven-plugin</artifactId>
-            <version>2.4</version>
+            <version>2.5.0</version>
             <executions>
                 <execution>
                     <id>schemagen</id>


### PR DESCRIPTION
## Description
microprofile-metrics uses jaxb2-maven-plugin - only version 2.5.0 is JDK11 compatible.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Compiled module on JDK 11. Ran microprofile-metrics module unit tests.

### Testing Environment
Windows 10, JDK 11, Maven 3.6.3

## Documentation
None.

## Notes for Reviewers
None.
