### PR TITLE
[QACI-723] - Use Maven Release Plugin for Releases

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -58,59 +58,59 @@
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara-web</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara-ml</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.distributions</groupId>
                 <artifactId>payara-web-ml</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>ejb-http-client</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-embedded-web</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-embedded-all</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.extras</groupId>
                 <artifactId>payara-micro</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-api</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>fish.payara.server.appclient</groupId>
                 <artifactId>payara-client</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!-- APIs -->
@@ -821,10 +821,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <properties>
-        <payara.version>${project.version}</payara.version>
-    </properties>
 
     <build>
         <plugins>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -52,7 +52,6 @@
     <name>Payara Docker Images</name>
 
     <properties>
-        <project.version>${project.version}</project.version>
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -52,7 +52,7 @@
     <name>Payara Docker Images</name>
 
     <properties>
-        <payara.version>${project.version}</payara.version>
+        <project.version>${project.version}</project.version>
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
@@ -64,7 +64,7 @@
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>
 
         <docker.payara.repository>payara/${project.artifactId}</docker.payara.repository>
-        <docker.payara.tag>${payara.version}</docker.payara.tag>
+        <docker.payara.tag>${project.version}</docker.payara.tag>
         <docker.payara.image>${docker.payara.repository}:${docker.payara.tag}</docker.payara.image>
     </properties>
 

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -52,6 +52,8 @@
     <name>Payara Docker Images</name>
 
     <properties>
+        <payara.version>${project.version}</payara.version>
+
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
@@ -63,7 +65,7 @@
         <docker.payara.rootDirectoryName>payara5</docker.payara.rootDirectoryName>
 
         <docker.payara.repository>payara/${project.artifactId}</docker.payara.repository>
-        <docker.payara.tag>${project.version}</docker.payara.tag>
+        <docker.payara.tag>${payara.version}</docker.payara.tag>
         <docker.payara.image>${docker.payara.repository}:${docker.payara.tag}</docker.payara.image>
     </properties>
 

--- a/appserver/packager/rest-monitoring/pom.xml
+++ b/appserver/packager/rest-monitoring/pom.xml
@@ -53,6 +53,7 @@
 
     <properties>
         <temp.dir>${project.build.directory}/dependency</temp.dir>
+        <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
     </properties>
 
     <build>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -88,7 +88,6 @@
         
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
-        <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
 
         <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
         <accessors-smart.version>1.2.payara-p2</accessors-smart.version>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -59,7 +59,7 @@
         <java.min.version>1.8</java.min.version>
         <maven.min.version>3.5</maven.min.version>
 
-        <project.version>${project.version}</project.version>
+        <payara.version>${project.version}</payara.version>
         <payara.debug>false</payara.debug>
         <!-- remote host for payara to connect to -->
         <payara.adminHost>localhost</payara.adminHost>
@@ -88,7 +88,7 @@
         <profile>
             <!--
             This profile will install a Payara server and start up the server per sample.
-            The Payara version that's used can be set via the project.version property.
+            The Payara version that's used can be set via the payara.version property.
             This is the default profile and does not have to be specified explicitly.
             -->
             <id>payara-server-managed</id>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -59,7 +59,7 @@
         <java.min.version>1.8</java.min.version>
         <maven.min.version>3.5</maven.min.version>
 
-        <payara.version>${project.version}</payara.version>
+        <project.version>${project.version}</project.version>
         <payara.debug>false</payara.debug>
         <!-- remote host for payara to connect to -->
         <payara.adminHost>localhost</payara.adminHost>
@@ -88,7 +88,7 @@
         <profile>
             <!--
             This profile will install a Payara server and start up the server per sample.
-            The Payara version that's used can be set via the payara.version property.
+            The Payara version that's used can be set via the project.version property.
             This is the default profile and does not have to be specified explicitly.
             -->
             <id>payara-server-managed</id>
@@ -158,7 +158,7 @@
                                         <artifactItem>
                                             <groupId>fish.payara.distributions</groupId>
                                             <artifactId>payara</artifactId>
-                                            <version>${payara.version}</version>
+                                            <version>${project.version}</version>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
@@ -177,7 +177,7 @@
             <id>payara-micro-managed</id>
             <!--
             This profile will install a Payara Micro and start up the server per sample.
-            The Payara version that's used can be set via the payara.version property.
+            The Payara version that's used can be set via the project.version property.
             -->
             <properties>
                 <payara.containerType>MICRO</payara.containerType>
@@ -212,10 +212,10 @@
                                         <artifactItem>
                                             <groupId>fish.payara.extras</groupId>
                                             <artifactId>payara-micro</artifactId>
-                                            <version>${payara.version}</version>
+                                            <version>${project.version}</version>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${session.executionRootDirectory}/target/</outputDirectory>
-                                            <destFileName>payara-micro-${payara.version}.jar</destFileName>
+                                            <destFileName>payara-micro-${project.version}.jar</destFileName>
                                         </artifactItem>
                                     </artifactItems>
                                 </configuration>
