### PR TITLE
FISH-1515 new grizzly version p1 patched from version 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>10.0.0</jakartaee.api.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <grizzly.version>4.0.0-M2</grizzly.version>
+        <grizzly.version>4.0.0.payara-p1</grizzly.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
         <jersey.version>3.1.0-M6</jersey.version>
         <jakarta.validation.version>3.0.1</jakarta.validation.version>


### PR DESCRIPTION
## Description
Connection Closes Prematurely On HTTP/2 HTTPS Connections When Request Takes Long To Complete

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed

1. "git checkout FISH-1515-Payara6" in Payara6
2. mvn clean install -T 3 -DskipTests
3. .\appserver\distributions\payara\target\stage\payara6\bin\asadmin start-domain --verbose
4. Deploy app message-board.war (attached in https://payara.atlassian.net/browse/FISH-1515)
5. Poke https://localhost:8181/message-board-war/app/wait?seconds=31
6. Response: HTTP_200_OK and the message: "OK, waited 31 seconds"

### Testing Environment
Zulu JDK 11.0.10 on Windows 10 with Maven 3.8.4
