### PR TITLE
FISH-6419 Proxy for TCK PolicyProvider

### DIFF
--- a/appserver/security/jacc.provider.inmemory/osgi.bundle
+++ b/appserver/security/jacc.provider.inmemory/osgi.bundle
@@ -40,3 +40,15 @@
 
 -exportcontents: fish.payara.security.jacc.provider; version=${project.osgi.version}
 
+Import-Package: \
+                        fish.payara.jacc, \
+                        jakarta.security.jacc, \
+                        javax.management, \
+                        javax.security.auth, \
+                        org.glassfish.deployment.common, \
+                        org.glassfish.exousia.modules.locked, \
+                        org.glassfish.internal.api, \
+                        org.jvnet.hk2.annotations, \
+                        javassist, \
+                        javassist.util.proxy, \
+                        *

--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyProviderImpl.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyProviderImpl.java
@@ -43,6 +43,7 @@ import fish.payara.jacc.ContextProvider;
 import fish.payara.jacc.JaccConfigurationFactory;
 import jakarta.security.jacc.PolicyContext;
 import java.security.Permission;
+import java.security.Policy;
 import java.security.ProtectionDomain;
 import org.glassfish.exousia.modules.locked.SimplePolicyProvider;
 
@@ -51,6 +52,17 @@ import org.glassfish.exousia.modules.locked.SimplePolicyProvider;
  * Implementation of jacc PolicyProvider class
  */
 public class PolicyProviderImpl extends SimplePolicyProvider {
+
+    private final Policy basePolicy;
+
+    /**
+     * Create a new instance of PolicyProviderImpl
+     * Delegates to existing policy provider
+     */
+    public PolicyProviderImpl() {
+        basePolicy = Policy.getPolicy();
+    }
+    
 
     private static ThreadLocal<Boolean> contextProviderReentry = new ThreadLocal<Boolean>() {
 
@@ -62,6 +74,9 @@ public class PolicyProviderImpl extends SimplePolicyProvider {
 
     @Override
     public boolean implies(ProtectionDomain domain, Permission permission) {
+        if (!permission.getClass().getName().startsWith("jakarta.")) {
+            return basePolicy.implies(domain, permission);
+        }
         String contextId = PolicyContext.getContextID();
         if (contextId != null) {
             ContextProvider contextProvider = getContextProvider(contextId, getPolicyFactory());

--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyProviderImpl.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/PolicyProviderImpl.java
@@ -73,7 +73,7 @@ public class PolicyProviderImpl extends SimplePolicyProvider {
 
     private static final ThreadLocal<Object> contextProviderReentry = new ThreadLocal<Object>() {
         @Override
-        protected synchronized Object initialValue() {
+        protected Object initialValue() {
             return new byte[]{0};
         }
     };

--- a/appserver/web/weld-integration-fragment/pom.xml
+++ b/appserver/web/weld-integration-fragment/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2021] [Payara Foundation] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -105,7 +105,6 @@
                                     org.jboss.weld.contexts.bound,
                                     org.jboss.weld.contexts.cache,
                                     org.jboss.weld.bean.builtin.ee,
-                                    javassist.util.proxy,
                                     org.jboss.weld.interceptor.proxy,
                                     org.jboss.weld.interceptor.util.proxy,
                                     org.jboss.weld.util.bean,

--- a/nucleus/core/javassist-packages/pom.xml
+++ b/nucleus/core/javassist-packages/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ 
+  Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ 
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+ 
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+ 
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+ 
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+ 
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.server.internal.core</groupId>
+        <artifactId>nucleus-core</artifactId>
+        <version>6.2022.1.Alpha5-SNAPSHOT</version>
+    </parent>
+    <artifactId>glassfish-javassist-packages</artifactId>
+    <name>GlassFish Javassist Packages</name>
+    <description>This bundle extends System Bundle to provide access to classes available in Javassist</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Fragment-Host>system.bundle; extension:=framework</Fragment-Host>
+                                <Bundle-Description>${project.description}</Bundle-Description>
+                                <Export-Package>
+                                    javassist,
+                                    javassist.bytecode,
+                                    javassist.bytecode.analysis,
+                                    javassist.bytecode.annotation,
+                                    javassist.bytecode.stackmap,
+                                    javassist.compiler,
+                                    javassist.compiler.ast,
+                                    javassist.convert,
+                                    javassist.expr,
+                                    javassist.runtime,
+                                    javassist.scopedpool,
+                                    javassist.tools,
+                                    javassist.tools.reflect,
+                                    javassist.tools.rmi,
+                                    javassist.tools.web,
+                                    javassist.util,
+                                    javassist.util.proxy
+                                </Export-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/nucleus/core/pom.xml
+++ b/nucleus/core/pom.xml
@@ -57,6 +57,7 @@
         <module>kernel</module>
         <module>api-exporter</module>
         <module>extra-jre-packages</module>
+        <module>javassist-packages</module>
         <module>logging</module>
         <module>logging-l10n</module>
         <module>kernel-l10n</module>

--- a/nucleus/packager/nucleus/pom.xml
+++ b/nucleus/packager/nucleus/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.core</groupId>
+            <artifactId>glassfish-javassist-packages</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>api-exporter</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/nucleus/security/core/pom.xml
+++ b/nucleus/security/core/pom.xml
@@ -237,8 +237,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.exousia</groupId>
-            <artifactId>exousia</artifactId>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/AuthenticationProxyHandler.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/AuthenticationProxyHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.security;
+
+import java.lang.reflect.Method;
+import java.security.Permission;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import javassist.util.proxy.MethodHandler;
+
+public class AuthenticationProxyHandler implements MethodHandler {
+
+    public final static Method impliesMethod = getMethod(
+            Policy.class, "implies", ProtectionDomain.class, Permission.class);
+
+    private final Policy javaSePolicy;
+
+    public AuthenticationProxyHandler(Policy javaSePolicy) {
+        this.javaSePolicy = javaSePolicy;
+    }
+
+    @Override
+    public Object invoke(Object self, Method overridden, Method forwarder, Object[] args) throws Throwable {
+        if (isImplementationOf(overridden, impliesMethod)) {
+            Permission permission = (Permission) args[1];
+            ProtectionDomain domain = (ProtectionDomain) args[0];
+            if (!permission.getClass().getName().startsWith("jakarta.")) {
+                return javaSePolicy.implies(domain, permission);
+            }
+        }
+
+        return forwarder.invoke(self, args);
+    }
+
+    public static boolean isImplementationOf(Method implementationMethod, Method interfaceMethod) {
+        return interfaceMethod.getDeclaringClass().isAssignableFrom(implementationMethod.getDeclaringClass())
+                && interfaceMethod.getName().equals(implementationMethod.getName())
+                && Arrays.equals(interfaceMethod.getParameterTypes(), implementationMethod.getParameterTypes());
+    }
+
+    public static Method getMethod(Class<?> base, String name, Class<?>... parameterTypes) {
+        try {
+            return base.getMethod(name, parameterTypes);
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/PolicyLoader.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/PolicyLoader.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.security;
 
 import static com.sun.enterprise.security.SecurityLoggerInfo.policyConfigFactoryNotDefined;
@@ -55,7 +55,6 @@ import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 import static org.glassfish.api.admin.ServerEnvironment.DEFAULT_INSTANCE_NAME;
 
-import java.security.Policy;
 import java.util.logging.Logger;
 
 import jakarta.inject.Inject;
@@ -69,6 +68,14 @@ import org.jvnet.hk2.config.types.Property;
 import com.sun.enterprise.config.serverbeans.JaccProvider;
 import com.sun.enterprise.config.serverbeans.SecurityService;
 import com.sun.enterprise.util.i18n.StringManager;
+import java.lang.reflect.InvocationTargetException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import static javassist.Modifier.PUBLIC;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import java.security.Policy;
 
 /**
  * Loads the default JACC Policy Provider into the system.
@@ -87,6 +94,9 @@ public class PolicyLoader {
     private static final String POLICY_PROVIDER_13 = "jakarta.security.jacc.auth.policy.provider";
     private static final String POLICY_CONF_FACTORY = "jakarta.security.jacc.PolicyConfigurationFactory.provider";
     private static final String POLICY_PROP_PREFIX = "com.sun.enterprise.jaccprovider.property.";
+
+    private static final String AUTH_PROXY_HANDLER = "com.sun.enterprise.security.AuthenticationProxyHandler";
+    private static final String DEFAULT_POLICY_PROVIDER = "fish.payara.security.jacc.provider.PolicyProviderImpl";
 
     @Inject
     @Named(DEFAULT_INSTANCE_NAME)
@@ -241,12 +251,18 @@ public class PolicyLoader {
             System.setProperty(name, value);
         }
     }
-    
+
     private void installPolicyFromClassName(String policyClassName, boolean j2ee13) {
         try {
             LOGGER.log(INFO, SecurityLoggerInfo.policyLoading, policyClassName);
-
-            Object policyInstance = loadClass(policyClassName);
+            Object policyInstance;
+            if (System.getSecurityManager() == null
+                    || policyClassName.equals(DEFAULT_POLICY_PROVIDER)) {
+                policyInstance = loadClass(policyClassName);
+            } else {
+                policyInstance = loadPolicyAsProxy(policyClassName);
+            }
+            
             installPolicy14(policyInstance);
 
         } catch (Exception e) {
@@ -277,11 +293,48 @@ public class PolicyLoader {
     }
     
     
-    private Object loadClass(String policyClassName) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
-        return 
-            Thread.currentThread()
-                  .getContextClassLoader()
-                  .loadClass(policyClassName)
-                  .newInstance();
+    private Object loadClass(String policyClassName)
+            throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, NoSuchMethodException,
+            IllegalArgumentException, InvocationTargetException {
+        return Thread.currentThread()
+                .getContextClassLoader()
+                .loadClass(policyClassName)
+                .getDeclaredConstructor()
+                .newInstance();
     }
+
+    private Policy loadPolicyAsProxy(String javaPolicyClassName) throws Exception {
+
+        ClassPool pool = ClassPool.getDefault();
+        CtClass clazz = pool.get(javaPolicyClassName);
+        clazz.defrost();
+        clazz.setModifiers(PUBLIC);
+        Class targetClass = clazz.toClass(
+                Thread.currentThread()
+                        .getContextClassLoader()
+                        .loadClass(System.getProperty(POLICY_CONF_FACTORY)));
+
+        ProxyObject instance;
+        
+        ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(targetClass);
+        instance = (ProxyObject) factory.createClass().getDeclaredConstructor().newInstance();
+
+        clazz = pool.get(AUTH_PROXY_HANDLER);
+        Class handlerClass = clazz.toClass(targetClass.getClassLoader(), targetClass.getProtectionDomain());
+        MethodHandler handler = (MethodHandler) handlerClass
+                .getDeclaredConstructor(Policy.class)
+                .newInstance(Policy.getPolicy());
+        instance.setHandler(handler);
+
+        if (!(instance instanceof Policy)) {
+            throw new RuntimeException(STRING_MANAGER.getString("enterprise.security.plcyload.not14"));
+        }
+
+        instance.toString();
+
+        return (Policy) instance;
+    }
+
 }

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityLifecycle.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityLifecycle.java
@@ -64,7 +64,6 @@ import com.sun.enterprise.security.audit.AuditManager;
 import com.sun.enterprise.security.auth.realm.RealmsManager;
 import com.sun.enterprise.security.common.Util;
 import com.sun.enterprise.security.ssl.SSLUtils;
-import org.glassfish.exousia.modules.locked.AuthorizationRoleMapper;
 
 /**
  * This class extends default implementation of ServerLifecycle interface.

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <jakarta.security.enterprise.version>3.0.0-M5</jakarta.security.enterprise.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
-        <exousia.version>2.1.0-M2</exousia.version>
+        <exousia.version>2.1.0</exousia.version>
         <jms-api.version>3.1.0</jms-api.version>
         <mq.version>6.1.0.payara-p2</mq.version>
         <jakarta.batch-api.version>2.1.0</jakarta.batch-api.version>


### PR DESCRIPTION
### Description
This PR adds Javassist proxy class for policy provider to delegate Java SE policy check. (Only needed for `TCKPolicy` as it does not support delegation, but Exousia impl (and `PolicyProviderImpl` from inmemory module) already do delegation so proxy is not needed).
Weld OSGI exports `javassist.util.proxy` which is having issue in Nucleus security module so exported Javassist from Nucleus.