### PR TITLE
Fish 6301 "Enable Asadmin Recorder" button is not visible

### DIFF
--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -176,7 +176,6 @@ helpWindowTitle=Help Window
 helpWindowTOC=Table of Contents
 helpWindowIndex=Index
 homeLinkTooltip=Return to Application Home Page
-homePageLinkTooltip=Return to Application HP
 versionTooltip=Display Product Version. (Opens a new window)
 helpWindowTooltip=Help in a new window
 enterpriseLinkTooltip=Visit the online Payara Enterprise description page

--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -176,6 +176,7 @@ helpWindowTitle=Help Window
 helpWindowTOC=Table of Contents
 helpWindowIndex=Index
 homeLinkTooltip=Return to Application Home Page
+homePageLinkTooltip=Return to Application HP
 versionTooltip=Display Product Version. (Opens a new window)
 helpWindowTooltip=Help in a new window
 enterpriseLinkTooltip=Visit the online Payara Enterprise description page

--- a/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
@@ -93,7 +93,7 @@
             </sun:button>
         </sun:panelGroup>
     </facet>
-    <!facet userInfoExtras>
+    <!facet asadminRecorderPanel>
         <sun:panelGroup id="asadminRecorderPanel">
             <sun:button id="enableAsadminRecorderLink" rendered="#{showEnableAsadminRecorderButton}" toolTip="$resource{i18n.enableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.enableAsadminRecorder}"
                         onClick="if (!confirm('$resource{i18n.msg.JS.confirmEnableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">

--- a/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
@@ -59,7 +59,7 @@
 
     <!facet utilityBar>
         <sun:panelGroup id="utilityBar">
-            <sun:hyperlink id="homeLink" toolTip="$resource{i18n.homePageLinkTooltip}" target="_top" text="$resource{i18n.masthead.Home}" url="#{request.contextPath}/common/index.jsf" />
+            <sun:hyperlink id="homeLink" toolTip="$resource{i18n.homeLinkTooltip}" target="_top" text="$resource{i18n.masthead.Home}" url="#{request.contextPath}/common/index.jsf" />
             <sun:hyperlink id="versionLink" toolTip="$resource{i18n.versionTooltip}" text="$resource{i18n.masthead.Version}"
                 onClick="javascript: var versionWin = window.open('#{request.contextPath}/common/version.jsf','VersionWindow','scrollbars,resizable,width=800,height=740,top='+((screen.height - (screen.height/1.618)) - (500/2))+',left='+((screen.width-650)/2) ); versionWin.focus(); return false;" onKeyPress="javascript: return true;" />
             <sun:hyperlink id="enterpriseLink" toolTip="$resource{i18n.enterpriseLinkTooltip}" target="_blank" text="$resource{i18n.masthead.EnterpriseLink}" url="https://www.payara.fish/products/payara-server/" />
@@ -79,6 +79,37 @@
                 setSessionAttribute(key="showEnableAsadminRecorderButton", value="false");
                 setSessionAttribute(key="showDisableAsadminRecorderButton", value="true");
                 gf.restRequest(endpoint="#{sessionScope.REST_URL}/enable-asadmin-recorder" method="POST");
