### PR TITLE
Fish 6308 Can't select a different instances when viewing Raw Log

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2684,7 +2684,7 @@ admingui.woodstock = {
 
     dropDownChanged: function(jumpDropdown) {
         if (typeof(jumpDropdown) === "string") {
-            jumpDropdown = webui.suntheme.dropDown.getSelectElement(jumpDropdown);
+            jumpDropdown = webuijsf.suntheme.dropDown.getSelectElement(jumpDropdown);
         }
 
         // Force WS "submitter" flag to true

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2684,8 +2684,7 @@ admingui.woodstock = {
 
     dropDownChanged: function(jumpDropdown) {
         if (typeof(jumpDropdown) === "string") {
-            console.log(jumpDropdown);
-            jumpDropdown = document.getElementById("propertyForm:propertySheetLogResults:propertSectionLogResults:instanceProp:instance"); // webui.suntheme.dropDown.getSelectElement(jumpDropdown);
+            jumpDropdown = document.getElementById(jumpDropdown); // webui.suntheme.dropDown.getSelectElement(jumpDropdown);
         }
 
         // Force WS "submitter" flag to true

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2601,7 +2601,9 @@ admingui.ajax = {
             }
             var src = document.getElementById('execButton');
             if ((src == null) || (typeof(src) === 'undefined')) {
-                alert("'execButton' not found!  Unable to submit JSF2 Ajax Request!");
+                if (args.content !== '') {
+                    alert("'execButton' not found!  Unable to submit JSF2 Ajax Request!");
+                }
             } else {
                 // Don't ping b/c this is from the header and therefor is a ping
                 jsf.ajax.request(src, null,

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2622,12 +2622,10 @@ admingui.ajax = {
     },
 
     getResource: function(path, callback) {
-        if (content) {
-            admingui.ajax.invoke("gf.serveResource", {
-                path: path,
-                content: content
-            }, callback, 1, true);
-        }
+        admingui.ajax.invoke("gf.serveResource", {
+            path: path,
+            content: ''
+        }, callback, 1, true);
     },
 
     /**

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2382,11 +2382,9 @@ admingui.ajax = {
         }
 
         if (!contentNode) {
-            var htmlElement = document.getElementsByTagName("html")[0]
-            htmlElement.innerHTML = result;
-        } else {
-            contentNode.innerHTML = result;
+            contentNode = document.getElementsByTagName("html")[0];
         }
+        contentNode.innerHTML = result;
 
         if (viewState != null) {
             var form = document.getElementById(this.context.formid);

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2622,10 +2622,12 @@ admingui.ajax = {
     },
 
     getResource: function(path, callback) {
-        admingui.ajax.invoke("gf.serveResource", {
-            path:path,
-            content:content
-        }, callback, 1, true);
+        if (content) {
+            admingui.ajax.invoke("gf.serveResource", {
+                path: path,
+                content: content
+            }, callback, 1, true);
+        }
     },
 
     /**

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2684,46 +2684,46 @@ admingui.woodstock = {
 
     dropDownChanged: function(jumpDropdown) {
         if (typeof(jumpDropdown) === "string") {
-            jumpDropdown = document.getElementById(jumpDropdown); // webui.suntheme.dropDown.getSelectElement(jumpDropdown);
+            require(['webui/suntheme/dropDown'], function (dropDown) {
+                jumpDropdown = dropDown.getSelectElement(jumpDropdown);
+
+                // Force WS "submitter" flag to true
+                var submitterFieldId = jumpDropdown.id + "_submitter";
+                var submitterField = document.getElementById(submitterFieldId);
+                if (!submitterField) {
+                    submitterFieldId = jumpDropdown.parentNode.id + "_submitter";
+                    submitterField = document.getElementById(submitterFieldId);
+                    if (!submitterField) {
+                        admingui.util.log("Unable to find dropDown submitter for: "
+                            + jumpDropdown.id);
+                        return false;
+                    }
+                }
+                submitterField.value = "true";
+                require(['webui/suntheme/props'], function (props) {
+                    // FIXME: Not sure why the following is done...
+                    var listItem = jumpDropdown.options;
+                    for (var cntr=0; cntr < listItem.length; ++cntr) {
+                        if (listItem[cntr].className == props.jumpDropDown.optionSeparatorClassName
+                            || listItem[cntr].className == props.jumpDropDown.optionGroupClassName) {
+                            continue;
+                        } else if (listItem[cntr].disabled) {
+                            // Regardless if the option is currently selected or not,
+                            // the disabled option style should be used when the option
+                            // is disabled. So, check for the disabled item first.
+                            // See CR 6317842.
+                            listItem[cntr].className = props.jumpDropDown.optionDisabledClassName;
+                        } else if (listItem[cntr].selected) {
+                            listItem[cntr].className = props.jumpDropDown.optionSelectedClassName;
+                        } else {
+                            listItem[cntr].className = props.jumpDropDown.optionClassName;
+                        }
+                    }
+                    admingui.ajax.postAjaxRequest(jumpDropdown);
+                });
+            });
         }
 
-        // Force WS "submitter" flag to true
-        var submitterFieldId = jumpDropdown.id + "_submitter";
-        var submitterField = document.getElementById(submitterFieldId);
-        if (!submitterField) {
-            submitterFieldId = jumpDropdown.parentNode.id + "_submitter";
-            submitterField = document.getElementById(submitterFieldId);
-            if (!submitterField) {
-                admingui.util.log("Unable to find dropDown submitter for: "
-                    + jumpDropdown.id);
-                return false;
-            }
-        }
-        submitterField.value = "true";
-
-        // FIXME: Not sure why the following is done...
-        /* webui breaks the code
-        var listItem = jumpDropdown.options;
-        for (var cntr=0; cntr < listItem.length; ++cntr) {
-            if (listItem[cntr].className ==
-                webui.suntheme.props.jumpDropDown.optionSeparatorClassName
-                || listItem[cntr].className ==
-                webui.suntheme.props.jumpDropDown.optionGroupClassName) {
-                continue;
-            } else if (listItem[cntr].disabled) {
-                // Regardless if the option is currently selected or not,
-                // the disabled option style should be used when the option
-                // is disabled. So, check for the disabled item first.
-                // See CR 6317842.
-                listItem[cntr].className = webui.suntheme.props.jumpDropDown.optionDisabledClassName;
-            } else if (listItem[cntr].selected) {
-                listItem[cntr].className = webui.suntheme.props.jumpDropDown.optionSelectedClassName;
-            } else {
-                listItem[cntr].className = webui.suntheme.props.jumpDropDown.optionClassName;
-            }
-        }
-         */
-        admingui.ajax.postAjaxRequest(jumpDropdown);
         return false;
     },
 

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2684,7 +2684,7 @@ admingui.woodstock = {
 
     dropDownChanged: function(jumpDropdown) {
         if (typeof(jumpDropdown) === "string") {
-            jumpDropdown = webuijsf.suntheme.dropDown.getSelectElement(jumpDropdown);
+            jumpDropdown = admingui.woodstock.dropDownChanged(jumpDropdown); // webui.suntheme.dropDown.getSelectElement(jumpDropdown);
         }
 
         // Force WS "submitter" flag to true
@@ -2702,6 +2702,7 @@ admingui.woodstock = {
         submitterField.value = "true";
 
         // FIXME: Not sure why the following is done...
+        /* webui breaks the code
         var listItem = jumpDropdown.options;
         for (var cntr=0; cntr < listItem.length; ++cntr) {
             if (listItem[cntr].className ==
@@ -2721,6 +2722,7 @@ admingui.woodstock = {
                 listItem[cntr].className = webui.suntheme.props.jumpDropDown.optionClassName;
             }
         }
+         */
         admingui.ajax.postAjaxRequest(jumpDropdown);
         return false;
     },

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2380,7 +2380,14 @@ admingui.ajax = {
                 }
             }
         }
-        contentNode.innerHTML = result;
+
+        if (!contentNode) {
+            var htmlElement = document.getElementsByTagName("html")[0]
+            htmlElement.innerHTML = result;
+        } else {
+            contentNode.innerHTML = result;
+        }
+
         if (viewState != null) {
             var form = document.getElementById(this.context.formid);
             if (!form) {

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2684,7 +2684,8 @@ admingui.woodstock = {
 
     dropDownChanged: function(jumpDropdown) {
         if (typeof(jumpDropdown) === "string") {
-            jumpDropdown = admingui.woodstock.dropDownChanged(jumpDropdown); // webui.suntheme.dropDown.getSelectElement(jumpDropdown);
+            console.log(jumpDropdown);
+            jumpDropdown = document.getElementById("propertyForm:propertySheetLogResults:propertSectionLogResults:instanceProp:instance"); // webui.suntheme.dropDown.getSelectElement(jumpDropdown);
         }
 
         // Force WS "submitter" flag to true

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
 
 -->
 
@@ -147,7 +147,8 @@
 </ui:event>
 <sun:html id="html2">
 <sun:head id="propertyhead" title="$resource{i18nc.logViewer.PageTitle}" debug="false" parseOnLoad="false">
-    <sun:script url="/resource/common/js/adminjsf.js" />
+	<h:outputScript name="jsf.js" library="jakarta.faces" target="head" />
+	<sun:script url="/resource/common/js/adminjsf.js" />
 </sun:head>
 <sun:body onLoad="javascript: checkHiddenElements(); setFocusTableResults('#{hasResults}');" id="body3">
 <sun:form id="propertyForm">

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
@@ -146,8 +146,8 @@
 
 </ui:event>
 <sun:html id="html2">
-	<h:outputScript name="jsf.js" library="jakarta.faces" target="head" />
 <sun:head id="propertyhead" title="$resource{i18nc.logViewer.PageTitle}" debug="false" parseOnLoad="false">
+	<h:outputScript name="jsf.js" library="jakarta.faces" target="head" />
     <sun:script url="/resource/common/js/adminjsf.js" />
 </sun:head>
 <sun:body onLoad="javascript: checkHiddenElements(); setFocusTableResults('#{hasResults}');" id="body3">

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
@@ -147,7 +147,6 @@
 </ui:event>
 <sun:html id="html2">
 <sun:head id="propertyhead" title="$resource{i18nc.logViewer.PageTitle}" debug="false" parseOnLoad="false">
-	<h:outputScript name="jsf.js" library="jakarta.faces" target="head" />
     <sun:script url="/resource/common/js/adminjsf.js" />
 </sun:head>
 <sun:body onLoad="javascript: checkHiddenElements(); setFocusTableResults('#{hasResults}');" id="body3">

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
@@ -146,6 +146,7 @@
 
 </ui:event>
 <sun:html id="html2">
+	<h:outputScript name="jsf.js" library="jakarta.faces" target="head" />
 <sun:head id="propertyhead" title="$resource{i18nc.logViewer.PageTitle}" debug="false" parseOnLoad="false">
     <sun:script url="/resource/common/js/adminjsf.js" />
 </sun:head>


### PR DESCRIPTION
## Description
The drop-down options to select the different instances in the Raw Log Viewer don’t load the logs of the selected instance. 

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
