### PR TITLE
FISH-6216 set core pool size in managedexecutorservice to same value as max

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -220,7 +220,7 @@ public class ManagedExecutorDescriptorDeployer implements ResourceDeployer {
 
         @Override
         public String getCorePoolSize() {
-            return "0";
+            return String.valueOf(managedExecutorDefinitionDescriptor.getMaximumPoolSize());
         }
 
         @Override


### PR DESCRIPTION
## Description
The pool doesn't start any task with default core pool size = 0
Setting core to max makes the MES behaving correctly.

## Testing
### Testing Performed
Fixes 3 Concurrency TCK failures.

### Testing Environment
Linux, OpenJDK
