### PR TITLE
FISH-6310 Reimplement J2EEInstanceListener as a Valve

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -234,8 +234,6 @@ public class WebModule extends PwcWebModule implements Context {
     public WebModule(ServiceLocator services) {
         super();
         this.services = services;
-        webModuleValve = new WebModuleValve(this);
-        getPipeline().addValve(webModuleValve);
     }
 
 
@@ -472,6 +470,16 @@ public class WebModule extends PwcWebModule implements Context {
         } else {
             super.setRealm(realm);
         }
+    }
+
+    @Override
+    public synchronized void initInternal() throws LifecycleException {
+        super.initInternal();
+
+        // Add our valve here instead of during construction, since we may want to perform lookup using the
+        // ServiceLocator obtained from the ServerContext, which would be null during construction
+        webModuleValve = new WebModuleValve(this);
+        getPipeline().addValve(webModuleValve);
     }
 
     /**

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -62,6 +62,7 @@ import com.sun.enterprise.web.session.PersistenceType;
 import com.sun.enterprise.web.session.SessionCookieConfig;
 import com.sun.web.security.RealmAdapter;
 import fish.payara.jacc.JaccConfigurationFactory;
+import fish.payara.web.WebModuleValve;
 import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContextException;
 import jakarta.servlet.Filter;
@@ -82,7 +83,6 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Realm;
 import org.apache.catalina.Valve;
-import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.servlets.DefaultServlet;
 import org.apache.jasper.servlet.JspServlet;
 import org.apache.tomcat.util.descriptor.web.FilterMap;
@@ -216,6 +216,8 @@ public class WebModule extends PwcWebModule implements Context {
 
     private final ServiceLocator services;
 
+    private WebModuleValve webModuleValve;
+
     // Originally from forked StandardContext
     protected boolean directoryDeployed = false;
 
@@ -232,6 +234,8 @@ public class WebModule extends PwcWebModule implements Context {
     public WebModule(ServiceLocator services) {
         super();
         this.services = services;
+        webModuleValve = new WebModuleValve(this);
+        getPipeline().addValve(webModuleValve);
     }
 
 

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
@@ -301,6 +301,14 @@ public class WebModuleValve extends ValveBase {
         }
     }
 
+    /**
+     * Retrieves the {@link AppServSecurityContext} service and sets the security context with the given
+     * {@link Principal}.
+     *
+     * @param principal The {@link Principal} to set the security context with.
+     * @throws IllegalStateException if a {@link ServerContext} to get a {@link ServiceLocator} from
+     *                               could not be obtained from the {@link WebModule} this valve is attached to.
+     */
     private void setSecurityContextWithPrincipal(Principal principal) throws IllegalStateException {
         ServerContext serverContext = getServerContext();
 
@@ -319,14 +327,22 @@ public class WebModuleValve extends ValveBase {
         }
     }
 
