### PR TITLE
FISH-6309 InstanceManager Implementation

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -724,85 +724,6 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
     }
 
     /**
-     * Instantiates and injects the given Servlet class for the given WebModule
-     */
-    <T extends Servlet> T createServletInstance(WebModule module, Class<T> clazz) throws Exception {
-        validateJSR299Scope(clazz);
-        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-
-        try {
-            invocationMgr.preInvoke(webComponentInvocation);
-            return injectionMgr.createManagedObject(clazz);
-        } finally {
-            invocationMgr.postInvoke(webComponentInvocation);
-        }
-    }
-
-    /**
-     * Instantiates and injects the given Filter class for the given WebModule
-     */
-    <T extends Filter> T createFilterInstance(WebModule module, Class<T> clazz) throws Exception {
-        validateJSR299Scope(clazz);
-        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-
-        try {
-            invocationMgr.preInvoke(webComponentInvocation);
-            return injectionMgr.createManagedObject(clazz);
-        } finally {
-            invocationMgr.postInvoke(webComponentInvocation);
-        }
-    }
-
-    /**
-     * Instantiates and injects the given EventListener class for the given WebModule
-     */
-    <T extends java.util.EventListener> T createListenerInstance(WebModule module, Class<T> clazz) throws Exception {
-        validateJSR299Scope(clazz);
-        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-
-        try {
-            invocationMgr.preInvoke(webComponentInvocation);
-            return injectionMgr.createManagedObject(clazz);
-        } finally {
-            invocationMgr.postInvoke(webComponentInvocation);
-        }
-    }
-
-    /**
-     * Instantiates and injects the given HttpUpgradeHandler class for the given WebModule
-     */
-    <T extends HttpUpgradeHandler> T createHttpUpgradeHandlerInstance(WebModule module, Class<T> clazz) throws Exception {
-        validateJSR299Scope(clazz);
-        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-
-        try {
-            invocationMgr.preInvoke(webComponentInvocation);
-            return injectionMgr.createManagedObject(clazz);
-        } finally {
-            invocationMgr.postInvoke(webComponentInvocation);
-        }
-    }
-
-    /**
-     * Instantiates and injects the given tag handler class for the given WebModule
-     *
-     * @param <T>
-     * @param module
-     * @param clazz
-     * @return
-     * @throws java.lang.Exception
-     */
-    public <T extends JspTag> T createTagHandlerInstance(WebModule module, Class<T> clazz) throws Exception {
-        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(module);
-        try {
-            invocationMgr.preInvoke(webComponentInvocation);
-            return injectionMgr.createManagedObject(clazz);
-        } finally {
-            invocationMgr.postInvoke(webComponentInvocation);
-        }
-    }
-
-    /**
      * Use an network-listener subelements and creates a corresponding Tomcat Connector for each.
      *
      * @param listener the NetworkListener config object.
@@ -2760,19 +2681,6 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     public Class<?> loadCommonClass(String className) throws Exception {
         return classLoaderHierarchy.getCommonClassLoader().loadClass(className);
-    }
-
-    /**
-     * According to SRV 15.5.15, Servlets, Filters, Listeners can only be without any scope annotation or are annotated with
-     *
-     * @Dependent scope. All other scopes are invalid and must be rejected.
-     */
-    private void validateJSR299Scope(Class<?> clazz) {
-        if (cdiService != null && cdiService.isCDIScoped(clazz)) {
-            String msg = rb.getString(LogFacade.INVALID_ANNOTATION_SCOPE);
-            msg = MessageFormat.format(msg, clazz.getName());
-            throw new IllegalArgumentException(msg);
-        }
     }
 
     /**

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -62,6 +62,7 @@ import com.sun.enterprise.web.session.PersistenceType;
 import com.sun.enterprise.web.session.SessionCookieConfig;
 import com.sun.web.security.RealmAdapter;
 import fish.payara.jacc.JaccConfigurationFactory;
+import fish.payara.web.WebModuleInstanceManager;
 import fish.payara.web.WebModuleValve;
 import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContextException;
@@ -83,8 +84,11 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Realm;
 import org.apache.catalina.Valve;
+import org.apache.catalina.core.DefaultInstanceManager;
+import org.apache.catalina.deploy.NamingResourcesImpl;
 import org.apache.catalina.servlets.DefaultServlet;
 import org.apache.jasper.servlet.JspServlet;
+import org.apache.tomcat.InstanceManager;
 import org.apache.tomcat.util.descriptor.web.FilterMap;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.embeddable.web.Context;
@@ -234,6 +238,11 @@ public class WebModule extends PwcWebModule implements Context {
     public WebModule(ServiceLocator services) {
         super();
         this.services = services;
+    }
+
+    @Override
+    public InstanceManager createInstanceManager() {
+        return new WebModuleInstanceManager(this);
     }
 
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -1333,33 +1333,6 @@ public class WebModule extends PwcWebModule implements Context {
     }
 
     /*
-     * Commented out for now.
-     * This method previously overrode a helper method in StandardContext, which has now been moved to Application and
-     * utilises private / protected methods in DefaultInstanceManager.
-     *
-     * If we want to maintain our own CDI integration, we may need to reimplement our own InstanceManager.
-     *
-     */
-
-//    /**
-//     * Create an instance of a given class.
-//     *
-//     * @param clazz
-//     *
-//     * @return an instance of the given class
-//     * @throws Exception
-//     */
-//    @Override
-//    public <T extends HttpUpgradeHandler> T createHttpUpgradeHandlerInstance(Class<T> clazz) throws Exception {
-//        if (webContainer != null) {
-//            return webContainer.createHttpUpgradeHandlerInstance(this, clazz);
-//        } else {
-//            return super.createHttpUpgradeHandlerInstance(clazz);
-//        }
-//    }
-
-
-    /*
      * Servlet related probe events
      */
 
