### PR TITLE
FISH-6415 Unexpected Error When Starting Instance Hosted On Remote SSH Node on Windows OS Via Cygwin

### DIFF
--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2022] Payara Foundation and/or affiliates
 
 package org.glassfish.cluster.ssh.launcher;
 
@@ -531,8 +531,8 @@ public class SSHLauncher {
             t1.join();
             t2.join();
 
-            // wait for some time since the delivery of the exit status often gets delayed
-            session.waitForCondition(ChannelCondition.EXIT_STATUS,3000);
+            // Wait for the command to return
+            session.waitForCondition(ChannelCondition.EXIT_STATUS, DEFAULT_TIMEOUT_MSEC);
             Integer r = session.getExitStatus();
             if(r!=null) return r.intValue();
             return -1;


### PR DESCRIPTION
## Description
An instance hosted on a remote SSH node in a Windows environment would quickly return saying that the command had failed, but when refreshing the instance page the instance would show as running.

This seems to come about due to a hard-coded 3 second wait, at which point the SSH connection is terminated. This PR ups the wait to the default of 120 seconds. This means:

* Commands which take less than 120 seconds to complete should still return within that time - the SSH connection won't just sit there for 120 seconds
* Commands which take longer than 120 seconds will show as failed, though if the command timeout itself is configured to be longer the command will still continue on the remote instance until it completes or times out.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Spun up two Windows VMs in AWS
Installed Cygwin and configured SSH between the two VMs
Installed server to both
Started Das on VM 1 and added the following JVM option so it doesn't just use "localhost" as the hostname: `-Dcom.sun.aas.hostName=$IP_ADDRESS`
Restarted Das
Created Remote SSH Node on VM2 from DAS (using password auth)
Created an instance on the remote node using DAS
Started instance on remote node using DAS

### Testing Environment
Windows 10, JDK 8

## Documentation
N/A

## Notes for Reviewers
None