### PR TITLE
FISH-6512 Jakarta Annotations 2.1.1 (Release Branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <javax.cache-api.version>1.1.1.payara-p1</javax.cache-api.version>
         <mail.version>2.1.0-RC2</mail.version>
         <angus.mail.version>1.0.0-M1</angus.mail.version>
-        <jakarta.annotation-api.version>2.1.0</jakarta.annotation-api.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <hk2.version>3.0.1.payara-p1</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>


### PR DESCRIPTION
## Description
Just the Jakarta annotations 2.1.1 update to fix the Jakarta EE TCK Signature tests - packaging jakarta.json-api seems to cause Jenkins to explode despite all the tests being proven to work on multiple local machines.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the Signature TCK - passed.

### Testing Environment
WSL OpenSUSE Leap 15.4, Zulu JDK 11.0.16

## Documentation
N/A

## Notes for Reviewers
The signature TCK also seemingly requires the `--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED` JVM option to be enabled server-side. I'm looking at adding this to the runner rather than enabling it by default in the domain since it **seems** very specific.