### PR TITLE
FISH-6298 OpenAPI document doesn't take into account multiple applications deployment

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -59,6 +59,7 @@ import java.util.logging.Logger;
 import com.sun.enterprise.v3.server.ApplicationLifecycle;
 import com.sun.enterprise.v3.services.impl.GrizzlyService;
 
+import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.deployment.archive.ReadableArchive;
@@ -136,6 +137,10 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
                         filterTypes(archive, config, types),
                         classLoader
                 ).process(doc, config);
+                if (doc.getPaths() != null && !doc.getPaths().getPathItems().isEmpty()) {
+                    ((OpenAPIImpl) doc).setEndpoints(ModelUtils.buildEndpoints(null, contextRoot,
+                            doc.getPaths().getPathItems().keySet()));
+                }
                 doc = new BaseProcessor(baseURLs).process(doc, config);
                 doc = new FilterProcessor().process(doc, config);
             } finally {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenApiService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -136,7 +136,7 @@ public class OpenApiService {
      * @throws OpenAPIBuildException if creating the document failed.
      * @throws java.io.IOException if source archive not accessible
      */
-    public synchronized OpenAPI getDocument() throws OpenAPIBuildException, IOException {
+    public synchronized OpenAPI getDocument() throws OpenAPIBuildException, IOException, CloneNotSupportedException {
         if (documents.isEmpty()) {
             return null;
         }
@@ -148,9 +148,9 @@ public class OpenApiService {
         do {
             OpenAPI next = iterator.next().get();
             if (result == null) {
-                result = next;
+                result = ((OpenAPIImpl) next).clone();
             } else {
-                OpenAPIImpl.merge(result, next, true, null);
+                OpenAPIImpl.merge(next, result, true, null);
             }
         } while (iterator.hasNext());
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.Map.Entry;
 import java.util.function.BiConsumer;
@@ -769,5 +770,15 @@ public final class ModelUtils {
             return null;
         }
         return new TreeMap<>(items);
+    }
+
+    public static Map<String, Set<String>> buildEndpoints(Map<String, Set<String>> original, String contextRoot, Set<String> paths) {
+        if (original == null || original.isEmpty()) {
+            original = createOrderedMap();
+        }
+        if (!original.containsKey(contextRoot)) {
+            original.put(contextRoot, paths);
+        }
+        return original;
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -82,8 +82,8 @@ public class OpenApiResource {
         OpenAPI document = null;
         try {
             document = openApiService.getDocument();
-        } catch (OpenAPIBuildException | IOException ex) {
-            LOGGER.log(WARNING, "OpenAPI document creation failed.", ex);
+        } catch (OpenAPIBuildException | IOException | CloneNotSupportedException ex) {
+            LOGGER.log(WARNING, "OpenAPI document creation failed: " + ex.getMessage(), ex);
         }
 
         // If there are none, return an empty OpenAPI document


### PR DESCRIPTION
## Description
When we have 2 applications deployed in one Payara Server instance, we are getting only one API Documentation

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps:
1. mvn clean install -DskipTests
2. ./appserver/distributions/payara/target/stage/payara6/bin/asadmin start-domain -v
3. Deploy two simple applications to the Payara server 6: https://payara.atlassian.net/browse/FISH-6298 (Payara6-Reproducers.zip)
4. http://localhost:8080/openapi/ shows the API documentation for the 2 apps.

### Testing Environment
JDK 11 on WSL with Maven 3.8.4
