### PR TITLE
FISH-6471 Upgrade Docker image JDK (Payara6)

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -56,8 +56,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.15</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.3</docker.jdk17.tag>
+        <docker.jdk11.tag>11.0.16</docker.jdk11.tag>
+        <docker.jdk17.tag>17.0.4</docker.jdk17.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara6</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
Updates the Docker image JDK versions to 11.0.16, and 17.0.4.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the Docker tests.

### Testing Environment
Windows 10.

## Documentation
N/A

## Notes for Reviewers
None