### PR TITLE
FISH-6216 support context service definition context sets in xml

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ContextServiceDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ContextServiceDefinitionDescriptor.java
@@ -39,6 +39,7 @@
  */
 package com.sun.enterprise.deployment;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import org.glassfish.deployment.common.JavaEEResourceType;
@@ -100,6 +101,13 @@ public class ContextServiceDefinitionDescriptor extends ResourceDescriptor {
         this.cleared = cleared;
     }
 
+    public void addCleared(String clearedItem) {
+        if (cleared == null) {
+            cleared = new HashSet<>();
+        }
+        this.cleared.add(clearedItem);
+    }
+
     public Set<String> getPropagated() {
         return propagated;
     }
@@ -108,12 +116,26 @@ public class ContextServiceDefinitionDescriptor extends ResourceDescriptor {
         this.propagated = propagated;
     }
 
+    public void addPropagated(String propagatedItem) {
+        if (propagated == null) {
+            propagated = new HashSet<>();
+        }
+        this.propagated.add(propagatedItem);
+    }
+
     public Set<String> getUnchanged() {
         return unchanged;
     }
 
     public void setUnchanged(Set<String> unchanged) {
         this.unchanged = unchanged;
+    }
+
+    public void addUnchanged(String unchangedItem) {
+        if (unchanged == null) {
+            unchanged = new HashSet<>();
+        }
+        this.unchanged.add(unchangedItem);
     }
 
     public java.util.Properties getProperties() {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/ContextServiceDefinitionNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/ContextServiceDefinitionNode.java
@@ -55,6 +55,9 @@ public class ContextServiceDefinitionNode extends DeploymentDescriptorNode<Conte
     protected java.util.Map getDispatchTable() {
         java.util.Map table = super.getDispatchTable();
         table.put(TagNames.CONTEXT_SERVICE_NAME, "setName");
+        table.put(TagNames.CONTEXT_SERVICE_PROPAGATED, "addPropagated");
+        table.put(TagNames.CONTEXT_SERVICE_CLEARED, "addCleared");
+        table.put(TagNames.CONTEXT_SERVICE_UNCHANGED, "addUnchanged");
         return table;
     }
 


### PR DESCRIPTION
## Description
Adds methods to load properly context sets from application.xml.

## Testing
### Testing Performed
Last change in Payara sources, all TCK tests run (except broken ones, properly excluded in runner).

### Testing Environment
Linux, OpenJDK

## Notes for Reviewers
Needs update all RI (another changes), API/RI (includes fixes before we properly do the TCK test challenges and exclude them from runner), Runner (few excluded tests).