### PR TITLE
FISH-6068 Add gRPC Sample to the Payara 'master' Branch

### DIFF
--- a/appserver/tests/payara-samples/samples/grpc-ejb/pom.xml
+++ b/appserver/tests/payara-samples/samples/grpc-ejb/pom.xml
@@ -53,11 +53,6 @@
     <name>Payara Samples - Payara - gRPC with EJB</name>
     <packaging>jar</packaging>
 
-    <properties>
-        <!-- gRPC versions -->
-        <grpc.version>1.43.1</grpc.version>
-    </properties>
-
     <dependencies>
         <!-- Dependencies for the Client side calls -->
         <dependency>
@@ -109,9 +104,9 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.43.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/appserver/tests/payara-samples/samples/grpc/pom.xml
+++ b/appserver/tests/payara-samples/samples/grpc/pom.xml
@@ -47,13 +47,6 @@
     <name>Payara Samples - Payara - gRPC test</name>
     <packaging>jar</packaging>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <grpc.version>1.43.1</grpc.version>
-        <protobuf.version>3.19.4</protobuf.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fish.payara.samples</groupId>

--- a/appserver/tests/payara-samples/samples/grpc/pom.xml
+++ b/appserver/tests/payara-samples/samples/grpc/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>payara-tests</artifactId>
+        <groupId>fish.payara.server.internal.tests</groupId>
+        <version>5.2022.3-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>grpc</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/appserver/tests/payara-samples/samples/grpc/pom.xml
+++ b/appserver/tests/payara-samples/samples/grpc/pom.xml
@@ -1,20 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+    Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>payara-tests</artifactId>
-        <groupId>fish.payara.server.internal.tests</groupId>
-        <version>5.2022.3-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>5.2022.3-SNAPSHOT</version>
+    </parent>
+
     <artifactId>grpc</artifactId>
+    <name>Payara Samples - Payara - gRPC test</name>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <grpc.client.version>1.43.1</grpc.client.version>
+        <protobuf.version>3.19.4</protobuf.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- gRPC dependencies -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.client.version}</version>
+        </dependency>
+
+        <!-- Resolve dependencies in Shrinkwrap -->
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Generate protobuf classes -->
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.client.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <!-- Generate OS specific classifier property -->
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
+    </build>
 
 </project>

--- a/appserver/tests/payara-samples/samples/grpc/pom.xml
+++ b/appserver/tests/payara-samples/samples/grpc/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <grpc.client.version>1.43.1</grpc.client.version>
+        <grpc.version>1.43.1</grpc.version>
         <protobuf.version>3.19.4</protobuf.version>
     </properties>
 
@@ -70,17 +70,17 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.client.version}</version>
+            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.client.version}</version>
+            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.client.version}</version>
+            <version>${grpc.version}</version>
         </dependency>
 
         <!-- Resolve dependencies in Shrinkwrap -->
@@ -100,7 +100,7 @@
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.client.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/appserver/tests/payara-samples/samples/grpc/pom.xml
+++ b/appserver/tests/payara-samples/samples/grpc/pom.xml
@@ -49,16 +49,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.samples</groupId>
-            <artifactId>samples-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <!-- gRPC dependencies -->
         <dependency>
             <groupId>io.grpc</groupId>

--- a/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/CdiBean.java
+++ b/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/CdiBean.java
@@ -1,0 +1,53 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.grpc;
+
+import java.util.Random;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CdiBean {
+    private int randomInt = new Random().nextInt(10);
+
+    public int getNextInt() {
+        return randomInt;
+    }
+}

--- a/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/ClashingServlet.java
+++ b/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/ClashingServlet.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.samples.grpc;
 
 import java.io.IOException;

--- a/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/ClashingServlet.java
+++ b/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/ClashingServlet.java
@@ -1,0 +1,26 @@
+package fish.payara.samples.grpc;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A test servlet to make sure that the gRPC service doesn't obstruct user
+ * servlets
+ */
+@WebServlet("/*")
+public class ClashingServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final PrintWriter out = resp.getWriter();
+        out.print("Hello World!");
+        out.flush();
+    }
+}

