### PR TITLE
FISH-5968 leave transaction intact if mentioned in unchanged parameter

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -189,7 +189,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
         ContextServiceImpl contextService = contextServiceMap.get(contextServiceJndiName);
         if (contextService == null) {
             // if the context service is not known, create it
-            Set<String> propagated = parseContextInfo(contextInfo, contextInfoEnabled);
+            Set<String> propagated = ContextServiceConfig.parseContextInfo(contextInfo, contextInfoEnabled);
             Set<String> cleared = Collections.EMPTY_SET;
             if (cleanupTransaction && !propagated.contains(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA)) {
                 // pass the cleanup transaction in list of cleared handlers
@@ -345,34 +345,6 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                         new TransactionSetupProviderImpl(transactionManager)
                 );
         return contextService;
-    }
-
-    private Set<String> parseContextInfo(String contextInfo, boolean isContextInfoEnabled) {
-        Set<String> contextTypeArray = new HashSet<>();
-        if (contextInfo == null) {
-            // by default, if no context info is passed, we propagate all context types
-            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_CLASSLOADING);
-            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_NAMING);
-            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_SECURITY);
-            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA);
-        } else if (isContextInfoEnabled) {
-            StringTokenizer st = new StringTokenizer(contextInfo, ",", false);
-            while(st.hasMoreTokens()) {
-                String token = st.nextToken().trim();
-                if (CONTEXT_INFO_CLASSLOADER.equalsIgnoreCase(token)) {
-                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_CLASSLOADING);
-                } else if (CONTEXT_INFO_JNDI.equalsIgnoreCase(token)) {
-                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_NAMING);
-                } else if (CONTEXT_INFO_SECURITY.equalsIgnoreCase(token)) {
-                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_SECURITY);
-                } else if (CONTEXT_INFO_WORKAREA.equalsIgnoreCase(token)) {
-                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA);
-                } else {
-                    contextTypeArray.add(token); // custom context
-                }
-            }
-        }
-        return contextTypeArray;
     }
 
     private void scheduleInternalTimer() {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -180,9 +180,9 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
         }
 
         // TODO: put initialization of providers to better place
-        if (allThreadContextProviders == null) {
-            synchronized (this) {
-                if (allThreadContextProviders == null) {
+//        if (allThreadContextProviders == null) {
+//            synchronized (this) {
+//                if (allThreadContextProviders == null) {
                     allThreadContextProviders = new HashMap<>();
                     for (ThreadContextProvider service : ServiceLoader.load(jakarta.enterprise.concurrent.spi.ThreadContextProvider.class, Utility.getClassLoader())) {
                         String serviceName = service.getThreadContextType();
@@ -194,9 +194,9 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
                     verifyProviders(contextPropagate);
                     verifyProviders(contextClear);
                     verifyProviders(contextUnchanged);
-                }
-            }
-        }
+//                }
+//            }
+//        }
 
         ComponentInvocation currentInvocation = invocationManager.getCurrentInvocation();
         if (currentInvocation != null) {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceConfig.java
@@ -43,23 +43,31 @@ package org.glassfish.concurrent.runtime.deployer;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.StringTokenizer;
 import org.glassfish.concurrent.config.ContextService;
+import org.glassfish.concurrent.runtime.ContextSetupProviderImpl;
 
 /**
  * Contains configuration information for a ContextService object
  */
 public class ContextServiceConfig extends BaseConfig {
 
-    private Set<String> propagatedContexts = new HashSet<>();
-    private Set<String> clearedContexts = new HashSet<>();
-    private Set<String> uchangedContexts = new HashSet<>();
+    private final Set<String> propagatedContexts;
+    private final Set<String> clearedContexts;
+    private final Set<String> uchangedContexts;
 
     public ContextServiceConfig(String jndiName) {
         super(jndiName, null, "true");
+        this.propagatedContexts = parseContextInfo(this.contextInfo, this.isContextInfoEnabledBoolean());
+        this.clearedContexts = new HashSet<>();
+        this.uchangedContexts = new HashSet<>();
     }
 
     public ContextServiceConfig(ContextService config) {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
+        this.propagatedContexts = parseContextInfo(this.contextInfo, this.isContextInfoEnabledBoolean());
+        this.clearedContexts = new HashSet<>();
+        this.uchangedContexts = new HashSet<>();
     }
 
     public ContextServiceConfig(String jndiName, String contextInfo, String contextInfoEnabled, Set<String> propagatedContexts, Set<String> clearedContexts, Set<String> uchangedContexts) {
@@ -69,6 +77,7 @@ public class ContextServiceConfig extends BaseConfig {
         this.uchangedContexts = uchangedContexts;
     }
 
+    @Override
     public TYPE getType() {
         return TYPE.CONTEXT_SERVICE;
     }
@@ -83,6 +92,34 @@ public class ContextServiceConfig extends BaseConfig {
 
     public Set<String> getUchangedContexts() {
         return uchangedContexts;
+    }
+
+    public static Set<String> parseContextInfo(String contextInfo, boolean isContextInfoEnabled) {
+        Set<String> contextTypeArray = new HashSet<>();
+        if (contextInfo == null) {
+            // by default, if no context info is passed, we propagate all context types
+            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_CLASSLOADING);
+            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_NAMING);
+            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_SECURITY);
+            contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA);
+        } else if (isContextInfoEnabled) {
+            StringTokenizer st = new StringTokenizer(contextInfo, ",", false);
+            while (st.hasMoreTokens()) {
+                String token = st.nextToken().trim();
+                if (org.glassfish.concurrent.runtime.ConcurrentRuntime.CONTEXT_INFO_CLASSLOADER.equalsIgnoreCase(token)) {
+                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_CLASSLOADING);
+                } else if (org.glassfish.concurrent.runtime.ConcurrentRuntime.CONTEXT_INFO_JNDI.equalsIgnoreCase(token)) {
+                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_NAMING);
+                } else if (org.glassfish.concurrent.runtime.ConcurrentRuntime.CONTEXT_INFO_SECURITY.equalsIgnoreCase(token)) {
+                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_SECURITY);
+                } else if (org.glassfish.concurrent.runtime.ConcurrentRuntime.CONTEXT_INFO_WORKAREA.equalsIgnoreCase(token)) {
+                    contextTypeArray.add(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA);
+                } else {
+                    contextTypeArray.add(token); // custom context
+                }
+            }
+        }
+        return contextTypeArray;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,8 @@
 
         <!-- BOM-referenced versions -->
         <!--<jakartaee.api.version>10.0.0-RC1</jakartaee.api.version> Currently fails with CDIEventbusNotifierService -->
