### PR TITLE
FISH-6321 EclipseLink 4.0.0-M3

### DIFF
--- a/appserver/packager/external/jakarta-ee9-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee9-shim/pom.xml
@@ -106,8 +106,6 @@
                                     jakarta.servlet.jsp-api,
                                     jakarta.enterprise.cdi-api,
                                     jakarta.xml.bind-api,
-                                    org.eclipse.persistence.core,
-                                    org.eclipse.persistence.moxy,
                                     jakarta.interceptor-api
                                 </Require-Bundle>
                                 <!-- Manually specify the shim versions of packages to be exported via this bundle -->
@@ -132,11 +130,6 @@
                                     jakarta.xml.bind;
                                     jakarta.xml.bind.annotation;
                                     jakarta.xml.bind.annotation.adapters;version="4.0.1";shim="true",
-
-                                    <!-- Eclipselink forward shim (3 exported as 4) -->
-                                    org.eclipse.persistence.internal.core.helper;
-                                    org.eclipse.persistence.jaxb;
-                                    org.eclipse.persistence.jaxb.rs;version="4.0.0";shim=true,
 
                                     <!-- Interceptor forward shim (2.0 -> 2.1) -->
                                     jakarta.interceptor;version="2.1.99";shim=true,

--- a/pom.xml
+++ b/pom.xml
@@ -175,9 +175,9 @@
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <json.bind-api.version>3.0.0</json.bind-api.version>
         <yasson.version>3.0.0-RC1</yasson.version>
-        <jakarta-persistence-api.version>3.1.0-RC2</jakarta-persistence-api.version>
-        <eclipselink.version>3.1.0-M1.payara-p1</eclipselink.version>
-        <eclipselink.asm.verison>9.1.1</eclipselink.asm.verison>
+        <jakarta-persistence-api.version>3.1.0</jakarta-persistence-api.version>
+        <eclipselink.version>4.0.0-M3.payara-p1</eclipselink.version>
+        <eclipselink.asm.verison>9.3.0</eclipselink.asm.verison>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
         <jakarta.interceptor-api.version>2.0.0</jakarta.interceptor-api.version>
         <jakarta.inject.version>2.0.0</jakarta.inject.version>


### PR DESCRIPTION
## Description
Updates Eclipselink to 4.0.0-M3.payara-p1 (4.0.0-M3 with out previous patches reapplied).

Also updates Eclipselink ASM to 9.3, since at least 9.2 is required.

Also removes the eclipselink gubbins from the shim, since a) no longer required and b) it causes errors if they're left in.

## Important Info
### Blockers
This requires https://github.com/payara/Payara/pull/5760, specifically the XML Binding upgrade bit of it.
Requires release of https://github.com/payara/patched-src-eclipselink/tree/eclipselink-4.0.0-M3.payara-maintenance

## Testing
### New tests
None

### Testing Performed
_**Testing done resolving conflicts: 91597739b**_

Pulled in the Metro upgrade, built server, started server, loaded admin console - no explosions other than the warning already mentioned on the Metro upgrade of `webservices-osgi` not finding a class.

Pulled in the Metro upgrade, built server, ran through _Payara6_ branch of EE7 samples - passed

### Testing Environment
Windows 10, Zulu JDK 11
WSL OpenSUSE 15.3, Zulu JDK 11

## Documentation
N/A

## Notes for Reviewers
This won't pass Jenkins test please until Eclipselink is built & deployed, and the metro upgrade is merged (at which point this might need rebasing on top or merging in HEAD of _Payara6_).

I have published a 4.0.0-M3.payara-p1-SNAPSHOT to https://nexus.payara.fish/#browse/browse:payara-snapshots if local testing is desired.