### PR TITLE
FISH-6415 Unexpected Error When Starting Instance Hosted On Remote SSH Node on Windows OS Via Cygwin (Payara6)

### DIFF
--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
@@ -1112,9 +1112,12 @@ public class SSHLauncher {
     private int getTimeout() {
         int timeout = DEFAULT_TIMEOUT_MSEC;
         try {
-            timeout = Integer.parseInt(System.getProperty(TIMEOUT_PROPERTY));
+            String timeoutPropertyValue = System.getProperty(TIMEOUT_PROPERTY);
+            if (StringUtils.ok(timeoutPropertyValue)) {
+                timeout = Integer.parseInt(timeoutPropertyValue);
+            }
         } catch (NumberFormatException numberFormatException) {
-            logger.log(Level.INFO, "Value of {0} does not appear to be a valid integer, defaulting to {1}ms: {2}",
+            logger.log(Level.WARNING, "Value of {0} does not appear to be a valid integer, defaulting to {1}ms: {2}",
                     new Object[]{TIMEOUT_PROPERTY, DEFAULT_TIMEOUT_MSEC, numberFormatException});
         }
 

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
@@ -78,8 +78,8 @@ public class SSHLauncher {
     private static final String SSH_DIR = ".ssh" + File.separator;
     private static final String AUTH_KEY_FILE = "authorized_keys";
 
-    private static final String TIMEOUT_PROPERTY = "fish.payara.node.ssh.timeout";
-    private static final int DEFAULT_TIMEOUT_MSEC = 120000; // 2 minutes
+    protected static final String TIMEOUT_PROPERTY = "fish.payara.node.ssh.timeout";
+    protected static final int DEFAULT_TIMEOUT_MSEC = 120000; // 2 minutes
 
     private static final String SSH_KEYGEN = "ssh-keygen";
     private static final char LINE_SEP = System.getProperty("line.separator").charAt(0);
@@ -1109,7 +1109,7 @@ public class SSHLauncher {
      *
      * @return The timeout in milliseconds.
      */
-    private int getTimeout() {
+    protected int getTimeout() {
         int timeout = DEFAULT_TIMEOUT_MSEC;
         try {
             String timeoutPropertyValue = System.getProperty(TIMEOUT_PROPERTY);

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
@@ -80,6 +80,7 @@ public class SSHLauncher {
 
     protected static final String TIMEOUT_PROPERTY = "fish.payara.node.ssh.timeout";
     protected static final int DEFAULT_TIMEOUT_MSEC = 120000; // 2 minutes
+    protected static final int MINIMUM_TIMEOUT_MSEC = 1;
 
     private static final String SSH_KEYGEN = "ssh-keygen";
     private static final char LINE_SEP = System.getProperty("line.separator").charAt(0);
@@ -1115,6 +1116,11 @@ public class SSHLauncher {
             String timeoutPropertyValue = System.getProperty(TIMEOUT_PROPERTY);
             if (StringUtils.ok(timeoutPropertyValue)) {
                 timeout = Integer.parseInt(timeoutPropertyValue);
+                if (timeout < MINIMUM_TIMEOUT_MSEC) {
+                    logger.log(Level.WARNING, "Value of {0} does not appear to be within accepted range of {1} and {2}, defaulting to {3}ms: {4}",
+                            new Object[]{TIMEOUT_PROPERTY, MINIMUM_TIMEOUT_MSEC, Integer.MAX_VALUE, DEFAULT_TIMEOUT_MSEC, timeout});
+                    timeout = DEFAULT_TIMEOUT_MSEC;
+                }
             }
         } catch (NumberFormatException numberFormatException) {
             logger.log(Level.WARNING, "Value of {0} does not appear to be a valid integer, defaulting to {1}ms: {2}",

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2022] Payara Foundation and/or affiliates
 
 package org.glassfish.cluster.ssh.launcher;
 
@@ -531,8 +531,8 @@ public class SSHLauncher {
             t1.join();
             t2.join();
 
-            // wait for some time since the delivery of the exit status often gets delayed
-            session.waitForCondition(ChannelCondition.EXIT_STATUS,3000);
+            // Wait for the command to return
+            session.waitForCondition(ChannelCondition.EXIT_STATUS, DEFAULT_TIMEOUT_MSEC);
             Integer r = session.getExitStatus();
             if(r!=null) return r.intValue();
             return -1;

--- a/nucleus/cluster/ssh/src/test/java/org/glassfish/cluster/ssh/launcher/SSHLauncherTest.java
+++ b/nucleus/cluster/ssh/src/test/java/org/glassfish/cluster/ssh/launcher/SSHLauncherTest.java
@@ -79,4 +79,40 @@ public class SSHLauncherTest {
         System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
         Assert.assertEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
     }
+
+    @Test
+    public void negativeTimeoutIgnoredTest() {
+        final String customTimeout = "-123456";
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
+    }
+
+    @Test
+    public void minimumTimeoutAllowedTest() {
+        final String customTimeout = "1";
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertEquals(Integer.parseInt(customTimeout), sshLauncher.getTimeout());
+    }
+
+    @Test
+    public void zeroTimeoutIgnoredTest() {
+        final String customTimeout = "0";
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
+    }
+
+    @Test
+    public void maximumTimeoutAllowedTest() {
+        final String customTimeout = Integer.toString(Integer.MAX_VALUE);
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertEquals(Integer.parseInt(customTimeout), sshLauncher.getTimeout());
+    }
+
+    @Test
+    public void overMaximumTimeoutIgnoredTest() {
+        final String customTimeout = Integer.toString(Integer.MAX_VALUE) + 1;
+        System.out.println(customTimeout);
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
+    }
 }

--- a/nucleus/cluster/ssh/src/test/java/org/glassfish/cluster/ssh/launcher/SSHLauncherTest.java
+++ b/nucleus/cluster/ssh/src/test/java/org/glassfish/cluster/ssh/launcher/SSHLauncherTest.java
@@ -1,0 +1,82 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package org.glassfish.cluster.ssh.launcher;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.logging.Logger;
+
+public class SSHLauncherTest {
+
+    private SSHLauncher sshLauncher;
+
+    @Before
+    public void clearAndInit() {
+        sshLauncher = new SSHLauncher();
+        sshLauncher.init(Logger.getLogger(SSHLauncherTest.class.getName()));
+        System.clearProperty(SSHLauncher.TIMEOUT_PROPERTY);
+    }
+
+    @Test
+    public void defaultTimeoutTest() {
+        Assert.assertEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
+    }
+
+    @Test
+    public void customTimeoutTest() {
+        final String customTimeout = "12345";
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertNotEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
+        Assert.assertEquals(Integer.parseInt(customTimeout), sshLauncher.getTimeout());
+    }
+
+    @Test
+    public void nonParseableTimeoutIgnoredTest() {
+        final String customTimeout = "asdsa";
+        System.setProperty(SSHLauncher.TIMEOUT_PROPERTY, customTimeout);
+        Assert.assertEquals(SSHLauncher.DEFAULT_TIMEOUT_MSEC, sshLauncher.getTimeout());
+    }
+}


### PR DESCRIPTION
## Description
Recreation of https://github.com/payara/Payara/pull/5896

An instance hosted on a remote SSH node in a Windows environment would quickly return saying that the command had failed, but when refreshing the instance page the instance would show as running.

This seems to come about due to a hard-coded 3 second wait, at which point the SSH connection is terminated. This PR ups the wait to the default of 120 seconds, which can be overidden using a new system property `fish.payara.node.ssh.timeout`. This means:

* Commands which take less than 120 (or user-defined x) seconds to complete should still return within that time - the SSH connection won't just sit there for 120  (or user-defined x) seconds
* Commands which take longer than 120 (or user-defined x) seconds will show as failed, though if the command timeout itself is configured to be longer the command will still continue on the remote instance until it completes or times out.

## Important Info
### Blockers
None

## Testing
### New tests
A set of three unit tests to check:
* Default is used with no property set
* Custom value is used with custom value set
* Default is used if invalid custom value set

### Testing Performed
#### Test Default
Spun up two Windows VMs in AWS
Installed Cygwin and configured SSH between the two VMs
Installed server to both
Started Das on VM 1 and added the following JVM option so it doesn't just use "localhost" as the hostname: `-Dcom.sun.aas.hostName=$IP_ADDRESS`
Restarted Das
Created Remote SSH Node on VM2 from DAS (using password auth)
Created an instance on the remote node using DAS
Started instance on remote node using DAS
Instance started without timeout

#### Test Custom
Spun up two Windows VMs in AWS
Installed Cygwin and configured SSH between the two VMs
Installed server to both
Started Das on VM 1 and added the following JVM option so it doesn't just use "localhost" as the hostname: `-Dcom.sun.aas.hostName=$IP_ADDRESS`
Restarted Das
Created Remote SSH Node on VM2 from DAS (using password auth)
Created an instance on the remote node using DAS
Set system property in server-config to 2 seconds
Started instance on remote node using DAS
Command timed out and reported failure
Instance continued to start

#### Test Invalid Custom
Spun up two Windows VMs in AWS
Installed Cygwin and configured SSH between the two VMs
Installed server to both
Started Das on VM 1 and added the following JVM option so it doesn't just use "localhost" as the hostname: `-Dcom.sun.aas.hostName=$IP_ADDRESS`
Restarted Das
Created Remote SSH Node on VM2 from DAS (using password auth)
Created an instance on the remote node using DAS
Set system property in server-config to "asdsa" seconds
Started instance on remote node using DAS
Instance started without timeout
Server log reported warning of invalid property value being ignored

### Testing Environment
Windows 10, JDK 8

## Documentation
https://github.com/payara/Payara-Documentation/pull/72

## Notes for Reviewers
None