@@ -278,7 +278,7 @@
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-bom</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -324,55 +324,55 @@
             <dependency>
                 <groupId>fish.payara.server.internal.admin</groupId>
                 <artifactId>config-api</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.common</groupId>
                 <artifactId>internal-api</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.common</groupId>
                 <artifactId>simple-glassfish-api</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.extras</groupId>
                 <artifactId>payara-micro-boot</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>hazelcast-bootstrap</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>healthcheck-core</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>notification-core</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>healthcheck-stuck</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.security</groupId>
                 <artifactId>security</artifactId>
-                <version>${payara.version}</version>
+                <version>${project.version}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -464,7 +464,7 @@
                         <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
                         <payara.domain.name>${payara.domain.name}</payara.domain.name>
                         <!-- affects micro only -->
-                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${payara.version}.jar</payara.microJar>
+                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${project.version}.jar</payara.microJar>
                         <payara.clusterEnabled>true</payara.clusterEnabled>
                         <payara.debug>${payara.debug}</payara.debug>
                     </systemPropertyVariables>
@@ -480,7 +480,7 @@
                         <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
                         <payara.domain.name>${payara.domain.name}</payara.domain.name>
                         <!-- affects micro only -->
-                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${payara.version}.jar</payara.microJar>
+                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${project.version}.jar</payara.microJar>
                         <payara.clusterEnabled>true</payara.clusterEnabled>
                         <payara.debug>${payara.debug}</payara.debug>
                     </systemPropertyVariables>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -158,7 +158,7 @@
                                         <artifactItem>
                                             <groupId>fish.payara.distributions</groupId>
                                             <artifactId>payara</artifactId>
-                                            <version>${project.version}</version>
+                                            <version>${payara.version}</version>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
@@ -177,7 +177,7 @@
             <id>payara-micro-managed</id>
             <!--
             This profile will install a Payara Micro and start up the server per sample.
-            The Payara version that's used can be set via the project.version property.
+            The Payara version that's used can be set via the payara.version property.
             -->
             <properties>
                 <payara.containerType>MICRO</payara.containerType>
@@ -212,10 +212,10 @@
                                         <artifactItem>
                                             <groupId>fish.payara.extras</groupId>
                                             <artifactId>payara-micro</artifactId>
-                                            <version>${project.version}</version>
+                                            <version>${payara.version}</version>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${session.executionRootDirectory}/target/</outputDirectory>
-                                            <destFileName>payara-micro-${project.version}.jar</destFileName>
+                                            <destFileName>payara-micro-${payara.version}.jar</destFileName>
                                         </artifactItem>
                                     </artifactItems>
                                 </configuration>
@@ -278,7 +278,7 @@
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-bom</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -324,55 +324,55 @@
             <dependency>
                 <groupId>fish.payara.server.internal.admin</groupId>
                 <artifactId>config-api</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.common</groupId>
                 <artifactId>internal-api</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.common</groupId>
                 <artifactId>simple-glassfish-api</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.extras</groupId>
                 <artifactId>payara-micro-boot</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>hazelcast-bootstrap</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>healthcheck-core</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>notification-core</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.payara-modules</groupId>
                 <artifactId>healthcheck-stuck</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.internal.security</groupId>
                 <artifactId>security</artifactId>
-                <version>${project.version}</version>
+                <version>${payara.version}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -464,7 +464,7 @@
                         <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
                         <payara.domain.name>${payara.domain.name}</payara.domain.name>
                         <!-- affects micro only -->
-                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${project.version}.jar</payara.microJar>
+                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${payara.version}.jar</payara.microJar>
                         <payara.clusterEnabled>true</payara.clusterEnabled>
                         <payara.debug>${payara.debug}</payara.debug>
                     </systemPropertyVariables>
@@ -480,7 +480,7 @@
                         <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
                         <payara.domain.name>${payara.domain.name}</payara.domain.name>
                         <!-- affects micro only -->
-                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${project.version}.jar</payara.microJar>
+                        <payara.microJar>${session.executionRootDirectory}/target/payara-micro-${payara.version}.jar</payara.microJar>
                         <payara.clusterEnabled>true</payara.clusterEnabled>
                         <payara.debug>${payara.debug}</payara.debug>
                     </systemPropertyVariables>


### PR DESCRIPTION
## Description
This PR updates the POMs to make use of the Maven Release Plugin for version management so we can move away from using scripts to create tags/branches

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
Performed release:prepare and release:perform with -DdryRun to ensure proper versioning

### Testing Environment
WSL2 Ubuntu 20.04 zulu JDK 1.8.0_342

## Notes for Reviewers
This will only automate the updating of version numbers for the time being as profiles also need configuring for deployment, the specifics of which are still in discussion
