### PR TITLE
FISH-6434: Upgrade security connectors to version with ADFS issuer support

### DIFF
--- a/appserver/tests/payara-samples/test-domain-setup/src/test/java/fish/payara/samples/setuptests/ViewLogWarningErrorTest.java
+++ b/appserver/tests/payara-samples/test-domain-setup/src/test/java/fish/payara/samples/setuptests/ViewLogWarningErrorTest.java
@@ -43,6 +43,7 @@ package fish.payara.samples.setuptests;
 import static fish.payara.samples.PayaraTestShrinkWrap.getWebArchive;
 import fish.payara.samples.ServerOperations;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -113,6 +114,6 @@ public class ViewLogWarningErrorTest {
      */
     private List<String> viewLog() throws IOException {
         Path serverLog = ServerOperations.getDomainPath("logs/server.log");
-        return Files.readAllLines(serverLog);
+        return Files.readAllLines(serverLog, Charset.defaultCharset());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <microprofile-rest-client.version>2.0</microprofile-rest-client.version>
         <microprofile-openapi.version>2.0</microprofile-openapi.version>
         <payara-arquillian-container.version>2.4.1</payara-arquillian-container.version>
-        <payara.security-connectors.version>2.3.0</payara.security-connectors.version>
+        <payara.security-connectors.version>2.4.0</payara.security-connectors.version>
         <opentracing.version>0.33.0</opentracing.version>
         <h2db.version>1.4.200</h2db.version>
         <websocket-api.version>1.1.2</websocket-api.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

Security connectors 2.4.0 add support for `accessTokenIssuer` - a different issuer URL to id token issuer. This is required to support Microsoft ADFS, which behaves exactly like that.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

Release of payara/ecosystem-security-connectors#221 to Maven central (in few hours, I suspect).

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Payara Samples openid tests against staged version of release artifacts.

Small fix added to `ViewLogWarningErrorTest` so it behaves correctly in non-unicode locales.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: C:\ProgramData\chocolatey\lib\maven\apache-maven-3.8.6
Java version: 1.8.0_302, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-8\jre
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```

