### PR TITLE
FISH-5935 Remove JDK 8 Docker build

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2021-2022 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -15,7 +56,6 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk8.tag>8u262</docker.jdk8.tag>
         <docker.jdk11.tag>11.0.7</docker.jdk11.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
@@ -99,15 +139,9 @@
                                 </goals>
                                 <configuration>
                                     <tasks>
-                                        <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk8">
-                                            <filterset>
-                                                <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk8.tag}"/>
-                                            </filterset>
-                                        </copy>
                                         <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk11">
                                             <filterset>
                                                 <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk11.tag}"/>
-                                                <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk11"/>
                                             </filterset>
                                         </copy>
                                     </tasks>
@@ -136,24 +170,6 @@
                                         <filter>@</filter>
                                         <tags>
                                             <tag>${docker.payara.tag}</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk8</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}-jdk11</tag>
                                         </tags>
                                         <cleanup>none</cleanup>
                                         <noCache>${docker.noCache}</noCache>


### PR DESCRIPTION
## Description
Removes JDK 8 build of Docker images.

## Important Info
### Blockers
Building of Docker images seems to be broken on the Payara6 branch - not broken by this change.
The build of Docker images is fixed by the master merge PR: https://github.com/payara/Payara/pull/5475

## Testing
### New tests
None

### Testing Performed
Built Docker image.

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
