### PR TITLE
FISH-6081 Upgrade WaSP to 3.1.0-M6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <jaxb-impl.version>4.0.0-M4</jaxb-impl.version>
         <jakarta.ejb-api.version>4.0.0</jakarta.ejb-api.version>
         <jsp-api.version>3.1.0</jsp-api.version>
-        <jsp-impl.version>3.1.0-M4</jsp-impl.version>
+        <jsp-impl.version>3.1.0-M6</jsp-impl.version>
         <jstl-api.version>3.0.0</jstl-api.version>
         <jstl-impl.version>3.0.0</jstl-impl.version>
         <jakarta.faces-api.version>3.0.0</jakarta.faces-api.version>


### PR DESCRIPTION
## Description
Upgrades WaSP to 3.1.0-M6.
Fixes:
* org.jboss.cdi.tck.tests.extensions.lifecycle.processInjectionTarget.ContainerEventTest#testProcessInjectionTargetEventFiredForTagHandler
 * org.jboss.cdi.tck.tests.extensions.lifecycle.processInjectionTarget.ContainerEventTest#testTypeOfProcessInjectionTargetParameter

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built server, ran CDI TCK `org.jboss.cdi.tck.tests.extensions.lifecycle.processInjectionTarget.ContainerEventTest`

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
