### PR TITLE
FISH-5955 Set app (system) class loader as the bundle parent CL

### DIFF
--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -113,10 +113,11 @@ org.osgi.framework.bootdelegation=${eclipselink.bootdelegation}, \
                                   org.netbeans.lib.profiler, org.netbeans.lib.profiler.*
 
 # The OSGi R4.2 spec says boot delegation uses the boot class loader by default. We need
-# to configure it to use the framework class loader because that class loader is
-# configured with extra classes like jdk tools.jar, derby jars, etc. that must be
-# made available in GlassFish to work.
-org.osgi.framework.bundle.parent=framework
+# to configure it to use the application class loader by default so we have access to
+# classes and resources on the system class path. From those classes and resources, only those 
+# that reside in packages listed in bootdelegation will be exposed, others will not be visible by
+# OSGi bundles.
+org.osgi.framework.bundle.parent=app
 
 # We don't set this value here, as expanding GlassFish_Platform gives us a file name with upper case
 # char in it. GlassFish file layout does not recommend use of upper case char, because some


### PR DESCRIPTION
## Description

This allows OSGi bundles to access classes on the system class path. 
However, bootdelegation rules apply (for both classes and resources) 
and thus this effectively only allows access to classes in the oracle.sql 
package if Oracle JDBC driver JAR is placed on the system classpath. 
This is required for the EclipseLink Oracle extension to work.

The issue [#11129](https://github.com/eclipse-ee4j/glassfish/issues/11129) (fixed by [this commit](https://github.com/javaee/glassfish/commit/77f541e39e18e4d1c90fbe4b051e1f9f9eab3ea1)) is no longer present. Felix now mandates 
bootdelegation rules also for resources and doesn't expose resources 
in the parent classloader that aren't listed in the bootdelegation property.

## Important Info
### Blockers
This needs to be properly tested before merged !!! It can have an impact on everything in Payara Server.

## Testing

This PR should be executed against the complete test suite to make sure that it doesn't break anything.

Should be tested against both Java 8 and Java 11.

### New tests

No new tests.

### Testing Performed

Manually tested that Oracle EcliseLink extension works and this fixes the customer's issue on Java 11

### Testing Environment

Ubuntu Linux, Zulu JDK 11.0.12

## Notes for Reviewers

* Documentation of [Felix configuration properties](https://felix.apache.org/documentation/subprojects/apache-felix-framework/apache-felix-framework-configuration-properties.html)
* Felix source code where it determines the parent class loader depending on the value of the `bundle.parent` property: [method `determineParentClassLoader` in `BundleWiringImpl.java`](https://github.com/apache/felix-dev/blob/master/framework/src/main/java/org/apache/felix/framework/BundleWiringImpl.java#L1235)