### PR TITLE
FISH-1336 Properly Shutdown Payara Micro on Ctrl+C

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1708,6 +1708,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             public void run() {
                 try {
                     if (gf != null) {
+                        gf.stop();
                         gf.dispose();
                     }
                 } catch (GlassFishException ex) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Improvement by invoking `gf.stop()` on payara micro shutdown rather than only `gf.dispose()`

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
N/A

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
None

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
+ Run integrations test on [arquillian-connectors](https://github.com/Payara/ecosystem-arquillian-connectors/tree/master)
+ Deploy and run simple servlet application that has servlet destroy method on it to Payara-micro

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows11, Ubuntu 20.04.4 LTS, OpenJDK8, Maven 3.8.4

## Documentation
<!-- Link documentation if a PR exists -->
None

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
None
