### PR TITLE
FISH-6298 OpenAPI document doesn't take into account multiple applications deployment

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
@@ -59,6 +59,7 @@ import java.util.logging.Logger;
 import com.sun.enterprise.v3.server.ApplicationLifecycle;
 import com.sun.enterprise.v3.services.impl.GrizzlyService;
 
+import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.deployment.archive.ReadableArchive;
@@ -136,6 +137,10 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
                         filterTypes(archive, config, types),
                         classLoader
                 ).process(doc, config);
+                if (doc.getPaths() != null && !doc.getPaths().getPathItems().isEmpty()) {
+                    ((OpenAPIImpl) doc).setEndpoints(ModelUtils.buildEndpoints(null, contextRoot,
+                            doc.getPaths().getPathItems().keySet()));
+                }
                 doc = new BaseProcessor(baseURLs).process(doc, config);
                 doc = new FilterProcessor().process(doc, config);
             } finally {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -136,7 +136,7 @@ public class OpenApiService {
      * @throws OpenAPIBuildException if creating the document failed.
      * @throws java.io.IOException if source archive not accessible
      */
-    public synchronized OpenAPI getDocument() throws OpenAPIBuildException, IOException {
+    public synchronized OpenAPI getDocument() throws OpenAPIBuildException, IOException, CloneNotSupportedException {
         if (documents.isEmpty()) {
             return null;
         }
@@ -148,9 +148,9 @@ public class OpenApiService {
         do {
             OpenAPI next = iterator.next().get();
             if (result == null) {
-                result = next;
+                result = ((OpenAPIImpl) next).clone();
             } else {
-                OpenAPIImpl.merge(result, next, true, null);
+                OpenAPIImpl.merge(next, result, true, null);
             }
         } while (iterator.hasNext());
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -45,13 +45,12 @@ import fish.payara.microprofile.openapi.impl.model.security.SecurityRequirementI
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
 import fish.payara.microprofile.openapi.impl.model.tags.TagImpl;
 import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createList;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
-import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -62,6 +61,8 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.*;
+
 public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Cloneable {
 
     protected String openapi;
@@ -71,6 +72,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
     protected List<SecurityRequirement> security = createList();
     protected List<Tag> tags = createList();
     protected Paths paths = new PathsImpl();
+    protected Map<String, Set<String>> endpoints = createOrderedMap();
     protected Components components = new ComponentsImpl();
     
     private ApiContext context;
@@ -331,4 +333,11 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         return clonedObj;
     }
 
+    public Map<String, Set<String>> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(Map<String, Set<String>> endpoints) {
+        this.endpoints = endpoints;
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -49,6 +49,8 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.create
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
@@ -60,7 +62,7 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 
-public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
+public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Cloneable {
 
     protected String openapi;
     protected Info info;
@@ -312,6 +314,20 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI {
         // Handle @Components
         ComponentsImpl.merge(from.getComponents(), to.getComponents(), override, context);
         PathsImpl.merge(from.getPaths(), to.getPaths(), override);
+    }
+
+    @Override
+    public OpenAPI clone()
+            throws CloneNotSupportedException {
+        OpenAPI clonedObj = new OpenAPIImpl();
+        clonedObj.setOpenapi(this.openapi);
+        clonedObj.setInfo(this.info);
+        clonedObj.setServers(new ArrayList<>(this.servers));
+        clonedObj.setSecurity(new ArrayList<>(this.security));
+        clonedObj.setTags(new ArrayList<>(this.tags));
+        clonedObj.setPaths(new PathsImpl(this.paths.getPathItems()));
+        clonedObj.setComponents(this.components);
+        return clonedObj;
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -317,8 +317,8 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         // Handle @Components
         ComponentsImpl.merge(from.getComponents(), to.getComponents(), override, context);
         PathsImpl.merge(from.getPaths(), to.getPaths(), override);
-        //Hanlde Endpoints
-        Map<String, Set<String>> endpoints = ((OpenAPIImpl) to).getEndpoints();
+        //Handle Endpoints
+        Map<String, Set<String>> endpoints = ((OpenAPIImpl) from).getEndpoints();
         if (!endpoints.isEmpty()) {
             OpenAPIImpl toImpl = (OpenAPIImpl) to;
             for (String root : endpoints.keySet()) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -322,6 +322,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         OpenAPI clonedObj = new OpenAPIImpl();
         clonedObj.setOpenapi(this.openapi);
         clonedObj.setInfo(this.info);
+        clonedObj.setExternalDocs(this.externalDocs);
         clonedObj.setServers(new ArrayList<>(this.servers));
         clonedObj.setSecurity(new ArrayList<>(this.security));
         clonedObj.setTags(new ArrayList<>(this.tags));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
@@ -316,6 +317,15 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         // Handle @Components
         ComponentsImpl.merge(from.getComponents(), to.getComponents(), override, context);
         PathsImpl.merge(from.getPaths(), to.getPaths(), override);
+        //Hanlde Endpoints
+        Map<String, Set<String>> endpoints = ((OpenAPIImpl) to).getEndpoints();
+        if (!endpoints.isEmpty()) {
+            OpenAPIImpl toImpl = (OpenAPIImpl) to;
+            for (String root : endpoints.keySet()) {
+                Set<String> paths = endpoints.get(root);
+                toImpl.setEndpoints(ModelUtils.buildEndpoints(toImpl.getEndpoints(), root, paths));
+            }
+        }
     }
 
     @Override
@@ -330,6 +340,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         clonedObj.setTags(new ArrayList<>(this.tags));
         clonedObj.setPaths(new PathsImpl(this.paths.getPathItems()));
         clonedObj.setComponents(this.components);
+        ((OpenAPIImpl) clonedObj).setEndpoints(new TreeMap<>(this.getEndpoints()));
         return clonedObj;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -49,13 +49,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -769,5 +763,17 @@ public final class ModelUtils {
             return null;
         }
         return new TreeMap<>(items);
+    }
+
+    public static Map<String, Set<String>> buildEndpoints(Map<String, Set<String>> original, String contextRoot, Set<String> paths) {
+        if (original == null || original.isEmpty()) {
+            original = createOrderedMap();
+        }
+        if (original.containsKey(contextRoot)) {
+            original.get(contextRoot).addAll(paths);
+            return original;
+        }
+        original.put(contextRoot, paths);
+        return original;
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -769,11 +769,9 @@ public final class ModelUtils {
         if (original == null || original.isEmpty()) {
             original = createOrderedMap();
         }
-        if (original.containsKey(contextRoot)) {
-            original.get(contextRoot).addAll(paths);
-            return original;
+        if (!original.containsKey(contextRoot)) {
+            original.put(contextRoot, paths);
         }
-        original.put(contextRoot, paths);
         return original;
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -83,7 +83,7 @@ public class OpenApiResource {
         try {
             document = openApiService.getDocument();
         } catch (OpenAPIBuildException | IOException | CloneNotSupportedException ex) {
-            LOGGER.log(WARNING, "OpenAPI document creation failed.", ex);
+            LOGGER.log(WARNING, "OpenAPI document creation failed: " + ex.getMessage(), ex);
         }
 
         // If there are none, return an empty OpenAPI document

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -82,7 +82,7 @@ public class OpenApiResource {
         OpenAPI document = null;
         try {
             document = openApiService.getDocument();
-        } catch (OpenAPIBuildException | IOException ex) {
+        } catch (OpenAPIBuildException | IOException | CloneNotSupportedException ex) {
             LOGGER.log(WARNING, "OpenAPI document creation failed.", ex);
         }
 


### PR DESCRIPTION
## Description
When we have 2 applications deployed in one Payara Server instance, we are getting only one API Documentation

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps:
1. mvn clean install -DskipTests
2. ./appserver/distributions/payara/target/stage/payara5/bin/asadmin start-domain -v
3. Deploy two simple applications to the Payara server: https://payara.atlassian.net/browse/FISH-6298
4. http://localhost:8080/openapi/ shows the API documentation for the 2 apps.

### Testing Environment
JDK 1.8_212 on Windows 10 with Maven 3.8.4