--- a/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/PayaraService.java
+++ b/appserver/tests/payara-samples/samples/grpc/src/main/java/fish/payara/samples/grpc/PayaraService.java
@@ -1,0 +1,73 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.samples.grpc;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import fish.payara.samples.grpc.PayaraServiceGrpc.PayaraServiceImplBase;
+import io.grpc.stub.StreamObserver;
+
+@Dependent
+public class PayaraService extends PayaraServiceImplBase {
+    @Inject
+    private CdiBean bean;
+
+    @PostConstruct
+    public void init() {
+        System.out.println("PostConstruct(): " + bean.getNextInt());
+    }
+
+    @Override
+    public void communicate(PayaraReq request, StreamObserver<PayaraResp> responseObserver) {
+        final String message = request.getMessage();
+        System.out.println("communicate(): " + bean.getNextInt());
+        responseObserver.onNext(response(message));
+        responseObserver.onCompleted();
+    }
+
+    private static final PayaraResp response(String message) {
+        return PayaraResp.newBuilder() //
+                .setMessage(message) //
+                .build();
+    }
+}

--- a/appserver/tests/payara-samples/samples/grpc/src/main/proto/payara.proto
+++ b/appserver/tests/payara-samples/samples/grpc/src/main/proto/payara.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "fish.payara.samples.grpc";
+option java_outer_classname = "PayaraProto";
+
+package fish.payara.samples.grpc;
+
+service PayaraService {
+  rpc communicate (PayaraReq) returns (stream PayaraResp) {}
+}
+
+message PayaraReq {
+  string message = 1;
+}
+
+message PayaraResp {
+  string message = 1;
+}

--- a/appserver/tests/payara-samples/samples/grpc/src/main/proto/payara.proto
+++ b/appserver/tests/payara-samples/samples/grpc/src/main/proto/payara.proto
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 syntax = "proto3";
 
 option java_multiple_files = true;

--- a/appserver/tests/payara-samples/samples/grpc/src/test/java/fish/payara/samples/grpc/GrpcClient.java
+++ b/appserver/tests/payara-samples/samples/grpc/src/test/java/fish/payara/samples/grpc/GrpcClient.java
@@ -1,0 +1,111 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.samples.grpc;
+
+import static java.util.logging.Level.*;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import fish.payara.samples.grpc.PayaraServiceGrpc.PayaraServiceStub;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+
+public class GrpcClient {
+    private static final Logger LOGGER = Logger.getLogger(GrpcClient.class.getName());
+
+    private final PayaraServiceStub stub;
+
+    private CountDownLatch latch;
+    private AtomicReference<Throwable> error;
+
+    public GrpcClient(URL url) throws URISyntaxException {
+        final Channel channel = ManagedChannelBuilder //
+                .forAddress(url.getHost(), url.getPort()) //
+                .usePlaintext() //
+                .build();
+
+        this.stub = PayaraServiceGrpc.newStub(channel);
+        this.error = new AtomicReference<>(null);
+    }
+
+    public synchronized void communicate() throws InterruptedException {
+        latch = new CountDownLatch(1);
+        stub.communicate(request("Hello World"), new ResponseObserver());
+        latch.await(20, TimeUnit.SECONDS);
+    }
+
+    public Throwable getError() {
+        return error.get();
+    }
+
+    private final class ResponseObserver implements StreamObserver<PayaraResp> {
+
+        @Override
+        public void onNext(PayaraResp response) {
+            LOGGER.log(INFO, "Response received: \"{0}\".", response.getMessage());
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            LOGGER.log(SEVERE, "Error received", t);
+            error.set(t);
+            latch.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            latch.countDown();
+        }
+
+    }
+
+    private static final PayaraReq request(String message) {
+        return PayaraReq.newBuilder() //
+                .setMessage(message) //
+                .build();
+    }
+}

--- a/appserver/tests/payara-samples/samples/grpc/src/test/java/fish/payara/samples/grpc/GrpcTest.java
+++ b/appserver/tests/payara-samples/samples/grpc/src/test/java/fish/payara/samples/grpc/GrpcTest.java
@@ -1,0 +1,102 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.grpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.PayaraTestShrinkWrap;
+
+@RunWith(PayaraArquillianTestRunner.class)
+@NotMicroCompatible
+public class GrpcTest {
+    @ArquillianResource
+    private URL baseUrl;
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+
+        final Archive<?> archive = PayaraTestShrinkWrap.getWebArchive() //
+                // Add protobuf classes
+                .addPackage(PayaraProto.class.getPackage()) //
+                // Add source package
+                .addPackage(PayaraService.class.getPackage()) //
+                // Add test classes
+                .addClasses(GrpcTest.class, GrpcClient.class)
+                // Make sure context root and classloading is configured by GF descriptor
+                .addAsWebInfResource("glassfish-web.xml");
+
+        return archive;
+    }
+
+    @Test
+    public void test_async_grpc_call_streams_correctly() throws InterruptedException, URISyntaxException {
+        final GrpcClient client = new GrpcClient(baseUrl);
+        client.communicate();
+        assertNull(client.getError());
+    }
+
+    @Test
+    public void test_non_grpc_call_skips_grpc_filtering() throws URISyntaxException {
+        final WebTarget target = ClientBuilder.newClient()
+                .target(baseUrl.toURI().resolve("/fish.payara.samples.grpc.PayaraService"));
+        final Response response = target.request().get();
+
+        final String body = response.readEntity(String.class);
+        assertEquals("Hello World!", body);
+    }
+}

