### PR TITLE
FISH-6216 implement jndi storage for managed thread factory and scheduled executor

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -46,27 +46,24 @@ import com.sun.enterprise.config.serverbeans.Resources;
 import com.sun.enterprise.deployment.ManagedScheduledExecutorDefinitionDescriptor;
 import jakarta.inject.Inject;
 import org.glassfish.api.invocation.InvocationManager;
-import org.glassfish.api.logging.LogHelper;
-import org.glassfish.concurrent.LogFacade;
 import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
 import org.glassfish.resourcebase.resources.api.ResourceConflictException;
 import org.glassfish.resourcebase.resources.api.ResourceDeployer;
 import org.glassfish.resourcebase.resources.api.ResourceDeployerInfo;
 import org.glassfish.resourcebase.resources.api.ResourceInfo;
 import org.glassfish.resourcebase.resources.naming.ResourceNamingService;
-import org.glassfish.resources.naming.SerializableObjectRefAddr;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.TransactionFailure;
 import org.jvnet.hk2.config.types.Property;
 
-import javax.naming.NamingException;
-import javax.naming.RefAddr;
 import java.beans.PropertyVetoException;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.glassfish.concurrent.runtime.ConcurrentRuntime;
+import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl;
 
 @Service
 @ResourceDeployerInfo(ManagedScheduledExecutorDefinitionDescriptor.class)
@@ -75,35 +72,30 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
     private static final Logger logger = Logger.getLogger(ManagedScheduledExecutorDefinitionDeployer.class.getName());
 
     @Inject
-    private ResourceNamingService namingService;
+    private InvocationManager invocationManager;
 
     @Inject
-    private InvocationManager invocationManager;
+    private ResourceNamingService resourceNamingService;
 
     @Override
     public void deployResource(Object resource, String applicationName, String moduleName) throws Exception {
-        ManagedScheduledExecutorDefinitionDescriptor descriptor = (ManagedScheduledExecutorDefinitionDescriptor) resource;
-        ManagedScheduledExecutorServiceConfig config =
-                new ManagedScheduledExecutorServiceConfig(new CustomManagedScheduledExecutorDefinitionImpl(descriptor));
-        String customNameOfResource = ConnectorsUtil.deriveResourceName(descriptor.getResourceId(),
-                descriptor.getName(), descriptor.getResourceType());
-        ResourceInfo resourceInfo = new ResourceInfo(customNameOfResource, applicationName, null);
-        javax.naming.Reference ref = new javax.naming.Reference(
-                jakarta.enterprise.concurrent.ManagedScheduledExecutorService.class.getName(),
-                "org.glassfish.concurrent.runtime.deployer.ConcurrentObjectFactory",
-                null);
-        RefAddr addr = new SerializableObjectRefAddr(ManagedScheduledExecutorServiceConfig.class.getName(), config);
-        ref.add(addr);
-        RefAddr resAddr = new SerializableObjectRefAddr(ResourceInfo.class.getName(), resourceInfo);
-        ref.add(resAddr);
+        ManagedScheduledExecutorDefinitionDescriptor mseDefinitionDescriptor = (ManagedScheduledExecutorDefinitionDescriptor) resource;
+        ManagedScheduledExecutorServiceConfig mseConfig
+                = new ManagedScheduledExecutorServiceConfig(new CustomManagedScheduledExecutorDefinitionImpl(mseDefinitionDescriptor));
 
-        try {
-            // Publish the object ref
-            namingService.publishObject(resourceInfo, ref, true);
-        } catch (NamingException ex) {
-            LogHelper.log(logger, Level.SEVERE, LogFacade.UNABLE_TO_BIND_OBJECT, ex,
-                    "ManagedScheduledExecutorService", config.getJndiName());
-        }
+        // prepare the contextService
+        String contextOfResource = mseDefinitionDescriptor.getContext();
+        ResourceInfo contextResourceInfo = new ResourceInfo(contextOfResource, applicationName, moduleName);
+        ContextServiceImpl contextService = (ContextServiceImpl) resourceNamingService.lookup(contextResourceInfo, contextOfResource);
+
+        // prepare name for JNDI
+        String customNameOfResource = ConnectorsUtil.deriveResourceName(mseDefinitionDescriptor.getResourceId(),
+                mseDefinitionDescriptor.getName(), mseDefinitionDescriptor.getResourceType());
+        ResourceInfo resourceInfo = new ResourceInfo(customNameOfResource, applicationName, moduleName);
+
+        ConcurrentRuntime concurrentRuntime = ConcurrentRuntime.getRuntime();
+        ManagedScheduledExecutorServiceImpl managedScheduledExecutorService = concurrentRuntime.createManagedScheduledExecutorService(resourceInfo, mseConfig, contextService);
+        resourceNamingService.publishObject(resourceInfo, customNameOfResource, managedScheduledExecutorService, true);
     }
 
     @Override


### PR DESCRIPTION
## Description
Correct storage in JDNI for managed thread factory and scheduled executor, which missed the correct behavior

## Testing
### Testing Performed
Current tests (with fixes in RI and TCK) results:
Tests run: 172, Failures: 23, Errors: 0, Skipped: 14

### Testing Environment
Linux, OpenJDK
