### PR TITLE
FISH 6082: upgrade jbatch to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,9 +193,9 @@
         <exousia.version>1.0.1</exousia.version>
         <jms-api.version>3.1.0</jms-api.version>
         <mq.version>6.1.0.payara-p2</mq.version>
-        <jakarta.batch-api.version>2.1.0-M1</jakarta.batch-api.version>
-        <com.ibm.jbatch.container.version>2.1.0-M1</com.ibm.jbatch.container.version>
-        <com.ibm.jbatch.spi.version>2.1.0-M1</com.ibm.jbatch.spi.version>
+        <jakarta.batch-api.version>2.1.0</jakarta.batch-api.version>
+        <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>
+        <com.ibm.jbatch.spi.version>2.1.1</com.ibm.jbatch.spi.version>
         <jaxws-api.version>3.0.0</jaxws-api.version>
         <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>
         <webservices.version>3.0.3</webservices.version>


### PR DESCRIPTION
## Description
JBatch implementation upgrade to the latest version, API remains on the latest 2.1.0.

## Testing
### Testing Performed
JBatch TCK 2.1.0 is testing only JBatch 2.1.0, so we will have to wait until platform TCK, which will test everything.

### Testing Environment
QuickLook tests are OK.

