### PR TITLE
FISH-5676 Apply Default Values in @DataSourceDefinition URL via Variable Expansion

### DIFF
--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -145,7 +145,7 @@ public class TranslatedConfigView implements ConfigView {
                 ConfigValue configValue = config.getConfigValue(matchValue);
                 String newValue = configValue.getValue();
                 if (newValue != null && !newValue.isEmpty() || defaultValue != null) {
-                    stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + (newValue == null ? defaultValue : newValue) + m3.group(3)));
+                    stringValue = m3.replaceFirst(Matcher.quoteReplacement(m3.group(1) + ((newValue != null && !newValue.isEmpty()) ? newValue : defaultValue) + m3.group(3)));
                     m3.reset(stringValue);
                     if (newValue != null && !newValue.isEmpty()) {
                         Logger.getAnonymousLogger().fine("Found property '" + matchValue + "' in source '" + configValue.getSourceName() + "' with ordinal '" + configValue.getSourceOrdinal() + "'");

--- a/nucleus/admin/config-api/src/test/java/org/glassfish/config/support/TranslatedValueTest.java
+++ b/nucleus/admin/config-api/src/test/java/org/glassfish/config/support/TranslatedValueTest.java
@@ -88,7 +88,7 @@ public class TranslatedValueTest {
 
     @Test
     public void envTranslationRequiredWithDefaultMultiple(){
-        System.out.println("envTranslationRequired");
+        System.out.println("envTranslationRequiredWithDefaultMultiple");
         assertEquals("jdbc:postgresql://localhost:5432/test", TranslatedConfigView.expandValue("jdbc:postgresql://${ENV=db.host:localhost}:${ENV=db.port:5432}/${ENV=DB_NAME:test}"));
     }
 }

--- a/nucleus/admin/config-api/src/test/java/org/glassfish/config/support/TranslatedValueTest.java
+++ b/nucleus/admin/config-api/src/test/java/org/glassfish/config/support/TranslatedValueTest.java
@@ -41,14 +41,14 @@
 package org.glassfish.config.support;
 
 import org.glassfish.hk2.api.ServiceLocator;
-import org.junit.*;
-
 import org.glassfish.tests.utils.Utils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
- *
  * @author cfiguera
  */
 public class TranslatedValueTest {
@@ -87,8 +87,14 @@ public class TranslatedValueTest {
     }
 
     @Test
-    public void envTranslationRequiredWithDefaultMultiple(){
+    public void envTranslationRequiredWithDefaultMultiple() {
         System.out.println("envTranslationRequiredWithDefaultMultiple");
         assertEquals("jdbc:postgresql://localhost:5432/test", TranslatedConfigView.expandValue("jdbc:postgresql://${ENV=db.host:localhost}:${ENV=db.port:5432}/${ENV=DB_NAME:test}"));
+    }
+
+    @Test
+    public void envTranslationOneRequired() {
+        System.out.println("envTranslationOneRequired");
+        assertEquals("${ENV=NOT_EXISTING_VARIABLE}_defaultVariable", TranslatedConfigView.expandValue("${ENV=NOT_EXISTING_VARIABLE}_${ENV=NOT_EXISTING_VARIABLE_2:defaultVariable}"));
     }
 }

--- a/nucleus/admin/config-api/src/test/java/org/glassfish/config/support/TranslatedValueTest.java
+++ b/nucleus/admin/config-api/src/test/java/org/glassfish/config/support/TranslatedValueTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -84,5 +84,11 @@ public class TranslatedValueTest {
         assertEquals("", TranslatedConfigView.expandConfigValue("${ENV=NOT_EXISTING_VARIABLE:}"));
         assertEquals("defaultVariable", TranslatedConfigView.expandConfigValue("${ENV=NOT_EXISTING_VARIABLE:defaultVariable}"));
         assertEquals("default:variable", TranslatedConfigView.expandConfigValue("${ENV=NOT_EXISTING_VARIABLE:default:variable}"));
+    }
+
+    @Test
+    public void envTranslationRequiredWithDefaultMultiple(){
+        System.out.println("envTranslationRequired");
+        assertEquals("jdbc:postgresql://localhost:5432/test", TranslatedConfigView.expandValue("jdbc:postgresql://${ENV=db.host:localhost}:${ENV=db.port:5432}/${ENV=DB_NAME:test}"));
     }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Strings with multiple default values in the DataSourceDefinition URL would change the entire string to the first default found if no value was found via env properties or mp-config properties.
resolves https://github.com/payara/Payara/issues/5322
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
N/A
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
Created test that uses multiple env properties with defaults
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested reproducer
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
openjdk version "11.0.11" 2021-04-20 LTS
Apache Maven 3.6.3
ubuntu 20.04
## Documentation
<!-- Link documentation if a PR exists -->
N/A
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
