### PR TITLE
 FISH-981 Add Distribution Type to glassfish-version.properties (Payara6)

### DIFF
--- a/appserver/distributions/distributions.xml
+++ b/appserver/distributions/distributions.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation and/or affiliates] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation and/or affiliates] -->
 
 <project name="GlassFish Distributions (IPS) Creation" basedir=".">
     <property name="image.root" value="target/local_image"/>
@@ -334,6 +334,12 @@
   <!-- Glassfish domain creation -->
 
     <target name="create-glassfish-domain" depends="init-glassfish-home, create-glassfish-domain-on-windows, create-glassfish-domain-on-unix"/>
+
+    <target name="set-distribution">
+        <echo message="Setting distribution in ${basedir}/target/stage/payara5/glassfish/config/branding/glassfish-version.properties"/>
+        <replace file="${basedir}/target/stage/payara5/glassfish/config/branding/glassfish-version.properties" token="@@@DISTRIBUTION@@@" value="${distribution}"/>
+    </target>
+
     <!--<target name="create-domain-ml" depends="init-glassfish-home-ml, create-domain-on-windows, create-domain-on-unix"/>-->
     <target name="init-glassfish-home">
         <property name="glassfish.home" value="${basedir}/${glassfish.image.dir}/${install.dir.name}/glassfish" />

--- a/appserver/distributions/distributions.xml
+++ b/appserver/distributions/distributions.xml
@@ -336,8 +336,8 @@
     <target name="create-glassfish-domain" depends="init-glassfish-home, create-glassfish-domain-on-windows, create-glassfish-domain-on-unix"/>
 
     <target name="set-distribution">
-        <echo message="Setting distribution in ${basedir}/target/stage/payara5/glassfish/config/branding/glassfish-version.properties"/>
-        <replace file="${basedir}/target/stage/payara5/glassfish/config/branding/glassfish-version.properties" token="@@@DISTRIBUTION@@@" value="${distribution}"/>
+        <echo message="Setting distribution in ${basedir}/target/stage/payara6/glassfish/config/branding/glassfish-version.properties"/>
+        <replace file="${basedir}/target/stage/payara6/glassfish/config/branding/glassfish-version.properties" token="@@@DISTRIBUTION@@@" value="${distribution}"/>
     </target>
 
     <!--<target name="create-domain-ml" depends="init-glassfish-home-ml, create-domain-on-windows, create-domain-on-unix"/>-->

--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2020] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation] -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -61,6 +61,26 @@
                 <executions>
                     <execution>
                         <id>clean-domain</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ant-magic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="distribution"
+                                          value="payara-ml"/>
+                                <ant antfile="../distributions.xml"
+                                     target="set-distribution"/>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -68,7 +68,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>ant-magic</id>
+                        <id>subtitute-distribution-property</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -70,7 +70,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>ant-magic</id>
+                        <id>subtitute-distribution-property</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2021] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation] -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -63,6 +63,26 @@
                 <executions>
                     <execution>
                         <id>clean-domain</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ant-magic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="distribution"
+                                          value="payara-web-ml"/>
+                                <ant antfile="../distributions.xml"
+                                     target="set-distribution"/>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>ant-magic</id>
+                        <id>subtitute-distribution-property</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -64,6 +64,26 @@
                 <executions>
                     <execution>
                         <id>clean-domain</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ant-magic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="distribution"
+                                          value="payara-web"/>
+                                <ant antfile="../distributions.xml"
+                                     target="set-distribution"/>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -83,7 +83,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>ant-magic</id>
+                        <id>subtitute-distribution-property</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2020] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation] -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -76,6 +76,26 @@
                         <goals>
                             <goal>exec</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ant-magic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="distribution"
+                                          value="payara"/>
+                                <ant antfile="../distributions.xml"
+                                     target="set-distribution"/>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/appserver/packager/appserver-base/src/main/resources/config/branding/glassfish-version.properties
+++ b/appserver/packager/appserver-base/src/main/resources/config/branding/glassfish-version.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016] [Payara Foundation]
+# Portions Copyright [2016-2021] [Payara Foundation]
 #
 product_name=${product.name}
 brief_product_name=${brief_product_name}
@@ -50,3 +50,4 @@ version_prefix=${version_prefix}
 version_suffix=${version_suffix}
 default_domain_template=${default_domain_template}
 admin_client_command_name=${admin_client_command_name}
