### PR TITLE
FISH-6007 Upgrade Exousia to 2.1.0-M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <jakarta.security.enterprise.version>2.0.1</jakarta.security.enterprise.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>
         <jakarta.security.auth.message-api.version>2.0.0</jakarta.security.auth.message-api.version>
-        <exousia.version>1.0.1</exousia.version>
+        <exousia.version>2.1.0-M2</exousia.version>
         <jms-api.version>3.1.0</jms-api.version>
         <mq.version>6.1.0.payara-p2</mq.version>
         <jakarta.batch-api.version>2.1.0-M1</jakarta.batch-api.version>


### PR DESCRIPTION
## Description
This PR upgrades Exousia to 2.1.0-M2 and depends on the following PRs:
[WASP version upgrade to 3.1.0-M4](https://github.com/payara/Payara/pull/5748)
[Jakarta Standard Tag Library version upgrade to 3.0](https://github.com/payara/Payara/pull/5756)
[Jakarta Authorization 2.1 TCK Runner](https://github.com/aubi/jakartaee-10-tck-runners/pull/3)

## Testing
### Testing Performed
````
Completed running 34 tests.
Number of Tests Passed      = 34
Number of Tests Failed      = 0
Number of Tests with Errors = 0
````

