### PR TITLE
FISH-5966: adding fix for maxasync configuration for executors

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedExecutorDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedExecutorDefinitionHandler.java
@@ -92,13 +92,17 @@ public class ManagedExecutorDefinitionHandler extends AbstractResourceHandler {
         ManagedExecutorDefinitionDescriptor medd = new ManagedExecutorDefinitionDescriptor();
         medd.setName(TranslatedConfigView.expandValue(managedExecutorDefinition.name()));
         medd.setContext(TranslatedConfigView.expandValue(managedExecutorDefinition.context()));
-        // FIXME: cdd.setContextInfo(??? Load from existing ContextServiceDefinition!);
+
         if(managedExecutorDefinition.hungTaskThreshold() < 0) {
             medd.setHungAfterSeconds(0);
+        } else {
+            medd.setHungAfterSeconds(managedExecutorDefinition.hungTaskThreshold());
         }
 
         if(managedExecutorDefinition.maxAsync() < 0) {
             medd.setMaximumPoolSize(Integer.MAX_VALUE);
+        } else {
+            medd.setMaximumPoolSize(managedExecutorDefinition.maxAsync());
         }
 
         medd.setMetadataSource(MetadataSource.ANNOTATION);

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedScheduledExecutorDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedScheduledExecutorDefinitionHandler.java
@@ -97,10 +97,14 @@ public class ManagedScheduledExecutorDefinitionHandler extends AbstractResourceH
 
         if(managedScheduledExecutorDefinition.hungTaskThreshold() < 0) {
             msedd.setHungTaskThreshold(0);
+        } else {
+            msedd.setHungTaskThreshold(managedScheduledExecutorDefinition.hungTaskThreshold());
         }
 
         if(managedScheduledExecutorDefinition.maxAsync() < 0) {
             msedd.setMaxAsync(Integer.MAX_VALUE);
+        } else {
+            msedd.setMaxAsync(managedScheduledExecutorDefinition.maxAsync());
         }
 
         msedd.setMetadataSource(MetadataSource.ANNOTATION);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fixing maxasync configuration for executors
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for TCK issues reported on logs
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
The TCK execution without the maxasync issues
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
windows 10, azul JDK 11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
