### PR TITLE
Fish 5672 tck policy files doprivileged p6

### DIFF
--- a/appserver/security/jacc.provider.file/src/main/java/com/sun/enterprise/security/provider/PolicyConfigurationImpl.java
+++ b/appserver/security/jacc.provider.file/src/main/java/com/sun/enterprise/security/provider/PolicyConfigurationImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2022] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security.provider;
 
 import static com.sun.enterprise.security.provider.PolicyParser.PrincipalEntry.WILDCARD_CLASS;
@@ -974,7 +974,7 @@ public class PolicyConfigurationImpl implements PolicyConfiguration {
         
         if (stateValue == INSERVICE_STATE && !inState) {
             Boolean fileArrived = AccessController.doPrivileged(
-                    (PrivilegedAction< Boolean>) () -> fileArrived(true) || fileArrived(false)
+                    (PrivilegedAction<Boolean>) () -> fileArrived(true) || fileArrived(false)
             );
             if (fileArrived) {
                 if (logger.isLoggable(Level.FINE)) {

--- a/appserver/security/jacc.provider.file/src/main/java/com/sun/enterprise/security/provider/PolicyConfigurationImpl.java
+++ b/appserver/security/jacc.provider.file/src/main/java/com/sun/enterprise/security/provider/PolicyConfigurationImpl.java
@@ -92,6 +92,7 @@ import com.sun.enterprise.security.provider.PolicyParser.PermissionEntry;
 import com.sun.enterprise.security.provider.PolicyParser.PrincipalEntry;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 
+import java.security.AccessController;
 import sun.security.provider.PolicyFile;
 
 /**
@@ -972,8 +973,13 @@ public class PolicyConfigurationImpl implements PolicyConfiguration {
         boolean inState = _stateIs(stateValue);
         
         if (stateValue == INSERVICE_STATE && !inState) {
-            if (fileArrived(true) || fileArrived(false)) {
-
+            Boolean fileArrived = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                @Override
+                public Boolean run() {
+                    return fileArrived(true) || fileArrived(false);
+                }
+            });
+            if (fileArrived) {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("JACC Policy Provider: file arrived transition to inService: " + " state: "
                             + (this.state == OPEN_STATE ? "open " : "deleted ") + CONTEXT_ID);

--- a/appserver/security/jacc.provider.file/src/main/java/com/sun/enterprise/security/provider/PolicyConfigurationImpl.java
+++ b/appserver/security/jacc.provider.file/src/main/java/com/sun/enterprise/security/provider/PolicyConfigurationImpl.java
@@ -973,12 +973,9 @@ public class PolicyConfigurationImpl implements PolicyConfiguration {
         boolean inState = _stateIs(stateValue);
         
         if (stateValue == INSERVICE_STATE && !inState) {
-            Boolean fileArrived = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                @Override
-                public Boolean run() {
-                    return fileArrived(true) || fileArrived(false);
-                }
-            });
+            Boolean fileArrived = AccessController.doPrivileged(
+                    (PrivilegedAction< Boolean>) () -> fileArrived(true) || fileArrived(false)
+            );
             if (fileArrived) {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("JACC Policy Provider: file arrived transition to inService: " + " state: "


### PR DESCRIPTION
## Description
TCK tests occasionally have problems with accessing granted.policy file. This change fixes it.

## Testing
### Testing Performed
TCK ejb30/lite/packaging executed many times without the issue reoccurring.

### Testing Environment
Linux, JDK 8 and 11
