### PR TITLE
FISH-6046 Update Docker JDK version

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -56,7 +56,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.13</docker.jdk11.tag>
+        <docker.jdk11.tag>11.0.14.1</docker.jdk11.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara6</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
Update the Docker image JDK versions from 11.0.13 to 11.0.14.1.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
None

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
