### PR TITLE
FISH-6373: Shrink shim to minimum required by legacy components

### DIFF
--- a/appserver/packager/external/jakarta-ee9-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee9-shim/pom.xml
@@ -119,17 +119,9 @@
                                 <_fixupmessages>set to different values in the source,JAR is empty</_fixupmessages>
                                 <!-- Add symbolic bundle names of API bundles here -->
                                 <Require-Bundle>
-                                    jakarta.servlet-api,
                                     jakarta.el-api,
-                                    jakarta.servlet.jsp-api,
                                     jakarta.enterprise.cdi-api,
-                                    jakarta.interceptor-api,
-                                    jakarta.xml.bind-api,
-                                    jakarta.security.auth.message-api,
-                                    com.sun.xml.bind.jaxb-osgi,
-                                    jakarta.servlet.jsp.jstl-api,
-                                    jakarta.security.enterprise-api,
-                                    org.glassfish.jakarta.security.enterprise
+                                    jakarta.xml.bind-api
                                 </Require-Bundle>
                                 <!-- Manually specify the shim versions of packages to be exported via this bundle -->
                                 <!-- Note the "shortened" syntax here: For every API the packages are delimited with
@@ -137,167 +129,20 @@
                                 informational though). Spares from repeating the version for every package of the api.
                                  We drop uses attributes as well.-->
                                 <Export-Package>
