### PR TITLE
FISH-6410: enabling java ee 8 sample tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,38 +128,38 @@ pipeline {
 //                 }
 //             }
 //         }
-//         stage('Checkout EE8 Tests') {
-//             steps{
-//                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Checking out EE8 tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-//                 checkout changelog: false, poll: false, scm: [$class: 'GitSCM',
-//                     branches: [[name: "*/Payara6"]],
-//                     userRemoteConfigs: [[url: "https://github.com/payara/patched-src-javaee8-samples.git"]]]
-//                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Checked out EE8 tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-//             }
-//         }
-//         stage('Setup for EE8 Tests') {
-//             steps {
-//                 setupDomain()
-//             }
-//         }
-//         stage('Run EE8 Tests') {
-//             steps {
-//                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Running test  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-//                 sh "mvn -B -V -ff -e clean install --strict-checksums -Dsurefire.useFile=false \
-//                 -Djavax.net.ssl.trustStore=${env.JAVA_HOME}/lib/security/cacerts \
-//                 -Djavax.xml.accessExternalSchema=all -Dpayara.version=${pom.version} \
-//                 -Ppayara-server-remote,stable"
-//                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Ran test  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-//             }
-//             post {
-//                 always {
-//                     processReportAndStopDomain()
-//                 }
-//                 cleanup {
-//                     saveLogsAndCleanup 'ee8-samples-log.zip'
-//                 }
-//             }
-//         }
+        stage('Checkout EE8 Tests') {
+             steps{
+                echo '*#*#*#*#*#*#*#*#*#*#*#*#  Checking out EE8 tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+                 checkout changelog: false, poll: false, scm: [$class: 'GitSCM',
+                     branches: [[name: "*/Payara6"]],
+                     userRemoteConfigs: [[url: "https://github.com/payara/patched-src-javaee8-samples.git"]]]
+                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Checked out EE8 tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+             }
+         }
+         stage('Setup for EE8 Tests') {
+             steps {
+                 setupDomain()
+             }
+         }
+         stage('Run EE8 Tests') {
+            steps {
+                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Running test  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+                 sh "mvn -B -V -ff -e clean install --strict-checksums -Dsurefire.useFile=false \
+                 -Djavax.net.ssl.trustStore=${env.JAVA_HOME}/lib/security/cacerts \
+                 -Djavax.xml.accessExternalSchema=all -Dpayara.version=${pom.version} \
+                 -Ppayara-server-remote,stable"
+                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Ran test  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+             }
+             post {
+                 always {
+                     processReportAndStopDomain()
+                 }
+                 cleanup {
+                     saveLogsAndCleanup 'ee8-samples-log.zip'
+                 }
+             }
+         }
         stage('Checkout CargoTracker Tests') {
             steps{
                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Checking out cargoTracker tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
This is a PR to enable the EE 8 samples
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix to enable the EE 8 samples
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
This depends of the following PR: https://github.com/payara/patched-src-javaee8-samples/pull/24
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
