### PR TITLE
FISH-6307 Can't collect domain logs from the Admin Console

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2399,8 +2399,8 @@ admingui.ajax = {
         }
 
         // FIXME: These 2 functions (should) only need be replaced after FPR...
-        webui.suntheme.hyperlink.submit = admingui.woodstock.hyperLinkSubmit;
-        webui.suntheme.jumpDropDown.changed = admingui.woodstock.dropDownChanged;
+        // webui.suntheme.hyperlink.submit = admingui.woodstock.hyperLinkSubmit;
+        // webui.suntheme.jumpDropDown.changed = admingui.woodstock.dropDownChanged;
         var contextObj = {};
         admingui.ajax.processElement(contextObj, contentNode, true);
         admingui.ajax.processScripts(contextObj);

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2399,9 +2399,13 @@ admingui.ajax = {
         }
 
         // FIXME: These 2 functions (should) only need be replaced after FPR...
-        // FIXME: The next 2 lines were commented because webui is not recognized and the code breaks with it
-        // webui.suntheme.hyperlink.submit = admingui.woodstock.hyperLinkSubmit;
-        // webui.suntheme.jumpDropDown.changed = admingui.woodstock.dropDownChanged;
+        require(['webui/suntheme/hyperlink'], function (hyperlink) {
+            hyperlink.submit = admingui.woodstock.hyperLinkSubmit;
+        });
+
+        require(['webui/suntheme/jumpDropDown'], function (jumpDropDown) {
+            jumpDropDown.changed = admingui.woodstock.dropDownChanged;
+        });
         var contextObj = {};
         admingui.ajax.processElement(contextObj, contentNode, true);
         admingui.ajax.processScripts(contextObj);

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-/*Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+/*Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 /*
  * Common utility
  */

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2399,6 +2399,7 @@ admingui.ajax = {
         }
 
         // FIXME: These 2 functions (should) only need be replaced after FPR...
+        // FIXME: The next 2 lines were commented because webui is not recognized and the code breaks with it
         // webui.suntheme.hyperlink.submit = admingui.woodstock.hyperLinkSubmit;
         // webui.suntheme.jumpDropDown.changed = admingui.woodstock.dropDownChanged;
         var contextObj = {};


### PR DESCRIPTION
## Description
When the Collect Logs button is clicked, it redirects to a page that doesn’t have the general admin console branding. Even if the Collect Logs button is clicked on the redirected page, nothing happens, and the domain logs are not collected. 

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed

1. mvn clean install -DskipTests
2. ./appserver/distributions/payara/target/stage/payara6/bin/asadmin start-domain
3. Open: localhost:4848
4. Click on Domain in the tree on the left
5. Choose Tab: Domain Logs
6. Click on "Collect Logs" button
7. The download should happens
8. Check if the zip file is correct.

### Testing Environment
Zulu JDK 11 on Ubuntu 18.04 with Maven 3.8.4

## Documentation
None

## Notes for Reviewers
Please clear your browser cache before executing the tests.