--- a/appserver/tests/payara-samples/samples/grpc/src/test/resources/glassfish-web.xml
+++ b/appserver/tests/payara-samples/samples/grpc/src/test/resources/glassfish-web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app error-url="">
+    <class-loader delegate="false" />
+    <context-root>/</context-root>
+</glassfish-web-app>

--- a/appserver/tests/payara-samples/samples/grpc/src/test/resources/glassfish-web.xml
+++ b/appserver/tests/payara-samples/samples/grpc/src/test/resources/glassfish-web.xml
@@ -1,4 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~ Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~ The contents of this file are subject to the terms of either the GNU
+  ~ General Public License Version 2 only ("GPL") or the Common Development
+  ~ and Distribution License("CDDL") (collectively, the "License").  You
+  ~ may not use this file except in compliance with the License.  You can
+  ~ obtain a copy of the License at
+  ~ https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~ See the License for the specific
+  ~ language governing permissions and limitations under the License.
+  ~
+  ~ When distributing the software, include this License Header Notice in each
+  ~ file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~ GPL Classpath Exception:
+  ~ The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~ exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~ file that accompanied this code.
+  ~
+  ~ Modifications:
+  ~ If applicable, add the following below the License Header, with the fields
+  ~ enclosed by brackets [] replaced by your own identifying information:
+  ~ "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~ Contributor(s):
+  ~ If you wish your version of this file to be governed by only the CDDL or
+  ~ only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~ elects to include this software in this distribution under the [CDDL or GPL
+  ~ Version 2] license."  If you don't indicate a single choice of license, a
+  ~ recipient has the option to distribute your version of this file under
+  ~ either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~ its licensees as provided above.  However, if you add GPL Version 2 code
+  ~ and therefore, elected the GPL Version 2 license, then the option applies
+  ~ only if the new code is made subject to such option by the copyright
+  ~ holder.
+  -->
 <!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
 <glassfish-web-app error-url="">
     <class-loader delegate="false" />

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -53,6 +53,11 @@
 
     <name>Payara Samples - Parallel Tests Root</name>
 
+    <properties>
+        <grpc.version>1.43.1</grpc.version>
+        <protobuf.version>3.19.4</protobuf.version>
+    </properties>
+
     <modules>
         <module>payara-expression-config-properties</module>
         <module>clustered-singleton</module>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -84,6 +84,7 @@
         <!-- Skip - this test needs to be run repeatedly for around 60 minutes to be effective -->
         <!--<module>corba-read-timeout</module>-->
         <module>microprofile-rest-client</module>
+        <module>grpc</module>
     </modules>
 
     <dependencies>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -42,10 +42,6 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
-    <modules>
-        <module>payara-samples/samples/grpc</module>
-    </modules>
-
     <parent>
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -42,6 +42,9 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
+    <modules>
+        <module>payara-samples/samples/grpc</module>
+    </modules>
 
     <parent>
         <groupId>fish.payara.server</groupId>


### PR DESCRIPTION
## Description
Sample added to the master branch of Payara, and updated to run as an automatic sample.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Start local Payara
.\appserver\distributions\payara\target\stage\payara5\bin\asadmin start-domain --verbose
2. Build Payara Samples
../Payara/appserver/tests/payara-samples$ mvn clean install -DskipTests
3. Install Test Domain Setup
../Payara/appserver/tests/payara-samples/test-domain-setup$ mvn clean install -Ppayara-server-remote
4. Verify grpc
../Payara/appserver/tests/payara-samples/samples/grpc$ mvn verify -Ppayara-server-remote

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 20.04 with Maven 3.8.4