@@ -1598,15 +1571,7 @@ public class WebModule extends PwcWebModule implements Context {
         }
 
         try {
-            T servletInstance = webContainer.createServletInstance(this, servletClass);
-            // Despite the method name getInstanceManager().newInstance(Object o) shouldn't actually create a
-            // new instance - it is expected to call through to the DefaultInstanceManager implementation which
-            // expects to be passed an instantiated object to perform annotation processing
-            getInstanceManager().newInstance(servletInstance);
-            return servletInstance;
-        } catch (ServletException servletException) {
-            // Throw without further processing
-            throw servletException;
+            return (T) getInstanceManager().newInstance(servletClass);
         } catch (Exception exception) {
             // Log and rethrow as ServletException
             logger.log(Level.SEVERE, LogFacade.EXCEPTION_CREATING_SERVLET_INSTANCE);
@@ -1646,15 +1611,7 @@ public class WebModule extends PwcWebModule implements Context {
         }
 
         try {
-            T filterInstance = webContainer.createFilterInstance(this, filterClass);
-            // Despite the method name getInstanceManager().newInstance(Object o) shouldn't actually create a
-            // new instance - it is expected to call through to the DefaultInstanceManager implementation which
-            // expects to be passed an instantiated object to perform annotation processing
-            getInstanceManager().newInstance(filterInstance);
-            return filterInstance;
-        } catch (ServletException servletException) {
-            // Throw without further processing
-            throw servletException;
+            return (T) getInstanceManager().newInstance(filterClass);
         } catch (Exception exception) {
             // Log and rethrow as ServletException
             logger.log(Level.SEVERE, LogFacade.EXCEPTION_CREATING_FILTER_INSTANCE);
@@ -1699,15 +1656,7 @@ public class WebModule extends PwcWebModule implements Context {
         }
 
         try {
-            T listenerInstance = webContainer.createListenerInstance(this, listenerClass);
-            // Despite the method name getInstanceManager().newInstance(Object o) shouldn't actually create a
-            // new instance - it is expected to call through to the DefaultInstanceManager implementation which
-            // expects to be passed an instantiated object to perform annotation processing
-            getInstanceManager().newInstance(listenerInstance);
-            return listenerInstance;
-        } catch (ServletException servletException) {
-            // Throw without further processing
-            throw servletException;
+            return (T) getInstanceManager().newInstance(listenerClass);
         } catch (Exception exception) {
             // Log and rethrow as ServletException
             logger.log(Level.SEVERE, LogFacade.EXCEPTION_CREATING_LISTENER_INSTANCE);

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleGlueUtil.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleGlueUtil.java
@@ -1,0 +1,77 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.web;
+
+import com.sun.enterprise.transaction.api.JavaEETransactionManager;
+import com.sun.enterprise.web.WebModule;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.ServerContext;
+import org.glassfish.web.LogFacade;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+import java.util.logging.Logger;
+
+public class WebModuleGlueUtil {
+
+    private static final Logger LOGGER = LogFacade.getLogger();
+    private static final ResourceBundle RESOURCE_BUNDLE = LOGGER.getResourceBundle();
+
+    /**
+     * Look up the {@link ServerContext} from the given {@link WebModule}.
+     *
+     * @param webModule the {@link WebModule} to look up the {@link ServerContext} from
+     * @return the {@link ServerContext} of the given {@link WebModule}.
+     * @throws IllegalStateException if a {@link ServerContext} could not be obtained from the {@link WebModule}
+     */
+    public static ServerContext getServerContext(WebModule webModule) throws IllegalStateException {
+        ServerContext serverContext = webModule.getServerContext();
+        if (serverContext == null) {
+            String message = RESOURCE_BUNDLE.getString(LogFacade.NO_SERVER_CONTEXT);
+            message = MessageFormat.format(message, webModule.getName());
+            throw new IllegalStateException(message);
+        }
+
+        return serverContext;
+    }
+
+}

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleInstanceManager.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleInstanceManager.java
@@ -181,7 +181,7 @@ public class WebModuleInstanceManager implements InstanceManager {
     }
 
     /**
-     * Processes and injects an already instantiated object (typically a programmatic dynamic filter registration)
+     * Processes and injects an already instantiated object.
      *
      * @param object The object to process and inject
      * @throws InvocationTargetException If there's an issue injecting the instance

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleInstanceManager.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleInstanceManager.java
@@ -1,0 +1,212 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.web;
+
+import com.sun.enterprise.container.common.spi.JCDIService;
+import com.sun.enterprise.container.common.spi.util.InjectionException;
+import com.sun.enterprise.container.common.spi.util.InjectionManager;
+import com.sun.enterprise.web.WebComponentInvocation;
+import com.sun.enterprise.web.WebModule;
+import jakarta.servlet.jsp.tagext.JspTag;
+import org.apache.tomcat.InstanceManager;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.ServerContext;
+import org.glassfish.web.LogFacade;
+
+import javax.naming.NamingException;
+import java.lang.reflect.InvocationTargetException;
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Implementation of Tomcat {@link InstanceManager} for use with {@link WebModule}. The
+ * {@link org.apache.catalina.core.DefaultInstanceManager} provided by Catalina would not integrate itself with the
+ * {@link InvocationManager} or {@link InjectionManager} (so would not use Weld as the CDI implementation).
+ */
+public class WebModuleInstanceManager implements InstanceManager {
+
+    private static final Logger LOGGER = LogFacade.getLogger();
+    private static final ResourceBundle RESOURCE_BUNDLE = LOGGER.getResourceBundle();
+
+    private InjectionManager injectionManager;
+
+    private InvocationManager invocationManager;
+
+    private JCDIService jcdiService;
+
+    private WebModule webModule;
+
+    public WebModuleInstanceManager(WebModule webModule) {
+        this.webModule = webModule;
+        initialiseServices();
+    }
+
+    /**
+     * Look up {@link InvocationManager}, {@link com.sun.enterprise.container.common.spi.util.InjectionManager},
+     * and {@link JCDIService} using {@link ServiceLocator} obtained from
+     * {@link ServerContext} if any of them have not already been injected or looked up.
+     *
+     * @throws IllegalStateException if a {@link ServerContext} could not be obtained from the {@link WebModule}
+     */
+    private void initialiseServices() throws IllegalStateException {
+        ServiceLocator services;
+        services = WebModuleGlueUtil.getServerContext(webModule).getDefaultServices();
+
+        if (invocationManager == null) {
+            invocationManager = services.getService(InvocationManager.class);
+        }
+
+        if (injectionManager == null) {
+            injectionManager = services.getService(InjectionManager.class);
+        }
+
+        if (jcdiService == null) {
+            jcdiService = services.getService(JCDIService.class);
+        }
+    }
+
+    @Override
+    public Object newInstance(Class<?> clazz) throws IllegalAccessException, InvocationTargetException, NamingException,
+            InstantiationException, IllegalArgumentException, NoSuchMethodException, SecurityException {
+        return createCdiManagedInstance(clazz);
+    }
+
+    @Override
+    public Object newInstance(String className) throws IllegalAccessException, InvocationTargetException,
+            NamingException, InstantiationException, ClassNotFoundException, IllegalArgumentException,
+            NoSuchMethodException, SecurityException {
+        Class<?> clazz = webModule.getClassLoader().loadClass(className);
+        return newInstance(clazz);
+    }
+
+    @Override
+    public Object newInstance(String className, ClassLoader classLoader) throws IllegalAccessException,
+            InvocationTargetException, NamingException, InstantiationException, ClassNotFoundException,
+            IllegalArgumentException, NoSuchMethodException, SecurityException {
+        Class<?> clazz = classLoader.loadClass(className);
+        return newInstance(clazz);
+    }
+
+    /**
+     * Creates a CDI managed instance of the given class and performs any necessary injections.
+     *
+     * This functionality previously existed under {@link com.sun.enterprise.web.WebContainer}, split over numerous
+     * methods (e.g. createServletInstance).
+     *
+     * @param clazz
+     * @return
+     * @throws IllegalArgumentException
+     * @throws SecurityException
+     * @throws InvocationTargetException
+     */
+    private Object createCdiManagedInstance(Class<?> clazz) throws IllegalArgumentException, SecurityException,
+            InvocationTargetException {
+        validateJSR299Scope(clazz);
+        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(webModule);
+
+        try {
+            invocationManager.preInvoke(webComponentInvocation);
+            return injectionManager.createManagedObject(clazz);
+        } catch (InjectionException injectionException) {
+            LOGGER.log(Level.SEVERE, injectionException.getMessage());
+            throw new InvocationTargetException(injectionException);
+        } finally {
+            invocationManager.postInvoke(webComponentInvocation);
+        }
+    }
+
+    /**
+     * According to SRV 15.5.15, Servlets, Filters, Listeners can only be without any scope annotation or are annotated
+     * with @Dependent scope. All other scopes are invalid and must be rejected.
+     *
+     * This method previously existed under {@link com.sun.enterprise.web.WebContainer}.
+     */
+    private void validateJSR299Scope(Class<?> clazz) {
+        // Don't validate if class extends JspTag
+        if (clazz.isInstance(JspTag.class)) {
+            return;
+        }
+
+        if (jcdiService != null && jcdiService.isCDIScoped(clazz)) {
+            String msg = RESOURCE_BUNDLE.getString(LogFacade.INVALID_ANNOTATION_SCOPE);
+            msg = MessageFormat.format(msg, clazz.getName());
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    @Override
+    public void newInstance(Object object) throws IllegalAccessException, InvocationTargetException, NamingException {
+        processInstantiatedInstance(object);
+    }
+
+    /**
+     * Processes and injects an already instantiated object (typically a programmatic dynamic filter registration)
+     *
+     * @param object The object to process and inject
+     * @throws InvocationTargetException If there's an issue injecting the instance
+     */
+    private void processInstantiatedInstance(Object object) throws InvocationTargetException {
+        validateJSR299Scope(object.getClass());
+        WebComponentInvocation webComponentInvocation = new WebComponentInvocation(webModule);
+
+        try {
+            invocationManager.preInvoke(webComponentInvocation);
+            injectionManager.injectInstance(object);
+        } catch (InjectionException injectionException) {
+            LOGGER.log(Level.SEVERE, injectionException.getMessage());
+            throw new InvocationTargetException(injectionException);
+        } finally {
+            invocationManager.postInvoke(webComponentInvocation);
+        }
+    }
+
+    @Override
+    public void destroyInstance(Object object) throws IllegalAccessException, InvocationTargetException {
+        try {
+            injectionManager.destroyManagedObject(object);
+        } catch (InjectionException injectionException) {
+            LOGGER.log(Level.WARNING, "Could not destroy managed object of class {0}", object.getClass().getName());
+        }
+    }
+}

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleInstanceManager.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleInstanceManager.java
@@ -109,7 +109,7 @@ public class WebModuleInstanceManager implements InstanceManager {
     @Override
     public Object newInstance(Class<?> clazz) throws IllegalAccessException, InvocationTargetException, NamingException,
             InstantiationException, IllegalArgumentException, NoSuchMethodException, SecurityException {
-        return createCdiManagedInstance(clazz);
+        return createManagedInstance(clazz);
     }
 
     @Override
@@ -129,7 +129,7 @@ public class WebModuleInstanceManager implements InstanceManager {
     }
 
     /**
-     * Creates a CDI managed instance of the given class and performs any necessary injections.
+     * Creates a managed instance of the given class and performs any necessary injections.
      *
      * This functionality previously existed under {@link com.sun.enterprise.web.WebContainer}, split over numerous
      * methods (e.g. createServletInstance).
@@ -140,7 +140,7 @@ public class WebModuleInstanceManager implements InstanceManager {
      * @throws SecurityException
      * @throws InvocationTargetException
      */
-    private Object createCdiManagedInstance(Class<?> clazz) throws IllegalArgumentException, SecurityException,
+    private Object createManagedInstance(Class<?> clazz) throws IllegalArgumentException, SecurityException,
             InvocationTargetException {
         validateJSR299Scope(clazz);
         WebComponentInvocation webComponentInvocation = new WebComponentInvocation(webModule);

--- a/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
+++ b/appserver/web/web-glue/src/main/java/fish/payara/web/WebModuleValve.java
@@ -156,7 +156,7 @@ public class WebModuleValve extends ValveBase {
     private void initialiseServices(boolean throwException) throws IllegalStateException {
         ServiceLocator services;
         try {
-            services = getServerContext().getDefaultServices();
+            services = WebModuleGlueUtil.getServerContext(webModule).getDefaultServices();
         } catch (IllegalStateException illegalStateException) {
             if (throwException) {
                 throw illegalStateException;
@@ -181,23 +181,6 @@ public class WebModuleValve extends ValveBase {
         if (invocationManager != null && injectionManager != null && transactionManager != null) {
             servicesInitialised = true;
         }
-    }
-
-    /**
-     * Look up the {@link ServerContext} from the {@link WebModule} this {@link WebModuleValve} is attached to.
-     *
-     * @return the {@link ServerContext} of the {@link WebModule} this {@link WebModuleValve} is attached to.
-     * @throws IllegalStateException if a {@link ServerContext} could not be obtained from the {@link WebModule}
-     */
-    private ServerContext getServerContext() throws IllegalStateException {
-        ServerContext serverContext = webModule.getServerContext();
-        if (serverContext == null) {
-            String msg = RESOURCE_BUNDLE.getString(LogFacade.NO_SERVER_CONTEXT);
-            msg = MessageFormat.format(msg, webModule.getName());
-            throw new IllegalStateException(msg);
-        }
-
-        return serverContext;
     }
 
     /**
@@ -310,7 +293,7 @@ public class WebModuleValve extends ValveBase {
      *                               could not be obtained from the {@link WebModule} this valve is attached to.
      */
     private void setSecurityContextWithPrincipal(Principal principal) throws IllegalStateException {
-        ServerContext serverContext = getServerContext();
+        ServerContext serverContext = WebModuleGlueUtil.getServerContext(webModule);
 
         AppServSecurityContext securityContext = serverContext.getDefaultServices().getService(
                 AppServSecurityContext.class);


### PR DESCRIPTION
## Description
Adds an implementation of the Tomcat Catalina `InstanceManager` to use instead of the `DefaultInstanceManager`, the intent being that we want to retain integration with the Payara `InjectionManager` and `InvocationManager`.

## Important Info
### Blockers
None.

## Testing
### New tests
None

### Testing Performed
Branch doesn't compile so none.

### Testing Environment
N/A

## Documentation
N/A

## Notes for Reviewers
Without the ability to debug it I'm a bit unsure of the behaviour to take with the `newInstance(Object object)` method - when the object has already been instantiated outside of the instance manager. I took inspiration from how the `InjectionManagerimpl#createManagedObject(Object object)` method works when it's not creating a managed bean via `ManagedBeanManagerImpl` and instead creating one via simple `clazz.getConstructor().newInstance()`.


