### PR TITLE
FISH-5980 Add Option to use ForkJoinPool for Managed Executor Service

### DIFF
--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
@@ -84,6 +84,10 @@
        <sun:property id="longrunningtasks"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.longRunningTasks}">
             <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['longRunningTasks']}" selectedValue="true"  />
        </sun:property>
+
+       <sun:property id="useforkjoinpool"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.useforkjoinpool}">
+           <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['useForkJoinPool']}" selectedValue="true"  />
+       </sun:property>
        
        <sun:property id="hungafter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.hungAfterSeconds}"  helpText="$resource{i18ncon.hungAfterSecondsHelp}">
             <sun:textField id="hungafter" styleClass="integer" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['hungAfterSeconds']}" />

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
@@ -63,15 +63,14 @@
 
     gf.buildResourceUrl(base="#{pageSession.parentUrl}/#{pageSession.childType}", resourceName="#{pageSession.Name}", url="#{pageSession.selfUrl}");
     gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
-    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks" });
-    setPageSessionAttribute(key="convertToFalseList2" value={"enabled", "contextInfoEnabled", "useForkJoinPool" });
+    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useForkJoinPool" });
     setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
     
     gf.restRequest(endpoint="#{pageSession.selfUrl}/property" method="GET" result="#{requestScope.propTable}");
     setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.properties}");
     setPageSessionAttribute(key="edit" value="#{true}" );
 
-    setPageSessionAttribute(key="convertToFalseList3" value={"enabled"});
+    setPageSessionAttribute(key="convertToFalseList2" value={"enabled"});
     setPageSessionAttribute(key="showMaxPoolSize" value="#{true}");
     setPageSessionAttribute(key="showTaskQueue" value="#{true}");
     setPageSessionAttribute(key="listCommand" value="list-managed-executor-services");

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
@@ -64,13 +64,14 @@
     gf.buildResourceUrl(base="#{pageSession.parentUrl}/#{pageSession.childType}", resourceName="#{pageSession.Name}", url="#{pageSession.selfUrl}");
     gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
     setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks" });
+    setPageSessionAttribute(key="convertToFalseList2" value={"enabled", "contextInfoEnabled", "useForkJoinPool" });
     setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
     
     gf.restRequest(endpoint="#{pageSession.selfUrl}/property" method="GET" result="#{requestScope.propTable}");
     setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.properties}");
     setPageSessionAttribute(key="edit" value="#{true}" );
 
-    setPageSessionAttribute(key="convertToFalseList2" value={"enabled"});
+    setPageSessionAttribute(key="convertToFalseList3" value={"enabled"});
     setPageSessionAttribute(key="showMaxPoolSize" value="#{true}");
     setPageSessionAttribute(key="showTaskQueue" value="#{true}");
     setPageSessionAttribute(key="listCommand" value="list-managed-executor-services");

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceNew.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceNew.jsf
@@ -55,7 +55,7 @@
         setPageSessionAttribute(key="parentPage" value="#{request.contextPath}/concurrent/managedExecutorServices.jsf");
         setPageSessionAttribute(key="childType" value="managed-executor-service");
         setPageSessionAttribute(key="isConcurrent" value="true");
-        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled","longRunningTasks" });
+        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useForkJoinPool" });
         setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/resources");
         gf.getDefaultValues(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}", valueMap="#{pageSession.valueMap}");
         setPageSessionAttribute(key="edit" value="#{false}" );

--- a/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceEdit.jsf
@@ -63,7 +63,7 @@
 
     gf.buildResourceUrl(base="#{pageSession.parentUrl}/#{pageSession.childType}", resourceName="#{pageSession.Name}", url="#{pageSession.selfUrl}");
     gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
-    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks" });
+    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useForkJoinPool" });
     setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
     
     gf.restRequest(endpoint="#{pageSession.selfUrl}/property" method="GET" result="#{requestScope.propTable}");

