### PR TITLE
add exclusion of testng from concurrent-api

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -409,6 +409,16 @@
                 <groupId>jakarta.enterprise.concurrent</groupId>
                 <artifactId>jakarta.enterprise.concurrent-api</artifactId>
                 <version>${concurrent-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.testng</groupId>
+                        <artifactId>arquillian-testng-container</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.testng</groupId>
+                        <artifactId>testng</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
 


### PR DESCRIPTION
## Description
Remove testng dependency from concurrent-api in Payara. It was obviously let in compile scope by mistake.