-        <jakartaee.api.version>10.0.0-SNAPSHOT</jakartaee.api.version>
+        <!--<jakartaee.api.version>10.0.0-SNAPSHOT</jakartaee.api.version>-->
+        <jakartaee.api.version>9.1.0</jakartaee.api.version>
         <servlet-api.version>5.0.0</servlet-api.version>
         <grizzly.version>3.0.1.payara-p1</grizzly.version>
         <jax-rs-api.impl.version>3.0.0</jax-rs-api.impl.version>
@@ -207,7 +208,8 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <jsonp.version>2.0.1</jsonp.version>
         <jbi.version>1.0</jbi.version>
-        <jakarta-platform.version>10.0.0-SNAPSHOT</jakarta-platform.version>
+        <!--<jakarta-platform.version>10.0.0-SNAPSHOT</jakarta-platform.version>-->
+        <jakarta-platform.version>9.1.0</jakarta-platform.version>
         <microprofile-release.version>5.0</microprofile-release.version>
         <microprofile-opentracing.version>3.0</microprofile-opentracing.version>
         <microprofile-config.version>3.0</microprofile-config.version>


### PR DESCRIPTION
## DescriptionFixes testContextServiceDefinitionAllAttributes TCK test, method ContextService.contextualFunction() with transaction defined as this:
```
@ContextServiceDefinition(name = "java:app/concurrent/ContextA",
                          propagated = { APPLICATION, IntContext.NAME },
                          cleared = StringContext.NAME,
                          unchanged = TRANSACTION)
```
Note the `unchanged = TRANSACTION` -- the transaction is now unchanged.


## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### Testing Performed
Failing tests in package `ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.*` decreased from 9 to 6.

### Testing Environment
Linux, OpenJDK

## Notes for Reviewers
Requires current version of concurrencty-ri, branch jakarta10: https://github.com/aubi/concurrency-ri/commit/7ce79fde06a97cdd6f788b6309cae5585b577930

I accidentally moved the payara6-concurrency-3.0-upgrade branch, so this diff doesn't include the main commit of this PR:
https://github.com/aubi/Payara/commit/65f0fd6e9e20f8fa9edab12d050ef5a96297ba26
