### PR TITLE
FISH-5955 FISH-5948 Support for lib/ext for Java 9+

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -76,7 +76,6 @@ public abstract class GFLauncher {
 
     private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile(".* version \"([^\"\\-]+)(-.*)?\".*");
     private final List<String> commandLine = new ArrayList<String>();
-    private final List<String> jvmOptionsList = new ArrayList<String>();
     private final GFLauncherInfo info;
     private Map<String, String> asenvProps;
     private JavaConfig javaConfig;
@@ -227,7 +226,6 @@ public abstract class GFLauncher {
         GFLauncherLogger.addLogFileHandler(logFilename);
         setClasspath();
         setCommandLine();
-        setJvmOptions();
         logCommandLine();
         checkJDKVersion();
         // if no <network-config> element, we need to upgrade this domain
@@ -689,22 +687,12 @@ public abstract class GFLauncher {
         }
     }
 
-    void setJvmOptions() {
-        List<String> jvmOpts = getJvmOptions();
-        jvmOpts.clear();
-
-        if (jvmOptions != null) {
-            addIgnoreNull(jvmOpts, jvmOptions.toStringArray());
-        }
-
-    }
-
     /**
-     * Returns the Java Virtual Machine options
+     * Returns the Java Virtual Machine options (for testing)
      * @return 
      */
-    public final List<String> getJvmOptions() {
-        return jvmOptionsList;
+    List<String> getJvmOptions() {
+        return jvmOptions.toStringArray();
     }
 
     /**
@@ -828,9 +816,16 @@ public abstract class GFLauncher {
         List<File> prefixCP = javaConfig.getPrefixClasspath();
         List<File> suffixCP = javaConfig.getSuffixClasspath();
         List<File> profilerCP = profiler.getClasspath();
+        List<File> extCP = Collections.emptyList();
+        if (!jvmOptions.getCombinedMap().containsKey("java.ext.dirs")) {
+            extCP = Collections.singletonList(
+                    new File(info.getInstanceRootDir(), "lib/ext/*")
+            );
+        }
 
         // create a list of all the classpath pieces in the right order
         List<File> all = new ArrayList<File>();
+        all.addAll(extCP);
         all.addAll(prefixCP);
         all.addAll(profilerCP);
         all.addAll(mainCP);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java
@@ -168,11 +168,11 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
             return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
                 @Override
                 public ClassLoader run() {
-                    return ClassLoader.getSystemClassLoader().getParent();
+                    return ClassLoader.getSystemClassLoader();
                 }
             });        
         } else {
-            return ClassLoader.getSystemClassLoader().getParent();
+            return ClassLoader.getSystemClassLoader();
         }
     }
 

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -113,10 +113,11 @@ org.osgi.framework.bootdelegation=${eclipselink.bootdelegation}, \
                                   org.netbeans.lib.profiler, org.netbeans.lib.profiler.*
 
 # The OSGi R4.2 spec says boot delegation uses the boot class loader by default. We need
-# to configure it to use the framework class loader because that class loader is
-# configured with extra classes like jdk tools.jar, derby jars, etc. that must be
-# made available in GlassFish to work.
-org.osgi.framework.bundle.parent=framework
+# to configure it to use the application class loader by default so we have access to
+# classes and resources on the system class path. From those classes and resources, only those 
+# that reside in packages listed in bootdelegation will be exposed, others will not be visible by
+# OSGi bundles.
+org.osgi.framework.bundle.parent=app
 
 # We don't set this value here, as expanding GlassFish_Platform gives us a file name with upper case
 # char in it. GlassFish file layout does not recommend use of upper case char, because some

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -102,7 +102,7 @@ extra-system-packages=${jre-${java.specification.version}}, org.glassfish.embedd
 # Although Eclipselink imports these packages, in typical GlassFish installation,
 # Oracle JDBC driver may not be available as a bundle, so we ask user to install it in
 # java.ext.dirs and the bootdelegation helps there.
-eclipselink.bootdelegation=oracle.sql, oracle.sql.*
+eclipselink.bootdelegation=oracle.sql, oracle.sql.*,oracle.jdbc, oracle.jdbc.*
 
 # There is no need to use bootdelegation except for the following issues:
 # 1. EclipseLink


### PR DESCRIPTION

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

This puts `${domainDir{/lib/ext/*` onto system classpath (argument `-cp` to launched server process). System classloader is then used as base for both Felix OSGi runtime, as well as application's API Classloader.

It was verified that this change doesn't alter the set of classes accessible to applications, anything on system classpath (glassfish.jar and its dependencies resolved via `Class-Path` manifest attribute) are already available over API Classloader, because it allows loading much more than just API classes.

Alternative solution to #5694, includes #5649.

Classpath is only extended when system property `java.ext.dirs` is not defined, which is true on any JDK >= 9 as that would cause fatal JVM error.

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
* Reproducer for FISH-5946 against Oracle 12.
* Verified that cp is not altered for Java 8
