### PR TITLE
FISH-6355: disabling trace method from http OPTIONS call

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -89,6 +89,7 @@ import org.glassfish.grizzly.http.util.ByteChunk;
 import org.glassfish.grizzly.http.util.CharChunk;
 import org.glassfish.grizzly.http.util.DataChunk;
 import org.glassfish.grizzly.http.util.MessageBytes;
+import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.web.valve.GlassFishValve;
 import org.glassfish.web.valve.ServletContainerInterceptor;
@@ -549,7 +550,8 @@ public class CoyoteAdapter extends HttpHandler {
         request.setWrapper((Wrapper) request.getMappingData().wrapper);
 
         // Filter trace method
-        if (!connector.getAllowTrace() && Method.TRACE.equals(req.getMethod())) {
+        if (!connector.getAllowTrace() &&
+                (Method.TRACE.equals(req.getMethod()) || Method.OPTIONS.equals(req.getMethod()))) {
             Wrapper wrapper = request.getWrapper();
             String header = null;
             if (wrapper != null) {
@@ -567,10 +569,19 @@ public class CoyoteAdapter extends HttpHandler {
                         }
                     }
                 }
-            }                               
-            res.setStatus(405, "TRACE method is not allowed");
-            res.addHeader("Allow", header);
-            return false;
+            }
+
+            if (Method.TRACE.equals(req.getMethod())) {
+                res.setStatus(405, "TRACE method is not allowed");
+                res.addHeader("Allow", header);
+                return false;
+            }
+
+            if (Method.OPTIONS.equals(req.getMethod())) {
+                res.setStatus(HttpStatus.OK_200);
+                res.addHeader("Allow", header);
+                return false;
+            }
         }
 
         // Possible redirect


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Disabling TRACE method from http OPTIONS call
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for a bug that returns the TRACE method available from an http OPTIONS call when the following property is set to false:

- configs.config.server-config.network-config.protocols.protocol.http-listener-{listener number}.http.trace-enabled

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
