### PR TITLE
FISH-6208 Deprecate and change WebAppClassLoader#getResources to return null for CVE-2022-22965 (Payara6)

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -581,10 +581,12 @@ public class WebappClassLoader
 
 
     /**
+     * Unused. Always returns {@code null}.
      * Get associated resources.
      */
+    @Deprecated
     public DirContext getResources() {
-        return this.resources;
+        return null;
     }
 
 

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -581,7 +581,7 @@ public class WebappClassLoader
 
 
     /**
-     * Unused. Always returns {@code null}.
+     * Unused. Always returns {@code null} - See CVE-2022-22965
      * Get associated resources.
      */
     @Deprecated


### PR DESCRIPTION
## Description
FISH-6208 Deprecate and change WebAppClassLoader#getResources to return null for CVE-2022-22965 (Enterprise)

## Important Info
Credit to https://github.com/apache/tomcat/commit/530108cb568ba7bb51594d0ecfc2421db2e4bf53
Unsure how to attribute Re: copyright

### Dependant PRs
None

### Blockers 
None

## Testing

### New tests
None

### Testing Performed
To Do

### Test suites executed
To Do

### Testing Environment
To Do

## Documentation
To Do

## Notes for Reviewers
None
