### PR TITLE
FISH-6483: Package Faces 3.0 for use by Admin GUI

### DIFF
--- a/appserver/admingui/cluster/pom.xml
+++ b/appserver/admingui/cluster/pom.xml
@@ -95,8 +95,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -115,12 +115,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating-dt</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -140,8 +137,9 @@
             <artifactId>expressly</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2096,25 +2096,29 @@ admingui.table = {
     },
 
     changeButtons : function (buttons,tableId){
-        try {
-            var table = document.getElementById(tableId);// + ":_table");
-            var selections = table.getAllSelectedRowsCount();
-            var disabled = (selections > 0) ? false : true;
-            for (count=0; count < buttons.length; count++) {
-                var element = document.getElementById(buttons[count]);
-                if (element) {
-                    element.disabled = disabled;
-                    element.className = disabled ? "Btn2Dis_sun4" : "Btn1_sun4";
+        require(["webui/suntheme/table"], function(themeTable) {
+            try {
+                var table = document.getElementById(tableId);// + ":_table");
+                var selections = table.getAllSelectedRowsCount();
+                var disabled = (selections > 0) ? false : true;
+                for (count=0; count < buttons.length; count++) {
+                    var element = document.getElementById(buttons[count]);
+                    if (element) {
+                        element.disabled = disabled;
+                        element.className = disabled ? "Btn2Dis_sun4" : "Btn1_sun4";
+                    }
                 }
-            }
-        } catch (err) {
+            } catch (err) {
             alert(err);
-        }
+            }
+        });
     },
 
     initAllRows : function (tableId) {
-        var table = document.getElementById(tableId);
-        table.initAllRows();
+        require(["webui/suntheme/table"], function(themeTable) {
+            var table = document.getElementById(tableId);
+            table.initAllRows();
+        });
     }
 }
 

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -108,8 +108,9 @@
             <version>${woodstock-jsf.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/faces-compat/pom.xml
+++ b/appserver/admingui/faces-compat/pom.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>admingui</artifactId>
+        <groupId>fish.payara.server.internal.admingui</groupId>
+        <version>6.2022.1.Alpha5-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>faces-compat</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>3.0.2</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jsftemplating</groupId>
+            <artifactId>jsftemplating</artifactId>
+            <optional>true</optional>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.el</groupId>
+                    <artifactId>jakarta.el-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jsftemplating</groupId>
+            <artifactId>jsftemplating-dt</artifactId>
+            <optional>true</optional>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>dataprovider</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.web</groupId>
+            <artifactId>web-glue</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>glassfish-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>common-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>container-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.deployment</groupId>
+            <artifactId>dol</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Embed-Dependency>*;artifactId=jakarta.faces|jsftemplating|jsftemplating-dt;inline=true</Embed-Dependency>
+                                <!-- Contents are exported with additional mandatory attribute, so they wouldn't match general import for e. g. jakarta.faces -->
+                                <Export-Package>fish.payara.server.internal.admingui,
+                                    !com.sun.faces.tlddoc-resources,
+                                    com.sun.faces.*;com.sun.jsft.*;com.sun.jsftemplating.*;jakarta.faces.*;version="3.0";usage="admingui";mandatory:=usage</Export-Package>
+                                <Import-Package>!com.sun.faces.*,!jakarta.faces.*,!com.sun.jsftemplating.*,!com.sun.jsft,*</Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- this module repackages direct faces dependency -->
+                        <id>no-direct-faces-dependency</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-inhabitant-generator</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-inhabitants</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/admingui/faces-compat/src/main/java/com/sun/faces/config/FacesInitializer2.java
+++ b/appserver/admingui/faces-compat/src/main/java/com/sun/faces/config/FacesInitializer2.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package com.sun.faces.config;
+
+import java.util.Set;
+
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+
+public class FacesInitializer2 implements ServletContainerInitializer {
+    @Override
+    public void onStartup(Set<Class<?>> set, ServletContext servletContext) throws ServletException {
+        // do nothing, just override Faces 4 initializer
+    }
+}

--- a/appserver/admingui/faces-compat/src/main/java/fish/payara/server/internal/admingui/GlassFishInjectionProvider.java
+++ b/appserver/admingui/faces-compat/src/main/java/fish/payara/server/internal/admingui/GlassFishInjectionProvider.java
@@ -1,0 +1,480 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2009-2012 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.server.internal.admingui;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import com.sun.enterprise.container.common.spi.JCDIService;
+import com.sun.enterprise.container.common.spi.util.ComponentEnvManager;
+import com.sun.enterprise.container.common.spi.util.InjectionException;
+import com.sun.enterprise.container.common.spi.util.InjectionManager;
+import com.sun.enterprise.deployment.BundleDescriptor;
+import com.sun.enterprise.deployment.InjectionInfo;
+import com.sun.enterprise.deployment.JndiNameEnvironment;
+import com.sun.faces.config.WebConfiguration;
+import com.sun.faces.spi.AnnotationScanner;
+import com.sun.faces.spi.DiscoverableInjectionProvider;
+import com.sun.faces.spi.HighAvailabilityEnabler;
+import com.sun.faces.spi.InjectionProviderException;
+import com.sun.faces.spi.ThreadContext;
+import com.sun.faces.util.FacesLogger;
+import jakarta.servlet.ServletContext;
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.api.invocation.ComponentInvocation;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
+import org.glassfish.hk2.classmodel.reflect.Type;
+import org.glassfish.hk2.classmodel.reflect.Types;
+
+import static com.sun.enterprise.web.Constants.DEPLOYMENT_CONTEXT_ATTRIBUTE;
+import static com.sun.enterprise.web.Constants.ENABLE_HA_ATTRIBUTE;
+import static com.sun.enterprise.web.Constants.IS_DISTRIBUTABLE_ATTRIBUTE;
+import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.EnableAgressiveSessionDirtying;
+import static java.lang.Boolean.TRUE;
+import static java.security.AccessController.doPrivileged;
+import static java.util.logging.Level.FINE;
+import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION;
+
+/**
+ * <p>
+ * This <code>InjectionProvider</code> is specific to the Payara/GlassFish/SJSAS 9.x PE/EE application servers.
+ * </p>
+ */
+public class GlassFishInjectionProvider extends DiscoverableInjectionProvider implements AnnotationScanner, HighAvailabilityEnabler, ThreadContext {
+
+    private static final Logger LOGGER = FacesLogger.APPLICATION.getLogger();
+    private static final String HABITAT_ATTRIBUTE = "org.glassfish.servlet.habitat";
+    
+    private ComponentEnvManager compEnvManager;
+    private InjectionManager injectionManager;
+    private InvocationManager invocationManager;
+    private JCDIService cdiService;
+
+    /**
+     * <p>
+     * Constructs a new <code>GlassFishInjectionProvider</code> instance.
+     * </p>
+     *
+     * @param servletContext
+     */
+    public GlassFishInjectionProvider(ServletContext servletContext) {
+        ServiceLocator defaultServices = (ServiceLocator) servletContext.getAttribute(HABITAT_ATTRIBUTE);
+        
+        compEnvManager = defaultServices.getService(ComponentEnvManager.class);
+        invocationManager = defaultServices.getService(InvocationManager.class);
+        injectionManager = defaultServices.getService(InjectionManager.class);
+        cdiService = defaultServices.getService(JCDIService.class);
+    }
+
+    @Override
+    public Map<String, List<ScannedAnnotation>> getAnnotatedClassesInCurrentModule(ServletContext servletContext) throws InjectionProviderException {
+
+        Map<String, List<ScannedAnnotation>> classesByAnnotation = new HashMap<String, List<ScannedAnnotation>>();
+        
+        Collection<Type> allTypes = ((DeploymentContext) 
+                servletContext.getAttribute(DEPLOYMENT_CONTEXT_ATTRIBUTE))
+                              .getTransientAppMetaData(Types.class.getName(), Types.class)
+                              .getAllTypes();
+        
+        for (Type type : allTypes) {
+            
+            for (AnnotationModel annotationModel : type.getAnnotations()) {
+                String annotationName = annotationModel.getType().getName();
+                
+                List<ScannedAnnotation> classesWithThisAnnotation = classesByAnnotation.get(annotationName);
+                
+                if (classesWithThisAnnotation == null) {
+                    classesWithThisAnnotation = new ArrayList<ScannedAnnotation>();
+                    classesByAnnotation.put(annotationName, classesWithThisAnnotation);
+                }
+                
+                ScannedAnnotation toAdd = new ScannedAnnotation() {
+
+                    @Override
+                    public boolean equals(Object obj) {
+                        boolean result = false;
+                        if (obj instanceof ScannedAnnotation) {
+                            String otherName = ((ScannedAnnotation) obj).getFullyQualifiedClassName();
+                            if (otherName != null) {
+                                result = type.getName().equals(otherName);
+                            }
+                        }
+
+                        return result;
+                    }
+
+                    @Override
+                    public int hashCode() {
+                        String str = getFullyQualifiedClassName();
+                        Collection<URI> obj = getDefiningURIs();
+                        int result = str != null ? str.hashCode() : 0;
+                        result = 31 * result + (obj != null ? obj.hashCode() : 0);
+                        return result;
+                    }
+
+                    @Override
+                    public String getFullyQualifiedClassName() {
+                        return type.getName();
+                    }
+
+                    @Override
+                    public Collection<URI> getDefiningURIs() {
+                        return type.getDefiningURIs();
+                    }
+
+                };
+                
+                if (!classesWithThisAnnotation.contains(toAdd)) {
+                    classesWithThisAnnotation.add(toAdd);
+                }
+            }
+        }
+        
+        return classesByAnnotation;
+    }
+
+    /**
+     * <p>
+     * The implementation of this method must perform the following steps:
+     * <ul>
+     * <li>Inject the supported resources per the Servlet 2.5 specification into the provided object</li>
+     * </ul>
+     * </p>
+     *
+     * @param managedBean
+     *            the target managed bean
+     */
+    public void inject(Object managedBean) throws InjectionProviderException {
+        try {
+            injectionManager.injectInstance(managedBean, getComponentEnvironment(), false);
+
+            if (cdiService.isCurrentModuleJCDIEnabled()) {
+                cdiService.injectManagedObject(managedBean, getBundle());
+
+            }
+
+        } catch (InjectionException ie) {
+            throw new InjectionProviderException(ie);
+        }
+    }
+    
+    /**
+     * <p>
+     * The implemenation of this method must invoke any method marked with the <code>@PostConstruct</code> annotation (per
+     * the Common Annotations Specification).
+     *
+     * @param managedBean
+     *            the target managed bean
+     *
+     * @throws InjectionProviderException
+     *             if an error occurs when invoking the method annotated by the <code>@PostConstruct</code> annotation
+     */
+    public void invokePostConstruct(Object managedBean) throws InjectionProviderException {
+        try {
+            invokePostConstruct(managedBean, getComponentEnvironment());
+        } catch (InjectionException ie) {
+            throw new InjectionProviderException(ie);
+        }
+
+    }
+
+    /**
+     * <p>
+     * The implemenation of this method must invoke any method marked with the <code>@PreDestroy</code> annotation (per the
+     * Common Annotations Specification).
+     *
+     * @param managedBean
+     *            the target managed bean
+     */
+    public void invokePreDestroy(Object managedBean) throws InjectionProviderException {
+        try {
+            injectionManager.invokeInstancePreDestroy(managedBean);
+        } catch (InjectionException ie) {
+            throw new InjectionProviderException(ie);
+        }
+    }
+    
+
+    // --------------------------------------------------------- ThreadContext
+    
+    @Override
+    public Object getParentWebContext() {
+        return invocationManager.getAllInvocations();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public void propagateWebContextToChild(Object context) {
+        
+        if (!(context instanceof List)) {
+            throw new IllegalArgumentException("Context of incorrect type, was it obtained by calling getParentWebContext()?");
+        }
+        
+        invocationManager.setThreadInheritableInvocation((List<? extends ComponentInvocation>) context);
+    }
+    
+    @Override
+    public void clearChildContext() {
+        invocationManager.popAllInvocations();
+    }
+    
+
+    
+    // --------------------------------------------------------- Private Methods
+
+    /**
+     * <p>
+     * This is based off of code in <code>InjectionManagerImpl</code>.
+     * </p>
+     * 
+     * @return <code>JndiNameEnvironment</code>
+     * @throws InjectionException
+     *             if we're unable to obtain the <code>JndiNameEnvironment</code>
+     */
+    private JndiNameEnvironment getComponentEnvironment() throws InjectionException {
+        ComponentInvocation invocation = invocationManager.getCurrentInvocation();
+        
+        if (invocation == null) {
+            throw new InjectionException("null invocation context");
+        }
+        
+        if (invocation.getInvocationType() != SERVLET_INVOCATION) {
+            throw new InjectionException("Wrong invocation type");
+        }
+
+        JndiNameEnvironment componentEnvironment = (JndiNameEnvironment) invocation.getJndiEnvironment();
+        
+        if (componentEnvironment == null) {
+            throw new InjectionException("No descriptor registered for " + " current invocation : " + invocation);
+        }
+        
+        return componentEnvironment;
+    }
+
+    /**
+     * <p>
+     * This is based off of code in <code>InjectionManagerImpl</code>.
+     * </p>
+     *
+     * @param instance
+     *            managed bean instance
+     * @param envDescriptor
+     *            JNDI environment
+     * @throws InjectionException
+     *             if an error occurs
+     */
+    private void invokePostConstruct(Object instance, JndiNameEnvironment envDescriptor) throws InjectionException {
+        LinkedList<Method> postConstructMethods = new LinkedList<Method>();
+
+        Class<? extends Object> nextClass = instance.getClass();
+
+        // Process each class in the inheritance hierarchy, starting with
+        // the most derived class and ignoring java.lang.Object.
+        while ((!Object.class.equals(nextClass)) && (nextClass != null)) {
+
+            InjectionInfo injectionInfo = envDescriptor.getInjectionInfoByClass(nextClass);
+
+            if (injectionInfo.getPostConstructMethodName() != null) {
+
+                Method postConstructMethod = getPostConstructMethod(injectionInfo, nextClass);
+
+                // Invoke the preDestroy methods starting from
+                // the least-derived class downward.
+                postConstructMethods.addFirst(postConstructMethod);
+            }
+
+            nextClass = nextClass.getSuperclass();
+        }
+
+        for (Method postConstructMethod : postConstructMethods) {
+            invokeLifecycleMethod(postConstructMethod, instance);
+        }
+
+    }
+
+    /**
+     * <p>
+     * This is based off of code in <code>InjectionManagerImpl</code>.
+     * </p>
+     * 
+     * @param injectionInfo
+     *            InjectionInfo
+     * @param resourceClass
+     *            target class
+     * @return a Method marked with the @PostConstruct annotation
+     * @throws InjectionException
+     *             if an error occurs
+     */
+    private Method getPostConstructMethod(InjectionInfo injectionInfo, Class<? extends Object> resourceClass) throws InjectionException {
+        
+        Method postConstructMethod = injectionInfo.getPostConstructMethod();
+
+        if (postConstructMethod == null) {
+            String postConstructMethodName = injectionInfo.getPostConstructMethodName();
+
+            // Check for the method within the resourceClass only.
+            // This does not include super-classses.
+            for (Method declaredMethod : resourceClass.getDeclaredMethods()) {
+                
+                // InjectionManager only handles injection into PostConstruct
+                // methods with no arguments.
+                if (declaredMethod.getName().equals(postConstructMethodName) && declaredMethod.getParameterTypes().length == 0) {
+                    postConstructMethod = declaredMethod;
+                    injectionInfo.setPostConstructMethod(postConstructMethod);
+                    break;
+                }
+            }
+        }
+
+        if (postConstructMethod == null) {
+            throw new InjectionException(
+                    "InjectionManager exception. PostConstruct method " + injectionInfo.getPostConstructMethodName() + 
+                    " could not be found in class " + injectionInfo.getClassName());
+        }
+
+        return postConstructMethod;
+    }
+
+    /**
+     * <p>
+     * This is based off of code in <code>InjectionManagerImpl</code>.
+     * </p>
+     * 
+     * @param lifecycleMethod
+     *            the method to invoke
+     * @param instance
+     *            the instanced to invoke the method against
+     * @throws InjectionException
+     *             if an error occurs
+     */
+    private void invokeLifecycleMethod(final Method lifecycleMethod, final Object instance) throws InjectionException {
+
+        try {
+
+            if (LOGGER.isLoggable(FINE)) {
+                LOGGER.fine("Calling lifecycle method " + lifecycleMethod + " on class " + lifecycleMethod.getDeclaringClass());
+            }
+
+            // Wrap actual value insertion in doPrivileged to
+            // allow for private/protected field access.
+            doPrivileged(new PrivilegedExceptionAction<Object>() {
+                public Object run() throws Exception {
+                    if (!lifecycleMethod.isAccessible()) {
+                        lifecycleMethod.setAccessible(true);
+                    }
+                    lifecycleMethod.invoke(instance);
+                    return null;
+                }
+            });
+        } catch (Exception t) {
+
+            String msg = "Exception attempting invoke lifecycle " + " method " + lifecycleMethod;
+            LOGGER.log(FINE, msg, t);
+            
+            InjectionException ie = new InjectionException(msg);
+            Throwable cause = (t instanceof InvocationTargetException) ? t.getCause() : t;
+            ie.initCause(cause);
+            throw ie;
+        }
+
+        return;
+    }
+
+    private BundleDescriptor getBundle() {
+        JndiNameEnvironment componentEnvironment = compEnvManager.getCurrentJndiNameEnvironment();
+
+        BundleDescriptor bundle = null;
+
+        if (componentEnvironment instanceof BundleDescriptor) {
+            bundle = (BundleDescriptor) componentEnvironment;
+        }
+
+        if (bundle == null) {
+            throw new IllegalStateException("Invalid context for managed bean creation");
+        }
+
+        return bundle;
+    }
+
+    /**
+     * Method to test with HA has been enabled. If so, then set the JSF context param
+     * com.sun.faces.enableAgressiveSessionDirtying to true
+     * 
+     * @param ctx
+     */
+    public void enableHighAvailability(ServletContext ctx) {
+        
+        // look at the following values for the web app
+        // 1> has <distributable /> in the web.xml
+        // 2> Was deployed with --availabilityenabled --target <clustername>
+        
+        WebConfiguration config = WebConfiguration.getInstance(ctx);
+        if (!config.isSet(EnableAgressiveSessionDirtying)) {
+            Object isDistributableObj = ctx.getAttribute(IS_DISTRIBUTABLE_ATTRIBUTE);
+            Object enableHAObj = ctx.getAttribute(ENABLE_HA_ATTRIBUTE);
+            
+            if (isDistributableObj instanceof Boolean && enableHAObj instanceof Boolean) {
+                boolean isDistributable = (Boolean) isDistributableObj;
+                boolean enableHA = (Boolean) enableHAObj;
+
+                if (LOGGER.isLoggable(FINE)) {
+                    LOGGER.log(FINE, "isDistributable = {0} enableHA = {1}", new Object[] { isDistributable, enableHA });
+                }
+                
+                if (isDistributable && enableHA) {
+                    LOGGER.fine("setting the EnableAgressiveSessionDirtying to true");
+                    config.overrideContextInitParameter(EnableAgressiveSessionDirtying, TRUE);
+                }
+            }
+        }
+    }
+}

--- a/appserver/admingui/full/pom.xml
+++ b/appserver/admingui/full/pom.xml
@@ -85,8 +85,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/jca/pom.xml
+++ b/appserver/admingui/jca/pom.xml
@@ -85,8 +85,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -130,8 +130,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/admingui/payara-console-extras/pom.xml
+++ b/appserver/admingui/payara-console-extras/pom.xml
@@ -96,16 +96,11 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.web</groupId>
-            <artifactId>weld-integration</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>

--- a/appserver/admingui/payara-console-extras/src/main/java/fish/payara/admingui/extras/rest/PayaraRestApiHandlers.java
+++ b/appserver/admingui/payara-console-extras/src/main/java/fish/payara/admingui/extras/rest/PayaraRestApiHandlers.java
@@ -37,8 +37,6 @@
  */
 package fish.payara.admingui.extras.rest;
 
-import static org.glassfish.weld.WeldDeployer.DEV_MODE_PROPERTY;
-
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -329,7 +327,8 @@ public class PayaraRestApiHandlers {
                     }
                 }
                 if (!enabled) {
-                    result.put(componentName, Boolean.getBoolean(DEV_MODE_PROPERTY));
+                    // constant inlined because we cannot transitively depend on Faces 4, which weld-integration would bring
+                    result.put(componentName, Boolean.getBoolean("org.jboss.weld.development"));
                 }
             }
 

