### PR TITLE
FISH-6477 Do not include LICENSE.md or NOTICE.md (Community Contribution)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
         <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
         <jms-api.version>2.0.2</jms-api.version>
-        <mq.version>5.1.4.payara-p2</mq.version>
+        <mq.version>5.1.4.payara-p3</mq.version>
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>1.0.3.payara-p3</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.3</com.ibm.jbatch.spi.version>


### PR DESCRIPTION
## Description
Upgrades OpenMQ to p3 which fixes the LICENSE.md and NOTICE.md files from being extracted in the top-level dir of Payara.

## Important Info

### Dependant PRs 
https://github.com/payara/patched-src-openmq/pull/20

### Blockers
Approval, build, and publication of OpenMQ PR.

## Testing

### New tests
None

### Testing Performed
Built MQ, built server using new MQ - no license or notice file under payara5 dir.

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
For a guide on building OpenMQ: https://payara.atlassian.net/wiki/spaces/PAYAR/pages/3135012872/OpenMQ