-                                    <!-- Servlet -->
-                                    jakarta.servlet;
-                                    jakarta.servlet.annotation;
-                                    jakarta.servlet.descriptor;
-                                    jakarta.servlet.http;
-                                    jakarta.servlet.resources;version="5.0.99";shim="true",
-                                    <!-- JSP -->
-                                    jakarta.servlet.jsp;
-                                    jakarta.servlet.jsp.el;
-                                    jakarta.servlet.jsp.tagext;version="3.0.99";shim="true",
-                                    <!-- EL -->
-                                    jakarta.el;version="4.0.99";shim="true",
-
-                                    <!-- Interceptor forward shim (2.0 -> 2.1) -->
-                                    jakarta.interceptor;version="2.1.99";shim=true,
-                                    <!-- CDI. enable after upgrade -->
-                                    jakarta.decorator;
-                                    jakarta.enterprise.context;
-                                    jakarta.enterprise.context.control;
-                                    jakarta.enterprise.context.spi;
-                                    jakarta.enterprise.event;
-                                    jakarta.enterprise.inject;
-                                    jakarta.enterprise.inject.literal;
-                                    jakarta.enterprise.inject.se;
-                                    jakarta.enterprise.inject.spi;
-                                    jakarta.enterprise.inject.spi.configurator;
-                                    jakarta.enterprise.util;version="3.0.99";shim="true",
-
-                                    <!-- Jakarta Authentication -->
-                                    jakarta.security.auth.message.callback;
-                                    jakarta.security.auth.message.config;
-                                    jakarta.security.auth.message.module;
-                                    jakarta.security.auth.message;version="2.0.0";shim="true",
-
-                                    <!-- XML WS -->
-                                    org.apache.xml.security;version="2.3.99";shim="true",
-
-                                    <!-- Jakarta XML Binding - forward shim (4 exported as 3) -->
-                                    jakarta.xml.bind;
-                                    jakarta.xml.bind.annotation;
-                                    jakarta.xml.bind.annotation.adapters;
-                                    jakarta.xml.bind.attachment;
-                                    jakarta.xml.bind.helpers;
-                                    jakarta.xml.bind.util;
-                                    com.sun.codemodel;
-                                    com.sun.codemodel.fmt;
-                                    com.sun.codemodel.util;
-                                    com.sun.codemodel.writer;
-                                    com.sun.codemodel;
-                                    com.sun.codemodel.fmt;
-                                    com.sun.codemodel.util;
-                                    com.sun.codemodel.writer;
-                                    com.sun.istack.tools;
-                                    com.sun.tools.rngdatatype;
-                                    com.sun.tools.rngdatatype.helpers;
-                                    com.sun.tools.rngom.ast.builder;
-                                    com.sun.tools.rngom.ast.om;
-                                    com.sun.tools.rngom.ast.util;
-                                    com.sun.tools.rngom.digested;
-                                    com.sun.tools.rngom.dt;
-                                    com.sun.tools.rngom.dt.builtin;
-                                    com.sun.tools.rngom.nc;
-                                    com.sun.tools.rngom.parse;
-                                    com.sun.tools.rngom.parse.compact;
-                                    com.sun.tools.rngom.parse.xml;
-                                    com.sun.tools.rngom.xml.sax;
-                                    com.sun.tools.rngom.xml.util;
-                                    com.sun.tools.xjc;
-                                    com.sun.tools.xjc.api;
-                                    com.sun.tools.xjc.generator.bean;
-                                    com.sun.tools.xjc.generator.bean.field;
-                                    com.sun.tools.xjc.model;
-                                    com.sun.tools.xjc.model.nav;
-                                    com.sun.tools.xjc.outline;
-                                    com.sun.tools.xjc.reader;
-                                    com.sun.tools.xjc.reader.gbind;
-                                    com.sun.tools.xjc.reader.internalizer;
-                                    com.sun.tools.xjc.reader.xmlschema;
-                                    com.sun.tools.xjc.reader.xmlschema.bindinfo;
-                                    com.sun.tools.xjc.util;
-                                    com.sun.xml.dtdparser;
-                                    com.sun.xml.xsom;
-                                    com.sun.xml.xsom.impl;
-                                    com.sun.xml.xsom.impl.parser;
-                                    com.sun.xml.xsom.impl.util;
-                                    com.sun.xml.xsom.parser;
-                                    com.sun.xml.xsom.util;
-                                    com.sun.xml.xsom.visitor;
-                                    org.glassfish.jaxb.core;
-                                    org.glassfish.jaxb.core.annotation;
-                                    org.glassfish.jaxb.core.api;
-                                    org.glassfish.jaxb.core.api.impl;
-                                    org.glassfish.jaxb.core.marshaller;
-                                    org.glassfish.jaxb.core.unmarshaller;
-                                    org.glassfish.jaxb.core.util;
-                                    org.glassfish.jaxb.core.v2;
-                                    org.glassfish.jaxb.core.v2.model.annotation;
-                                    org.glassfish.jaxb.core.v2.model.core;
-                                    org.glassfish.jaxb.core.v2.model.impl;
-                                    org.glassfish.jaxb.core.v2.model.nav;
-                                    org.glassfish.jaxb.core.v2.model.util;
-                                    org.glassfish.jaxb.core.v2.runtime;
-                                    org.glassfish.jaxb.core.v2.runtime.unmarshaller;
-                                    org.glassfish.jaxb.core.v2.schemagen.episode;
-                                    org.glassfish.jaxb.core.v2.util;
-                                    org.glassfish.jaxb.runtime;
-                                    org.glassfish.jaxb.runtime.api;
-                                    org.glassfish.jaxb.runtime.marshaller;
-                                    org.glassfish.jaxb.runtime.unmarshaller;
-                                    org.glassfish.jaxb.runtime.util;
-                                    org.glassfish.jaxb.runtime.v2;
-                                    org.glassfish.jaxb.runtime.v2.model.annotation;
-                                    org.glassfish.jaxb.runtime.v2.model.impl;
-                                    org.glassfish.jaxb.runtime.v2.model.runtime;
-                                    org.glassfish.jaxb.runtime.v2.runtime;
-                                    org.glassfish.jaxb.runtime.v2.runtime.output;
-                                    org.glassfish.jaxb.runtime.v2.runtime.property;
-                                    org.glassfish.jaxb.runtime.v2.runtime.reflect;
-                                    org.glassfish.jaxb.runtime.v2.runtime.unmarshaller;
-                                    org.glassfish.jaxb.runtime.v2.schemagen;
-                                    org.glassfish.jaxb.runtime.v2.schemagen.xmlschema;
-                                    org.glassfish.jaxb.runtime.v2.util;version="3.0.99";shim="true",
-
-                                    <!-- JSTL -->
-                                    jakarta.servlet.jsp.jstl.core;
-                                    jakarta.servlet.jsp.jstl.tlv;
-                                    jakarta.servlet.jsp.jstl.sql;
-                                    jakarta.servlet.jsp.jstl.fmt;version="2.0.0";shim="true",
-
                                     <!-- Minimal version of shim for MP 5.0. -->
