### PR TITLE
FISH-5927 Document --installdir Command and Installation Directory for Docker Nodes

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
+++ b/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 tree.clusters=Clusters (Deprecated)
 tree.dgs=Deployment Groups
@@ -263,7 +263,7 @@ node.EditPageTitle=Edit Node
 node.EditPageTitleHelp=Edit properties for the selected node.
 node.InstallDir=Installation Directory:
 node.InstallDirHelp=The full path to the parent of the base installation directory of the Payara Server software on the host, for example, /export/payara41.
-node.DockerInstallDirHelp=The full path to the parent of the base installation directory of the Payara Server software in the Docker container. Defaults to /opt/payara/payara6
+node.DockerInstallDirHelp=The full path to the parent of the base installation directory of the Payara Server software in the Docker container. Unless you are using a custom Docker image, this option should be left as the default. Defaults to /opt/payara/payara6
 node.force=Force:
 node.forceHelp=Specifies whether the node is created even if validation of the node's parameters fails.
 node.type=Type:


### PR DESCRIPTION
## Description
An improvement to the DockerInstallDirHelp label, changing the label so this is clear the Installation Directory should be left as the default unless using a custom Docker image.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the server, updated label is shown in the admin console for DOCKER Node Types.

### Testing Environment
Windows 10, JDK 11, Maven 3.6.3

## Documentation
The documentation surrounding this is already correct

## Notes for Reviewers
None