--- a/appserver/admingui/pom.xml
+++ b/appserver/admingui/pom.xml
@@ -151,6 +151,7 @@
         <module>rest-monitoring-plugin</module>
         <module>microprofile-console-plugin</module>
         <module>microprofile-console-plugin-l10n</module>
+        <module>faces-compat</module>
     </modules>
 
     <properties>
@@ -178,6 +179,30 @@
               </execution>
             </executions>
           </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>no-direct-faces-dependency</id>
+                        <inherited>true</inherited>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.glassfish:jakarta.faces</exclude>
+                                        <exclude>org.glassfish.jsftemplating:*</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
           <resource>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -103,7 +103,7 @@
                         <manifestEntries>
                             <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
                             <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client,
-                                jakarta.servlet-api,jakarta.servlet.jsp-api,org.glassfish.expressly,org.glassfish.jsftemplating,fish.payara.server.internal.admingui.dataprovider,com.sun.pkg.client</HK2-Import-Bundles>
+                                jakarta.servlet-api,jakarta.servlet.jsp-api,org.glassfish.expressly,fish.payara.server.internal.admingui.faces-compat,fish.payara.server.internal.admingui.dataprovider,com.sun.pkg.client</HK2-Import-Bundles>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -133,13 +133,6 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.internal.admingui</groupId>
-            <artifactId>dataprovider</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.sun.woodstock.dependlibs</groupId>
             <artifactId>dojo-ajax-nodemo</artifactId>
         </dependency>
