### PR TITLE
FISH-6512 Jakarta Annotations 2.1.1 (Payara6-tck Branch)

### DIFF
--- a/appserver/packager/json/pom.xml
+++ b/appserver/packager/json/pom.xml
@@ -123,11 +123,6 @@
     
     <dependencies>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
## Description
Update Jakarta Annotations to 2.1.1 to pass the signature test.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
See https://github.com/payara/Payara/pull/5927

### Testing Environment
WSL OpenSUSE Leap 15.4, Zulu JDK 11.0.16

## Documentation
N/A

## Notes for Reviewers
The signature TCK also seemingly requires the `--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED` JVM option to be enabled server-side. I'm looking at adding this to the runner rather than enabling it by default in the domain since it **seems** very specific.