### PR TITLE
FISH-6203 Upgrade Jakarta Standard Tag Library to 3.0

### DIFF
--- a/appserver/packager/external/jakarta-ee9-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee9-shim/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -108,7 +114,8 @@
                                     jakarta.xml.bind-api,
                                     org.eclipse.persistence.core,
                                     org.eclipse.persistence.moxy,
-                                    jakarta.interceptor-api
+                                    jakarta.interceptor-api,
+                                    jakarta.servlet.jsp.jstl-api
                                 </Require-Bundle>
                                 <!-- Manually specify the shim versions of packages to be exported via this bundle -->
                                 <!-- Note the "shortened" syntax here: For every API the packages are delimited with
@@ -151,7 +158,13 @@
                                     jakarta.enterprise.inject.se;
                                     jakarta.enterprise.inject.spi;
                                     jakarta.enterprise.inject.spi.configurator;
-                                    jakarta.enterprise.util;version="4.0.99";shim="true"
+                                    jakarta.enterprise.util;version="4.0.99";shim="true",
+                                    
+                                    <!-- JSTL -->
+                                    jakarta.servlet.jsp.jstl.core;
+                                    jakarta.servlet.jsp.jstl.tlv;
+                                    jakarta.servlet.jsp.jstl.sql;
+                                    jakarta.servlet.jsp.jstl.fmt;version="2.0.0";shim="true"
 
                                     <!-- Minimal version of shim for MP 5.0. -->
                                     <!-- TODO: This is only thing that should remain in final release -->

--- a/pom.xml
+++ b/pom.xml
@@ -167,8 +167,8 @@
         <jakarta.ejb-api.version>4.0.0</jakarta.ejb-api.version>
         <jsp-api.version>3.1.0</jsp-api.version>
         <jsp-impl.version>3.1.0-M4</jsp-impl.version>
-        <jstl-api.version>2.0.0</jstl-api.version>
-        <jstl-impl.version>2.0.0</jstl-impl.version>
+        <jstl-api.version>3.0.0</jstl-api.version>
+        <jstl-impl.version>3.0.0</jstl-impl.version>
         <jakarta.faces-api.version>3.0.0</jakarta.faces-api.version>
         <mojarra.version>3.0.1</mojarra.version>
         <tyrus.version>2.1.0-M3</tyrus.version>


### PR DESCRIPTION
`Jakarta Tags TCK 3.0.0` Test result :
Number of tests completed:  542 (542 passed, 0 failed, 0 with errors)