-    private void checkObjectForDoAsPermission(final Object o) throws AccessControlException {
+    /**
+     * Check that the "doAsPrivileged" permission is granted for the given {@link Object}
+     *
+     * @param object the {@link Object} to check the "doAsPrivileged" permission is granted for
+     * @throws AccessControlException if the {@link Object} does not have the "doAsPrivileged" permission granted
+     */
+    private void checkObjectForDoAsPermission(final Object object) throws AccessControlException {
         if (System.getSecurityManager() != null) {
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                ProtectionDomain protectionDomain = o.getClass().getProtectionDomain();
-                Policy policy = Policy.getPolicy(); if (!policy.implies(protectionDomain, doAsPrivilegedPerm)) {
+                ProtectionDomain protectionDomain = object.getClass().getProtectionDomain();
+                Policy policy = Policy.getPolicy();
+                if (!policy.implies(protectionDomain, doAsPrivilegedPerm)) {
                     throw new AccessControlException("permission required to override getUserPrincipal",
                             doAsPrivilegedPerm);
-                } return null;
+                }
+                return null;
             });
         }
     }

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
@@ -1,0 +1,266 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2016 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+// Portions Copyright 2021-2022 Payara Foundation and/or its affiliates
+
+package fish.payara.web;
+
+import com.sun.enterprise.container.common.spi.util.InjectionManager;
+import com.sun.enterprise.security.integration.AppServSecurityContext;
+import com.sun.enterprise.security.integration.SecurityConstants;
+import com.sun.enterprise.transaction.api.JavaEETransactionManager;
+import com.sun.enterprise.web.WebComponentInvocation;
+import com.sun.enterprise.web.WebModule;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.catalina.Container;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Realm;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.core.StandardWrapper;
+import org.apache.catalina.valves.ValveBase;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.ServerContext;
+import org.glassfish.web.LogFacade;
+
+import java.io.IOException;
+import java.security.AccessControlException;
+import java.security.AccessController;
+import java.security.Policy;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Reimplementation of the J2EEInstanceListener class (see Payara 5.x sources) which previously handled the
+ * INIT, DESTROY, SERVICE, and FILTER events that got fired by Tomcat during request processing.
+ *
+ * Specifically this class looks to associate servlet requests with the Payara TransactionManager, link up the
+ * Tomcat Catalina Realm with the {@link AppServSecurityContext}, and ensure managed objects are destroyed in Weld.
+ */
+public class WebModuleValve extends ValveBase {
+
+    private static final Logger LOGGER = LogFacade.getLogger();
+    private static final ResourceBundle RESOURCE_BUNDLE = LOGGER.getResourceBundle();
+
+    private static final javax.security.auth.AuthPermission doAsPrivilegedPerm =
+            new javax.security.auth.AuthPermission("doAsPrivileged");
+
+    @Inject
+    private InvocationManager invocationManager;
+
+    @Inject
+    private JavaEETransactionManager transactionManager;
+
+    @Inject
+    private InjectionManager injectionManager;
+
+    private WebModule webModule;
+
+    public WebModuleValve() {
+        this(null);
+    }
+
+    public WebModuleValve(WebModule webModule) {
+        super(true);
+        this.webModule = webModule;
+    }
+
+    @Override
+    protected void initInternal() throws LifecycleException {
+        super.initInternal();
+
+        // Backup
+        if (webModule == null) {
+            // The container should be StandardWrapper, whose parent should be WebModule (StandardContext) - if it's not
+            // panic and exit out
+            Container parentContainer = getContainer().getParent();
+            if (parentContainer instanceof WebModule) {
+                webModule = (WebModule) getContainer().getParent();
+            } else {
+                throw new IllegalStateException("Expected parent container of WebModuleValve to be WebModule but was " +
+                        parentContainer.getClass().getName());
+            }
+        }
+
+        // Look up and services if they haven't been injected
+        if (invocationManager == null || injectionManager == null || transactionManager == null) {
+            ServerContext serverContext = getServerContext();
+            ServiceLocator services = serverContext.getDefaultServices();
+            invocationManager = services.getService(InvocationManager.class);
+            transactionManager = getJavaEETransactionManager(services);
+            injectionManager = services.getService(InjectionManager.class);
+        }
+    }
+
+    private ServerContext getServerContext() throws IllegalStateException {
+        ServerContext serverContext = webModule.getServerContext();
+        if (serverContext == null) {
+            String msg = RESOURCE_BUNDLE.getString(LogFacade.NO_SERVER_CONTEXT);
+            msg = MessageFormat.format(msg, webModule.getName());
+            throw new IllegalStateException(msg);
+        }
+
+        return serverContext;
+    }
+
+    private JavaEETransactionManager getJavaEETransactionManager(ServiceLocator services) {
+        JavaEETransactionManager tm = null;
+        ServiceHandle<JavaEETransactionManager> inhabitant = services.getServiceHandle(JavaEETransactionManager.class);
+        if (inhabitant != null && inhabitant.isActive()) {
+            tm = inhabitant.getService();
+        }
+
+        return tm;
+    }
+
+    @Override
+    public void invoke(Request request, Response response) throws IOException, ServletException {
+        beforeEvents(request);
+        try {
+            getNext().invoke(request, response);
+        } finally {
+            afterEvents(request, response);
+        }
+    }
+
+    private void beforeEvents(Request request) {
+        Realm realm = webModule.getRealm();
+        if (realm != null) {
+            HttpServletRequest httpServletRequest = request.getRequest();
+            HttpServletRequest baseHttpServletRequest = httpServletRequest;
+            Principal userPrincipal = httpServletRequest.getUserPrincipal();
+            Principal basePrincipal = userPrincipal;
+
+            while (userPrincipal != null) {
+                if (baseHttpServletRequest instanceof ServletRequestWrapper) {
+                    // Unwrap any wrappers to find the base object
+                    ServletRequest servletRequest = ((ServletRequestWrapper) baseHttpServletRequest).getRequest();
+
+                    if (servletRequest instanceof HttpServletRequest) {
+                        baseHttpServletRequest = (HttpServletRequest) servletRequest;
+                        continue;
+                    }
+                }
+
+                basePrincipal = baseHttpServletRequest.getUserPrincipal();
+
+                break;
+            }
+
+            if (userPrincipal != null && userPrincipal == basePrincipal && userPrincipal.getClass().getName()
+                    .equals(SecurityConstants.WEB_PRINCIPAL_CLASS)) {
+                setSecurityContextWithPrincipal(userPrincipal);
+            } else if (userPrincipal != basePrincipal) {
+                // The wrapper has overridden getUserPrincipal reject the request if the wrapper does not have
+                // the necessary permission.
+                checkObjectForDoAsPermission(httpServletRequest);
+                setSecurityContextWithPrincipal(userPrincipal);
+            }
+        }
+
+        // The container should be StandardWrapper, from which we can get the Servlet instance
+        StandardWrapper standardWrapper = (StandardWrapper) getContainer();
+        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(webModule,
+                standardWrapper.getServlet());
+        try {
+            invocationManager.preInvoke(webComponentInvocation);
+
+            // Emit monitoring probe event
+            webModule.beforeServiceEvent(standardWrapper.getName());
+
+            // Enlist resources with TransactionManager for service method
+            if (transactionManager != null) {
+                transactionManager.enlistComponentResources();
+            }
+        } catch (Exception ex) {
+            invocationManager.postInvoke(webComponentInvocation); // See CR 6920895
+            String msg = RESOURCE_BUNDLE.getString(LogFacade.EXCEPTION_DURING_VALVE_EVENT);
+            msg = MessageFormat.format(msg, webModule);
+            throw new RuntimeException(msg, ex);
+        }
+    }
+
+    private void setSecurityContextWithPrincipal(Principal principal) throws IllegalStateException {
+        ServerContext serverContext = getServerContext();
+
+        AppServSecurityContext securityContext = serverContext.getDefaultServices().getService(
+                AppServSecurityContext.class);
+        if (securityContext != null) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, LogFacade.SECURITY_CONTEXT_OBTAINED, securityContext);
+            }
+
+            securityContext.setSecurityContextWithPrincipal(principal);
+        } else {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, LogFacade.SECURITY_CONTEXT_FAILED);
+            }
+        }
+    }
+
+
+
+    private void checkObjectForDoAsPermission(final Object o) throws AccessControlException {
+        if (System.getSecurityManager() != null) {
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                ProtectionDomain protectionDomain = o.getClass().getProtectionDomain();
+                Policy policy = Policy.getPolicy(); if (!policy.implies(protectionDomain, doAsPrivilegedPerm)) {
+                    throw new AccessControlException("permission required to override getUserPrincipal",
+                            doAsPrivilegedPerm);
+                } return null;
+            });
+        }
+    }
+
+    private void afterEvents(Request request, Response response) {
+
+    }
+
+}

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
@@ -132,7 +132,7 @@ public class WebModuleValve extends ValveBase {
             }
         }
 
