### PR TITLE
Fish 6216 Fix unspecified standard contexts, move the to Remaining

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -202,9 +202,6 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
         }
 
         // TODO: put initialization of providers to better place; caching is a problem due to different classloaders
-//        if (allThreadContextProviders == null) {
-//            synchronized (this) {
-//                if (allThreadContextProviders == null) {
         allThreadContextProviders = new HashMap<>();
         for (ThreadContextProvider service : ServiceLoader.load(jakarta.enterprise.concurrent.spi.ThreadContextProvider.class, Utility.getClassLoader())) {
             String serviceName = service.getThreadContextType();
@@ -221,14 +218,8 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
         verifyProviders(contextPropagate);
         verifyProviders(contextClear);
         verifyProviders(contextUnchanged);
-//                }
-//            }
-//        }
 
         ComponentInvocation currentInvocation = invocationManager.getCurrentInvocation();
-//        if (currentInvocation != null && !contextUnchanged.contains(CONTEXT_TYPE_NAMING)) {
-//            savedInvocation = createComponentInvocation(currentInvocation);
-//        }
         if (currentInvocation != null) {
             if (contextPropagate.contains(CONTEXT_TYPE_NAMING)) {
                 savedInvocation = createComponentInvocation(currentInvocation);
@@ -289,13 +280,6 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
                     }
                 }
             }
-            // TODO - implementation of JNDI clear and unchanged, not working
-//            if (contextClear.contains(CONTEXT_TYPE_NAMING)) {
-//                invocation.setJNDIEnvironment(null);
-//            } else if (contextUnchanged.contains(CONTEXT_TYPE_NAMING)) {
-//                ComponentInvocation currentInvocation = invocationManager.getCurrentInvocation();
-//                invocation.setJNDIEnvironment(currentInvocation == null ? null : currentInvocation.getJNDIEnvironment());
-//            }
         }
 
         // Check whether the application component submitting the task is still running. Throw IllegalStateException if not.

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
 package org.glassfish.api.invocation;
 
 import static java.lang.ThreadLocal.withInitial;
@@ -77,8 +77,7 @@ public class InvocationManagerImpl implements InvocationManager {
 
     private static final Logger LOGGER = Logger.getLogger(InvocationManagerImpl.class.getName());
 
-    private final ThreadLocal<InvocationFrames> framesByThread;
-//    private final InheritableThreadLocal<InvocationFrames> framesByThread;
+    private final InheritableThreadLocal<InvocationFrames> framesByThread;
     private final ThreadLocal<Deque<ApplicationEnvironment>> appEnvironments = withInitial(ArrayDeque::new);
     private final ThreadLocal<Deque<Method>> webServiceMethods = withInitial(ArrayDeque::new);
     private final ConcurrentMap<ComponentInvocationType, ListComponentInvocationHandler> typeHandlers = new ConcurrentHashMap<>();
@@ -100,19 +99,17 @@ public class InvocationManagerImpl implements InvocationManager {
     private InvocationManagerImpl(Iterable<ComponentInvocationHandler> handlers) {
         this.allTypesHandler = initInvocationHandlers(handlers);
 
-//        framesByThread = new InheritableThreadLocal<InvocationFrames>() {
-        framesByThread = new ThreadLocal<InvocationFrames>() {
+        framesByThread = new InheritableThreadLocal<InvocationFrames>() {
 
             @Override
             protected InvocationFrames initialValue() {
                 return new InvocationFrames();
             }
 
-            // comment
-//            @Override
-//            protected InvocationFrames childValue(InvocationFrames parentValue) {
-//                return computeChildTheadInvocation(parentValue);
-//            }
+            @Override
+            protected InvocationFrames childValue(InvocationFrames parentValue) {
+                return computeChildTheadInvocation(parentValue);
+            }
         };
     }
 

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 package org.glassfish.api.invocation;
 
 import static java.lang.ThreadLocal.withInitial;
@@ -77,7 +77,8 @@ public class InvocationManagerImpl implements InvocationManager {
 
     private static final Logger LOGGER = Logger.getLogger(InvocationManagerImpl.class.getName());
 
-    private final InheritableThreadLocal<InvocationFrames> framesByThread;
+    private final ThreadLocal<InvocationFrames> framesByThread;
+//    private final InheritableThreadLocal<InvocationFrames> framesByThread;
     private final ThreadLocal<Deque<ApplicationEnvironment>> appEnvironments = withInitial(ArrayDeque::new);
     private final ThreadLocal<Deque<Method>> webServiceMethods = withInitial(ArrayDeque::new);
     private final ConcurrentMap<ComponentInvocationType, ListComponentInvocationHandler> typeHandlers = new ConcurrentHashMap<>();
@@ -99,17 +100,19 @@ public class InvocationManagerImpl implements InvocationManager {
     private InvocationManagerImpl(Iterable<ComponentInvocationHandler> handlers) {
         this.allTypesHandler = initInvocationHandlers(handlers);
 
-        framesByThread = new InheritableThreadLocal<InvocationFrames>() {
+//        framesByThread = new InheritableThreadLocal<InvocationFrames>() {
+        framesByThread = new ThreadLocal<InvocationFrames>() {
 
             @Override
             protected InvocationFrames initialValue() {
                 return new InvocationFrames();
             }
 
-            @Override
-            protected InvocationFrames childValue(InvocationFrames parentValue) {
-                return computeChildTheadInvocation(parentValue);
-            }
+            // comment
+//            @Override
+//            protected InvocationFrames childValue(InvocationFrames parentValue) {
+//                return computeChildTheadInvocation(parentValue);
+//            }
         };
     }
 


### PR DESCRIPTION
## Description
Fixes handling of standard contexts (Security, Application) when not specified (e.g. when loading from xml file). They are configured to the context given by Remaining. If Remaining is not specified, they go to propagated.

Edit: REVERTED - This change stops inheriting JNDI contexts from calling thread when creating new thread from ManagedExecutorService.

## Testing
### Testing Performed
Currently it decreased number of failing tests from 16 to 11.

### Testing Environment
Linux, OpenJDK

## Notes for Reviewers
Requires current version of wip-payara Referential implementation.
