### PR TITLE
Fish 5978 Set TLS 1.3 as Default Protocol

### DIFF
--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IIOPSSLSocketFactory.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IIOPSSLSocketFactory.java
@@ -231,7 +231,7 @@ public class IIOPSSLSocketFactory implements ORBSocketFactory {
      * Return a default SSLInfo object.
      */
     private SSLInfo getDefaultSslInfo() throws Exception {
-       return init(null, false, null, true, null, true, true, true, false);
+       return init(null, false, null, true, null, true, false, true, true);
     }
 
     /**

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -69,7 +69,7 @@ public final class HttpConnectorAddress {
     static final String HTTPS_CONNECTOR = "https";
     public static final String  AUTHORIZATION_KEY     = "Authorization";
     private static final String AUTHORIZATION_TYPE = "Basic ";
-    private static final String DEFAULT_PROTOCOL = TLS12;
+    private static final String DEFAULT_PROTOCOL = TLS13;
 
     private String host;
     private int    port;

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/integration/AppClientSSL.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/security/integration/AppClientSSL.java
@@ -47,7 +47,7 @@ package com.sun.enterprise.security.integration;
  */
 public class AppClientSSL {
     private boolean tlsEnabled = true;
-    private boolean tlsEnabled11 = true;
+    private boolean tlsEnabled11 = false;
     private boolean tlsEnabled12 = true;
     private boolean tlsEnabled13 = true;
     private boolean tlsRollbackEnabled = true;

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
@@ -58,9 +58,9 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     boolean SSL2_ENABLED = false;
     boolean SSL3_ENABLED = false;
     boolean TLS_ENABLED = true;
-    boolean TLS11_ENABLED = true;
+    boolean TLS11_ENABLED = false;
     boolean TLS12_ENABLED = true;
-    boolean TLS13_ENABLED = false;
+    boolean TLS13_ENABLED = true;
     boolean TLS_ROLLBACK_ENABLED = true;
     boolean HSTS_ENABLED = false;
     boolean HSTS_SUBDOMAINS = false;


### PR DESCRIPTION
## Description
Payara6 changed to handle https requests using TLSv1.3 as default

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Build Payara6: mvn clean install -T 4 -DskipTests
2. Run Payara6: .\appserver\distributions\payara\target\stage\payara6\bin\asadmin start-domain --verbose
3. Open Google Chrome & press CTRL+Shift+i to open dev tools
4. Make a request to https://localhost:8181/
5. In dev tools go to "Security" sheet 
6. Verify if "connection" says "authenticated using TLS 1.3"

### Testing Environment
Windows 10 (on Linux I think it will not work unless you have a certificate configured locally), JDK  version "11.0.10" 2021-01-19 LTS, Maven 3.8.4"-->