-        // Look up and services if they haven't been injected
+        // Look up services using ServiceLocator obtained from ServerContext if they haven't been injected
         if (invocationManager == null || injectionManager == null || transactionManager == null) {
             ServerContext serverContext = getServerContext();
             ServiceLocator services = serverContext.getDefaultServices();

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/LogFacade.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/LogFacade.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.web;
 
@@ -1572,7 +1572,7 @@ public class LogFacade {
     public static final String EXCEPTION_CREATING_CATALINA_CONFIG_FILE_ABSOLUTE_URL = PREFIX + "00289";
 
     @LogMessageInfo(
-            message = "Exception during processing of valve for web module {1}",
+            message = "Exception during processing of valve for web module {0}",
             level = "SEVERE",
             cause = "An exception occurred during processing valve",
             action = "Check the exception for the error")

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/LogFacade.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/LogFacade.java
@@ -1570,4 +1570,11 @@ public class LogFacade {
             cause = "An exception occurred during creation of absolute URL of Catalina config file {0}",
             action = "Check the Exception for error")
     public static final String EXCEPTION_CREATING_CATALINA_CONFIG_FILE_ABSOLUTE_URL = PREFIX + "00289";
+
+    @LogMessageInfo(
+            message = "Exception during processing of valve for web module {1}",
+            level = "SEVERE",
+            cause = "An exception occurred during processing valve",
+            action = "Check the exception for the error")
+    public static final String EXCEPTION_DURING_VALVE_EVENT = PREFIX + "00290";
 }


### PR DESCRIPTION
## Description
Reimplements most of the functionality the `J2EEInstanceListener` class used to, namely:
* Creating a `WebComponentInvocation` for the request
* Creating a transaction around the request in the `JavaEETransactionManager` and clearing up after it has been serviced
* Setting the `AppServSecurityContext` with the `Principal` obtained from the `Request` and clearing up after it has been serviced

Potentially important reimplementation details:
* As a `Valve` instead of an `InstanceListener`, we're no longer doing all of the above for each "sub-invocation" of the request (before & after each `Filter#doFilter`, before & after each `Servlet#service`, etc.).
* I've dropped the check for the `getUnwrappedCoyoteRequest` if the `Request` is a subclass of `RequestFacade`. I didn't find any case where this would be the case (unless I was being blind), and this permission appears to be undocumented to the point I'm not sure what it was ever doing - I think it's specifically to do with `ProgrammaticLogin` which is a GlassFish feature (it's **not** the programmatic login feature of Servlets - I checked) and the `SecurityManager` is _potentially_ on its way out anyway.
* We probably need to review if we still need the `AppServSecurityContext` stuff or if there's a better way to link this in, though trying to figure that out dry without compiling and running the server probably isn't worth the effort.
* There were some fixes previously put in (by @pdudits) around checking if we were failing out to prevent us calling `InvocationManager#postInvoke(ComponentInvocation)` twice or more - I don't think it's relevant any more since we're not iterating over each `Filter` any more

## Important Info
### Blockers
Nothing on this PR, but obviously the server doesn't compile.

## Testing
### New tests
None

### Testing Performed
None - server doesn't compile on this branch at the moment. When it's running we probably need to run it through the TCK and test the `ProgrammaticLogin` feature with the security manager enabled (potentially using the EJB over HTTP feature?)

### Testing Environment
N/A

## Documentation
N/A

## Notes for Reviewers
See above.
