### PR TITLE
FISH-6102: fixing null classloader and returning normal thread priority

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedThreadFactoryDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedThreadFactoryDefinitionHandler.java
@@ -96,8 +96,10 @@ public class ManagedThreadFactoryDefinitionHandler extends AbstractResourceHandl
         mtfdd.setMetadataSource(MetadataSource.ANNOTATION);
         mtfdd.setName(TranslatedConfigView.expandValue(managedThreadFactoryDefinition.name()));
         mtfdd.setContext(TranslatedConfigView.expandValue(managedThreadFactoryDefinition.context()));
-        if(managedThreadFactoryDefinition.priority() < 0) {
-            mtfdd.setPriority(Thread.MIN_PRIORITY);
+        if(managedThreadFactoryDefinition.priority() <= 0) {
+            mtfdd.setPriority(Thread.NORM_PRIORITY);
+        } else {
+            mtfdd.setPriority(managedThreadFactoryDefinition.priority());
         }
         return mtfdd;
     }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedThreadFactoryDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedThreadFactoryDefinitionDescriptor.java
@@ -50,7 +50,7 @@ public class ManagedThreadFactoryDefinitionDescriptor extends ResourceDescriptor
 
     private String name;
     private String context;
-    private int priority = Thread.MIN_PRIORITY;
+    private int priority = Thread.NORM_PRIORITY;
     private Properties properties = new Properties();
 
     public ManagedThreadFactoryDefinitionDescriptor() {

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/OSGiObjectInputOutputStreamFactoryImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/OSGiObjectInputOutputStreamFactoryImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2022] Payara Foundation and/or affiliates
 
 package org.glassfish.common.util;
 

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/OSGiObjectInputOutputStreamFactoryImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/OSGiObjectInputOutputStreamFactoryImpl.java
@@ -57,6 +57,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.sun.enterprise.util.Utility.getClassLoader;
+
 /**
  * @author Sanjeeb.Sahoo@Sun.COM
  */
@@ -122,6 +124,9 @@ public class OSGiObjectInputOutputStreamFactoryImpl
             throws IOException
     {
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            loader = getClassLoader();
+        }
         return new OSGiObjectInputStream(in, loader);
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Adding change to set classloader and fix IllegalArgumentException when classloader is null
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
this is a fix of some issues when the classloader is null
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
execution of the concurrency tck
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, Azul jdk 11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
