### PR TITLE
Stabilize MP FT tests

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -60,6 +60,13 @@
                     <target>${javase.version}</target>
                 </configuration>
             </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <rerunFailingTestsCount>3</rerunFailingTestsCount>
+                    </configuration>
+                </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadMetricTckTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadMetricTckTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadMetricTckTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadMetricTckTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.concurrent.Future;
 
+import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.metrics.Counter;
@@ -111,7 +112,7 @@ public class BulkheadMetricTckTest extends AbstractMetricTest {
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         // time spent during initialization of , it needs to be added to the expected time
-        long initTime = (System.nanoTime() - beforeInitTimestamp) / 1_000_000; // from nano to milli
+        long initTime = TimeUnit.NANOSECONDS.toMillis((System.nanoTime() - beforeInitTimestamp));
         waitUntilPermitsAquired(2, 0);
 
         assertFurtherThreadThrowsBulkheadException(1);

--- a/appserver/tests/payara-samples/samples/concurrency/src/test/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorRestIT.java
+++ b/appserver/tests/payara-samples/samples/concurrency/src/test/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorRestIT.java
@@ -108,7 +108,7 @@ public class ManagedScheduledExecutorRestIT {
         String[] data = message.split(":");
         if(data[1] != null) {
             int numberOfExecutions = Integer.parseInt(data[1]);
-            assertTrue( numberOfExecutions > 0 && numberOfExecutions <= 3);
+            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Number of execution expected >0 and <=3, was " + numberOfExecutions);
         }
         assertTrue(message.contains("CronTrigger Submitted"));
     }


### PR DESCRIPTION
## Description
Microprofile Fault Tolerance tests rely on exact time measuring, which occasionally fail during build on cloud machines. These changes
* calculate preparation time and add this time to tolerated time error
* repeat the time-sensitive tests 3 times, so they can pass without repeating whole huge build+testing.

## Testing
### Testing Performed
Tested with artificial delays, runs very reliably

### Testing Environment
OpenJDK, Linux
