### PR TITLE
FISH-6512 Assorted Fixes for Jakarta EE Signature Tests (Payara6 Branch)

### DIFF
--- a/appserver/packager/json/pom.xml
+++ b/appserver/packager/json/pom.xml
@@ -123,6 +123,11 @@
     
     <dependencies>
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <javax.cache-api.version>1.1.1.payara-p1</javax.cache-api.version>
         <mail.version>2.1.0-RC2</mail.version>
         <angus.mail.version>1.0.0-M1</angus.mail.version>
-        <jakarta.annotation-api.version>2.1.0</jakarta.annotation-api.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <hk2.version>3.0.1.payara-p1</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>


### PR DESCRIPTION
## Description
Assorted fixes for the Jakarta EE TCK Signature tests.
* Jakarta Annotations - 2.1.1
* Package `jakarta.json-api.jar`.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the Signature TCK - passed.

### Testing Environment
WSL OpenSUSE Leap 15.4, Zulu JDK 11.0.16

## Documentation
N/A

## Notes for Reviewers
The signature TCK also seemingly requires the `--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED` JVM option to be enabled server-side. I'm looking at adding this to the runner rather than enabling it by default in the domain since it **seems** very specific.