-                                    <!-- TODO: This is only thing that should remain in final release -->
-                                    <!--
                                     jakarta.enterprise.util;
                                     jakarta.enterprise.inject;
-                                    jakarta.enterprise.context;version="3.0.99";shim=true
-                                    -->
-                                    <!-- security-->
-                                    jakarta.security.enterprise;
-                                    jakarta.security.enterprise.authentication.mechanism.http;
-                                    jakarta.security.enterprise.authentication.mechanism.http.openid;
-                                    jakarta.security.enterprise.credential;
-                                    jakarta.security.enterprise.identitystore;
-                                    jakarta.security.enterprise.identitystore.openid;version="2.0.99";shim="true",
-                                    <!-- soteria -->
-                                    org.glassfish.soteria;
-                                    org.glassfish.soteria.authorization;
-                                    org.glassfish.soteria.authorization.spi;
-                                    org.glassfish.soteria.authorization.spi.impl;
-                                    org.glassfish.soteria.cdi;
-                                    org.glassfish.soteria.cdi.spi;
-                                    org.glassfish.soteria.cdi.spi.impl;
-                                    org.glassfish.soteria.identitystores;
-                                    org.glassfish.soteria.identitystores.annotation;
-                                    org.glassfish.soteria.identitystores.hash;
-                                    org.glassfish.soteria.mechanisms;
-                                    org.glassfish.soteria.mechanisms.jaspic;
-                                    org.glassfish.soteria.openid;
-                                    org.glassfish.soteria.openid.controller;
-                                    org.glassfish.soteria.openid.domain;
-                                    org.glassfish.soteria.openid.http;
-                                    org.glassfish.soteria.servlet;version="2.0.99";shim="true"
+                                    jakarta.enterprise.context;version="3.0.99";shim=true,
+
+                                    <!-- Shim for XML Binding 3.0 needed by jackson-module-jakarta-xmlbind-annotations -->
+                                    jakarta.xml.bind;
+                                    jakarta.xml.bind.annotation;
+                                    jakarta.xml.bind.annotation.adapters;version="3.0.99";shim=true,
+
+                                    <!-- Shim for EL required by jsftemplating, but that's not enough anyway because of
+                                    dependency on jakartafaces.beans that no longer exists -->
+                                    jakarta.el;version="4.0.99";shim=true
+
                                 </Export-Package>
                             </instructions>
                         </configuration>

--- a/appserver/packager/external/jakarta-ee9-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee9-shim/pom.xml
@@ -129,10 +129,14 @@
                                 informational though). Spares from repeating the version for every package of the api.
                                  We drop uses attributes as well.-->
                                 <Export-Package>
-                                    <!-- Minimal version of shim for MP 5.0. -->
+                                    <!-- Minimal version of shim for MP 5.0. and security connectors-->
                                     jakarta.enterprise.util;
                                     jakarta.enterprise.inject;
-                                    jakarta.enterprise.context;version="3.0.99";shim=true,
+                                    jakarta.enterprise.context;
+                                    jakarta.enterprise.event;
+                                    jakarta.enterprise.context.spi;
+                                    jakarta.enterprise.inject.spi;
+                                    jakarta.enterprise.inject.spi.configurator;version="3.0.99";shim=true,
 
                                     <!-- Shim for XML Binding 3.0 needed by jackson-module-jakarta-xmlbind-annotations -->
                                     jakarta.xml.bind;

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <microprofile-rest-client.version>3.0</microprofile-rest-client.version>
         <microprofile-openapi.version>3.0</microprofile-openapi.version>
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
-        <payara.security-connectors.version>3.0.alpha4</payara.security-connectors.version>
+        <payara.security-connectors.version>3.0.alpha5</payara.security-connectors.version>
         <opentracing.version>0.33.0</opentracing.version>
         <h2db.version>2.1.212</h2db.version>
         <websocket-api.version>2.1.0</websocket-api.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This removes all of packages and bundles that are no longer necessary after all APIs have been updated.

Only few CDI packages are retained for microprofile APIs, and JAXB for jackson JAXB annotations. 
I also attempted to make `jsftemplating` happy with older EL, but it also needs faces classes that no longer exist.

