### PR TITLE
FISH-6353 JDK 17 Docker Image

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,6 +58,7 @@
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk8.tag>8u322</docker.jdk8.tag>
         <docker.jdk11.tag>11.0.14.1</docker.jdk11.tag>
+        <docker.jdk17.tag>17.0.2</docker.jdk17.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>
@@ -151,6 +152,12 @@
                                                 <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk11"/>
                                             </filterset>
                                         </copy>
+                                        <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk17">
+                                            <filterset>
+                                                <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk17.tag}"/>
+                                                <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk17"/>
+                                            </filterset>
+                                        </copy>
                                     </tasks>
                                 </configuration>
                             </execution>
@@ -199,6 +206,24 @@
                                         <cleanup>none</cleanup>
                                         <noCache>${docker.noCache}</noCache>
                                         <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
+                                        <assembly>
+                                            <mode>tar</mode>
+                                            <descriptor>assembly.xml</descriptor>
+                                            <tarLongFileMode>gnu</tarLongFileMode>
+                                        </assembly>
+                                    </build>
+                                </image>
+                                <image>
+                                    <name>${docker.payara.repository}</name>
+                                    <build>
+                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                        <filter>@</filter>
+                                        <tags>
+                                            <tag>${docker.payara.tag}-jdk17</tag>
+                                        </tags>
+                                        <cleanup>none</cleanup>
+                                        <noCache>${docker.noCache}</noCache>
+                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk17</dockerFile>
                                         <assembly>
                                             <mode>tar</mode>
                                             <descriptor>assembly.xml</descriptor>


### PR DESCRIPTION
## Description
Adds a JDK 17 Docker image to the build

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the tests under `appserver/extra/docker-images/docker-tests` with the pom edited to run test against JDK 17 images - passed.
Built images, started JDK 17 image, deployed an application - no explosions.

### Testing Environment
WSL OpenSUSE 15.3

## Documentation
https://github.com/payara/Payara-Community-Documentation/pull/312

## Notes for Reviewers
None