### PR TITLE
FISH-5983 Upgrade woodstock-webui-jsf-suntheme to v5.0.0.payara-p1

### DIFF
--- a/appserver/admingui/pom.xml
+++ b/appserver/admingui/pom.xml
@@ -204,7 +204,7 @@
             <dependency>
                 <groupId>org.glassfish.woodstock</groupId>
                 <artifactId>woodstock-webui-jsf-suntheme</artifactId>
-                <version>${woodstock-jsf.version}</version>
+                <version>${woodstock-jsf-suntheme.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -60,5 +60,5 @@
         <parameter-encoding default-charset="UTF-8" />
     </locale-charset-info>
     <class-loader delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock-jsf.version}${enterprise.theme.classifier}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock-jsf.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar:WEB-INF/extra/json-${woodstock-json.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock-jsf-suntheme.version}${enterprise.theme.classifier}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock-jsf.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar:WEB-INF/extra/json-${woodstock-json.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar" />
 </sun-web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <org.apache.santuario.version>2.3.0</org.apache.santuario.version>
         <woodstox.version>6.2.7</woodstox.version>
         <woodstock-jsf.version>5.0.0</woodstock-jsf.version>
+        <woodstock-jsf-suntheme.version>5.0.0.payara-p1</woodstock-jsf-suntheme.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
         <jakarta.enterprise.deploy-api.version>1.7.2</jakarta.enterprise.deploy-api.version>


### PR DESCRIPTION
This PR fixes the Payara Admin Console Branding layout in Payara6
![image](https://user-images.githubusercontent.com/15934072/174295900-417474fb-72e3-4d6b-9e47-04f0c61104c8.png)
![image](https://user-images.githubusercontent.com/15934072/174295835-d71b36a3-e127-4c32-8ed9-447380456ae9.png)



## Depends on:
https://github.com/payara/patched-src-glassfish-woodstock/pull/2
