### PR TITLE
FISH-6103 SimplePolicyProvider cannot be used for JACC Per Application

### DIFF
--- a/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
+++ b/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
@@ -167,7 +167,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -147,7 +147,7 @@
                 <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
                     <property value="true" name="certificate-validation"/>
                 </auth-realm>
-                <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
                 <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
                     <property value="false" name="auditOn" />
                 </audit-module>
@@ -371,7 +371,7 @@
                 <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
                     <property name="certificate-validation" value="true" />
                 </auth-realm>
-                <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
                 <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
                     <property value="false" name="auditOn" />
                 </audit-module>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -142,7 +142,7 @@
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
           <property value="true" name="certificate-validation"/>
         </auth-realm>
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>
@@ -362,7 +362,7 @@
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
           <property value="true" name="certificate-validation"/>
         </auth-realm>
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -124,7 +124,7 @@
           <property value="fileRealm" name="jaas-context" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>
@@ -323,7 +323,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -147,7 +147,7 @@
           <property value="fileRealm" name="jaas-context" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>
@@ -341,7 +341,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>

--- a/appserver/admingui/common/src/main/help/en/help/task-jaccprovidernew.html
+++ b/appserver/admingui/common/src/main/help/en/help/task-jaccprovidernew.html
@@ -47,11 +47,11 @@
 </li>
 <li>
 <p>In the Policy Configuration field, type the name of the class that implements the policy configuration factory.</p>
-<p>The <code>default</code> provider uses <code>org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory</code>. The <code>simple</code> provider uses <code>org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory</code>.</p>
+<p>The <code>default</code> provider uses <code>fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl</code>. The <code>simple</code> provider uses <code>fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl</code>.</p>
 </li>
 <li>
 <p>In the Policy Provider field, type the name of the class that implements the policy factory.</p>
-<p>The <code>default</code> provider uses <code>org.glassfish.exousia.modules.locked.SimplePolicyProvider</code>. The <code>simple</code> provider uses <code>org.glassfish.exousia.modules.locked.SimplePolicyProvider</code>.</p>
+<p>The <code>default</code> provider uses <code>fish.payara.security.jacc.provider.PolicyProviderImpl</code>. The <code>simple</code> provider uses <code>fish.payara.security.jacc.provider.PolicyProviderImpl</code>.</p>
 </li>
 <li>
 <p>In the Additional Properties section, specify additional properties.</p>

--- a/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-jacc-provider.html
+++ b/appserver/admingui/reference-manual/src/main/help/en/help/reference/create-jacc-provider.html
@@ -230,8 +230,8 @@ in <code>domain.xml</code>.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code class="language-oac_no_warn" data-lang="oac_no_warn">asadmin&gt; create-jacc-provider
---policyproviderclass org.glassfish.exousia.modules.locked.SimplePolicyProvider
---policyconfigfactoryclass org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory
+--policyproviderclass fish.payara.security.jacc.provider.PolicyProviderImpl
+--policyconfigfactoryclass fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl
 testJACC
 
 Command create-jacc-provider executed successfully.</code></pre>

--- a/appserver/connectors/admin/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/admin/src/test/resources/DomainTest.xml
@@ -103,7 +103,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
@@ -102,7 +102,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
@@ -110,7 +110,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/extras/embedded/all/src/main/resources/config/domain.xml
+++ b/appserver/extras/embedded/all/src/main/resources/config/domain.xml
@@ -144,7 +144,7 @@
                     <property value="fileRealm" name="jaas-context" />
                 </auth-realm>
                 <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
                 <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
                     <property value="false" name="auditOn" />
                 </audit-module>

--- a/appserver/extras/embedded/web/src/main/resources/config/domain.xml
+++ b/appserver/extras/embedded/web/src/main/resources/config/domain.xml
@@ -137,7 +137,7 @@
                     <property value="fileRealm" name="jaas-context" />
                 </auth-realm>
                 <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
                 <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
                     <property value="false" name="auditOn" />
                 </audit-module>

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -115,7 +115,7 @@ Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
                     <property value="fileRealm" name="jaas-context" />
                 </auth-realm>
                 <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-                <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+                <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
                 <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
                     <property value="false" name="auditOn" />
                 </audit-module>

