### PR TITLE
FISH-6043 Configuring Payara Notification Logging Service causes NullPointerException (P6)

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/NotificationLogViewer.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/NotificationLogViewer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 package org.glassfish.admin.rest.resources.custom;
 
 import com.sun.enterprise.server.logging.logviewer.backend.LogFilter;
@@ -220,7 +220,7 @@ public class NotificationLogViewer extends LogViewerResource {
         try (BufferedReader br = new BufferedReader(new FileReader(file))) {
             String sCurrentLine;
             while ((sCurrentLine = br.readLine()) != null) {
-                if (sCurrentLine.contains("LogNotifierService") || sCurrentLine.contains("RequestEvent")
+                if (sCurrentLine.contains("LogNotifier") || sCurrentLine.contains("RequestEvent")
                         || sCurrentLine.contains("ServletRequestEvent") || sCurrentLine.contains("conversationId")
                         || sCurrentLine.contains("elapsedTime") || sCurrentLine.contains("user-agent")
                         || sCurrentLine.contains("requestTracing") || sCurrentLine.contains("alarmType")) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogManagerService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
@@ -241,7 +241,7 @@ public class LogManagerService implements PostConstruct, PreDestroy, org.glassfi
     
     private  PayaraNotificationFileHandler pyFileHandler = null;
     
-    private String payaraNotificationLogger = "fish.payara.nucleus.notification.log.LogNotifierService";
+    private String payaraNotificationLogger = "fish.payara.nucleus.notification.log.LogNotifier";
     
     /**
      * Returns properties based on the DAS/Cluster/Instance

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/PayaraNotificationFileHandler.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/PayaraNotificationFileHandler.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,7 +37,6 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2022 [Payara Foundation and/or its affiliates]
 package fish.payara.enterprise.server.logging;
 
 import com.sun.enterprise.server.logging.GFFileHandler;

--- a/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/PayaraNotificationFileHandler.java
+++ b/nucleus/core/logging/src/main/java/fish/payara/enterprise/server/logging/PayaraNotificationFileHandler.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2022 [Payara Foundation and/or its affiliates]
 package fish.payara.enterprise.server.logging;
 
 import com.sun.enterprise.server.logging.GFFileHandler;
@@ -46,7 +47,7 @@ import java.util.logging.LogManager;
 import org.glassfish.config.support.TranslatedConfigView;
 
 /**
- * Service class that is created and initialised by @{code fish.payara.nucleus.notification.log.LogNotifierService}
+ * Service class that is created and initialised by @{code fish.payara.nucleus.notification.log.LogNotifier}
  * The lifecycle of the bean is not managed by HK2 in order to prevent notification.log file creation upon domain start.
  *
  * @author mertcaliskan


### PR DESCRIPTION
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Bug fixed the Payara notification logging service configuration by fixing incorrect logger name of LoggerNotifier

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
N/A

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
N/A

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Start the server and configure the Notification Service to use a separate log file and update any of the Payara Notification Logging Service logger settings

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, OpenJDK11, Maven 3.8.4

## Documentation
<!-- Link documentation if a PR exists -->
N/A

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
N/A