### PR TITLE
Fish 6287 fix ManagedThreadFactory's saving context, around newThread()

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -78,7 +78,6 @@ import org.glassfish.enterprise.concurrent.ManagedExecutorServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.glassfish.enterprise.concurrent.spi.ContextHandle;
-import org.glassfish.javaee.services.JndiLookupNotifier;
 import org.glassfish.resourcebase.resources.naming.ResourceNamingService;
 
 /**
@@ -446,7 +445,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
     /**
      * context loader propagation to threads causes memory leaks on redeploy
      */
-    private static final class ThreadFactoryWrapper extends ManagedThreadFactoryImpl implements JndiLookupNotifier {
+    private static final class ThreadFactoryWrapper extends ManagedThreadFactoryImpl {
         public ThreadFactoryWrapper(String string, ContextServiceImpl contextService, int threadPriority) {
             super(string, contextService, threadPriority);
         }
@@ -461,14 +460,6 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                 Utility.setContextClassLoader(appClassLoader);
             }
         }
-
-        /**
-         * Save current thread context when MTF was looked up in JNDI.
-         */
-        public void notifyJndiLookup() {
-            savedContextHandleForSetup = (contextSetupProvider == null) ? null : contextSetupProvider.saveContext(contextService);
-        }
-
     }
 
     @Override

--- a/appserver/packager/external/jakarta-ee9-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee9-shim/pom.xml
@@ -124,7 +124,7 @@
                                     jakarta.servlet.jsp.tagext;version="3.0.99";shim="true",
                                     <!-- EL -->
                                     jakarta.el;version="4.0.99";shim="true",
-                                    <!-- CDI. enable after upgrade -->
+                                    <!-- CDI. after upgrade change to 3.0.99 -->
                                     jakarta.decorator;
                                     jakarta.enterprise.context;
                                     jakarta.enterprise.context.control;
@@ -135,7 +135,7 @@
                                     jakarta.enterprise.inject.se;
                                     jakarta.enterprise.inject.spi;
                                     jakarta.enterprise.inject.spi.configurator;
-                                    jakarta.enterprise.util;version="3.0.99";shim="true"
+                                    jakarta.enterprise.util;version="4.0.99";shim="true"
 
                                     <!-- Minimal version of shim for MP 5.0. -->
                                     <!-- TODO: This is only thing that should remain in final release -->

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <h2db.version>1.4.200</h2db.version>
         <websocket-api.version>2.0.0</websocket-api.version>
-        <concurrent-api.version>3.0.0-SNAPSHOT</concurrent-api.version>
+        <concurrent-api.version>3.0.0</concurrent-api.version>
         <concurrent.version>3.0.0-SNAPSHOT</concurrent.version>
         <asm.version>9.2</asm.version>
         <monitoring-console-api.version>2.0.1</monitoring-console-api.version>


### PR DESCRIPTION
## Description
Mainly reverted the behavior with storing thread context in ManagedThreadFactory during jndi lookup, it is stored at the beginning of newThread() as it always did. The TCK test will be challenged.

Other changes just fix running in current Payara6 branch.

## Testing
### Testing Performed
TCKs, failing tests:

**ee.jakarta.tck.concurrent.spec.ManagedThreadFactory.resourcedef.ManagedThreadFactoryDefinitionTests**
* testManagedThreadFactoryDefinitionAllAttributes
* testManagedThreadFactoryDefinitionAllAttributesEJB
* testParallelStreamBackedByManagedThreadFactory
* testParallelStreamBackedByManagedThreadFactoryEJB

**ee.jakarta.tck.concurrent.spec.Platform.dd.DeploymentDescriptorTests**
* testDeploymentDescriptorDefinesManagedThreadFactory

### Testing Environment
Linux, OpenJDK 11
