### PR TITLE
FISH-6459 replacing ./ to / (Payara 6 Release)

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package org.apache.catalina.core;
 
@@ -288,6 +288,10 @@ final class StandardContextValve
         // starts with a double-slash
         if(rv.indexOf("//") == 0) {
             rv = rv.replace("//", "/");
+        }
+        // starts with dot-slash
+        if(rv.indexOf("./") == 0) {
+            rv = rv.replaceFirst("./", "/");
         }
 
         // Normalize the slashes and add leading slash if necessary

--- a/appserver/web/web-core/src/test/java/org/apache/catalina/core/StandardContextValveTest.java
+++ b/appserver/web/web-core/src/test/java/org/apache/catalina/core/StandardContextValveTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2021-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -95,6 +95,7 @@ public class StandardContextValveTest extends TestCase {
     public void normalizeURLTest() {
         String path1 = "/app/../some/../something/../my.jsp";
         String path2 = "/app/./some/./something/./my.jsp";
+        String path3 = "./my.jsp";
 
         String result = standardContextValve.normalize(path1);
 
@@ -103,6 +104,10 @@ public class StandardContextValveTest extends TestCase {
         result = standardContextValve.normalize(path2);
 
         assertEquals("/app/some/something/my.jsp", result);
+
+        result = standardContextValve.normalize(path3);
+
+        assertEquals("/my.jsp", result);
     }
 
     protected void verifyThatResourceIsNotFound(int pipelineResult, int times, HttpRequest httpRequest, HttpResponse httpResponse,


### PR DESCRIPTION
Cherry-pick of https://github.com/payara/Payara-Enterprise/pull/630 (by @luiseufrasio) 

## Description
FISH-6459

## Testing

### New tests
New case in StandardContextValveTest.normalizeURLTest

### Testing Performed
Steps in https://payara.atlassian.net/browse/FISH-6459
using Payara Server Enterprise instead of microprofile.

### Test suites executed
- Quicklook
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples
- Payara Microprofile TCKs Runner
- Jakarta TCKs
- Mojarra
- Cargo Tracker

### Testing Environment
JDK 1.8_212 on Windows 10  with Maven 3.8.0
