### PR TITLE
Revert "FISH-5747 Upgrade Corba to version 4.2.4.payara-p1"

### DIFF
--- a/appserver/common/glassfish-naming/pom.xml
+++ b/appserver/common/glassfish-naming/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2022] Payara Foundation and/or affiliates -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>fish.payara.server.internal.common</groupId>
@@ -102,9 +102,5 @@
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.corba</groupId>
-            <artifactId>glassfish-corba-orb</artifactId>
-        </dependency>
-    </dependencies>
+   </dependencies>
 </project>

--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/GlassfishNamingManagerImpl.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/GlassfishNamingManagerImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2022] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2019] Payara Foundation and/or affiliates
  */
 
 package com.sun.enterprise.naming.impl;
@@ -165,7 +165,7 @@ public final class  GlassfishNamingManagerImpl implements GlassfishNamingManager
             // Now that we have an ORB, initialize the CosNaming service
             // and set it on the server's naming service.
             Hashtable<String, Object> cosNamingEnv = new Hashtable<>();
-            cosNamingEnv.put("java.naming.factory.initial", org.glassfish.jndi.cosnaming.CNCtxFactory.class.getName());
+            cosNamingEnv.put("java.naming.factory.initial", "com.sun.jndi.cosnaming.CNCtxFactory");
             cosNamingEnv.put("java.naming.corba.orb", orb);
             cosContext = new InitialContext(cosNamingEnv);
             ProviderManager pm = ProviderManager.getProviderManager();

--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/util/IIOPObjectFactory.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/util/IIOPObjectFactory.java
@@ -36,9 +36,6 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
- *
- * Portions Copyright [2022] Payara Foundation and/or affiliates
- *
  */
 
 package com.sun.enterprise.naming.util;
@@ -62,7 +59,7 @@ public class IIOPObjectFactory implements ObjectFactory {
                                     Name name,
                                     Context nameCtx,
                                     Hashtable env) throws Exception {
-        env.put("java.naming.factory.initial", org.glassfish.jndi.cosnaming.CNCtxFactory.class.getName());
+        env.put("java.naming.factory.initial", "com.sun.jndi.cosnaming.CNCtxFactory");
 
         InitialContext ic = new InitialContext(env);
 

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/GlassFishORBManager.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/GlassFishORBManager.java
@@ -750,7 +750,7 @@ public final class GlassFishORBManager {
         }
 
         // Make sure we set initial port in System properties so that
-        // any instantiations of org.glassfish.jndi.cosnaming.CNCtxFactory
+        // any instantiations of com.sun.jndi.cosnaming.CNCtxFactory
         // use same port.
         props.setProperty(ORBConstants.INITIAL_PORT_PROPERTY, initialPort);
 

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/RoundRobinPolicy.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/RoundRobinPolicy.java
@@ -37,13 +37,13 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.enterprise.iiop.impl;
 
 import com.sun.corba.ee.spi.folb.ClusterInstanceInfo;
 import com.sun.corba.ee.spi.folb.SocketInfo;
-import org.glassfish.jndi.cosnaming.IiopUrl;
+import com.sun.jndi.cosnaming.IiopUrl;
 import org.glassfish.internal.api.ORBLocator;
 import org.glassfish.logging.annotation.LogMessageInfo;
 

--- a/nucleus/core/extra-jre-packages/pom.xml
+++ b/nucleus/core/extra-jre-packages/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -94,6 +94,7 @@
                                     com.sun.j3d.utils.image,
                                     com.sun.j3d.utils.timer,
                                     com.sun.java.swing.plaf.windows,
+                                    com.sun.jndi.cosnaming,
                                     com.sun.jndi.ldap,
                                     com.sun.mirror.apt,
                                     com.sun.mirror.declaration,

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -123,7 +123,7 @@
         <hk2.plugin.version>2.6.1.payara-p1</hk2.plugin.version>
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
 
-        <glassfish-corba.version>4.2.4.payara-p1</glassfish-corba.version>
+        <glassfish-corba.version>4.1.1.payara-p4</glassfish-corba.version>
         <saaj-api.version>1.4.0</saaj-api.version>
 
         <!-- Library for introspecting types with full generic information including resolving of field and method types. -->


### PR DESCRIPTION
Reverts payara/Payara#5818

Breaks web profile - we need to look at the dependency structure, since it seems the fix adopted elsewhere is to pull full Corba into the web distribution which shouldn't strictly require it.