### PR TITLE
FISH-6352 File locks prevent undeployment on Windows

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -3381,8 +3381,8 @@ public class WebappClassLoader
         Map<Class, ?> m = null;
         try {
             m = getBeanELResolverProperties(fld);
-        } catch (IllegalAccessException iae) {
-            logger.log(Level.WARNING, LogFacade.UNABLE_PURGE_BEAN_CLASSES, iae);
+        } catch (Exception ex) {
+            logger.log(Level.WARNING, LogFacade.UNABLE_PURGE_BEAN_CLASSES, ex);
             return;
         }
 


### PR DESCRIPTION
## Description
Undeployment of an application takes a long time on Payara6 on Windows.

## Fix
This issue is caused by the NPE exception thrown in the stop operation of WebappClassloader which results in an uncleaned classloader and locking in Windows.

NPE exception is caused during cleaning the cache of BeanELResolver.properties field via Reflection API which is now changed from static to non-static, and that already fixes the cache issue as per the following ticket details.

[BeanELResolver needs cleanup method · Issue #171 · jakartaee/expression-language](https://github.com/jakartaee/expression-language/issues/171) 
[Fix #171. Make cache per instance rather than per class · jakartaee/expression-language@3ec9258](https://github.com/jakartaee/expression-language/commit/3ec9258dd20ebedb76e1a72a63c69bf71b14775b)

## Testing
### Testing Performed
Java EE 7 Samples

