### PR TITLE
FISH-5956 Replace 'sun.rmi.rmic' with 'org.glassfish.rmic'

### DIFF
--- a/appserver/ejb/ejb-container/osgi.bundle
+++ b/appserver/ejb/ejb-container/osgi.bundle
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright 2022 Payara Foundation and/or its affiliates
 
 -exportcontents: \
                         com.sun.ejb; \
@@ -62,6 +63,7 @@ Import-Package: \
                         jakarta.jws;resolution:=optional, \
                         org.glassfish.apf.context, \
                         org.glassfish.ejb.deployment.archive, \
+                        org.glassfish.rmic, \
                         *
 
 Bundle-SymbolicName: \

--- a/appserver/ejb/ejb-container/osgi.bundle
+++ b/appserver/ejb/ejb-container/osgi.bundle
@@ -38,6 +38,8 @@
 # holder.
 #
 # Portions Copyright 2022 Payara Foundation and/or its affiliates
+# Payara Foundation and/or its affiliates elects to include this software
+# in this distribution under the GPL Version 2 license.
 
 -exportcontents: \
                         com.sun.ejb; \

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -41,6 +41,7 @@
 
 -->
 <!-- Portions Copyright 2016-2022 Payara Foundation and/or its affiliates -->
+<!-- Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]" -->
+<!-- Portions Copyright 2016-2022 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
 
@@ -257,6 +257,10 @@
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>rmic</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/StaticRmiStubGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/StaticRmiStubGenerator.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2019-2022 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license.
 
 package com.sun.ejb.codegen;
 
@@ -297,7 +298,7 @@ public class StaticRmiStubGenerator {
         _logger.info("[RMIC] options: " + cmds);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        sun.rmi.rmic.Main compiler = new sun.rmi.rmic.Main(baos, "rmic");
+        org.glassfish.rmic.Main compiler = new org.glassfish.rmic.Main(baos, "rmic");
         boolean success = compiler.compile(cmds.toArray(new String[cmds.size()]));
         //success = true;  // it ALWAYS returns an "error" if -Xnocompile is used!!
 

--- a/appserver/packager/glassfish-corba-base/pom.xml
+++ b/appserver/packager/glassfish-corba-base/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2022 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -132,6 +133,10 @@
             <type>zip</type>
             <optional>true</optional>
          </dependency>
+         <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>glassfish-corba-orb</artifactId>
+       </dependency>
     </dependencies>
 </project>
 

--- a/appserver/packager/glassfish-corba/pom.xml
+++ b/appserver/packager/glassfish-corba/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2022 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -121,10 +122,6 @@
     </profiles>
     
     <dependencies>
-       <dependency>
-            <groupId>org.glassfish.corba</groupId>
-            <artifactId>glassfish-corba-orb</artifactId>
-       </dependency>
        <dependency>
             <groupId>org.glassfish.corba</groupId>
             <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/nucleus/packager/nucleus-corba-base/pom.xml
+++ b/nucleus/packager/nucleus-corba-base/pom.xml
@@ -40,6 +40,8 @@
     holder.
 
 -->
+<!-- Portions Copyright 2022 Payara Foundation and/or its affiliates -->
+<!-- Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/nucleus/packager/nucleus-corba-base/pom.xml
+++ b/nucleus/packager/nucleus-corba-base/pom.xml
@@ -87,5 +87,9 @@
             <artifactId>pfl-dynamic</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>rmic</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -42,6 +42,7 @@
 -->
 <!-- Portions Copyright 2016-2022 Payara Foundation and/or its affiliates -->
 
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]" -->
+<!-- Portions Copyright 2016-2022 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -830,6 +830,11 @@ Parent is ${project.parent}</echo>
             <dependency>
                 <groupId>org.glassfish.corba</groupId>
                 <artifactId>glassfish-corba-internal-api</artifactId>
+                <version>${glassfish-corba.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.corba</groupId>
+                <artifactId>rmic</artifactId>
                 <version>${glassfish-corba.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Description
Removes more sun packages which JDK 11 doesn't like.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Compiled server on JDK 11 - no complaints.

### Testing Environment
Windows 11, Zulu JDK 11

## Documentation
N/A

## Notes for Reviewers
None
