### PR TITLE
FISH-5923 Remove JDK 8 vs. 9 checks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ git remote add origin https://github.com/<YourUsername>/Payara
 You are now free to start working on Payara issues, adding new features, or tinkering with the codebase.
 
 ## Building Payara
-Payara uses maven to build the server, you can use either JDK 7 or JDK 8 to build Payara Server, we distribute Payara built with JDK 8.
+Payara uses maven to build the server, you can use JDK 11 to build Payara Server, we distribute Payara built with JDK 11.
 To build Payara from the root of the cloned source code tree execute;
 ```
 mvn -DskipTests clean package

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
+// Portions Copyright 2018-2022 Payara Foundation and/or affiliates
 
 /*
  * UtilHandlers.java
@@ -48,7 +48,6 @@
 
 package org.glassfish.admingui.common.handlers;
 
-import com.sun.enterprise.util.JDK;
 import com.sun.jsftemplating.annotation.Handler;
 import com.sun.jsftemplating.annotation.HandlerInput;
 import com.sun.jsftemplating.annotation.HandlerOutput;
@@ -58,6 +57,12 @@ import com.sun.jsftemplating.layout.descriptors.LayoutElement;
 import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
 import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
 import com.sun.jsftemplating.util.FileUtil;
+import jakarta.faces.component.UIViewRoot;
+import org.glassfish.admin.rest.utils.JsonUtil;
+import org.glassfish.admingui.common.util.GuiUtil;
+import org.glassfish.admingui.common.util.JSONUtil;
+import org.glassfish.admingui.common.util.RestUtil;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
@@ -76,11 +81,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
-import jakarta.faces.component.UIViewRoot;
-import org.glassfish.admin.rest.utils.JsonUtil;
-import org.glassfish.admingui.common.util.GuiUtil;
-import org.glassfish.admingui.common.util.JSONUtil;
-import org.glassfish.admingui.common.util.RestUtil;
 
 /**
  *
@@ -1162,14 +1162,6 @@ public class UtilHandlers {
             ch = it.next();
         }
         return builder.toString();
-    }
-
-    @Handler(id = "py.isTls13Supported",
-            output = {
-                @HandlerOutput(name = "result", type = Boolean.class)}
-    )
-    public static void isTls13Supported(HandlerContext handlerCtx) {
-        handlerCtx.setOutputValue("result", JDK.isTls13Supported() || JDK.isOpenJSSEFlagRequired());
     }
 
     private static final String PATH_SEPARATOR = "${path.separator}";

--- a/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
@@ -39,7 +39,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2020] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright 2018-2022 Payara Foundation and/or affiliates -->
 
 <!-- sslAttrs.inc -->
 
@@ -61,8 +61,6 @@
                 OtherCiphersList="#{requestScope.availableOther}"
                 EccCiphersList="#{requestScope.availableEcc}")
 
-        py.isTls13Supported(result="#{requestScope.isTls13Supported}");
-        setPageSessionAttribute(key="showTLS13Prop", value="#{requestScope.isTls13Supported}");
     />
      <!afterCreate
         getClientId(component="$this{component}" clientId=>$page{sheetId});
@@ -85,7 +83,7 @@
      <sun:property id="TLSProp12"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.tlsLabel12}" >
         <sun:checkbox id="TLS12" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['tls12Enabled']}" selectedValue="true"/>
      </sun:property>
-     <sun:property id="TLSProp13"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.tlsLabel13}" helpText="$resource{i18n.ssl.tlsLabel13Help}" rendered="#{pageSession.showTLS13Prop}">
+     <sun:property id="TLSProp13"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.tlsLabel13}" helpText="$resource{i18n.ssl.tlsLabel13Help}" >
         <sun:checkbox id="TLS13" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['tls13Enabled']}" selectedValue="true"/>
      </sun:property>
 

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientFacade.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientFacade.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2022 Payara Foundation and/or its affiliates
 
 package org.glassfish.appclient.client;
 
@@ -46,36 +47,11 @@ import com.sun.enterprise.universal.glassfish.TokenResolver;
 import com.sun.enterprise.util.JDK;
 import com.sun.enterprise.util.LocalStringManager;
 import com.sun.enterprise.util.LocalStringManagerImpl;
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.CharArrayWriter;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
-import java.lang.instrument.Instrumentation;
-import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import jakarta.xml.bind.*;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.ValidationEvent;
 import jakarta.xml.bind.util.ValidationEventCollector;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.sax.SAXSource;
 import org.glassfish.appclient.client.acc.ACCClassLoader;
 import org.glassfish.appclient.client.acc.ACCLogger;
 import org.glassfish.appclient.client.acc.AgentArguments;
@@ -97,6 +73,33 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.sax.SAXSource;
+import java.io.BufferedReader;
+import java.io.CharArrayWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  *
@@ -184,17 +187,14 @@ public class AppClientFacade {
         acc.launch(args);
     }
 
-    public static void prepareACC(String agentArgsText, Instrumentation inst) throws UserError, MalformedURLException, URISyntaxException, JAXBException, FileNotFoundException, ParserConfigurationException, SAXException, IOException, Exception {
-        int minor = JDK.getMinor();
+    public static void prepareACC(String agentArgsText, Instrumentation inst) throws UserError, Exception {
         int major = JDK.getMajor();
-        if (major<9) {
-            if (minor < 6) {
+        if (major < 11) {
             throw new UserError(localStrings.getLocalString(
                     stringsAnchor,
                     "main.badVersion",
                     "Current Java version {0} is too low; {1} or later required",
-                    new Object[] {System.getProperty("java.version"), "1.6"}));
-            }
+                    new Object[]{System.getProperty("java.version"), "11"}));
         }
 
         /*

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -37,28 +37,27 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright 2018-2022 Payara Foundation and/or affiliates
 
 package org.glassfish.appclient.client;
 
 import com.sun.enterprise.util.LocalStringManager;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.OS;
+import org.glassfish.appclient.client.acc.UserError;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import static java.util.Objects.nonNull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import static java.util.stream.Collectors.joining;
 import java.util.stream.Stream;
-import org.glassfish.appclient.client.acc.UserError;
 
-import com.sun.enterprise.util.JDK;
-import com.sun.enterprise.util.OS;
-import java.util.Arrays;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.joining;
 
 /**
  *
@@ -268,7 +267,7 @@ public class CLIBootstrap {
          * Add the elements in this order so the regex patterns will match the correct elements. In this arrangement, the
          * patterns are from most specific to most general.
          */
-        elementsInScanOrder = new CommandLineElement[] {
+        elementsInScanOrder = new CommandLineElement[]{
                 extDirs,
                 endorsedDirs,
                 accValuedOptions,
@@ -282,32 +281,15 @@ public class CLIBootstrap {
         /*
          * Add the elements in this order so they appear in the generated java command in the correct positions.
          */
-        //In JDK 9 and later ext and endorsed directory removed.
-        int major = JDK.getMajor();
-        if (major >= 9) {
-            elementsInOutputOrder = new CommandLineElement[]{
-                    jvmValuedOptions,
-                    jvmPropertySettings,
-                    otherJVMOptions,
-                    accUnvaluedOptions,
-                    accValuedOptions,
-                    jvmMainSetting,
-                    arguments
-            };
-        } else {
-            elementsInOutputOrder = new CommandLineElement[]{
-                    jvmValuedOptions,
-                    jvmPropertySettings,
-                    otherJVMOptions,
-                    extDirs,
-                    endorsedDirs,
-                    accUnvaluedOptions,
-                    accValuedOptions,
-                    jvmMainSetting,
-                    arguments
-            };
-        }
-        
+        elementsInOutputOrder = new CommandLineElement[]{
+                jvmValuedOptions,
+                jvmPropertySettings,
+                otherJVMOptions,
+                accUnvaluedOptions,
+                accValuedOptions,
+                jvmMainSetting,
+                arguments
+        };
     }
 
     /**

--- a/appserver/common/glassfish-ee-api/src/main/java/com/sun/appserv/ClassLoaderUtil.java
+++ b/appserver/common/glassfish-ee-api/src/main/java/com/sun/appserv/ClassLoaderUtil.java
@@ -37,16 +37,16 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] Payara Foundation and/or affiliates.
+// Portions Copyright 2017-2022 Payara Foundation and/or affiliates.
 package com.sun.appserv;
 
-import com.sun.enterprise.util.JDK;
-import static java.util.logging.Level.WARNING;
+import com.sun.logging.LogDomains;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URLClassLoader;
 import java.text.MessageFormat;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
@@ -54,8 +54,7 @@ import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.sun.logging.LogDomains;
-import java.util.Collection;
+import static java.util.logging.Level.WARNING;
 
 
 /**
@@ -73,12 +72,11 @@ public class ClassLoaderUtil {
     // ### Names of classes and fields of interest for closing the loader's jar files
     
     private static final String URLCLASSLOADER_UCP_FIELD_NAME = "ucp"; // URLClassPath reference
-    
-    private static final String URLCLASSPATH_JDK8_CLASS_NAME = "sun.misc.URLClassPath";
+
     private static final String URLCLASSPATH_JDK9_CLASS_NAME = "jdk.internal.loader.URLClassPath";
     
     private static final String URLCLASSPATH_LOADERS_FIELD_NAME = "loaders"; // ArrayList of URLClassPath.Loader 
-    private static final String URLCLASSPATH_URLS_FIELD_NAME = JDK.getMajor() < 11 ? "urls" : "unopenedUrls";
+    private static final String URLCLASSPATH_URLS_FIELD_NAME = "unopenedUrls";
     private static final String URLCLASSPATH_LMAP_FIELD_NAME = "lmap"; // HashMap of String -> URLClassPath.Loader
 
     private static final String URLCLASSPATH_JARLOADER_INNER_CLASS_NAME = "$JarLoader";
@@ -274,17 +272,12 @@ public class ClassLoaderUtil {
         
         Class<?> ucpCLass = null;
         String jarLoaderClass = null;
-                
+
         try {
-            ucpCLass = Class.forName(URLCLASSPATH_JDK8_CLASS_NAME, false, Thread.currentThread().getContextClassLoader());
-            jarLoaderClass = URLCLASSPATH_JDK8_CLASS_NAME + URLCLASSPATH_JARLOADER_INNER_CLASS_NAME;
-        } catch (ClassNotFoundException e) {
-            try {
-                ucpCLass = Class.forName(URLCLASSPATH_JDK9_CLASS_NAME, false, Thread.currentThread().getContextClassLoader());
-                jarLoaderClass = URLCLASSPATH_JDK9_CLASS_NAME + URLCLASSPATH_JARLOADER_INNER_CLASS_NAME;
-            } catch (ClassNotFoundException ee) {
-                // ignore for now will throw npe later
-            }
+            ucpCLass = Class.forName(URLCLASSPATH_JDK9_CLASS_NAME, false, Thread.currentThread().getContextClassLoader());
+            jarLoaderClass = URLCLASSPATH_JDK9_CLASS_NAME + URLCLASSPATH_JARLOADER_INNER_CLASS_NAME;
+        } catch (ClassNotFoundException ee) {
+            // ignore for now will throw npe later
         }
         
         loadersField = getField(ucpCLass, URLCLASSPATH_LOADERS_FIELD_NAME);

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/StaticRmiStubGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/StaticRmiStubGenerator.java
@@ -42,27 +42,31 @@
 
 package com.sun.ejb.codegen;
 
-import java.io.*;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.sun.enterprise.config.serverbeans.JavaConfig;
+import com.sun.enterprise.deployment.Application;
+import com.sun.enterprise.deployment.EjbBundleDescriptor;
+import com.sun.enterprise.deployment.EjbDescriptor;
+import com.sun.enterprise.deployment.util.TypeUtil;
+import com.sun.enterprise.util.OS;
+import com.sun.enterprise.util.i18n.StringManager;
+import com.sun.logging.LogDomains;
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.deployment.common.ClientArtifactsManager;
 import org.glassfish.ejb.spi.CMPDeployer;
 import org.glassfish.hk2.api.ServiceLocator;
 
-import com.sun.enterprise.util.i18n.StringManager;
-import com.sun.logging.LogDomains;
-
-import com.sun.enterprise.config.serverbeans.JavaConfig;
-import com.sun.enterprise.deployment.Application;
-import com.sun.enterprise.deployment.EjbDescriptor;
-import com.sun.enterprise.deployment.EjbBundleDescriptor;
-import com.sun.enterprise.deployment.util.TypeUtil;
-import com.sun.enterprise.util.JDK;
-import com.sun.enterprise.util.OS;
-import org.glassfish.api.admin.ServerEnvironment;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class is used to generate the RMI-IIOP version of a 
@@ -78,17 +82,15 @@ public class StaticRmiStubGenerator {
 
      private static final String ORG_OMG_STUB_PREFIX  = "org.omg.stub.";
 
-     private final String toolsJarPath;
-
      private List<String> rmicOptionsList;
 
     /**
      * This class is only instantiated internally.
      */
     public StaticRmiStubGenerator(ServiceLocator services) {
-        // Find java path and tools.jar
+        // Find java path
 
-        //Try this jre's parent
+        // Try this jre's parent
         String jreHome = System.getProperty("java.home");
         File jdkDir = null;
         if(jreHome != null) {
@@ -125,14 +127,6 @@ public class StaticRmiStubGenerator {
 
         if(jdkDir == null) {
             _logger.warning("Cannot identify JDK location.");
-            toolsJarPath = null;
-        } else {
-            File toolsJar = new File(jdkDir + "/lib/tools.jar" );
-            if (toolsJar != null && toolsJar.exists()) {
-                toolsJarPath = toolsJar.getPath();
-            } else {
-                toolsJarPath = null;
-            }
         }
 
         JavaConfig jc = services.getService(JavaConfig.class,
@@ -269,11 +263,6 @@ public class StaticRmiStubGenerator {
             return;
         }
 
-        if (toolsJarPath == null && !OS.isDarwin() && JDK.getMajor() < 9) {
-            _logger.log(Level.INFO, "[RMIC] tools.jar location was not found");
-            return;
-        }
-
         progress(localStrings.getStringWithDefault(
                                          "generator.compiling_rmi_iiop",
                                          "Compiling RMI-IIOP code."));
@@ -283,9 +272,6 @@ public class StaticRmiStubGenerator {
         cmds.add("-classpath");
 
         StringBuilder sb = new StringBuilder().append(System.getProperty("java.class.path"));
-        if (toolsJarPath != null) {
-             sb.append(File.pathSeparator).append(toolsJarPath);
-        }
         sb.append(File.pathSeparator).append(explodedDir)
           .append(File.pathSeparator).append(repository)
           .append(File.pathSeparator).append(classPath);

--- a/appserver/packager/appserver-base/src/main/docs/README.txt
+++ b/appserver/packager/appserver-base/src/main/docs/README.txt
@@ -8,11 +8,9 @@ Here are a few short steps to get you started...
 
 Payara Server currently supports the following Java Virtual Machines:
 
-* Oracle JDK8 (u162+), Oracle JDK 11 (11.0.5+)
-* Azul Zulu JDK8 (u162+), Azul Zulu JDK 11 (11.0.5u10+)
-* OpenJDK JDK8 (u162+), OpenJDK 11 (11.0.5+)
-
-TLS 1.3 is supported on JDK 8 with Azul Zulu 1.8.222+ only and all JDK 11 versions.
+* Oracle JDK 11 (11.0.5+)
+* Azul Zulu JDK 11 (11.0.5u10+)
+* OpenJDK 11 (11.0.5+)
 
 1. Installing Payara Server
 ===========================

--- a/appserver/packager/glassfish-web/pom.xml
+++ b/appserver/packager/glassfish-web/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2016-2022 [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -129,9 +129,7 @@
                 <jdk>[1.8,)</jdk>
             </activation>
             <dependencies>
-                <!-- Soteria / Java EE Security
-                     Required in Payara 5, but optional for JDK 8+ builds in Payara 4
-                -->
+                <!-- Soteria / Java EE Security -->
                 <dependency>
                     <groupId>jakarta.security.enterprise</groupId>
                     <artifactId>jakarta.security.enterprise-api</artifactId>

--- a/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/URLClassPath.java
+++ b/appserver/persistence/cmp/enhancer/src/main/java/com/sun/jdo/api/persistence/enhancer/URLClassPath.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,7 +38,7 @@
  * holder.
  */
 package com.sun.jdo.api.persistence.enhancer;
-import com.sun.enterprise.util.JDK;
+
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -53,7 +53,7 @@ import java.util.jar.Manifest;
  */
 public class URLClassPath {
 
-    private static final String URL_CLASSPATH_CLASS_NAME = JDK.getMajor() > 8 ? "jdk.internal.loader.URLClassPath" : "sun.misc.URLClassPath";
+    private static final String URL_CLASSPATH_CLASS_NAME = "jdk.internal.loader.URLClassPath";
     private static Constructor constructor;
     private static final String GET_RESOURCE_METHOD_NAME = "getResource";
     private static Method getResource;

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2022 Payara Foundation and/or its affiliates
 
 package org.glassfish.web.loader;
 
@@ -66,16 +66,19 @@ import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.security.integration.DDPermissionsLoader;
 import com.sun.enterprise.security.integration.PermsHolder;
-import com.sun.enterprise.util.JDK;
 import com.sun.enterprise.util.io.FileUtils;
 import org.apache.naming.JndiPermission;
 import org.apache.naming.resources.DirContextURLStreamHandler;
 import org.apache.naming.resources.JarFileResourcesProvider;
 import org.apache.naming.resources.ProxyDirContext;
-import org.apache.naming.resources.WebDirContext;
 import org.apache.naming.resources.Resource;
 import org.apache.naming.resources.ResourceAttributes;
+import org.apache.naming.resources.WebDirContext;
+import org.glassfish.api.deployment.GeneratedResourceEntry;
 import org.glassfish.api.deployment.InstrumentableClassLoader;
+import org.glassfish.api.deployment.ResourceClassLoader;
+import org.glassfish.api.deployment.ResourceEntry;
+import org.glassfish.common.util.InstanceCounter;
 import org.glassfish.hk2.api.PreDestroy;
 import org.glassfish.web.util.ExceptionUtils;
 import org.glassfish.web.util.IntrospectionUtils;
@@ -85,7 +88,13 @@ import javax.naming.NameClassPair;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilePermission;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.ref.Reference;
@@ -98,10 +107,32 @@ import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.security.*;
+import java.security.AccessControlException;
+import java.security.AccessController;
+import java.security.AllPermission;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.jar.Attributes;
@@ -113,10 +144,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
-import org.glassfish.api.deployment.GeneratedResourceEntry;
-import org.glassfish.api.deployment.ResourceEntry;
-import org.glassfish.api.deployment.ResourceClassLoader;
-import org.glassfish.common.util.InstanceCounter;
 
 /**
  * Specialized web application class loader.
@@ -408,7 +435,6 @@ public class WebappClassLoader
 
     private static final Class<?>[] CONSTRUCTOR_ARGS_TYPES;
     private static final Object CONSTRUCTOR_ARGUMENTS;
-    private static final boolean IS_JDK_VERSION_HIGHER_THAN_8 = JDK.getMajor() > 8;
     private static final Boolean isMultiReleaseJar;
     private static final Name MULTI_RELEASE = new Name("Multi-Release");
 
@@ -416,23 +442,18 @@ public class WebappClassLoader
         Class<?>[] constructorArgsTypes;
         Object constructorArguments;
 
-        if (!IS_JDK_VERSION_HIGHER_THAN_8) {
-            isMultiReleaseJar = false;
+        boolean isException = false;
+        try {
+            final Class<?> runtimeVersionClass = Class.forName("java.lang.Runtime$Version");
+            constructorArgsTypes = new Class[]{File.class, boolean.class, int.class, runtimeVersionClass};
+            constructorArguments = Runtime.class.getDeclaredMethod("version").invoke(null);
+        } catch (Exception e) {
+            isException = true;
             constructorArgsTypes = null;
             constructorArguments = null;
-        } else {
-            boolean isException = false;
-            try {
-                final Class<?> runtimeVersionClass = Class.forName("java.lang.Runtime$Version");
-                constructorArgsTypes = new Class[]{File.class, boolean.class, int.class, runtimeVersionClass};
-                constructorArguments = Runtime.class.getDeclaredMethod("version").invoke(null);
-            } catch (Exception e) {
-                isException = true;
-                constructorArgsTypes = null;
-                constructorArguments = null;
-            }
-            isMultiReleaseJar = !isException;
         }
+        isMultiReleaseJar = !isException;
+
         CONSTRUCTOR_ARGS_TYPES = constructorArgsTypes;
         CONSTRUCTOR_ARGUMENTS = constructorArguments;
     }
@@ -3570,7 +3591,7 @@ public class WebappClassLoader
     private static JarFile newJarFile(final File file) throws IOException {
 
         JarFile jarFile = new JarFile(file);
-        if (!IS_JDK_VERSION_HIGHER_THAN_8 || !isMultiReleaseJar) {
+        if (!isMultiReleaseJar) {
             return jarFile;
         }
 

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/monitoring/WebServiceTesterServlet.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/monitoring/WebServiceTesterServlet.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2018-2022 Payara Foundation and/or its affiliates
 /*
  * WebServiceTesterServlet.java
  *
@@ -47,25 +47,28 @@
 package org.glassfish.webservices.monitoring;
 
 import com.sun.enterprise.deployment.WebServiceEndpoint;
-import com.sun.enterprise.util.JDK;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.tools.ws.spi.WSToolsObjectFactory;
-import org.glassfish.jaxb.runtime.api.JAXBRIContext;
-import org.glassfish.webservices.LogUtils;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.WebEndpoint;
+import org.glassfish.jaxb.runtime.api.JAXBRIContext;
+import org.glassfish.webservices.LogUtils;
+
 import javax.xml.namespace.QName;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import jakarta.xml.ws.Service;
-import jakarta.xml.ws.WebEndpoint;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -527,10 +530,7 @@ public class WebServiceTesterServlet extends HttpServlet {
             logger.log(Level.SEVERE, LogUtils.CREATE_DIR_FAILED, classesDir);
         }
 
-        String[] wsimportArgs = new String[8];
-        if (JDK.getMajor() >= 9) {
-            wsimportArgs = new String[14];
-        }
+        String[] wsimportArgs = new String[14];
         wsimportArgs[0] = "-d";
         wsimportArgs[1] = classesDir.getAbsolutePath();
         wsimportArgs[2] = "-keep";
@@ -539,15 +539,12 @@ public class WebServiceTesterServlet extends HttpServlet {
         wsimportArgs[5] = "-target";
         wsimportArgs[6] = "2.1";
         wsimportArgs[7] = "-extension";
-        // If JDK version is 9 or higher, we need to add the JWS and related JARs
-        if (JDK.getMajor() >= 9) {
-            String modulesDir = System.getProperty("com.sun.aas.installRoot") + File.separator + "modules" + File.separator;
-            wsimportArgs[8] = modulesDir + "jakarta.jws-api.jar";
-            wsimportArgs[10] = modulesDir + "webservices-osgi.jar";
-            wsimportArgs[11] = modulesDir + "jaxb-osgi.jar";
-            wsimportArgs[12] = modulesDir + "jakarta.xml.ws-api.jar";
-            wsimportArgs[13] = modulesDir + "jakarta.activation-api.jar";
-        }
+        String modulesDir = System.getProperty("com.sun.aas.installRoot") + File.separator + "modules" + File.separator;
+        wsimportArgs[8] = modulesDir + "jakarta.jws-api.jar";
+        wsimportArgs[10] = modulesDir + "webservices-osgi.jar";
+        wsimportArgs[11] = modulesDir + "jaxb-osgi.jar";
+        wsimportArgs[12] = modulesDir + "jakarta.xml.ws-api.jar";
+        wsimportArgs[13] = modulesDir + "jakarta.activation-api.jar";
         WSToolsObjectFactory tools = WSToolsObjectFactory.newInstance();
         logger.log(Level.INFO, LogUtils.WSIMPORT_INVOKE, wsdlLocation);
         boolean success = tools.wsimport(System.out, wsimportArgs);

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright 2018-2022 Payara Foundation and/or affiliates
 package com.sun.enterprise.admin.cli;
 
 import com.sun.enterprise.admin.remote.reader.ProprietaryReaderFactory;
@@ -204,16 +204,10 @@ public class AdminMain {
     }
 
     protected int doMain(String[] args) {
-        int minor = JDK.getMinor();
         int major = JDK.getMajor();
-        //In case of JDK1 to JDK8 the major version would be 1 always.Starting from
-        //JDK9 the major verion would be the real major version e.g in case
-        // of JDK9 major version is 9.So in that case checking the major version only.
-        if (major<9) {
-            if (minor < 6) {
-                System.err.println(strings.get( "OldJdk", "" + minor));
-                return ERROR;
-            }
+        if (major < 11) {
+            System.err.println(strings.get( "OldJdk", major));
+            return ERROR;
         }
 
         boolean trace = env.trace();

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/JavaConfig.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/JavaConfig.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright 2018-2022 Payara Foundation and/or affiliates
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -72,7 +72,7 @@ public interface JavaConfig extends ConfigBeanProxy, PropertyBag, JvmOptionBag {
      * Gets the value of the javaHome property.
      *
      * Specifies the installation directory for Java runtime. 
-     * JDK 7 or higher is supported.
+     * JDK 11 or higher is supported.
      * 
      * @return possible object is
      *         {@link String }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JavaConfig.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JavaConfig.java
@@ -37,15 +37,21 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2019-2022 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.admin.launcher;
 
 import com.sun.enterprise.universal.glassfish.GFLauncherUtils;
-import static com.sun.enterprise.admin.launcher.GFLauncherConstants.*;
-import com.sun.enterprise.util.JDK;
-import java.io.*;
-import java.util.*;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.sun.enterprise.admin.launcher.GFLauncherConstants.NATIVE_LIB_PREFIX;
+import static com.sun.enterprise.admin.launcher.GFLauncherConstants.NATIVE_LIB_SUFFIX;
 
 /**
  *
@@ -140,25 +146,23 @@ class JavaConfig {
             return empty;
         }
 
-        if (JDK.getMajor() >= 9) {
-            boolean serverMode = false;
-            String address = null;
-            for (String debugOption : debugOptions.split(",")) {
-                if (debugOption.startsWith("server")) {
-                    String[] serverAttr = debugOption.split("=");
-                    serverMode = serverAttr.length > 1 && serverAttr[1].equals("y");
-                }
-                if (debugOption.startsWith("address")) {
-                    String[] addressAttr = debugOption.split("=");
-                    if (addressAttr.length > 1) {
-                        address = addressAttr[1];
-                    }
+        boolean serverMode = false;
+        String address = null;
+        for (String debugOption : debugOptions.split(",")) {
+            if (debugOption.startsWith("server")) {
+                String[] serverAttr = debugOption.split("=");
+                serverMode = serverAttr.length > 1 && serverAttr[1].equals("y");
+            }
+            if (debugOption.startsWith("address")) {
+                String[] addressAttr = debugOption.split("=");
+                if (addressAttr.length > 1) {
+                    address = addressAttr[1];
                 }
             }
-            if (serverMode && address != null) {
-                if (address.split(":").length < 2) {
-                    debugOptions = debugOptions.replace("address=", "address=*:");
-                }
+        }
+        if (serverMode && address != null) {
+            if (address.split(":").length < 2) {
+                debugOptions = debugOptions.replace("address=", "address=*:");
             }
         }
 

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/JavaConfigTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/JavaConfigTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,13 +39,12 @@
  */
 package com.sun.enterprise.admin.launcher;
 
-import com.sun.enterprise.universal.xml.MiniXmlParserException;
-import com.sun.enterprise.util.JDK;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  *
@@ -70,10 +69,6 @@ public class JavaConfigTest {
         config.put("debug-options", DEBUG_CONFIG);
         JavaConfig javaConfig = new JavaConfig(config);
         List<String> debugOptions = javaConfig.getDebugOptions();
-        if (JDK.getMajor() >= 9) {
-            Assert.assertEquals("-agentlib:jdwp=transport=dt_socket,address=*:9009,server=y,suspend=n", debugOptions.get(0));
-        } else {
-            Assert.assertEquals(DEBUG_CONFIG, debugOptions.get(0));
-        }
+        Assert.assertEquals("-agentlib:jdwp=transport=dt_socket,address=*:9009,server=y,suspend=n", debugOptions.get(0));
     }
 }

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -38,16 +38,16 @@
  * holder.
  */
 
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2022 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.admin.util;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.glassfish.grizzly.config.dom.Ssl.TLS1;
-import static org.glassfish.grizzly.config.dom.Ssl.TLS11;
-import static org.glassfish.grizzly.config.dom.Ssl.TLS12;
-import static org.glassfish.grizzly.config.dom.Ssl.TLS13;
-
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -56,14 +56,11 @@ import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-
-import com.sun.enterprise.util.JDK;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.glassfish.grizzly.config.dom.Ssl.TLS1;
+import static org.glassfish.grizzly.config.dom.Ssl.TLS11;
+import static org.glassfish.grizzly.config.dom.Ssl.TLS12;
+import static org.glassfish.grizzly.config.dom.Ssl.TLS13;
 
 
 public final class HttpConnectorAddress {
@@ -207,13 +204,6 @@ public final class HttpConnectorAddress {
                                         break;
 
                         case TLS13: protocol = TLS13;
-                                        if (!JDK.isTls13Supported()) {
-                                            if (JDK.isOpenJSSEFlagRequired()) {
-                                                protocol = TLS13;
-                                            } else {
-                                                protocol = DEFAULT_PROTOCOL;
-                                            }
-                                        }
                                         logger.log(Level.FINE, 
                                                 AdminLoggerInfo.settingHttpsProtocol,
                                                 protocol);

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/JDK.java
@@ -37,12 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2018-2022 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.util;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -55,35 +53,12 @@ import java.util.Optional;
  */
 public final class JDK {
 
-    private static final int TLS13_MINIMUM_MINOR_VERSION = 8;
-    private static final int TLS13_MINIMUM_UPDATE_VERSION = 261;
-
-    private static final String OPENJSSE_VENDOR = "Azul";
-    private static final int OPENJSSE_MINIMUM_UPDATE_VERSION = 222;
-    private static final int OPENJSSE_MAXIMUM_UPDATE_VERSION = 260;
-    private static final List<Integer> OPENJSSE_KNOWN_NOT_TO_WORK_MINOR = Arrays.asList(252);
-
-    public static boolean isTls13Supported() {
-        return getMinor() >= TLS13_MINIMUM_MINOR_VERSION
-            && getUpdate() >= TLS13_MINIMUM_UPDATE_VERSION;
-    }
-
-    public static boolean isOpenJSSEFlagRequired() {
-        final String vendor = getVendor();
-        final int updateVersion = getUpdate();
-        return vendor != null
-            && vendor.contains(OPENJSSE_VENDOR)
-            && updateVersion >= OPENJSSE_MINIMUM_UPDATE_VERSION
-            && updateVersion <= OPENJSSE_MAXIMUM_UPDATE_VERSION
-            && !OPENJSSE_KNOWN_NOT_TO_WORK_MINOR.contains(updateVersion);
-    }
-
     /**
      * See if the current JDK is legal for running GlassFish
-     * @return true if the JDK is >= 1.6.0
+     * @return true if the JDK is >= 11
      */
     public static boolean ok() {
-        return major == 1 && minor >= 6;
+        return major >= 11;
     }
 
     public static int getMajor() {

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/Util.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/Util.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2022 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.glassfish.bootstrap;
 
@@ -160,16 +161,6 @@ public class Util {
             }
         }
         return null;
-    }
-
-    static File getJDKToolsJar() {
-        File javaHome = new File(System.getProperty("java.home"));
-        File jdktools = null;
-        if (javaHome.getParent() != null) {
-            jdktools = new File(javaHome.getParent(),
-                    "lib" + File.separator + "tools.jar");
-        }
-        return jdktools;
     }
 
     private static final String DELIM_START = "${";

--- a/nucleus/packager/nucleus-grizzly/pom.xml
+++ b/nucleus/packager/nucleus-grizzly/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2018-2022 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -94,36 +94,6 @@
                                     <artifactId>grizzly-npn-api</artifactId>
                                     <version>${grizzly.npn.api.version}</version>
                                     <destFileName>grizzly-npn-api.jar</destFileName>
-                                </artifactItem>
-                                <!-- NPN Bootstrap versions are referenced in domain.xml, real time version depends on JDK used -->
-                                <!-- Default NPN Bootstrap Jar for old domain.xml files without bootclasspath changes -->
-                                <!-- It is 1.8.1, compatible with JDK 8u191-8u250; newer JDK versions do not need bootstrap -->
-                                <artifactItem>
-                                    <groupId>org.glassfish.grizzly</groupId>
-                                    <artifactId>grizzly-npn-bootstrap</artifactId>
-                                    <version>1.8.1</version>
-                                    <destFileName>grizzly-npn-bootstrap.jar</destFileName>
-                                </artifactItem>
-                                <!-- Other versioned NPN Bootstrap Jars referenced in new domain.xml (since 5.184) -->
-                                <artifactItem>
-                                    <groupId>org.glassfish.grizzly</groupId>
-                                    <artifactId>grizzly-npn-bootstrap</artifactId>
-                                    <version>1.8.1</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.glassfish.grizzly</groupId>
-                                    <artifactId>grizzly-npn-bootstrap</artifactId>
-                                    <version>1.8</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.glassfish.grizzly</groupId>
-                                    <artifactId>grizzly-npn-bootstrap</artifactId>
-                                    <version>1.7</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.glassfish.grizzly</groupId>
-                                    <artifactId>grizzly-npn-bootstrap</artifactId>
-                                    <version>1.6</version>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}/dependency/lib</outputDirectory>


### PR DESCRIPTION
## Description
Removes the various checks of JDK 8 vs. 9, along with other references to support for JDK 8

## Important Info
### Blockers
None - but related to https://github.com/payara/Payara/pull/5567

## Testing
### New tests
None

### Testing Performed
Compiled server on JDK 11.
Attempted to start on JDK 8 - expected error.
Server starts on JDK 11.
TLS 1.3 shown as an available option in admin console.

### Testing Environment
Windows 11, Zulu JDK 11 (and 8)

## Documentation
N/A - no Payara6 branch yet

## Notes for Reviewers
You'll need to pull in the Payara 6 branch (and optionally PR 5567) for the server to compile.
