### PR TITLE
FISH-6477 Do not include LICENSE.md or NOTICE.md (Payara6-tck) (Community Contribution)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
         <exousia.version>2.1.0-M2</exousia.version>
         <jms-api.version>3.1.0</jms-api.version>
-        <mq.version>6.3.0.payara-p1</mq.version>
+        <mq.version>6.3.0.payara-p2</mq.version>
         <jakarta.batch-api.version>2.1.0</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>2.1.1</com.ibm.jbatch.spi.version>


### PR DESCRIPTION
## Description
Upgrades OpenMQ to p2 which fixes the LICENSE.md and NOTICE.md files from being extracted in the top-level dir of Payara.

## Important Info

### Dependant PRs 
https://github.com/payara/patched-src-openmq/pull/21

### Blockers
Approval, build, and publication of OpenMQ PR.

## Testing

### New tests
None

### Testing Performed
Built MQ, built server using new MQ - no license or notice file under payara5 dir.

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
For a guide on building OpenMQ: https://payara.atlassian.net/wiki/spaces/PAYAR/pages/3135012872/OpenMQ