+                redirect("#{request.contextPath}/common/index.jsf");
+                />
+            </sun:button>
+            <sun:button id="disableAsadminRecorderLink" rendered="#{showDisableAsadminRecorderButton}" toolTip="$resource{i18n.disableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.disableAsadminRecorder}"
+                        onClick="if (!confirm('$resource{i18n.msg.JS.confirmDisableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
+                <!command
+                setSessionAttribute(key="showEnableAsadminRecorderButton", value="true");
+                setSessionAttribute(key="showDisableAsadminRecorderButton", value="false");
+                gf.restRequest(endpoint="#{sessionScope.REST_URL}/disable-asadmin-recorder" method="POST");
+                redirect("#{request.contextPath}/common/index.jsf");
+                />
+            </sun:button>
+        </sun:panelGroup>
+    </facet>
+    <!facet userInfoExtras>
+        <sun:panelGroup id="asadminRecorderPanel">
+            <sun:button id="enableAsadminRecorderLink" rendered="#{showEnableAsadminRecorderButton}" toolTip="$resource{i18n.enableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.enableAsadminRecorder}"
+                        onClick="if (!confirm('$resource{i18n.msg.JS.confirmEnableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
+                <!command
+                setSessionAttribute(key="showEnableAsadminRecorderButton", value="false");
+                setSessionAttribute(key="showDisableAsadminRecorderButton", value="true");
+                gf.restRequest(endpoint="#{sessionScope.REST_URL}/enable-asadmin-recorder" method="POST");
+                redirect("#{request.contextPath}/common/index.jsf");
+                />
+            </sun:button>
+            <sun:button id="disableAsadminRecorderLink" rendered="#{showDisableAsadminRecorderButton}" toolTip="$resource{i18n.disableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.disableAsadminRecorder}"
+                        onClick="if (!confirm('$resource{i18n.msg.JS.confirmDisableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
+                <!command
+                setSessionAttribute(key="showEnableAsadminRecorderButton", value="true");
+                setSessionAttribute(key="showDisableAsadminRecorderButton", value="false");
+                gf.restRequest(endpoint="#{sessionScope.REST_URL}/disable-asadmin-recorder" method="POST");
                 redirect("#{request.contextPath}/common/index.jsf");
                 />
             </sun:button>
@@ -102,28 +133,6 @@
             <!afterCreate
                 includeIntegrations(type="org.glassfish.admingui:mastheadStatusArea" root="$this{component}");
             />
-        </sun:panelGroup>
-    </facet>
-    <!facet userInfoExtras>
-        <sun:panelGroup id="asadminRecorderPanel">
-            <sun:button id="enableAsadminRecorderLink" rendered="#{showEnableAsadminRecorderButton}" toolTip="$resource{i18n.enableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.enableAsadminRecorder}"
-                onClick="if (!confirm('$resource{i18n.msg.JS.confirmEnableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
-                    <!command
-                        setSessionAttribute(key="showEnableAsadminRecorderButton", value="false");
-                        setSessionAttribute(key="showDisableAsadminRecorderButton", value="true");
-                        gf.restRequest(endpoint="#{sessionScope.REST_URL}/enable-asadmin-recorder" method="POST");
-                        redirect("#{request.contextPath}/common/index.jsf");
-                    />
-            </sun:button>
-            <sun:button id="disableAsadminRecorderLink" rendered="#{showDisableAsadminRecorderButton}" toolTip="$resource{i18n.disableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.disableAsadminRecorder}"
-                onClick="if (!confirm('$resource{i18n.msg.JS.confirmDisableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
-                    <!command
-                        setSessionAttribute(key="showEnableAsadminRecorderButton", value="true");
-                        setSessionAttribute(key="showDisableAsadminRecorderButton", value="false");
-                        gf.restRequest(endpoint="#{sessionScope.REST_URL}/disable-asadmin-recorder" method="POST");
-                        redirect("#{request.contextPath}/common/index.jsf");
-                    />
-            </sun:button>
         </sun:panelGroup>
     </facet>
 </sun:masthead>

--- a/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
@@ -59,7 +59,7 @@
 
     <!facet utilityBar>
         <sun:panelGroup id="utilityBar">
-            <sun:hyperlink id="homeLink" toolTip="$resource{i18n.homeLinkTooltip}" target="_top" text="$resource{i18n.masthead.Home}" url="#{request.contextPath}/common/index.jsf" />
+            <sun:hyperlink id="homeLink" toolTip="$resource{i18n.homePageLinkTooltip}" target="_top" text="$resource{i18n.masthead.Home}" url="#{request.contextPath}/common/index.jsf" />
             <sun:hyperlink id="versionLink" toolTip="$resource{i18n.versionTooltip}" text="$resource{i18n.masthead.Version}"
                 onClick="javascript: var versionWin = window.open('#{request.contextPath}/common/version.jsf','VersionWindow','scrollbars,resizable,width=800,height=740,top='+((screen.height - (screen.height/1.618)) - (500/2))+',left='+((screen.width-650)/2) ); versionWin.focus(); return false;" onKeyPress="javascript: return true;" />
             <sun:hyperlink id="enterpriseLink" toolTip="$resource{i18n.enterpriseLinkTooltip}" target="_blank" text="$resource{i18n.masthead.EnterpriseLink}" url="https://www.payara.fish/products/payara-server/" />
