### PR TITLE
FISH-5926 Update Documentation Around Java 11

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -33,5 +33,5 @@ Describe a [SCCE](http://sscce.org/ "Short, Self-Contained, Correct Example") re
 ## Environment ##
 
 - **Distribution**: <!-- Server Full Profile / Server Web Profile / Micro / Embedded -->
-- **JDK Version**: <!-- 6/7/8 uXX - Oracle/IBM/OpenJDK -->
+- **JDK Version**: <!-- 11/17 uXX - Oracle/IBM/OpenJDK -->
 - **Operating System**: <!-- Windows / Linux / Mac -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 <!--- Please describe how you tested these changes. Which test suites did you run?  -->
 
 ### Testing Environment
-<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
+<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
 
 ## Documentation
 <!-- Link documentation if a PR exists -->

--- a/appserver/tests/payara-samples/README.md
+++ b/appserver/tests/payara-samples/README.md
@@ -24,7 +24,7 @@ Note that any test must have a `@Deployment` since otherwise the tests aren't de
   connects to a running server (cannot be micro)
 
 * `payara6`: 
-  downloads, installs and runs tests on a Payara 5 with `{$payara.version}` (use with `-Dpayara-version=???`)
+  downloads, installs and runs tests on a Payara 6 with `{$payara.version}` (use with `-Dpayara-version=???`)
 
 * `payara4`: 
   downloads, installs and runs tests on a Payara 4 with `{$payara.version}` (use with `-Dpayara-version=???`)


### PR DESCRIPTION
## Description
Updates some files for JDK 11 being the minimum version.

## Important Info
### Blockers
None

## Documentation
Documentation is on this branch: [FISH-5926 Payara 6 documentation for JDK 11 · JamesHillyard/Payara-Community-Documentation@94b08b2](https://github.com/JamesHillyard/Payara-Community-Documentation/commit/94b08b2ac60dfda3fad0df6e832025e880b2d2f1) which when approved will be a new `Payara6` branch on the Community documentation repo.

## Notes for Reviewers
None