@@ -156,8 +149,10 @@
             <artifactId>woodstock-webui-jsf</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -60,5 +60,6 @@
         <parameter-encoding default-charset="UTF-8" />
     </locale-charset-info>
     <class-loader delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock-jsf-suntheme.version}${enterprise.theme.classifier}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock-jsf.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar:WEB-INF/extra/json-${woodstock-json.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock-jsf-suntheme.version}${enterprise.theme.classifier}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock-jsf.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar:WEB-INF/extra/json-${woodstock-json.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar"/>
+    <property name="useBundledJsf" value="true"/>
 </sun-web-app>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/web.xml
@@ -79,7 +79,14 @@
         <param-name>jakarta.faces.SEPARATOR_CHAR</param-name>
         <param-value>:</param-value>
     </context-param>
-
+    <!-- Manual initialization for Faces 3 impl bundled just for admingui -->
+    <context-param>
+        <param-name>com.sun.faces.injectionProvider</param-name>
+        <param-value>fish.payara.server.internal.admingui.GlassFishInjectionProvider</param-value>
+    </context-param>
+    <listener>
+        <listener-class>com.sun.faces.config.ConfigureListener</listener-class>
+    </listener>
     <filter>
         <filter-name>UploadFilter</filter-name>
         <filter-class>com.sun.webui.jsf.util.UploadFilter</filter-class>

--- a/appserver/admingui/web/pom.xml
+++ b/appserver/admingui/web/pom.xml
@@ -113,8 +113,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/extras/certificate-management/certificate-management-console-plugin/pom.xml
+++ b/appserver/extras/certificate-management/certificate-management-console-plugin/pom.xml
@@ -66,8 +66,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.orb</groupId>

--- a/appserver/osgi-platforms/glassfish-osgi-console-plugin/pom.xml
+++ b/appserver/osgi-platforms/glassfish-osgi-console-plugin/pom.xml
@@ -86,8 +86,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/packager/glassfish-gui/pom.xml
+++ b/appserver/packager/glassfish-gui/pom.xml
@@ -223,8 +223,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>faces-compat</artifactId>
+            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
@@ -303,11 +303,6 @@ public class ClassLoaderHierarchyImpl implements ClassLoaderHierarchy {
         }
 
         @Override
-        public String getName() {
-            return "AppClassloader of "+ first.getName();
-        }
-
-        @Override
         protected Class<?> findClass(String name) throws ClassNotFoundException {
             try {
                 return first.loadClass(name);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
@@ -43,24 +43,28 @@
 package com.sun.enterprise.v3.server;
 
 import com.sun.enterprise.loader.CurrentBeforeParentClassLoader;
+import com.sun.enterprise.module.common_impl.CompositeEnumeration;
 import org.glassfish.internal.api.ClassLoaderHierarchy;
 import jakarta.inject.Inject;
 
+import org.glassfish.internal.api.DelegatingClassLoader;
 import org.jvnet.hk2.annotations.Optional;
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.jvnet.hk2.config.TranslationException;
 import org.jvnet.hk2.config.VariableResolver;
-import org.glassfish.internal.api.DelegatingClassLoader;
 import org.glassfish.internal.api.ConnectorClassLoaderService;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.api.deployment.DeploymentContext;
 
 import java.net.URI;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -223,7 +227,12 @@ public class ClassLoaderHierarchyImpl implements ClassLoaderHierarchy {
         if (defs.isEmpty()) {
             return parent;
         }  else {
-            return modulesRegistry.getModulesClassLoader(parent, defs);
+            // modules formed from requirements need to have higher priority than application classloader, so that
+            // admin gui can override faces implementation that resides in API ClassLoader
+            ClassLoader preferredClassLoader = modulesRegistry.getModulesClassLoader(modulesRegistry.getParentClassLoader(), defs);
+            // DelegatingClassLoader does exist in the codebase, but it has requirement that all delegates have same parent
+            // which is exactly what we do not want to have here as that parent would be API ClassLoader.
+            return new SimpleDelegatingClassLoader(modulesRegistry.getParentClassLoader(), preferredClassLoader, parent);
         }
     }
 
@@ -280,5 +289,45 @@ public class ClassLoaderHierarchyImpl implements ClassLoaderHierarchy {
 	    final String result = translate(value);
 	    return result;
 	}
+    }
+
+    private static class SimpleDelegatingClassLoader extends ClassLoader {
+        private final ClassLoader first;
+
+        private final ClassLoader second;
+
+        public SimpleDelegatingClassLoader(ClassLoader parent, ClassLoader first, ClassLoader second) {
+            super(parent);
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public String getName() {
+            return "AppClassloader of "+ first.getName();
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            try {
+                return first.loadClass(name);
+            } catch (ClassNotFoundException cne) {
+                return second.loadClass(name);
+            }
+        }
+
+        @Override
+        protected URL findResource(String name) {
+            URL result = first.getResource(name);
+            if (result == null) {
+                return second.getResource(name);
+            }
+            return result;
+        }
+
+        @Override
+        protected Enumeration<URL> findResources(String name) throws IOException {
+            return new CompositeEnumeration(Arrays.asList(first.getResources(name), second.getResources(name)));
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -100,10 +100,13 @@
             </snapshots>
         </repository>
 
-        <!-- Temporal for Jakarta EE 10 development until the jar files are available on maven central -->
+        <!-- Temporary repo for Jakarta EE 10 development until the jar files are available on maven central -->
         <repository>
             <id>staged-jakarta-releases</id>
             <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

This builds on top of classloading features of admingui that allow importing additional OSGi bundles into its application classloader. These bundles now take precedence over delegation to common application classloader and that allows us to override Faces 4 API and implementation with Faces 3.0.2.

This then also requires bit of manual initialization and injection provider from `jsf-connector` need to be copied as well.

I base this on top of TCK branch, which possibly doesn't have any fixed for admin console integrated yet, I didn't check.

## Important Info

This covers classloading and start up aspects of it, few other things need to be covered in followup tasks:

* There is still ocassional JS error like `table.getAllSelectedRowsCount is not a function`, for which we already know a fix and we must either apply or revert it :)
* Non-OSGi distributions need to be checked -- those will not be able to run admin console anymore, I suspect it used to be possible for embedded.

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Verified that console starts up in non-secure mode, pages load up, AJAX POST works, theme is correct.
JSF samples for ee7-samples do use Mojarra 4

It would be useful to run JSF TCK against this branch.


