### PR TITLE
FISH-6260 Fix NoSuchField exception

### DIFF
--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCClassLoader.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCClassLoader.java
@@ -38,6 +38,7 @@
  * holder.
  */
 // Portions Copyright [2019-2022] Payara Foundation and/or affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.appclient.client.acc;
 


### PR DESCRIPTION
## Testing
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Ran Quicklook on JDK 8, 11 and 17

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
Stacktrace is now the following

[testng] ERROR>OpenJDK 64-Bit Server VM warning: Archived non-system classes are disabled because the java.system.class.loader property is specified (value = "org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader"). To use archived non-system classes, this property must not be set
   [testng] ERROR>May 04, 2022 4:07:48 PM org.glassfish.enterprise.iiop.api.GlassFishORBHelper postConstruct
   [testng] ERROR>INFO: GlassFishORBFactory service initialized.
   [testng] ERROR>com.sun.enterprise.container.common.spi.util.InjectionException: Exception attempting to inject Unresolved Message-Destination-Ref MsgBeanQueue@java.lang.String@null into class com.sun.mdb.client.Client: Lookup failed for 'java:comp/env/MsgBeanQueue' in SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.url.pkgs=com.sun.enterprise.naming, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl}
   [testng] ERROR>      at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl._inject(InjectionManagerImpl.java:638)
   [testng] ERROR>      at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl.inject(InjectionManagerImpl.java:439)
   [testng] ERROR>      at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl.injectClass(InjectionManagerImpl.java:199)
   [testng] ERROR>      at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl.injectClass(InjectionManagerImpl.java:195)
   [testng] ERROR>      at org.glassfish.appclient.client.acc.AppClientContainer$ClientMainClassSetting.getClientMainClass(AppClientContainer.java:639)
   [testng] ERROR>      at org.glassfish.appclient.client.acc.AppClientContainer.getMainMethod(AppClientContainer.java:526)
   [testng] ERROR>      at org.glassfish.appclient.client.acc.AppClientContainer.completePreparation(AppClientContainer.java:420)
   [testng] ERROR>      at org.glassfish.appclient.client.acc.AppClientContainer.prepare(AppClientContainer.java:321)
   [testng] ERROR>      at org.glassfish.appclient.client.AppClientFacade.prepareACC(AppClientFacade.java:279)
   [testng] ERROR>      at org.glassfish.appclient.client.acc.agent.AppClientContainerAgent.premain(AppClientContainerAgent.java:83)
   [testng] ERROR>      at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
   [testng] ERROR>      at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
   [testng] ERROR>      at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   [testng] ERROR>      at java.base/java.lang.reflect.Method.invoke(Method.java:568)
   [testng] ERROR>      at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:491)
   [testng] ERROR>      at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:503)
   [testng] ERROR>Caused by: javax.naming.NamingException: Lookup failed for 'java:comp/env/MsgBeanQueue' in SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.url.pkgs=com.sun.enterprise.naming, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl} [Root exception is javax.naming.CommunicationException: Communication exception for SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.url.pkgs=com.sun.enterprise.naming, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl, com.sun.enterprise.naming.logicalName=java:comp/env/MsgBeanQueue} [Root exception is java.lang.NullPointerException: Cannot invoke "com.sun.enterprise.naming.impl.SerialContextProvider.lookup(String)" because "prvdr" is null]]
   [testng] ERROR>      at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:496)
   [testng] ERROR>      at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:442)
   [testng] ERROR>      at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
   [testng] ERROR>      at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl._inject(InjectionManagerImpl.java:561)
   [testng] ERROR>      ... 15 more
   [testng] ERROR>Caused by: javax.naming.CommunicationException: Communication exception for SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.url.pkgs=com.sun.enterprise.naming, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl, com.sun.enterprise.naming.logicalName=java:comp/env/MsgBeanQueue} [Root exception is java.lang.NullPointerException: Cannot invoke "com.sun.enterprise.naming.impl.SerialContextProvider.lookup(String)" because "prvdr" is null]
   [testng] ERROR>      at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:518)
   [testng] ERROR>      at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:442)
   [testng] ERROR>      at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
   [testng] ERROR>      at com.sun.enterprise.naming.util.JndiNamingObjectFactory.create(JndiNamingObjectFactory.java:97)
   [testng] ERROR>      at com.sun.enterprise.naming.impl.GlassfishNamingManagerImpl.lookup(GlassfishNamingManagerImpl.java:770)
   [testng] ERROR>      at com.sun.enterprise.naming.impl.GlassfishNamingManagerImpl.lookup(GlassfishNamingManagerImpl.java:738)
   [testng] ERROR>      at com.sun.enterprise.naming.impl.JavaURLContext.lookup(JavaURLContext.java:159)
   [testng] ERROR>      at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:476)
   [testng] ERROR>      ... 18 more
   [testng] ERROR>Caused by: java.lang.NullPointerException: Cannot invoke "com.sun.enterprise.naming.impl.SerialContextProvider.lookup(String)" because "prvdr" is null
   [testng] ERROR>      at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:483)
   [testng] ERROR>      ... 25 more