### PR TITLE
FISH-5964: upgrading jakartaee-web-api for server

### DIFF
--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>9.0.0</version>
+            <version>${jakarta-platform.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -129,7 +129,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.platform</groupId>
                                     <artifactId>jakarta.jakartaee-web-api</artifactId>
-                                    <version>9.0.0</version>
+                                    <version>${jakarta-platform.version}</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/appserver/tests/payara-samples/samples/concurrency/pom.xml
+++ b/appserver/tests/payara-samples/samples/concurrency/pom.xml
@@ -57,7 +57,6 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <jakartaee-api.version>10.0.0-SNAPSHOT</jakartaee-api.version>
         <arquillian-bom.version>1.7.0.Alpha10</arquillian-bom.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <arquillian-payara.version>3.0.alpha3</arquillian-payara.version>
@@ -67,12 +66,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>jakarta.platform</groupId>
-                <artifactId>jakarta.jakartaee-api</artifactId>
-                <version>${jakartaee-api.version}</version>
-                <scope>provided</scope>
-            </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
@@ -91,11 +84,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>${jakartaee-api.version}</version>
-        </dependency>
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>

--- a/appserver/tests/payara-samples/samples/concurrency/pom.xml
+++ b/appserver/tests/payara-samples/samples/concurrency/pom.xml
@@ -57,7 +57,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <jakartaee-api.version>9.1.0</jakartaee-api.version>
+        <jakartaee-api.version>10.0.0-SNAPSHOT</jakartaee-api.version>
         <arquillian-bom.version>1.7.0.Alpha10</arquillian-bom.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <arquillian-payara.version>3.0.alpha3</arquillian-payara.version>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>10.0.0-RC1</version>
+            <version>${jakartaee-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 
         <!-- BOM-referenced versions -->
         <!--<jakartaee.api.version>10.0.0-RC1</jakartaee.api.version> Currently fails with CDIEventbusNotifierService -->
-        <jakartaee.api.version>9.1.0</jakartaee.api.version>
+        <jakartaee.api.version>10.0.0-SNAPSHOT</jakartaee.api.version>
         <servlet-api.version>5.0.0</servlet-api.version>
         <grizzly.version>3.0.1.payara-p1</grizzly.version>
         <jax-rs-api.impl.version>3.0.0</jax-rs-api.impl.version>
@@ -207,7 +207,7 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <jsonp.version>2.0.1</jsonp.version>
         <jbi.version>1.0</jbi.version>
-        <jakarta-platform.version>9.1.0</jakarta-platform.version>
+        <jakarta-platform.version>10.0.0-SNAPSHOT</jakarta-platform.version>
         <microprofile-release.version>5.0</microprofile-release.version>
         <microprofile-opentracing.version>3.0</microprofile-opentracing.version>
         <microprofile-config.version>3.0</microprofile-config.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Upgrading concurrency dependencies
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
this is to upgrade concurrency dependencies for 3.0 and be included on the web-profile
## Important Info
The 10.0.0-SNAPSHOT version is temporal and should be upgraded when the release of the jakarta 10 is done. For now this can be tested by building the last version of the jakarta api project here: https://github.com/eclipse-ee4j/jakartaee-api
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested with a sample Web application with the jakarta.jakartaee-web-api dependency with provided scope into the payara-web distribution
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, Azul JDK 11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
