### PR TITLE
Fish 1515 - Using new patched grizzly version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
-        <grizzly.version>2.4.4.payara-p7</grizzly.version>
+        <grizzly.version>2.4.4.payara-p8</grizzly.version>
         <jax-rs-api.impl.version>2.1.6</jax-rs-api.impl.version>
         <jersey.version>2.34.payara-p2</jersey.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>


### PR DESCRIPTION
## Description
Patched Grizzly dependency updated to solve timeout HTTP/2 issue.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. mvn clean install -T 3 -DskipTests
2. .\appserver\distributions\payara\target\stage\payara5\bin\asadmin start-domain --verbose
3. Deploy app backend.war (https://payara.atlassian.net/browse/FISH-1515)
4. Poke https://localhost:8181/?wait=31
5. Response: HTTP_200_OK and the message: "OK, waited 31 seconds"

### Testing Environment
Zulu JDK 1.8_312 on Windows 10 with Maven 3.8.4

## Documentation
None