### PR TITLE
FISH-5803 Added local commands option to generate-bash-autocomplete P6

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/GenerateBashAutoCompletionCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/GenerateBashAutoCompletionCommand.java
@@ -93,16 +93,22 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
     private static final String DEFAULT_FILE = File.separator + "bin" + File.separator + "bash_autocomplete";
     private final static LocalStringsImpl strings = new LocalStringsImpl(GenerateBashAutoCompletionCommand.class);
     private final Logger LOGGER = Logger.getLogger(GenerateBashAutoCompletionCommand.class.getName());
+
     @Param(optional = true, primary = true, name = "file")
     String filePath;
+
     @Param(optional = true, defaultValue = "false")
     Boolean force;
+
     @Param(optional = true, defaultValue = "false")
     Boolean localCommands;
+
     @Inject
     ServiceLocator habitat;
+
     @Inject
     ServerContext serverContext;
+
     private CLIContainer cliContainer;
     private File file;
 
@@ -118,6 +124,7 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
 
         List<String> commandNames = new ArrayList<>();
         List<ServiceHandle<AdminCommand>> allCommandHandles = habitat.getAllServiceHandles(AdminCommand.class, new Annotation[0]);
+
         for (ServiceHandle<AdminCommand> commandHandler : allCommandHandles) {
             AdminCommand trueCommand = commandHandler.getService();
             CommandModel model = new CommandModelImpl(trueCommand.getClass());
@@ -130,7 +137,6 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
         if (localCommands) {
             ClassLoader classLoader = GenerateBashAutoCompletionCommand.class.getClassLoader();
             cliContainer = new CLIContainer(classLoader, getExtensions(), LOGGER);
-            CLIUtil.getLocalCommands(cliContainer);
             Arrays.stream(CLIUtil.getLocalCommands(cliContainer)).forEach((commandName) -> {
                 if (commandName == null || commandName.startsWith("_")) {
                     return;
@@ -138,6 +144,7 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
                 commandNames.add(commandName);
             });
         }
+
         if (writeCommands(commandNames)) {
             report.setActionExitCode(ActionReport.ExitCode.SUCCESS);
             report.setMessage("Written bash autocomplete file to " + filePath);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/GenerateBashAutoCompletionCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/GenerateBashAutoCompletionCommand.java
@@ -1,8 +1,8 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- *  Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
- * 
+ *
+ *  Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
  *  and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,23 +11,23 @@
  *  https://github.com/payara/Payara/blob/master/LICENSE.txt
  *  See the License for the specific
  *  language governing permissions and limitations under the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License.
- * 
+ *
  *  When distributing the software, include this License Header Notice in each
  *  file and include the License file at glassfish/legal/LICENSE.txt.
- * 
+ *
  *  GPL Classpath Exception:
  *  The Payara Foundation designates this particular file as subject to the "Classpath"
  *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *  file that accompanied this code.
- * 
+ *
  *  Modifications:
  *  If applicable, add the following below the License Header, with the fields
  *  enclosed by brackets [] replaced by your own identifying information:
  *  "Portions Copyright [year] [name of copyright owner]"
- * 
+ *
  *  Contributor(s):
  *  If you wish your version of this file to be governed by only the CDDL or
  *  only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -43,23 +43,13 @@
 
 package com.sun.enterprise.v3.admin;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import jakarta.inject.Inject;
+import com.sun.enterprise.admin.cli.CLIContainer;
+import com.sun.enterprise.admin.cli.CLIUtil;
+import com.sun.enterprise.universal.i18n.LocalStringsImpl;
+import com.sun.enterprise.util.SystemPropertyConstants;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.Param;
-import org.glassfish.api.admin.AccessRequired;
-import org.glassfish.api.admin.AdminCommand;
-import org.glassfish.api.admin.AdminCommandContext;
-import org.glassfish.api.admin.CommandLock;
-import org.glassfish.api.admin.CommandModel;
+import org.glassfish.api.admin.*;
 import org.glassfish.common.util.admin.CommandModelImpl;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceHandle;
@@ -67,8 +57,16 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.ServerContext;
 import org.jvnet.hk2.annotations.Service;
 
+import jakarta.inject.Inject;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 /**
- *
  * @author jonathan
  */
 @Service(name = "generate-bash-autocomplete")
@@ -76,20 +74,6 @@ import org.jvnet.hk2.annotations.Service;
 @CommandLock(CommandLock.LockType.NONE)
 @AccessRequired(resource = "domain", action = "read")
 public class GenerateBashAutoCompletionCommand implements AdminCommand {
-
-    @Param(optional = true, primary = true, name = "file")
-    String filePath;
-
-    @Param(optional = true, defaultValue = "false")
-    Boolean force;
-
-    @Inject
-    ServiceLocator habitat;
-
-    @Inject
-    ServerContext serverContext;
-
-    private File file;
 
     // constants for writing bash script
     private static final String VARNAME = "__asadmin_commands=\"";
@@ -106,8 +90,21 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
             + "}\n";
     private static final String COMPLETE_CALL = "complete -F _asadmin asadmin";
     private static final String ADD_PATH = "PATH=$PATH:";
-    
     private static final String DEFAULT_FILE = File.separator + "bin" + File.separator + "bash_autocomplete";
+    private final static LocalStringsImpl strings = new LocalStringsImpl(GenerateBashAutoCompletionCommand.class);
+    private final Logger LOGGER = Logger.getLogger(GenerateBashAutoCompletionCommand.class.getName());
+    @Param(optional = true, primary = true, name = "file")
+    String filePath;
+    @Param(optional = true, defaultValue = "false")
+    Boolean force;
+    @Param(optional = true, defaultValue = "false")
+    Boolean localCommands;
+    @Inject
+    ServiceLocator habitat;
+    @Inject
+    ServerContext serverContext;
+    private CLIContainer cliContainer;
+    private File file;
 
     @Override
     public void execute(AdminCommandContext context) {
@@ -128,18 +125,41 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
                 continue;
             }
             commandNames.add(model.getCommandName());
-            for (String param : model.getParametersNames()) {
-                //    System.out.print("\t" + param);
-            }
         }
-        if (writeCommands(commandNames)){
+
+        if (localCommands) {
+            ClassLoader classLoader = GenerateBashAutoCompletionCommand.class.getClassLoader();
+            cliContainer = new CLIContainer(classLoader, getExtensions(), LOGGER);
+            CLIUtil.getLocalCommands(cliContainer);
+            Arrays.stream(CLIUtil.getLocalCommands(cliContainer)).forEach((commandName) -> {
+                if (commandName == null || commandName.startsWith("_")) {
+                    return;
+                }
+                commandNames.add(commandName);
+            });
+        }
+        if (writeCommands(commandNames)) {
             report.setActionExitCode(ActionReport.ExitCode.SUCCESS);
             report.setMessage("Written bash autocomplete file to " + filePath);
         } else {
             report.setActionExitCode(ActionReport.ExitCode.FAILURE);
             report.setMessage("Unable to write to file at " + filePath + ", see server.log for details");
         }
-        
+    }
+
+    private Set<File> getExtensions() {
+        Set<File> result = new HashSet<>();
+        final File inst = new File(System.getProperty(SystemPropertyConstants.INSTALL_ROOT_PROPERTY));
+        final File ext = new File(new File(inst, "lib"), "asadmin");
+        if (ext.exists() && ext.isDirectory()) {
+            result.add(ext);
+        } else {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer(strings.get("ExtDirMissing", ext));
+            }
+        }
+        result.add(new File(new File(inst, "modules"), "admin-cli.jar"));
+        return result;
     }
 
     private boolean validate() {
@@ -157,11 +177,9 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
         }
         return false;
     }
-    
-    
+
 
     /**
-     * 
      * @param commands
      * @return true if written to file successfully, false otherwise
      */
@@ -170,7 +188,7 @@ public class GenerateBashAutoCompletionCommand implements AdminCommand {
             //Write the opening to the list of commands
             writer.write(VARNAME);
             //Write all the commands to the list
-            for (String command: commands){
+            for (String command : commands) {
                 writer.write(command);
                 writer.newLine();
             }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/LocalStrings.properties
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/LocalStrings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright [2022] Payara Foundation and/or affiliates
 
 adapter.param.decode=Cannot decode parameter {0} = {1}
 adapter.param.missing={0} command requires the {1} parameter : {2}
@@ -194,6 +195,7 @@ list.message.security.provider.success=list-message-security-providers successfu
 set.usagetext=set [-?|--help[=<help(default:false)>]]\n\t(dotted-attribute-name=value)+
 version={0}
 version.verbose={0}, JRE version {1}
+ExtDirMissing=Warning: admin command extension directory is missing: {0}
 
 
 #### Command Replication related stuff


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Added option to generate-bash-autocomplete command to include local commands
This option is disabled by default

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
N/A
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
N/A
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built Payara, Started server and executed command with localCommands option set to true
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.6.3
Ubuntu 20.04
openjdk version "11.0.11" 2021-04-20 LTS

## Documentation
<!-- Link documentation if a PR exists -->
https://github.com/payara/Payara-Community-Documentation/pull/293
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
I got inspiration from https://github.com/payara/Payara/blob/cf883d86b7583761e6dd35f9aa7ee4317a412f9c/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java#L262 in order to get the Local Commands. I was unable to Inject the CLIContainer to use the CLIUtil.getLocalCommands Method.