### PR TITLE
FISH-6360 Payara Does Not Status Code Set In 'WebApplicationException'

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/valves/ErrorReportValve.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/valves/ErrorReportValve.java
@@ -55,16 +55,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2019-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2022] Payara Foundation and/or affiliates
 
 package org.apache.catalina.valves;
 
 
+import jakarta.ws.rs.WebApplicationException;
 import org.apache.catalina.HttpResponse;
 import org.apache.catalina.LogFacade;
 import org.apache.catalina.Logger;
 import org.apache.catalina.Request;
 import org.apache.catalina.Response;
+import org.apache.catalina.core.StandardWrapper;
 import org.apache.catalina.util.ServerInfo;
 import org.apache.catalina.util.StringManager;
 import org.glassfish.web.util.HtmlEntityEncoder;
@@ -210,14 +212,17 @@ public class ErrorReportValve extends ValveBase {
             }
             // END IT 13858
 
-            /* GlassFish 6386229
-            if (sresponse instanceof HttpServletResponse)
-                ((HttpServletResponse) sresponse).sendError
-                    (HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            */
-            // START GlassFish 6386229
-            sresponse.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            // END GlassFish 6386229
+            // Fix for Core Profile CustomJsonbSerializationIT#testMissingClientSerializationWithCDIProvider test, which
+            // throws a WebApplicationException with a 400 error status while deserialising and expects to get said status
+            int errorCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+            if (throwable instanceof ServletException) {
+                Throwable rootCause = StandardWrapper.getRootCause((ServletException) throwable);
+                if (rootCause instanceof WebApplicationException) {
+                    errorCode = ((WebApplicationException) rootCause).getResponse().getStatus();
+                }
+            }
+
+            sresponse.sendError(errorCode);
         }
 
         response.setSuspended(false);

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <tyrus.version>2.1.0-M3</tyrus.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <json.bind-api.version>3.0.0</json.bind-api.version>
-        <yasson.version>3.0.0-RC1</yasson.version>
+        <yasson.version>3.0.0-RC2</yasson.version>
         <jakarta-persistence-api.version>3.1.0</jakarta-persistence-api.version>
         <eclipselink.version>4.0.0-M3.payara-p1</eclipselink.version>
         <eclipselink.asm.verison>9.3.0</eclipselink.asm.verison>


### PR DESCRIPTION
## Description
Fix for Core Profile TCK test `CustomJsonbSerializationIT.testMissingClientSerializationWithCDIProvider`.
This test throws a `WebApplicationException` with a response status code of 400 (Bad Request) if it fails to deserialize, and the test expects to receive said status code.

There's likely some underlying bugs happening within Jersey / Yasson itself as there are numerous calls to `ResponseWriter#getResponseContext` that fail and throw container exceptions as it tries to map the error (doesn't happen on Jersey 3.0.x), but given that Jersey is deferring the processing of it to the container (Payara) I believe this is the actual fix. There's a couple of other places where the error code is explicitly set to HTTP 500 (e.g. `StandardWrapperValve#exception`) which was done in GlassFish a while ago all as a part of a fix to the same issue, but this is the end point where the final response code is set.

Also includes Yasson RC2 since we should be using it :)

## Important Info
### Blockers
None

## Testing
### New tests
None - tested via Core Profile TCK.

### Testing Performed
Ran Core Profile TCK - passed.

### Testing Environment
Windows 10, JDK 11.

## Documentation
N/A

## Notes for Reviewers
None
