### PR TITLE
FISH-5974 Specify system-property with Double Quotes in preboot-command File

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/Parser.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/Parser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2022] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 
@@ -122,7 +122,7 @@ public class Parser {
 
             // is it an operand or option value?
             if (!arg.startsWith("-") || arg.length() <= 1) {
-                operands.add(StringUtils.trimQuotes(arg));
+                operands.add(StringUtils.removeEnclosingQuotes(arg));
                 if (ignoreUnknown) {
                     continue;
                 }

--- a/nucleus/admin/cli/src/test/java/com/sun/enterprise/admin/cli/ParserTest.java
+++ b/nucleus/admin/cli/src/test/java/com/sun/enterprise/admin/cli/ParserTest.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2019-2022] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 
@@ -62,7 +63,7 @@ public class ParserTest {
         String[] args = new String[]{
             "create-custom-resource", "--restype", "java.lang.String",
             "--enabled=true", "--name", "'custom-res'",
-            "--description", "\"results in error\"",
+            "--description", "\"results \'in\' error\"",
             "--property", "value=\"${ENV=ini_ws_uri}\"",
             "vfp/vfp-menu/ini.ws.uri"
         };
@@ -73,7 +74,7 @@ public class ParserTest {
         assertThat(parse.getOptions().size(), is(5));
 
         assertEquals(parse.getOperands().get(0), "create-custom-resource");
-        assertEquals(parse.getOptions().getOne("description"), "results in error");
+        assertEquals(parse.getOptions().getOne("description"), "results 'in' error");
         assertEquals(parse.getOptions().getOne("name"), "custom-res");
     }
 

--- a/nucleus/core/bootstrap/src/main/java/fish/payara/boot/runtime/BootCommands.java
+++ b/nucleus/core/bootstrap/src/main/java/fish/payara/boot/runtime/BootCommands.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -66,12 +66,17 @@ public class BootCommands {
 
     /**
      * Command flag pattern include 3 groups to parse the command-line flag
-     * [^\"']\\S+=[\"'].+?[\"'] e.g --description="results in error"
+     * Double and Single Quotes can be included in properties if they are escaped.
+     * This is achieved by the following flag pattern: (?:(?!(?<!\\)["']).)*
+     *
+     * [^"']\S+=["'](?:(?!(?<!\\)["']).)*["'] e.g --description="results \"in\" error"
      * [^\"']\\S+ e.g --enabled=true, --enabled true
-     * [\"'].+?[\"'] e.g --description "results in error"
+     * [^"']\S+=["'](?:(?!(?<!\\)["']).)*["'] e.g --description "results \"in\" error"
      *
      */
-    private static final Pattern COMMAND_FLAG_PATTERN = Pattern.compile("([^\"']\\S+=[\"'].+?[\"']|[^\"']\\S*|[\"'].+?[\"'])\\s*");
+    private static final Pattern COMMAND_FLAG_PATTERN = Pattern.compile("([^\"']\\S+=[\"'](?:(?!(?<!\\\\)[\"']).)*[\"']|" +
+                                                                        "[^\"']\\S*|" +
+                                                                        "[\"'](?:(?!(?<!\\\\)\").)*[\"'])\\s*");
     private final List<BootCommand> commands;
 
     private static final Logger LOGGER = Logger.getLogger(BootCommands.class.getName());

--- a/nucleus/core/bootstrap/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
+++ b/nucleus/core/bootstrap/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -56,7 +56,7 @@ public class BootCommandsTest {
     @Test
     public void parseCommand() throws IOException {
         BootCommands bootCommands = new BootCommands();
-        String commandText = "create-custom-resource --restype java.lang.String -s v --name='custom-res' --description=\"results in error\" --property value=\"${ENV=ini_ws_uri}\" vfp/vfp-menu/ini.ws.uri";
+        String commandText = "create-custom-resource --restype java.lang.String -s v --name='custom-res' --description=\"results \\\"in\\\" error\" --property value=\"${ENV=ini_ws_uri}\" vfp/vfp-menu/ini.ws.uri";
         try (Reader reader = new StringReader(commandText)){
             bootCommands.parseCommandScript(reader);
         }
@@ -69,7 +69,7 @@ public class BootCommandsTest {
         assertEquals(command.getArguments()[2], "-s");
         assertEquals(command.getArguments()[3], "v");
         assertEquals(command.getArguments()[4], "--name='custom-res'");
-        assertEquals(command.getArguments()[5], "--description=\"results in error\"");
+        assertEquals(command.getArguments()[5], "--description=\"results \\\"in\\\" error\"");
         assertEquals(command.getArguments()[6], "--property");
         assertEquals(command.getArguments()[7], "value=\"${ENV=ini_ws_uri}\"");
         assertEquals(command.getArguments()[8], "vfp/vfp-menu/ini.ws.uri");


### PR DESCRIPTION
## Description
A bug fix where putting double quotes in a command stored in a preboot-command file would result in `UnacceptableValueException: Invalid parameter: name_value.  This parameter may not have more than one value.` 

## Important Info
### Blockers
None

## Testing
### New tests
No new tests. Added this scenario to existing tests

### Testing Performed
Manually tested against the reproducer and values from unit test in regex101.

### Testing Environment
Windows 10, JDK 11, Maven 3.6.3

## Documentation
N/A

## Notes for Reviewers
The new regex works by using a positive lookahead to check the current character is not a double or single quote preceded by a backslash, which checked by using a nested negative lookbehind.

This regex can be seen and tested in regex101 here: https://regex101.com/r/2aVRtd/1