--- a/appserver/jdbc/admin/src/test/resources/DomainTest.xml
+++ b/appserver/jdbc/admin/src/test/resources/DomainTest.xml
@@ -89,7 +89,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
+++ b/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
@@ -110,7 +110,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
+++ b/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
@@ -104,7 +104,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/packager/appserver-core/pom.xml
+++ b/appserver/packager/appserver-core/pom.xml
@@ -213,6 +213,11 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>
+            <artifactId>jacc.provider.inmemory</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>jaspic.provider.framework</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/resources/javamail/javamail-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/javamail/javamail-connector/src/test/resources/DomainTest.xml
@@ -103,7 +103,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/resources/resources-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/resources-connector/src/test/resources/DomainTest.xml
@@ -102,7 +102,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/appserver/security/jacc.provider.inmemory/osgi.bundle
+++ b/appserver/security/jacc.provider.inmemory/osgi.bundle
@@ -1,0 +1,42 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#  Copyright (c) [2022] Payara Foundation and/or its affiliates. 
+#  All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the 
+# "Classpath" exception as provided by the Payara Foundation in the GPL 
+# Version 2 section of the License file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+
+-exportcontents: fish.payara.security.jacc.provider; version=${project.osgi.version}
+

--- a/appserver/security/jacc.provider.inmemory/pom.xml
+++ b/appserver/security/jacc.provider.inmemory/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>fish.payara.server.internal.security</groupId>
         <artifactId>securitymodule</artifactId>
-        <version>6.2022.1.Alpha4-SNAPSHOT</version>
+        <version>6.2022.1.Alpha5-SNAPSHOT</version>
     </parent>
 
     <artifactId>jacc.provider.inmemory</artifactId>

--- a/appserver/security/jacc.provider.inmemory/pom.xml
+++ b/appserver/security/jacc.provider.inmemory/pom.xml
@@ -41,35 +41,69 @@
 
 -->
 
-<!-- Portions Copyright [2018-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
-        <groupId>fish.payara.server</groupId>
-        <artifactId>payara-parent</artifactId>
-        <version>6.2022.1.Alpha5-SNAPSHOT</version>
+        <groupId>fish.payara.server.internal.security</groupId>
+        <artifactId>securitymodule</artifactId>
+        <version>6.2022.1.Alpha4-SNAPSHOT</version>
     </parent>
+
+    <artifactId>jacc.provider.inmemory</artifactId>
+    <packaging>glassfish-jar</packaging>
+
+    <name>A Pluggable InMemory JACC Provider</name>
+    <description>
+    	This module implements a JACC provider (authorization module) that uses in-memory
+    	storage to put the Permissions instances in that are received from the JACC parser.
+    	
+    	This module is pluggable by the end-user and uses the standard JACC SPI to facilitate
+    	this pluggability, but the implementation is partially Payara specific.
+    </description>
+
+    <developers>
+        <developer>
+            <id>monzillo</id>
+            <name>Ron Monzillo</name>
+            <organization>Oracle, Inc.</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
     
-    <groupId>fish.payara.server.internal.security</groupId>
-    <artifactId>securitymodule</artifactId>
-    <packaging>pom</packaging>
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
     
-    <name>GlassFish Security Parent</name>
-    <description>Security Infrastructure and Technology Integration Modules</description>
-    
-    <modules>
-        <module>webintegration</module>
-        <module>core-ee</module>
-        <module>security-all</module>
-        <module>jacc.provider.inmemory</module>
-        <module>jaspic-provider-framework</module>
-        <module>webservices.security</module>
-        <module>ejb.security</module>
-        <module>appclient.security</module>
-        <module>core-ee-l10n</module>
-        <module>webservices.security-l10n</module>
-        <module>realm-stores</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+                <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.authorization</groupId>
+            <artifactId>jakarta.authorization-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.exousia</groupId>
+            <artifactId>exousia</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/ContextProviderImpl.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/ContextProviderImpl.java
@@ -1,0 +1,66 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.security.jacc.provider;
+
+import fish.payara.jacc.ContextProvider;
+import jakarta.security.jacc.PolicyConfigurationFactory;
+import java.security.Policy;
+
+public class ContextProviderImpl implements ContextProvider {
+
+    private final PolicyConfigurationFactory factory;
+    private final Policy policy;
+
+    public ContextProviderImpl(PolicyConfigurationFactory factory, Policy policy) {
+        this.factory = factory;
+        this.policy = policy;
+    }
+    
+    @Override
+    public PolicyConfigurationFactory getPolicyConfigurationFactory() {
+        return factory;
+    }
+  
+    @Override
+    public Policy getPolicy() {
+        return policy;
+    }
+
+}

--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyConfigurationFactoryImpl.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyConfigurationFactoryImpl.java
@@ -230,24 +230,6 @@ public class PolicyConfigurationFactoryImpl extends SimplePolicyConfigurationFac
         return super.inService(contextId);
         
     }
