### PR TITLE
FISH-5803 Added local commands option to generate-bash-autocomplete

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/GenerateBashAutoCompletionCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/GenerateBashAutoCompletionCommand.java
@@ -94,16 +94,22 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
     private static final String DEFAULT_FILE = File.separator + "bin" + File.separator + "bash_autocomplete";
     private final static LocalStringsImpl strings = new LocalStringsImpl(GenerateBashAutoCompletionCommand.class);
     private final Logger LOGGER = Logger.getLogger(GenerateBashAutoCompletionCommand.class.getName());
+
     @Param(optional = true, primary = true, name = "file")
     String filePath;
+
     @Param(optional = true, defaultValue = "false")
     Boolean force;
+
     @Param(optional = true, defaultValue = "false")
     Boolean localCommands;
+
     @Inject
     ServiceLocator habitat;
+
     @Inject
     ServerContext serverContext;
+
     private CLIContainer cliContainer;
     private File file;
 
@@ -119,6 +125,7 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
 
         List<String> commandNames = new ArrayList<>();
         List<ServiceHandle<AdminCommand>> allCommandHandles = habitat.getAllServiceHandles(AdminCommand.class, new Annotation[0]);
+
         for (ServiceHandle<AdminCommand> commandHandler : allCommandHandles) {
             AdminCommand trueCommand = commandHandler.getService();
             CommandModel model = new CommandModelImpl(trueCommand.getClass());
@@ -131,7 +138,6 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
         if (localCommands) {
             ClassLoader classLoader = GenerateBashAutoCompletionCommand.class.getClassLoader();
             cliContainer = new CLIContainer(classLoader, getExtensions(), LOGGER);
-            CLIUtil.getLocalCommands(cliContainer);
             Arrays.stream(CLIUtil.getLocalCommands(cliContainer)).forEach((commandName) -> {
                 if (commandName == null || commandName.startsWith("_")) {
                     return;
@@ -139,6 +145,7 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
                 commandNames.add(commandName);
             });
         }
+
         if (writeCommands(commandNames)) {
             report.setActionExitCode(ActionReport.ExitCode.SUCCESS);
             report.setMessage("Written bash autocomplete file to " + filePath);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/LocalStrings.properties
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/LocalStrings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2022] Payara Foundation and/or affiliates
 
 adapter.param.decode=Cannot decode parameter {0} = {1}
 adapter.param.missing={0} command requires the {1} parameter : {2}
@@ -194,6 +195,7 @@ list.message.security.provider.success=list-message-security-providers successfu
 set.usagetext=set [-?|--help[=<help(default:false)>]]\n\t(dotted-attribute-name=value)+
 version={0}
 version.verbose={0}, JRE version {1}
+ExtDirMissing=Warning: admin command extension directory is missing: {0}
 
 
 #### Command Replication related stuff


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Added option to generate-bash-autocomplete command to include local commands
This option is disabled by default

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
N/A
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
N/A
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built Payara, Started server and executed command with localCommands option set to true
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.6.3
Ubuntu 20.04
openjdk version "1.8.0_302"

## Documentation
<!-- Link documentation if a PR exists -->
https://github.com/payara/Payara-Community-Documentation/pull/293
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
I got inspiration from https://github.com/payara/Payara/blob/cf883d86b7583761e6dd35f9aa7ee4317a412f9c/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java#L262 in order to get the Local Commands. I was unable to Inject the CLIContainer to use the CLIUtil.getLocalCommands Method.