--- a/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceNew.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceNew.jsf
@@ -55,7 +55,7 @@
         setPageSessionAttribute(key="parentPage" value="#{request.contextPath}/concurrent/managedScheduledExecutorServices.jsf");
         setPageSessionAttribute(key="childType" value="managed-scheduled-executor-service");
         setPageSessionAttribute(key="isConcurrent" value="true");
-        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks" });
+        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useForkJoinPool" });
         setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/resources");
         gf.getDefaultValues(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}", valueMap="#{pageSession.valueMap}");
         setPageSessionAttribute(key="edit" value="#{false}" );

--- a/appserver/admingui/concurrent/src/main/resources/org/glassfish/concurrent/admingui/Strings.properties
+++ b/appserver/admingui/concurrent/src/main/resources/org/glassfish/concurrent/admingui/Strings.properties
@@ -114,6 +114,7 @@ contextInfoLabelHelp=Container contexts to propagate to other threads. If disabl
 threadPriorityLabel=Thread Priority:
 threadPriorityLabelHelp=Priority to assign to created threads
 longRunningTasks=Long-Running Tasks:
+useforkjoinpool=Use ForkJoinPool:
 longRunningTasksHelp=Use the resource for long-running tasks. If enabled, long-running tasks are not reported as stuck. 
 hungAfterSeconds=Hung After:
 hungAfterSecondsHelp=Number of seconds tasks can execute before they are considered unresponsive

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
@@ -92,6 +92,23 @@ public interface ManagedExecutorServiceBase extends ConfigBeanProxy,
      *              {@link String }
      */
     void setLongRunningTasks(String value) throws PropertyVetoException;