-//    /**
-//     * This method tries to find the Policy Configuration copied into the file system (by the DAS) after the 
-//     * repository was initialized. 
-//     * 
-//     * This will only open the Policy Configuration if remove is true (otherwise the Policy Configuration will
-//     * remain in service);
-//     */
-//    private SimplePolicyConfiguration getPolicyConfigurationImplFromDirectory(String contextId, boolean open, boolean remove) {
-//        SimplePolicyConfiguration policyConfigurationImpl = null;
-//        
-//        File contextDirectory = new File(getContextDirectoryName(contextId));
-//        if (contextDirectory.exists()) {
-//            policyConfigurationImpl = new PolicyConfigurationImpl(contextDirectory, open, remove, this);
-//            contextToConfigurationMap.put(contextId, policyConfigurationImpl);
-//        }
-//        
-//        return policyConfigurationImpl;
-//    }
 
     protected List<PolicyConfiguration> getPolicyConfigurationImpls() {
         return new ArrayList<>(contextToConfigurationMap.values());

--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyConfigurationFactoryImpl.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyConfigurationFactoryImpl.java
@@ -1,0 +1,270 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.security.jacc.provider;
+
+import static com.sun.logging.LogDomains.SECURITY_LOGGER;
+import fish.payara.jacc.ContextProvider;
+import fish.payara.jacc.JaccConfigurationFactory;
+import jakarta.security.jacc.PolicyConfiguration;
+import jakarta.security.jacc.PolicyConfigurationFactory;
+import jakarta.security.jacc.PolicyContextException;
+import java.security.Permission;
+import java.security.Policy;
+import java.security.SecurityPermission;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import static java.util.logging.Level.FINE;
+import java.util.logging.Logger;
+import org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory;
+import org.jvnet.hk2.annotations.ContractsProvided;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ * Implementation of jacc PolicyConfigurationFactory class
+ */
+@Service
+@ContractsProvided({ PolicyConfigurationFactoryImpl.class, PolicyConfigurationFactory.class })
+public class PolicyConfigurationFactoryImpl extends SimplePolicyConfigurationFactory implements JaccConfigurationFactory {
+
+    
+    private static Logger logger = Logger.getLogger(SECURITY_LOGGER);
+    private Map<String, String> applicationToPolicyContextIdMap = new ConcurrentHashMap<String, String>();
+
+    // Map of ContextId -> ContextProvider (per context PolicyConfigurationFactory and Policy)
+    private Map<String, ContextProvider> contextToContextProviderMap = new ConcurrentHashMap<>();
+    
+    
+    // Map of ContextId -> PolicyConfiguration
+    private Map<String, PolicyConfiguration> contextToConfigurationMap = new ConcurrentHashMap<>();
+    
+    private Permission setPolicyPermission;
+    
+    private static PolicyConfigurationFactoryImpl singleton;
+
+    public PolicyConfigurationFactoryImpl() {
+        singleton = this;
+    }
+    
+    static PolicyConfigurationFactoryImpl getInstance() {
+        return singleton;
+    }
+    
+    @Override
+    public void registerContextProvider(String applicationContextId, PolicyConfigurationFactory factory, Policy policy) {
+        checkSetPolicyPermission();
+        
+        try {
+            String policyContextId = applicationToPolicyContextIdMap.get(applicationContextId);
+            if (policyContextId == null) {
+                throw new IllegalStateException(
+                        "No policyContextId available for applicationContextId " + applicationContextId + 
+                        " Is this JaccConfigurationFactory instance used by the container?");
+            }
+            
+            if (inService(policyContextId)) {
+                throw new IllegalStateException("Context :" + policyContextId + " already has an active global provider");
+            }
+        
+            ContextProvider contextProvider = contextToContextProviderMap.get(policyContextId);
+            if (contextProvider != null && contextProvider.getPolicyConfigurationFactory().inService(policyContextId)) {
+                throw new IllegalStateException("Context :" + policyContextId + " already has an active context (per app) provider");
+            }
+            
+            contextToContextProviderMap.put(policyContextId, new ContextProviderImpl(factory, policy));
+            
+        } catch (PolicyContextException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void addContextIdMapping(String applicationContextId, String policyContextId) {
+         applicationToPolicyContextIdMap.put(applicationContextId, policyContextId);
+    }
+
+    @Override
+    public boolean removeContextIdMappingByPolicyContextId(String policyContextId) {
+        return applicationToPolicyContextIdMap.entrySet().removeIf(e -> e.getValue().equals(policyContextId));
+    }
+    
+    @Override
+    public ContextProvider getContextProviderByPolicyContextId(String policyContextId) {
+        return contextToContextProviderMap.get(policyContextId);
+    }
+
+    @Override
+    public ContextProvider removeContextProviderByPolicyContextId(String policyContextId) {
+          return contextToContextProviderMap.remove(policyContextId);
+    }
+    
+    protected List<PolicyConfiguration> getPolicyConfigurations() {
+        return new ArrayList<>(contextToConfigurationMap.values());
+    }
+
+    protected PolicyConfiguration removePolicyConfiguration(String contextID) {
+        return contextToConfigurationMap.remove(contextID);
+    }
+
+    
+    /**
+     * This method is used to obtain an instance of the provider specific class that implements the PolicyConfiguration
+     * interface that corresponds to the identified policy context within the provider. The methods of the
+     * PolicyConfiguration interface are used to define the policy statements of the identified policy context.
+     * <P>
+     * If at the time of the call, the identified policy context does not exist in the provider, then the policy context
+     * will be created in the provider and the Object that implements the context's PolicyConfiguration Interface will be
+     * returned. If the state of the identified context is "deleted" or "inService" it will be transitioned to the "open"
+     * state as a result of the call. The states in the lifecycle of a policy context are defined by the PolicyConfiguration
+     * interface.
+     * <P>
+     * For a given value of policy context identifier, this method must always return the same instance of
+     * PolicyConfiguration and there must be at most one actual instance of a PolicyConfiguration with a given policy
+     * context identifier (during a process context).
+     * <P>
+     * To preserve the invariant that there be at most one PolicyConfiguration object for a given policy context, it may be
+     * necessary for this method to be thread safe.
+     * <P>
+     * 
+     * @param contextID A String identifying the policy context whose PolicyConfiguration interface is to be returned. The
+     * value passed to this parameter must not be null.
+     * <P>
+     * @param remove A boolean value that establishes whether or not the policy statements of an existing policy context are
+     * to be removed before its PolicyConfiguration object is returned. If the value passed to this parameter is true, the
+     * policy statements of an existing policy context will be removed. If the value is false, they will not be removed.
+     *
+     * @return an Object that implements the PolicyConfiguration Interface matched to the Policy provider and corresponding
+     * to the identified policy context.
+     *
+     * @throws java.lang.SecurityException when called by an AccessControlContext that has not been granted the "setPolicy"
+     * SecurityPermission.
+     *
+     * @throws javax.security.jacc.PolicyContextException if the implementation throws a checked exception that has not been
+     * accounted for by the getPolicyConfiguration method signature. The exception thrown by the implementation class will
+     * be encapsulated (during construction) in the thrown PolicyContextException.
+     */
+    @Override
+    public PolicyConfiguration getPolicyConfiguration(String contextId, boolean remove) throws PolicyContextException {
+        checkSetPolicyPermission();
+
+        if (logger.isLoggable(FINE)) {
+            logger.fine("JACC Policy Provider: Getting PolicyConfiguration object with id = " + contextId);
+        }
+
+        ContextProvider contextProvider = contextToContextProviderMap.get(contextId);
+
+        if (contextProvider != null) {
+            return contextProvider.getPolicyConfigurationFactory().getPolicyConfiguration(contextId, remove);
+        }
+
+        PolicyConfiguration policyConfiguration = super.getPolicyConfiguration(contextId, remove);
+        contextToConfigurationMap.put(contextId, policyConfiguration);
+        return policyConfiguration;
+    }
+        
+    /**
+     * This method determines if the identified policy context exists with state "inService" in the Policy provider
+     * associated with the factory.
+     * <P>
+     * 
+     * @param contextID A string identifying a policy context
+     *
+     * @return true if the identified policy context exists within the provider and its state is "inService", false
+     * otherwise.
+     *
+     * @throws java.lang.SecurityException when called by an AccessControlContext that has not been granted the "setPolicy"
+     * SecurityPermission.
+     *
+     * @throws javax.security.jacc.PolicyContextException if the implementation throws a checked exception that has not been
+     * accounted for by the inService method signature. The exception thrown by the implementation class will be
+     * encapsulated (during construction) in the thrown PolicyContextException.
+     */
+    @Override
+    public boolean inService(String contextId) throws PolicyContextException {
+        checkSetPolicyPermission();
+        
+        ContextProvider contextProvider = contextToContextProviderMap.get(contextId);
+        
+        if (contextProvider != null) {
+            return contextProvider.getPolicyConfigurationFactory().inService(contextId);
+        }
+        
+        return super.inService(contextId);
+        
+    }
+//    /**
+//     * This method tries to find the Policy Configuration copied into the file system (by the DAS) after the 
+//     * repository was initialized. 
+//     * 
+//     * This will only open the Policy Configuration if remove is true (otherwise the Policy Configuration will
+//     * remain in service);
+//     */
+//    private SimplePolicyConfiguration getPolicyConfigurationImplFromDirectory(String contextId, boolean open, boolean remove) {
+//        SimplePolicyConfiguration policyConfigurationImpl = null;
+//        
+//        File contextDirectory = new File(getContextDirectoryName(contextId));
+//        if (contextDirectory.exists()) {
+//            policyConfigurationImpl = new PolicyConfigurationImpl(contextDirectory, open, remove, this);
+//            contextToConfigurationMap.put(contextId, policyConfigurationImpl);
+//        }
+//        
+//        return policyConfigurationImpl;
+//    }
+
+    protected List<PolicyConfiguration> getPolicyConfigurationImpls() {
+        return new ArrayList<>(contextToConfigurationMap.values());
+    }
+    
+    protected PolicyConfiguration removePolicyConfigurationImpl(String contextID) {
+        return contextToConfigurationMap.remove(contextID);
+    }
+    
+    protected void checkSetPolicyPermission() {
+        SecurityManager securityManager = System.getSecurityManager();
+        if (securityManager != null) {
+            if (setPolicyPermission == null) {
+                setPolicyPermission = new SecurityPermission("setPolicy");
+            }
+            securityManager.checkPermission(setPolicyPermission);
+        }
+    }
+
+}

--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyProviderImpl.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyProviderImpl.java
@@ -1,0 +1,96 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.security.jacc.provider;
+
+import fish.payara.jacc.ContextProvider;
+import fish.payara.jacc.JaccConfigurationFactory;
+import jakarta.security.jacc.PolicyContext;
+import java.security.Permission;
+import java.security.ProtectionDomain;
+import org.glassfish.exousia.modules.locked.SimplePolicyProvider;
+
+
+/**
+ * Implementation of jacc PolicyProvider class
+ */
+public class PolicyProviderImpl extends SimplePolicyProvider {
+
+    private static ThreadLocal<Boolean> contextProviderReentry = new ThreadLocal<Boolean>() {
+
+        @Override
+        protected Boolean initialValue() {
+            return false;
+        }
+    };
+
+    @Override
+    public boolean implies(ProtectionDomain domain, Permission permission) {
+        String contextId = PolicyContext.getContextID();
+        if (contextId != null) {
+            ContextProvider contextProvider = getContextProvider(contextId, getPolicyFactory());
+            if (contextProvider != null) {
+
+                if (contextProviderReentry.get()) {
+                    return false;
+                }
+
+                contextProviderReentry.set(true);
+                try {
+                    return contextProvider.getPolicy().implies(domain, permission);
+                } finally {
+                    contextProviderReentry.set(false);
+                }
+            }
+        }
+        return super.implies(domain, permission);
+    }
+
+    // Obtains PolicyConfigurationFactory
+    private PolicyConfigurationFactoryImpl getPolicyFactory() {
+        return PolicyConfigurationFactoryImpl.getInstance();
+    }
+
+    private ContextProvider getContextProvider(String contextId, JaccConfigurationFactory configurationFactory) {
+        if (configurationFactory != null && contextId != null) {
+            return configurationFactory.getContextProviderByPolicyContextId(contextId);
+        }
+        return null;
+    }
+}

--- a/appserver/tests/payara-samples/samples/jacc-per-app/src/test/java/fish/payara/samples/jaccperapp/InstallJaccProviderTest.java
+++ b/appserver/tests/payara-samples/samples/jacc-per-app/src/test/java/fish/payara/samples/jaccperapp/InstallJaccProviderTest.java
@@ -104,9 +104,8 @@ public class InstallJaccProviderTest {
         return archive;
     }
 
-    //@Test
-    //TODO - uncomment after fixing problem: SimplePolicyConfigurationFactory is not an instance of fish.payara.jacc.JaccConfigurationFactory
-    //@RunAsClient
+    @Test
+    @RunAsClient
     public void testAuthenticated() throws IOException {
 
         String response =
@@ -139,9 +138,8 @@ public class InstallJaccProviderTest {
 
     }
 
-    //@Test
-    //TODO - uncomment after fixing problem: SimplePolicyConfigurationFactory is not an instance of fish.payara.jacc.JaccConfigurationFactory
-    //@RunAsClient
+    @Test
+    @RunAsClient
     public void testNotAuthenticated() throws IOException {
 
         String response =

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DefaultConfigUpgrade.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DefaultConfigUpgrade.java
@@ -507,10 +507,10 @@ public class DefaultConfigUpgrade implements ConfigurationUpgrade, PostConstruct
      *      <property name="jaas-context" value="fileRealm"/>
      *  </auth-realm>
      *  <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"/>
-     *  <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory">
+     *  <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl">
      *      <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy"/>
      *  </jacc-provider>
-     *  <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"/>
+     *  <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="simple" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"/>
      *  <audit-module classname="com.sun.enterprise.security.Audit" name="default">
      *      <property name="auditOn" value="false"/>
      *  </audit-module>
@@ -625,10 +625,10 @@ public class DefaultConfigUpgrade implements ConfigurationUpgrade, PostConstruct
     /* Loop through all jacc-provider elements in the template and create JaccProvider config objects.
      * Cursor should already be at first jacc-provider START_ELEMENT.
      * from template:
-     * <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory">
+     * <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl">
      *  <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy"/>
      * </jacc-provider>
-     * <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"/>
+     * <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="simple" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"/>
      */
     private void createJaccProvider(SecurityService ss) throws PropertyVetoException {
         while (!(parser.getEventType() == START_ELEMENT && parser.getLocalName().equals("audit-module"))) {

--- a/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
+++ b/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
@@ -76,7 +76,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -200,7 +200,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -324,7 +324,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/DGDomain.xml
+++ b/nucleus/admin/config-api/src/test/resources/DGDomain.xml
@@ -80,7 +80,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -204,7 +204,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -328,7 +328,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/DomainTest.xml
+++ b/nucleus/admin/config-api/src/test/resources/DomainTest.xml
@@ -102,7 +102,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
@@ -116,7 +116,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -238,7 +238,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -366,7 +366,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -494,7 +494,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -622,7 +622,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -750,7 +750,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -878,7 +878,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
@@ -127,7 +127,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -249,7 +249,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -377,7 +377,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -505,7 +505,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -633,7 +633,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -761,7 +761,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -889,7 +889,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1.xml
@@ -94,7 +94,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -216,7 +216,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -344,7 +344,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
@@ -105,7 +105,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -227,7 +227,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -355,7 +355,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -483,7 +483,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
@@ -94,7 +94,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -216,7 +216,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>
@@ -344,7 +344,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/admin/config-api/src/test/resources/parser/stock.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/stock.xml
@@ -104,7 +104,7 @@
           <property value="fileRealm" name="jaas-context" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>
@@ -258,7 +258,7 @@
                  <property name="jaas-context" value="fileRealm" />
              </auth-realm>
              <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-             <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+             <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
              <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
                  <property name="auditOn" value="false" />
              </audit-module>

--- a/nucleus/admin/launcher/src/test/resources/domains/baddomain/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/baddomain/config/domain.xml
@@ -119,7 +119,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
@@ -117,7 +117,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/admin/launcher/src/test/resources/domains/domain2/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain2/config/domain.xml
@@ -119,7 +119,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/admin/launcher/src/test/resources/domains/domain3/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain3/config/domain.xml
@@ -118,7 +118,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
@@ -115,7 +115,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -108,7 +108,7 @@
           <property value="fileRealm" name="jaas-context" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <message-security-config auth-layer="SOAP">
           <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
             <request-policy auth-source="content" />
@@ -258,7 +258,7 @@
                  <property name="jaas-context" value="fileRealm" />
              </auth-realm>
              <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-             <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+             <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
              <message-security-config auth-layer="SOAP">
                  <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
                      <request-policy auth-source="content" />

--- a/nucleus/common/common-util/src/test/resources/adminport.xml
+++ b/nucleus/common/common-util/src/test/resources/adminport.xml
@@ -117,7 +117,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/adminport2.xml
+++ b/nucleus/common/common-util/src/test/resources/adminport2.xml
@@ -104,7 +104,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/big.xml
+++ b/nucleus/common/common-util/src/test/resources/big.xml
@@ -108,7 +108,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/clusters1.xml
+++ b/nucleus/common/common-util/src/test/resources/clusters1.xml
@@ -138,7 +138,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -294,7 +294,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -457,7 +457,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -620,7 +620,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -783,7 +783,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -946,7 +946,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/hasprofiler.xml
+++ b/nucleus/common/common-util/src/test/resources/hasprofiler.xml
@@ -118,7 +118,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/manysysprops.xml
+++ b/nucleus/common/common-util/src/test/resources/manysysprops.xml
@@ -143,7 +143,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -299,7 +299,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -465,7 +465,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -628,7 +628,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -791,7 +791,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>
@@ -954,7 +954,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
@@ -108,7 +108,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/monitoringNone.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringNone.xml
@@ -108,7 +108,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
@@ -108,7 +108,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/noconfig.xml
+++ b/nucleus/common/common-util/src/test/resources/noconfig.xml
@@ -113,7 +113,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/nodomainname.xml
+++ b/nucleus/common/common-util/src/test/resources/nodomainname.xml
@@ -118,7 +118,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/olddomain.xml
+++ b/nucleus/common/common-util/src/test/resources/olddomain.xml
@@ -97,7 +97,7 @@
           <property value="fileRealm" name="jaas-context" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default"></jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property value="false" name="auditOn" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/rightorder.xml
+++ b/nucleus/common/common-util/src/test/resources/rightorder.xml
@@ -118,7 +118,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/rightordernoclosedomain.xml
+++ b/nucleus/common/common-util/src/test/resources/rightordernoclosedomain.xml
@@ -161,7 +161,7 @@
     </auth-realm>
     <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm">
     </auth-realm>
-    <jacc-provider name="default" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+    <jacc-provider name="default" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
     <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
 	<property name="auditOn" value="false"/>
     </audit-module>

--- a/nucleus/common/common-util/src/test/resources/v2domain.xml
+++ b/nucleus/common/common-util/src/test/resources/v2domain.xml
@@ -172,7 +172,7 @@
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
     </auth-realm>
-        <jacc-provider name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider"></jacc-provider>
+        <jacc-provider name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"/>
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/wrongorder.xml
+++ b/nucleus/common/common-util/src/test/resources/wrongorder.xml
@@ -105,7 +105,7 @@
           <property name="jaas-context" value="fileRealm" />
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false" />
         </audit-module>

--- a/nucleus/common/common-util/src/test/resources/wrongordernoclosedomain.xml
+++ b/nucleus/common/common-util/src/test/resources/wrongordernoclosedomain.xml
@@ -149,7 +149,7 @@
     </auth-realm>
     <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm">
     </auth-realm>
-    <jacc-provider name="default" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+    <jacc-provider name="default" policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
     <audit-module name="default" classname="com.sun.enterprise.security.ee.Audit">
 	<property name="auditOn" value="false"/>
     </audit-module>

--- a/nucleus/core/kernel/src/test/resources/DomainTest.xml
+++ b/nucleus/core/kernel/src/test/resources/DomainTest.xml
@@ -66,7 +66,7 @@
           <property name="jaas-context" value="fileRealm"></property>
         </auth-realm>
         <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate"></auth-realm>
-        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl"></jacc-provider>
         <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
           <property name="auditOn" value="false"></property>
         </audit-module>

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityUpgradeService.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityUpgradeService.java
@@ -179,7 +179,7 @@ public class SecurityUpgradeService implements ConfigurationUpgrade, PostConstru
         try {
             List<JaccProvider> jaccProviders = securityService.getJaccProvider();
             for (JaccProvider jacc : jaccProviders) {
-                if ("org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory".equals(jacc.getPolicyConfigurationFactoryProvider())) {
+                if ("fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl".equals(jacc.getPolicyConfigurationFactoryProvider())) {
                     //simple policy provider already present
                     return;
                 }
@@ -188,8 +188,8 @@ public class SecurityUpgradeService implements ConfigurationUpgrade, PostConstru
                 JaccProvider jacc = secServ.createChild(JaccProvider.class);
                 //add the simple provider to the domain's security service
                 jacc.setName("simple");
-                jacc.setPolicyConfigurationFactoryProvider("org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory");
-                jacc.setPolicyProvider("org.glassfish.exousia.modules.locked.SimplePolicyProvider");
+                jacc.setPolicyConfigurationFactoryProvider("fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl");
+                jacc.setPolicyProvider("fish.payara.security.jacc.provider.PolicyProviderImpl");
                 secServ.getJaccProvider().add(jacc);
                 return secServ;
             }, securityService);

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateJACCProvider.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateJACCProvider.java
@@ -84,7 +84,7 @@ import org.jvnet.hk2.config.types.Property;
  *
  *
  * domain.xml element example
- *   <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory">
+ *   <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl">
  *   </jacc-provider>
  *
  */

--- a/nucleus/security/core/src/main/manpages/com/sun/enterprise/security/cli/create-jacc-provider.1
+++ b/nucleus/security/core/src/main/manpages/com/sun/enterprise/security/cli/create-jacc-provider.1
@@ -95,8 +95,8 @@ EXAMPLES
            testJACC on the default server target.
 
                asadmin> create-jacc-provider
-               --policyproviderclass org.glassfish.exousia.modules.locked.SimplePolicyProvider
-               --policyconfigfactoryclass org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory
+               --policyproviderclass fish.payara.security.jacc.provider.PolicyProviderImpl
+               --policyconfigfactoryclass fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl
                testJACC
 
                Command create-jacc-provider executed successfully.


### PR DESCRIPTION
This PR wraps exousia Policy Provider and provides JACC per application feature by implementing JaccConfigurationFactory

