### PR TITLE
FISH-6216: adding missed deploy methods and reordering

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -82,15 +82,9 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
 
     @Override
     public void deployResource(Object resource, String applicationName, String moduleName) throws Exception {
-
-    }
-
-    @Override
-    public void deployResource(Object resource) throws Exception {
         ManagedScheduledExecutorDefinitionDescriptor descriptor = (ManagedScheduledExecutorDefinitionDescriptor) resource;
         ManagedScheduledExecutorServiceConfig config =
                 new ManagedScheduledExecutorServiceConfig(new CustomManagedScheduledExecutorDefinitionImpl(descriptor));
-        String applicationName = invocationManager.getCurrentInvocation().getAppName();
         String customNameOfResource = ConnectorsUtil.deriveResourceName(descriptor.getResourceId(),
                 descriptor.getName(), descriptor.getResourceType());
         ResourceInfo resourceInfo = new ResourceInfo(customNameOfResource, applicationName, null);
@@ -110,6 +104,13 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
             LogHelper.log(logger, Level.SEVERE, LogFacade.UNABLE_TO_BIND_OBJECT, ex,
                     "ManagedScheduledExecutorService", config.getJndiName());
         }
+    }
+
+    @Override
+    public void deployResource(Object resource) throws Exception {
+        String applicationName = invocationManager.getCurrentInvocation().getAppName();
+        String moduleName = invocationManager.getCurrentInvocation().getModuleName();
+        deployResource(resource, applicationName, moduleName);
     }
 
     @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -82,14 +82,8 @@ public class ManagedThreadFactoryDescriptorDeployer implements ResourceDeployer 
 
     @Override
     public void deployResource(Object resource, String applicationName, String moduleName) throws Exception {
-
-    }
-
-    @Override
-    public void deployResource(Object resource) throws Exception {
         ManagedThreadFactoryDefinitionDescriptor descriptor = (ManagedThreadFactoryDefinitionDescriptor) resource;
         ManagedThreadFactoryConfig config = new ManagedThreadFactoryConfig(new CustomManagedThreadFactory(descriptor));
-        String applicationName = invocationManager.getCurrentInvocation().getAppName();
         String customNameOfResource = ConnectorsUtil.deriveResourceName(descriptor.getResourceId(),
                 descriptor.getName(), descriptor.getResourceType());
         ResourceInfo resourceInfo = new ResourceInfo(customNameOfResource, applicationName, null);
@@ -109,6 +103,13 @@ public class ManagedThreadFactoryDescriptorDeployer implements ResourceDeployer 
             LogHelper.log(logger, Level.SEVERE, LogFacade.UNABLE_TO_BIND_OBJECT, ex,
                     "ManagedThreadFactory", config.getJndiName());
         }
+    }
+
+    @Override
+    public void deployResource(Object resource) throws Exception {
+        String applicationName = invocationManager.getCurrentInvocation().getAppName();
+        String moduleName = invocationManager.getCurrentInvocation().getModuleName();
+        deployResource(resource, applicationName, moduleName);
     }
 
     @Override


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Adding deploy methods and reordering
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix to add missed deploy methods and reordering the calls between them
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
the tck execution
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 10, Azul JDK 11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
