### PR TITLE
Fish 6216 managedthreadfactory jndi lookup

### DIFF
--- a/appserver/common/container-common/src/main/java/org/glassfish/javaee/services/CommonResourceProxy.java
+++ b/appserver/common/container-common/src/main/java/org/glassfish/javaee/services/CommonResourceProxy.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 package org.glassfish.javaee.services;
 
 import com.sun.appserv.connectors.internal.api.ConnectorsUtil;

--- a/appserver/common/container-common/src/main/java/org/glassfish/javaee/services/CommonResourceProxy.java
+++ b/appserver/common/container-common/src/main/java/org/glassfish/javaee/services/CommonResourceProxy.java
@@ -95,7 +95,11 @@ public class CommonResourceProxy implements NamingObjectProxy.InitializationNami
                 throw ne;
             }
         }
-        return ic.lookup(actualResourceName);
+        Object obj = ic.lookup(actualResourceName);
+        if (obj instanceof JndiLookupNotifier) {
+            ((JndiLookupNotifier) obj).notifyJndiLookup();
+        }
+        return obj;
     }
 
     protected ResourceDeployer getResourceDeployer(Object resource) {

--- a/appserver/common/container-common/src/main/java/org/glassfish/javaee/services/JndiLookupNotifier.java
+++ b/appserver/common/container-common/src/main/java/org/glassfish/javaee/services/JndiLookupNotifier.java
@@ -1,0 +1,53 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.javaee.services;
+
+/**
+ * Notification, that a CommonResourceProxy object was looked up.
+ *
+ * @author Petr Aubrecht <aubrecht@asoftware.cz>
+ */
+public interface JndiLookupNotifier {
+
+    /**
+     * Called when Jndi looked up this object.
+     */
+    void notifyJndiLookup();
+}

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ContextServiceDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ContextServiceDefinitionHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.concurrent.runtime.deployer.deployment.annotation.handlers;
+package org.glassfish.concurrent.runtime.deployment.annotation.handlers;
 
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.deployment.ContextServiceDefinitionDescriptor;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ContextServiceDefinitionListHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ContextServiceDefinitionListHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.concurrent.runtime.deployer.deployment.annotation.handlers;
+package org.glassfish.concurrent.runtime.deployment.annotation.handlers;
 
 import com.sun.enterprise.deployment.annotation.context.ResourceContainerContext;
 import com.sun.enterprise.deployment.annotation.handlers.AbstractResourceHandler;


### PR DESCRIPTION
## Description
Implement thread context saving on jndi lookup for ManagedThreadFactory as required by  TCK test.

We also open discussion to interpret spec, that context saving should happen on process thread -- if succeeded, it will be necessary to revert this commit.

## Testing
### Testing Performed
All TCKs tests in ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.* now pass.

### Testing Environment
Linux, OpenJDK

## Notes for Reviewers
Other part of the changes is in our Concurrency RI fork, branch jakartaee10.