+
+    /**
+     * Gets the value of the useForkJoinPool property.
+     *
+     * @return possible object is
+     *         {@link String }
+     */
+    @Attribute(defaultValue="false", dataType=Boolean.class)
+    String getUseForkJoinPool();
+
+    /**
+     * Sets the value of the useForkJoinPool property.
+     *
+     * @param value allowed object is
+     *              {@link String }
+     */
+    void setUseForkJoinPool(String value) throws PropertyVetoException;
     
     /**
      * Gets the value of the hungAfterSeconds property.

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorServiceBase.java
@@ -77,6 +77,9 @@ public class CreateManagedExecutorServiceBase {
     @Param(name="longrunningtasks", alias="longRunningTasks", defaultValue="false", optional=true)
     protected Boolean longrunningtasks;
 
+    @Param(name="useforkjoinpool", alias="useForkJoinPool", defaultValue="false", optional=true)
+    protected Boolean useforkjoinpool;
+
     @Param(name="hungafterseconds", alias="hungAfterSeconds", defaultValue="0", optional=true)
     protected Integer hungafterseconds;
 
@@ -106,6 +109,8 @@ public class CreateManagedExecutorServiceBase {
             threadpriority.toString());
         attrList.put(ResourceConstants.LONG_RUNNING_TASKS, 
             longrunningtasks.toString());
+        attrList.put(ResourceConstants.USE_FORK_JOIN_POOL,
+            useforkjoinpool.toString());
         attrList.put(ResourceConstants.HUNG_AFTER_SECONDS, 
             hungafterseconds.toString());
         attrList.put(ResourceConstants.CORE_POOL_SIZE, 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
@@ -83,6 +83,7 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
     protected String contextInfoEnabled = Boolean.TRUE.toString();
     protected String contextInfo = CONTEXT_INFO_DEFAULT_VALUE;
     protected String longRunningTasks = Boolean.FALSE.toString();
+    protected String useForkJoinPool = Boolean.FALSE.toString();
     protected String hungAfterSeconds = "0";
     protected String corePoolSize = "0";
     protected String keepAliveSeconds = "60";
@@ -164,6 +165,7 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         contextInfoEnabled = (String) attributes.get(CONTEXT_INFO_ENABLED);
         threadPriority = (String) attributes.get(THREAD_PRIORITY);
         longRunningTasks = (String) attributes.get(LONG_RUNNING_TASKS);
+        useForkJoinPool =  (String) attributes.get(USE_FORK_JOIN_POOL);
         hungAfterSeconds = (String) attributes.get(HUNG_AFTER_SECONDS);
         corePoolSize = (String) attributes.get(CORE_POOL_SIZE);
         keepAliveSeconds = (String) attributes.get(KEEP_ALIVE_SECONDS);
@@ -199,6 +201,7 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         managedExecutorService.setEnabled(enabled);
         //Fix for GLASSFISH-21251
         managedExecutorService.setLongRunningTasks(longRunningTasks);
+        managedExecutorService.setUseForkJoinPool(useForkJoinPool);
         //end of fix GLASSFISH-21251
         if (properties != null) {
             for ( Map.Entry e : properties.entrySet()) {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
@@ -137,9 +137,8 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         return new ResourceStatus(ResourceStatus.SUCCESS, msg);
     }
 
-    protected ResourceStatus isValid(Resources resources, boolean validateResourceRef, String target){
-        ResourceStatus status ;
-
+    protected ResourceStatus isValid(Resources resources, boolean validateResourceRef, String target) {
+        ResourceStatus status;
 
         if (jndiName == null) {
             String msg = localStrings.getLocalString("managed.executor.service.noJndiName", "No JNDI name defined for managed executor service.");

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
@@ -77,17 +77,19 @@ public class ManagedExecutorServiceManager extends ManagedExecutorServiceBaseMan
     }
 
     @Override
-    protected ResourceStatus isValid(Resources resources, boolean validateResourceRef, String target){
-        if (Integer.parseInt(corePoolSize) == 0 &&
-            Integer.parseInt(maximumPoolSize) == 0) {
-            String msg = localStrings.getLocalString("coresize.maxsize.both.zero", "Options corepoolsize and maximumpoolsize cannot both have value 0.");
-            return new ResourceStatus(ResourceStatus.FAILURE, msg);
-        }
+    protected ResourceStatus isValid(Resources resources, boolean validateResourceRef, String target) {
+        if ("false".equals(useForkJoinPool)) {
+            if (Integer.parseInt(corePoolSize) == 0 &&
+                    Integer.parseInt(maximumPoolSize) == 0) {
+                String msg = localStrings.getLocalString("coresize.maxsize.both.zero", "Options corepoolsize and maximumpoolsize cannot both have value 0.");
+                return new ResourceStatus(ResourceStatus.FAILURE, msg);
+            }
 
-        if (Integer.parseInt(corePoolSize) >
-            Integer.parseInt(maximumPoolSize)) {
-            String msg = localStrings.getLocalString("coresize.biggerthan.maxsize", "Option corepoolsize cannot have a bigger value than option maximumpoolsize.");
-            return new ResourceStatus(ResourceStatus.FAILURE, msg);
+            if (Integer.parseInt(corePoolSize) >
+                    Integer.parseInt(maximumPoolSize)) {
+                String msg = localStrings.getLocalString("coresize.biggerthan.maxsize", "Option corepoolsize cannot have a bigger value than option maximumpoolsize.");
+                return new ResourceStatus(ResourceStatus.FAILURE, msg);
+            }
         }
 
         return super.isValid(resources, validateResourceRef, target); 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -196,9 +196,11 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                 managedThreadFactory,
                 config.getHungAfterSeconds() * 1000L, // in millseconds
                 config.isLongRunningTasks(),
+                config.getUseForkJoinPool(),
                 config.getCorePoolSize(),
                 config.getMaximumPoolSize(),
-                config.getKeepAliveSeconds(), TimeUnit.SECONDS,
+                config.getKeepAliveSeconds(),
+                TimeUnit.SECONDS,
                 config.getThreadLifeTimeSeconds(),
                 config.getTaskQueueCapacity(),
                 createContextService(config.getJndiName() + "-contextservice",

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -246,6 +246,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                 managedThreadFactory,
                 config.getHungAfterSeconds() * 1000L, // in millseconds
                 config.isLongRunningTasks(),
+                config.getUseForkJoinPool(),
                 config.getCorePoolSize(),
                 config.getKeepAliveSeconds(), TimeUnit.SECONDS,
                 config.getThreadLifeTimeSeconds(),
@@ -371,6 +372,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
             internalScheduler = new ManagedScheduledExecutorServiceImpl(name,
                     managedThreadFactory,
                     0L,
+                    false,
                     false,
                     1,
                     60, TimeUnit.SECONDS,

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
@@ -49,6 +49,7 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
 
     private int hungAfterSeconds;
     private boolean longRunningTasks;
+    private boolean useForkJoinPool;
     private int threadPriority;
     private int corePoolSize;
     private long keepAliveSeconds;
@@ -60,6 +61,7 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         hungAfterSeconds = parseInt(config.getHungAfterSeconds(), 0);
         longRunningTasks = Boolean.valueOf(config.getLongRunningTasks());
+        useForkJoinPool = Boolean.valueOf(config.getUseForkJoinPool());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
         corePoolSize = parseInt(config.getCorePoolSize(), 0);
         keepAliveSeconds = parseLong(config.getKeepAliveSeconds(), 60);
@@ -98,6 +100,10 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
 
     public long getThreadLifeTimeSeconds() {
         return threadLifeTimeSeconds;
+    }
+    
+    public boolean getUseForkJoinPool() {
+        return useForkJoinPool;
     }
 
     @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
@@ -48,6 +48,7 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
 
     private int hungAfterSeconds;
     private boolean longRunningTasks;
+    private boolean useForkJoinPool;
     private int threadPriority;
     private int corePoolSize;
     private long keepAliveSeconds;
@@ -57,6 +58,7 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         hungAfterSeconds = parseInt(config.getHungAfterSeconds(), 0);
         longRunningTasks = Boolean.valueOf(config.getLongRunningTasks());
+        useForkJoinPool = Boolean.valueOf(config.getUseForkJoinPool());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
         corePoolSize = parseInt(config.getCorePoolSize(), 0);
         keepAliveSeconds = parseLong(config.getKeepAliveSeconds(), 60);
@@ -85,6 +87,10 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
 
     public long getThreadLifeTimeSeconds() {
         return threadLifeTimeSeconds;
+    }
+
+    public boolean getUseForkJoinPool() {
+        return useForkJoinPool;
     }
 
     @Override

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -252,6 +252,7 @@ public final class ResourceConstants {
     public static final String CONTEXT_INFO_ENABLED = "context-info-enabled";
     public static final String THREAD_PRIORITY = "thread-priority";
     public static final String LONG_RUNNING_TASKS = "long-runnings-tasks";
+    public static final String USE_FORK_JOIN_POOL = "use-forkjoinpool";
     public static final String HUNG_AFTER_SECONDS = "hung-after-seconds";
     public static final String CORE_POOL_SIZE = "core-pool-size";
     public static final String MAXIMUM_POOL_SIZE = "maximum-pool-size";

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <h2db.version>1.4.200</h2db.version>
         <websocket-api.version>1.1.2</websocket-api.version>
         <concurrent-api.version>1.1.2</concurrent-api.version>
-        <concurrent.version>1.0.payara-p2</concurrent.version>
+        <concurrent.version>1.0.payara-p3</concurrent.version>
         <asm.version>9.2</asm.version>
         <monitoring-console-api.version>1.2</monitoring-console-api.version>
         <monitoring-console-process.version>1.8.1</monitoring-console-process.version>


### PR DESCRIPTION
## Description
Add --useforkjoinpool option to create-managed-executor-service and create-managed-scheduled-executor-service . When set, the ForkJoinPool is used instead of ThreadPoolExecutor

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed

1. git clone https://github.com/luiseufrasio/patched-src-cu-ri/tree/FISH-5980
2. cd patched-src-cu-ri
3. mvn clean install
4. go to Payara folder
5. mvn clean install -DskipTests
6. run Payara
7. .\appserver\distributions\payara\target\stage\payara5\bin\asadmin create-managed-executor-service --useforkjoinpool
8. Open localhost:4848
9. Check the creation in Resources... Use ForkJoinPool option should be checked

### Testing Environment
Zulu JDK 1.8_212 on Windows 10 with Maven 3.8.4"-->