+distribution=@@@DISTRIBUTION@@@

--- a/appserver/packager/appserver-base/src/main/resources/config/branding/glassfish-version.properties
+++ b/appserver/packager/appserver-base/src/main/resources/config/branding/glassfish-version.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2021] [Payara Foundation]
+# Portions Copyright [2016-2022] [Payara Foundation]
 #
 product_name=${product.name}
 brief_product_name=${brief_product_name}

--- a/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or affiliates]
 
 package com.sun.appserv.server.util;
 
@@ -77,6 +77,7 @@ public class Version {
     private static final String DEFAULT_DOMAIN_TEMPLATE_JAR = "nucleus-domain.jar";
     private static final String ADMIN_CLIENT_COMMAND_NAME_KEY = "admin_client_command_name";
     private static final String INITIAL_ADMIN_GROUPS_KEY = "initial_admin_user_groups";
+    private static final String DISTRIBUTION_KEY = "distribution";
     private static final List<Properties> VERSION_PROPS = new ArrayList<Properties>();
     private static final Map<String,Properties> VERSION_PROPS_MAP = new HashMap<String,Properties>();
     private static final Properties versionProp = getVersionProp();
@@ -282,6 +283,8 @@ public class Version {
     public static String getInitialAdminGroups() {
         return getProperty(INITIAL_ADMIN_GROUPS_KEY, "asadmin");
     }
+
+    public static String getDistributionKey(){ return getProperty(DISTRIBUTION_KEY, "");}
     
     /*
      * Fetch the value for the property identified by key

--- a/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
@@ -46,22 +46,14 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 /**
- *
  * This class provides static methods to make accessible the version as well as
  * the individual parts that make up the version
- * 
-*/
+ */
 public class Version {
-    
+
     private static final String INSTALL_ROOT_PROP_NAME = "com.sun.aas.installRoot";
     private static final String PRODUCT_NAME_KEY = "product_name";
     private static final String BRIEF_PRODUCT_NAME_KEY = "brief_product_name";
@@ -79,7 +71,7 @@ public class Version {
     private static final String INITIAL_ADMIN_GROUPS_KEY = "initial_admin_user_groups";
     private static final String DISTRIBUTION_KEY = "distribution";
     private static final List<Properties> VERSION_PROPS = new ArrayList<Properties>();
-    private static final Map<String,Properties> VERSION_PROPS_MAP = new HashMap<String,Properties>();
+    private static final Map<String, Properties> VERSION_PROPS_MAP = new HashMap<String, Properties>();
     private static final Properties versionProp = getVersionProp();
 
     private static Properties getVersionProp() {
@@ -186,7 +178,7 @@ public class Version {
         }
         return v;
     }
-    
+
     /**
      * Returns full version including build id
      */
@@ -212,7 +204,7 @@ public class Version {
      * Returns Minor version
      */
     public static String getMinorVersion() {
-        return getProperty(MINOR_VERSION_KEY, "0").replace("-SNAPSHOT","");
+        return getProperty(MINOR_VERSION_KEY, "0").replace("-SNAPSHOT", "");
     }
 
     /**
@@ -221,7 +213,7 @@ public class Version {
     public static String getUpdateVersion() {
         return getProperty(UPDATE_VERSION_KEY, "0");
     }
-    
+
     /**
      * Returns Build version
      */
@@ -242,7 +234,7 @@ public class Version {
     public static String getVersionSuffix() {
         return getProperty(VERSION_SUFFIX_KEY, "");
     }
-    
+
     /**
      * Returns Proper Product Name
      */
@@ -284,8 +276,10 @@ public class Version {
         return getProperty(INITIAL_ADMIN_GROUPS_KEY, "asadmin");
     }
 
-    public static String getDistributionKey(){ return getProperty(DISTRIBUTION_KEY, "");}
-    
+    public static String getDistributionKey() {
+        return getProperty(DISTRIBUTION_KEY, "");
+    }
+
     /*
      * Fetch the value for the property identified by key
      * from the first Properties object in the list. If it doesn't exist


### PR DESCRIPTION
## Description
Missed sync from Enterprise. Allows easier determination of distribution type.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built server (non-quickbuild) - each distribution has the correct type in glassfish-version.properties.

### Testing Environment
WSL,  JDK 8.

## Documentation
N/A

## Notes for Reviewers
Port from Enterprise.
