### PR TITLE
fixe #5761  Bouncy castle fips integration for https connection

### DIFF
--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/JSSE14SocketFactory.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/JSSE14SocketFactory.java
@@ -135,8 +135,6 @@ public class JSSE14SocketFactory extends JSSESocketFactory {
             // START SJSAS 6439313
             context = SSLContext.getInstance(protocol);
             // END SJSAS 6439313 
-            // Configure SSL session timeout and cache size
-            configureSSLSessionContext(context.getServerSessionContext());
             String trustAlgorithm = (String) attributes.get("truststoreAlgorithm");
             if (trustAlgorithm == null) {
                 trustAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
@@ -145,6 +143,8 @@ public class JSSE14SocketFactory extends JSSESocketFactory {
                 (String) attributes.get("keyAlias")),
                 getTrustManagers(trustAlgorithm),
                 new SecureRandom());
+            // Configure SSL session timeout and cache size
+            configureSSLSessionContext(context.getServerSessionContext());
             // create proxy
             sslProxy = context.getServerSocketFactory();
             // Determine which cipher suites to enable


### PR DESCRIPTION
Ticket github:  Enhancement: Bouncy castle fips integration for https connection #5761 

Change the init method in the JSSE14SocketFactory class. With the fix the SslContext is initialized before the call of getServerSessionContext() to avoid an exception from bouncy castle in fips mode.


## Description
Bouncycastle want the sslcontext to be initialized before any use. In the init method of the JSSE14SocketFactory class in payara, a call of getServerSessionContext method is made before any initialization. Today, the call of this method raises an exception when bouncy castle fips is linked to payara as the first java provider. My proposal changes the position of the getServerSessionContext  method to avoid the exception.

## Important Info

To check if this fix is working correctly, the JVM needs to use the bouncy castle java provider in fips mode and the fips JSSE bouncy castle provider.  To do this, i change my java.security to :

security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{ALL}; 
security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
security.provider.3=SUN
security.provider.4=SunRsaSign
security.provider.5=SunEC
security.provider.6=SunJCE
security.provider.7=SunJGSS
security.provider.8=SunSASL
security.provider.9=XMLDSig
security.provider.10=SunPCSC
security.provider.11=JdkLDAP
security.provider.12=JdkSASL

To add the path to the bouncy castle jar, i add the following jvm option in the domain.xml:
<jvm-options>-Xbootclasspath/a:D:\bcfips\bc-fips-1.0.2.3.jar</jvm-options>
<jvm-options>-Xbootclasspath/a:D:\bcfips\bctls-fips-1.0.13.jar</jvm-options>


## Testing

### Testing Performed
To test if the fix work correctly, i run the official payara V5.2022.2 and deploy an application that open an HTTPS server. when a client try to connect to the server in https, an exception is raised < SSL support could not be configured! java.io.IOException: SSLContext has not been initialized>. 
With the same application i try again but with my modification and the server works correctly. 

### Testing Environment

OS: Windows 10
JDK: Openjdk Temurin-11.0.15+10
Maven: 3.8.5
