### PR TITLE
SERV-714 Update Documentation Around `prefer-validate-over-recreate` Property

### DIFF
--- a/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-jdbc-connection-pool.html
+++ b/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-jdbc-connection-pool.html
@@ -17,7 +17,7 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-<!-- Portions Copyright [2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2019-2022] [Payara Foundation and/or its affiliates] -->
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
@@ -677,7 +677,7 @@ false.</p>
 <dt class="hdlist1"><code>Prefer-Validate-Over-Recreate</code></dt>
 <dd>
 <p>Specifies whether pool resizer should validate idle connections
-before destroying and recreating them. The default value is true.</p>
+before destroying and recreating them. The default value is false.</p>
 </dd>
 <dt class="hdlist1"><code>time-to-keep-queries-in-minutes</code></dt>
 <dd>

--- a/appserver/jdbc/admin/src/main/manpages/org/glassfish/jdbc/admin/cli/create-jdbc-connection-pool.1
+++ b/appserver/jdbc/admin/src/main/manpages/org/glassfish/jdbc/admin/cli/create-jdbc-connection-pool.1
@@ -490,7 +490,7 @@ OPTIONS
            Prefer-Validate-Over-Recreate
                Specifies whether pool resizer should validate idle connections
                before destroying and recreating them. The default value is
-               true.
+               false.
 
            time-to-keep-queries-in-minutes
                Specifies the number of minutes that will be cached for use in


### PR DESCRIPTION
## Description
The documentation within the admin console (reference docs) and on the admin command currently states that this property defaults to true - it does not, it defaults to false.

## Important Info
### Blockers
N/A

## Testing
### New tests
N/A

### Testing Performed
Tested the help info shows correctly

### Testing Environment
Windows 10, JDK 11, Maven 3.6.3

## Documentation
N/A - This property isn't written in the documentation

## Notes for Reviewers
None
