### PR TITLE
FISH-6429 Move JDK17 Docker Image Generation into a Separate Profile

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -124,6 +124,7 @@
             <id>generate-docker-images-only-if-dockerfile-exists</id>
             <activation>
                 <file>
+                    <!-- Essentially - Skip this aggregator pom -->
                     <exists>src/main/docker/Dockerfile</exists>
                 </file>
             </activation>
@@ -152,6 +153,89 @@
                                                 <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk11"/>
                                             </filterset>
                                         </copy>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-docker-image</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk8</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                            </build>
+                                        </image>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}-jdk11</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>generate-docker-images-only-if-dockerfile-exists-jdk17</id>
+            <activation>
+                <file>
+                    <!-- Essentially - Skip this aggregator pom -->
+                    <exists>src/main/docker/Dockerfile</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Required until https://github.com/fabric8io/docker-maven-plugin/issues/859 is resolved -->
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>filter-dockerfiles-jdk17</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
                                         <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk17">
                                             <filterset>
                                                 <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk17.tag}"/>
@@ -168,71 +252,35 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>build-docker-image</id>
+                                <id>build-docker-image-jdk17</id>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
                                 <phase>package</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}-jdk17</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk17</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk8</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}-jdk11</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}-jdk17</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk17</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -214,6 +214,7 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Split into a separate profile for when we want to update images for distributions that don't support JDK 17 -->
         <profile>
             <id>generate-jdk17-docker-image</id>
             <activation>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -121,7 +121,7 @@
             </modules>
         </profile>
         <profile>
-            <id>generate-docker-images-only-if-dockerfile-exists</id>
+            <id>generate-docker-images</id>
             <activation>
                 <file>
                     <!-- Essentially - Skip this aggregator pom -->
@@ -215,7 +215,7 @@
             </build>
         </profile>
         <profile>
-            <id>generate-docker-images-only-if-dockerfile-exists-jdk17</id>
+            <id>generate-jdk17-docker-image</id>
             <activation>
                 <file>
                     <!-- Essentially - Skip this aggregator pom -->


### PR DESCRIPTION
## Description
When updating Docker images for older releases of Payara the build will attempt to create a JDK17 image - this won't work for releases older than 5.2021.10.

This splits off the JDK17 image generation into a separate profile and execution, so that it can be disabled via explicitly turning the profile off e.g. `mvn clean install -pl ./appserver/extras/docker-images -amd -PBuildDockerImages,QuickBuild,!generate-jdk17-docker-image -Dpayara.version=5.2021.3`

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* `mvn clean install -pl ./appserver/extras/docker-images -amd -PBuildDockerImages,QuickBuild,!generate-jdk17-docker-image -Dpayara.version=5.2021.3` - build succeeded and jdk8 & 11 images created
* `mvn clean install -pl ./appserver/extras/docker-images -amd -PBuildDockerImages,QuickBuild -Dpayara.version=5.2021.3` - build failed as expected due to trying to create a JDK17 image for a version of the server that doesn't support it
* `mvn clean install -pl ./appserver/extras/docker-images -amd -PBuildDockerImages,QuickBuild -Dpayara.version=5.2022.2` - build passed and jdk8, 11, and 17 images created

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
