### PR TITLE
FISH-5939 Application Redeployment Breaks virtual server When Using it as Default Module (Payara6)

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -125,6 +125,7 @@ import org.apache.catalina.util.ServerInfo;
 import org.apache.jasper.runtime.JspFactoryImpl;
 import org.apache.jasper.xmlparser.ParserUtils;
 import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.Events;
@@ -146,6 +147,7 @@ import org.glassfish.internal.api.ClassLoaderHierarchy;
 import org.glassfish.internal.api.ServerContext;
 import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.data.ApplicationRegistry;
+import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.internal.grizzly.ContextMapper;
 import org.glassfish.web.LogFacade;
 import org.glassfish.web.admin.monitor.HttpServiceStatsProviderBootstrap;
@@ -618,6 +620,23 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             loadDefaultWebModulesAfterAllAppsProcessed();
         } else if (event.is(PREPARE_SHUTDOWN)) {
             isShutdown = true;
+        } else if (event.is(Deployment.DEPLOYMENT_COMMAND_FINISH)) {
+            ApplicationInfo applicationInfo = (ApplicationInfo) event.hook();
+            if (applicationInfo.getSource().getArchiveMetaData("commandparams", DeployCommandParameters.class).isRedeploy()) {
+                for (VirtualServer vs : getVirtualServers()) {
+                    if (ADMIN_VS.equals(vs.getName())) {
+                        continue;
+                    }
+
+                    if (vs.getDefaultWebModuleID().equals(applicationInfo.getName())) {
+                        try {
+                            updateHost(vs.getBean());
+                        } catch (LifecycleException e) {
+                            logger.log(Level.SEVERE, LogFacade.EXCEPTION_WEB_CONFIG, e);
+                        }
+                    }
+                }
+            }
         } else if (event.is(DEPLOYMENT_FAILURE) || event.is(UNDEPLOYMENT_FAILURE)) {
             DeploymentContext deploymentContext = (DeploymentContext) event.hook();
             try {

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -621,6 +621,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         } else if (event.is(PREPARE_SHUTDOWN)) {
             isShutdown = true;
         } else if (event.is(Deployment.DEPLOYMENT_COMMAND_FINISH)) {
+            // If this application is the default web module of a virtual server, reload the virtual server
             ApplicationInfo applicationInfo = (ApplicationInfo) event.hook();
             if (applicationInfo.getSource().getArchiveMetaData("commandparams", DeployCommandParameters.class).isRedeploy()) {
                 for (VirtualServer vs : getVirtualServers()) {

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/Deployment.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.internal.deployment;
 
@@ -117,6 +117,12 @@ public interface Deployment {
      * succeeded.
      */
     EventTypes<ApplicationInfo> DEPLOYMENT_SUCCESS = EventTypes.create("Deployment_Success", ApplicationInfo.class);
+
+    /**
+     * This synchronous event is sent at the end of deployment command process
+     */
+    EventTypes<ApplicationInfo> DEPLOYMENT_COMMAND_FINISH = EventTypes.create("Deployment_Command_Finish", ApplicationInfo.class);
+
 
     /**
      * This asynchronous event is sent when a new deployment or loading of an already deployed application start. It is invoked

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.deployment.admin;
 
@@ -623,11 +623,15 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
                         // register application information in domain.xml
                         deployment.registerAppInDomainXML(appInfo, deploymentContext, tx);
+
                     }
                     if (retrieve != null) {
                         retrieveArtifacts(context, downloadableArtifacts.getArtifacts(), retrieve, false, name);
                     }
                     suppInfo.setDeploymentContext(deploymentContext);
+                    // send new event to notify the deployment process is finish
+                    events.send(new Event<ApplicationInfo>(Deployment.DEPLOYMENT_COMMAND_FINISH, appInfo), false);
+
                     //Fix for issue 14442
                     //We want to report the worst subreport value.
                     ActionReport.ExitCode worstExitCode = ExitCode.SUCCESS;


### PR DESCRIPTION
## Description
Whenever an application that is being used as the default web module of a virtual server gets redeployed, the virtual server will stop working and not correctly process requests sent to it.

## Important Info
### Blockers
N/A

## Testing
### New tests
N/A

### Testing Performed
The server must be tested remotely as the error will only trigger when accessing the virtual server through its hostname. A suggested environment to test this is AWS.
It can be tested locally by changing the domain URL from "localhost" to your local hostname.
Built Payara, Start server, deploy apps, setup default web module on a virtual server, redeploy the application

### Testing Environment
Windows 11, RHEL8.4.0, JDK8, Maven 3.8.4

## Notes for Reviewers
None