@@ -71,6 +71,16 @@
                         logout();
                         redirect("#{request.contextPath}/common/index.jsf");
                     />
+            </sun:button>
+
+            <sun:button id="enableAsadminRecorderLink" rendered="#{showEnableAsadminRecorderButton}" toolTip="$resource{i18n.enableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.enableAsadminRecorder}"
+                        onClick="if (!confirm('$resource{i18n.msg.JS.confirmEnableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
+                <!command
+                setSessionAttribute(key="showEnableAsadminRecorderButton", value="false");
+                setSessionAttribute(key="showDisableAsadminRecorderButton", value="true");
+                gf.restRequest(endpoint="#{sessionScope.REST_URL}/enable-asadmin-recorder" method="POST");
+                redirect("#{request.contextPath}/common/index.jsf");
+                />
             </sun:button>
         </sun:panelGroup>
     </facet>

--- a/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
@@ -72,29 +72,6 @@
                         redirect("#{request.contextPath}/common/index.jsf");
                     />
             </sun:button>
-
-            <sun:button id="enableAsadminRecorderLink" rendered="#{showEnableAsadminRecorderButton}" toolTip="$resource{i18n.enableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.enableAsadminRecorder}"
-                        onClick="if (!confirm('$resource{i18n.msg.JS.confirmEnableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
-                <!command
-                setSessionAttribute(key="showEnableAsadminRecorderButton", value="false");
-                setSessionAttribute(key="showDisableAsadminRecorderButton", value="true");
-                gf.restRequest(endpoint="#{sessionScope.REST_URL}/enable-asadmin-recorder" method="POST");
-                redirect("#{request.contextPath}/common/index.jsf");
-                />
-            </sun:button>
-            <sun:button id="disableAsadminRecorderLink" rendered="#{showDisableAsadminRecorderButton}" toolTip="$resource{i18n.disableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.disableAsadminRecorder}"
-                        onClick="if (!confirm('$resource{i18n.msg.JS.confirmDisableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
-                <!command
-                setSessionAttribute(key="showEnableAsadminRecorderButton", value="true");
-                setSessionAttribute(key="showDisableAsadminRecorderButton", value="false");
-                gf.restRequest(endpoint="#{sessionScope.REST_URL}/disable-asadmin-recorder" method="POST");
-                redirect("#{request.contextPath}/common/index.jsf");
-                />
-            </sun:button>
-        </sun:panelGroup>
-    </facet>
-    <!facet asadminRecorderPanel>
-        <sun:panelGroup id="asadminRecorderPanel">
             <sun:button id="enableAsadminRecorderLink" rendered="#{showEnableAsadminRecorderButton}" toolTip="$resource{i18n.enableAsadminRecorderToolTip}" target="_top" text="$resource{i18n.masthead.enableAsadminRecorder}"
                         onClick="if (!confirm('$resource{i18n.msg.JS.confirmEnableAsadminRecorder}')) {return false;} else {this.value='$resource{i18n.button.Processing}';}" onKeyPress="javascript: return true;">
                 <!command


### PR DESCRIPTION
## Description
The "Enable Asadmin Recorder" button is not visible in the header of the Admin Console

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed

1. mvn clean install -DskipTests
2. ./appserver/distributions/payara/target/stage/payara6/bin/asadmin start-domain
3. Open localhost:4848 in a web browser
4. Check if the button appears


### Testing Environment
Zulu JDK 11 on Ubuntu 18.04 with Maven 3.8.4
