### PR TITLE
Fish 6204 Improve Implementation of Context Switching

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -342,7 +342,9 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                 = new ContextServiceImpl(
                         jndiName,
                         contextSetupProvider,
-                        new TransactionSetupProviderImpl(transactionManager, unchanged.contains(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA))
+                        new TransactionSetupProviderImpl(transactionManager,
+                                unchanged.contains(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA),
+                                cleared.contains(ContextSetupProviderImpl.CONTEXT_TYPE_WORKAREA))
                 );
         return contextService;
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -77,6 +77,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.propagation.Format;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -188,6 +189,17 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
                         String serviceName = service.getThreadContextType();
                         if (contextPropagate.contains(serviceName) || contextClear.contains(serviceName) || contextUnchanged.contains(serviceName)) {
                             allThreadContextProviders.put(serviceName, service);
+                        } else {
+                            if (contextPropagate.contains(ContextServiceDefinition.ALL_REMAINING)) {
+                                contextPropagate.add(serviceName);
+                                allThreadContextProviders.put(serviceName, service);
+                            } else if (contextClear.contains(ContextServiceDefinition.ALL_REMAINING)) {
+                                contextClear.add(serviceName);
+                                allThreadContextProviders.put(serviceName, service);
+                            } else if (contextUnchanged.contains(ContextServiceDefinition.ALL_REMAINING)) {
+                                contextUnchanged.add(serviceName);
+                                allThreadContextProviders.put(serviceName, service);
+                            }
                         }
                     }
                     // check, if there is no unexpected provider name
@@ -442,6 +454,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
                 case CONTEXT_TYPE_SECURITY:
                 case CONTEXT_TYPE_NAMING:
                 case CONTEXT_TYPE_WORKAREA:
+                case ContextServiceDefinition.ALL_REMAINING:
                     // OK, they are known
                     break;
                 default:

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -179,7 +179,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
             currentSecurityContext = SecurityContext.getCurrent();
         }
 
-        // TODO: put initialization of providers to better place
+        // TODO: put initialization of providers to better place; caching is a problem due to different classloaders
 //        if (allThreadContextProviders == null) {
 //            synchronized (this) {
 //                if (allThreadContextProviders == null) {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/deployment/annotation/handlers/ContextServiceDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/deployment/annotation/handlers/ContextServiceDefinitionHandler.java
@@ -129,6 +129,7 @@ public class ContextServiceDefinitionHandler extends AbstractResourceHandler {
         for (String context : sourceContexts) {
             if (ContextServiceDefinition.ALL_REMAINING.equals(context)) {
                 contexts.addAll(unusedContexts);
+                contexts.add(ContextServiceDefinition.ALL_REMAINING); // keep remaining for custom context providers
             } else {
                 contexts.add(context);
             }


### PR DESCRIPTION
## Description
Fix transaction suspend in contextual call - if ContextServiceDefinition.cleared contains TRANSACTION, suspend the current transaction on a contextual call.
Keep ALL_REMAINING in the lists of contexts and then add there the custom providers.

## Important Info
## Testing
### Testing Performed
TCK: from 9 passed and 6 failing we have got  to 12 passed and 4 failing.

### Testing Environment
Linux, OpenJDK 11

## Notes for Reviewers
It is necessary to update to up-to-date our RI.
