### PR TITLE
FISH-5857 FISH-5982 Fix Error Starting Embedded EJB Container (Payara6)

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/embedded/DomainXmlTransformer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/embedded/DomainXmlTransformer.java
@@ -74,7 +74,7 @@ public class DomainXmlTransformer {
     private final XMLOutputFactory xof = XMLOutputFactory.newInstance();
 
     private Logger _logger = Logger.getAnonymousLogger(
-            "com.sun.logging.enterprise.system.container.ejb.LogStrings");
+            "com.sun.logging.enterprise.system.container.ejb.LogMessages");
 
     private static final String VIRTUAL_SERVER = "virtual-server"; // should not skip
     private static final String NETWORK_LISTENERS = "network-listeners";


### PR DESCRIPTION
## Description
TCK tests reveal a recent file change has broken the Embedded EJB Container, specifically in DomainXmlTransformer when it tries to find its logger.

```
jakarta.ejb.EJBException: Caught unexpected exception trying to create a temporary domain.xml file.
...
Caused by: java.util.MissingResourceException: Can't find com.sun.logging.enterprise.system.container.ejb.LogStrings bundle from
```

The log file name was changed in a recent PR to fix another error, and so this fixes the new error by having it point to the moved file.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran ejb30/lite/packaging TCK locally

### Testing Environment
WSL, JDK 11

## Documentation
N/A

## Notes for Reviewers
PR which changed file name here: https://github.com/payara/Payara/pull/5580
