### PR TITLE
FISH-5942 Create JDK17 based Docker Image

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,6 +57,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.14.1</docker.jdk11.tag>
+        <docker.jdk17.tag>17.0.2</docker.jdk17.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara6</docker.payara.rootDirectoryName>
@@ -144,6 +145,11 @@
                                                 <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk11.tag}"/>
                                             </filterset>
                                         </copy>
+                                        <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk17">
+                                            <filterset>
+                                                <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk17.tag}"/>
+                                            </filterset>
+                                        </copy>
                                     </tasks>
                                 </configuration>
                             </execution>
@@ -174,6 +180,24 @@
                                         <cleanup>none</cleanup>
                                         <noCache>${docker.noCache}</noCache>
                                         <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
+                                        <assembly>
+                                            <mode>tar</mode>
+                                            <descriptor>assembly.xml</descriptor>
+                                            <tarLongFileMode>gnu</tarLongFileMode>
+                                        </assembly>
+                                    </build>
+                                </image>
+                                <image>
+                                    <name>${docker.payara.repository}</name>
+                                    <build>
+                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                        <filter>@</filter>
+                                        <tags>
+                                            <tag>${docker.payara.tag}-jdk17</tag>
+                                        </tags>
+                                        <cleanup>none</cleanup>
+                                        <noCache>${docker.noCache}</noCache>
+                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk17</dockerFile>
                                         <assembly>
                                             <mode>tar</mode>
                                             <descriptor>assembly.xml</descriptor>


### PR DESCRIPTION
## Description
Adds JDK 17 build of Docker images

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built JDK 17 docker image

### Testing Environment
Windows 10, JDK 17, Maven 3.6.3

## Documentation
N/A

## Notes for Reviewers
None
