### PR TITLE
FISH-5892: recreating truststore file when corrupted

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -256,9 +256,12 @@ public class AsadminSecurityUtil {
         try {
             asadminTruststore = openTruststore(passwordToUse);
         } catch (IOException e) {
+            //If we're using the default trust store try to recreate it, otherwise just throw the exception
             if (System.getProperty(SystemPropertyConstants.CLIENT_TRUSTSTORE_PROPERTY) == null) {
                 logger.log(Level.WARNING, String.format("Error when reading truststore, exception:%s. Now recreating file", e));
                 recreateDefaultTrustStore(passwordToUse);
+            } else {
+                throw e;
             }
         }
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -256,8 +256,10 @@ public class AsadminSecurityUtil {
         try {
             asadminTruststore = openTruststore(passwordToUse);
         } catch (IOException e) {
-            logger.log(Level.WARNING, String.format("Error when reading truststore, exception:%s. Now recreating file", e));
-            recreateDefaultTrustStore(passwordToUse);
+            if (System.getProperty(SystemPropertyConstants.CLIENT_TRUSTSTORE_PROPERTY) == null) {
+                logger.log(Level.WARNING, String.format("Error when reading truststore, exception:%s. Now recreating file", e));
+                recreateDefaultTrustStore(passwordToUse);
+            }
         }
     }
 
@@ -268,18 +270,16 @@ public class AsadminSecurityUtil {
      * @throws IOException
      */
     protected void recreateDefaultTrustStore(char[] passwordToUse) throws IOException {
-        if (System.getProperty(SystemPropertyConstants.CLIENT_TRUSTSTORE_PROPERTY) == null) {
-            File trustStoreFile = new File(AsadminSecurityUtil.getDefaultClientDir(), "truststore");
-            logger.log(Level.INFO, String.format("Recreating default truststore file: %s", trustStoreFile.getPath()));
-            try {
-                Files.deleteIfExists(trustStoreFile.toPath());
-                asadminTruststore = openTruststore(passwordToUse);
-            } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
-                logger.log(Level.WARNING,
-                        String.format("Error when processing truststore with path:%s and exception:%s",
-                                trustStoreFile.getPath(), e));
-                throw new RuntimeException(e);
-            }
+        File trustStoreFile = new File(AsadminSecurityUtil.getDefaultClientDir(), "truststore");
+        logger.log(Level.INFO, String.format("Recreating default truststore file: %s", trustStoreFile.getPath()));
+        try {
+            Files.deleteIfExists(trustStoreFile.toPath());
+            asadminTruststore = openTruststore(passwordToUse);
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+            logger.log(Level.WARNING,
+                    String.format("Error when processing truststore with path:%s and exception:%s",
+                            trustStoreFile.getPath(), e));
+            throw new RuntimeException(e);
         }
     }
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/store/AsadminSecurityUtil.java
@@ -257,25 +257,29 @@ public class AsadminSecurityUtil {
             asadminTruststore = openTruststore(passwordToUse);
         } catch (IOException e) {
             logger.log(Level.WARNING, String.format("Error when reading truststore, exception:%s. Now recreating file", e));
-            recreateTrustStore(AsadminTruststore.getAsadminTruststore(), passwordToUse);
+            recreateDefaultTrustStore(passwordToUse);
         }
     }
 
     /**
-     * Method to recreate the truststore file
-     * @param fileTruststore File of the truststore
+     * Method to recreate the default truststore file from the .gfclient folder
+     *
      * @param passwordToUse password to use
      * @throws IOException
      */
-    private void recreateTrustStore(File fileTruststore, char[] passwordToUse) throws IOException {
-        try {
-            Files.deleteIfExists(fileTruststore.toPath());
-            asadminTruststore = openTruststore(passwordToUse);
-        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
-            logger.log(Level.WARNING,
-                    String.format("Error when processing truststore with path:%s and exception:%s",
-                            fileTruststore.toPath(), e));
-            throw new RuntimeException(e);
+    protected void recreateDefaultTrustStore(char[] passwordToUse) throws IOException {
+        if (System.getProperty(SystemPropertyConstants.CLIENT_TRUSTSTORE_PROPERTY) == null) {
+            File trustStoreFile = new File(AsadminSecurityUtil.getDefaultClientDir(), "truststore");
+            logger.log(Level.INFO, String.format("Recreating default truststore file: %s", trustStoreFile.getPath()));
+            try {
+                Files.deleteIfExists(trustStoreFile.toPath());
+                asadminTruststore = openTruststore(passwordToUse);
+            } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+                logger.log(Level.WARNING,
+                        String.format("Error when processing truststore with path:%s and exception:%s",
+                                trustStoreFile.getPath(), e));
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

Recreating truststore file when corrupted

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

this is a fix of a reported issue when reading a corrupted truststore for secure administration

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Local testing by using a blank truststore file to simulate corrupted file

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11,  zulu JDK 8U312 

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
