### PR TITLE
FISH-6092 Upgrade Jackson to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <hk2.version>3.0.1.payara-p1</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
-        <jackson.version>2.13.0</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <snakeyaml.version>1.29</snakeyaml.version>
         <hazelcast.version>4.2</hazelcast.version>
         <hazelcast.kubernetes.version>2.2.3.payara-p1</hazelcast.kubernetes.version>


### PR DESCRIPTION
## Description
Increment Jackson to 2.13.1 because of CVE: https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698

Addresses Community Issue: https://github.com/payara/Payara/issues/5641

## Important Info

## Testing
### New tests
None

### Testing Performed
Started the server on JDK 11 and 17 - No warnings, failures or compilation failures.

### Testing Environment
Windows 10, Maven 3.6.3, Zulu JDK 11 & 17

## Documentation
None

## Notes for Reviewers
None
