### PR TITLE
FISH-6238 Microprofile Interceptors [@Fallback@/CircuitBreaker] are not getting invoked if the EJB is a @Stateless Bean

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -51,6 +51,7 @@ import javax.enterprise.context.control.RequestContextController;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -77,6 +78,7 @@ public class FaultToleranceInterceptor implements Stereotypes, Serializable {
     protected static final String PAYARA_FAULT_TOLERANCE_INTERCEPTOR_EXECUTED =
             "fish.payara.microprofile.faulttolerance.executed";
 
+    @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         if (!shouldIntercept(context)) {
             return context.proceed();

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -93,6 +93,7 @@
         <module>grpc</module>
         <module>grpc-ejb</module>
         <module>resources</module>
+        <module>reproducers</module>
     </modules>
 
     <dependencies>

--- a/appserver/tests/payara-samples/samples/reproducers/pom.xml
+++ b/appserver/tests/payara-samples/samples/reproducers/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/master/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at glassfish/legal/LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>5.2022.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>reproducers</artifactId>
+    <name>Payara Samples - Payara - Reproducers</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>4.1</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/resource/fish6238/SingletonBean.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/resource/fish6238/SingletonBean.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.resource.fish6238;
+
+import javax.inject.Singleton;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@Singleton
+public class SingletonBean {
+
+    @Fallback(fallbackMethod = "fallback")
+    @CircuitBreaker
+    public String sayHello(String message) {
+        throw new RuntimeException("Testing the fallback method");
+    }
+
+    public String fallback(String message) {
+        return "fallback singleton";
+    }
+}

--- a/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/resource/fish6238/StatelessBean.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/resource/fish6238/StatelessBean.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.resource.fish6238;
+
+import javax.ejb.Stateless;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@Stateless
+public class StatelessBean {
+
+    @Fallback(fallbackMethod = "fallback")
+    @CircuitBreaker
+    public String sayHello(String message) {
+        throw new RuntimeException("Testing the fallback method");
+    }
+
+    public String fallback(String message) {
+        return "fallback stateless";
+    }
+}

--- a/appserver/tests/payara-samples/samples/reproducers/src/test/java/fish/payara/samples/resource/fish6238/FaultToleranceTest.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/test/java/fish/payara/samples/resource/fish6238/FaultToleranceTest.java
@@ -1,0 +1,80 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.resource.fish6238;
+
+import fish.payara.samples.resource.fish6238.SingletonBean;
+import fish.payara.samples.resource.fish6238.StatelessBean;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(Arquillian.class)
+public class FaultToleranceTest {
+
+    @Inject
+    private SingletonBean singletonBean;
+
+    @Inject
+    private StatelessBean statelessBean;
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(SingletonBean.class, StatelessBean.class);
+    }
+
+    @Test
+    public void statelessBeanTest() {
+        assertEquals(statelessBean.sayHello("MyMessage"), "fallback stateless");
+    }
+
+    @Test
+    public void singletonBeanTest() {
+        assertEquals(singletonBean.sayHello("MyMessage"), "fallback singleton");
+    }
+
+}

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
@@ -284,15 +284,6 @@ public class EjbServicesImpl implements EjbServices {
 
             while (interceptorClass != null && !interceptorClass.equals(Object.class)) {
                 String methodName = getInterceptorMethod(interceptorClass, getInterceptorAnnotationType(interceptionType));
-                // Validating interceptor that implemented programmatically instead of annotation
-                // we have to look for "intercept" method name explicitly for aroundInvoke interception type.
-                if (methodName == null && ejbInt.getInterceptor() != null && ejbInt.getInterceptor().intercepts(InterceptionType.AROUND_INVOKE)) {
-                    try {
-                        methodName = interceptorClass.getMethod("intercept", InvocationContext.class).getName();
-                    } catch (NoSuchMethodException ignored) {
-                        // ignore
-                    }
-                }
                 if (methodName != null) {
                     LifecycleCallbackDescriptor lifecycleDesc = new LifecycleCallbackDescriptor();
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld.services;
 
@@ -65,6 +65,7 @@ import javax.enterprise.inject.spi.Interceptor;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.AroundTimeout;
+import javax.interceptor.InvocationContext;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
@@ -282,7 +283,16 @@ public class EjbServicesImpl implements EjbServices {
             Class<?> interceptorClass = next.getBeanClass();
 
             while (interceptorClass != null && !interceptorClass.equals(Object.class)) {
-                String methodName = getInterceptorMethod( interceptorClass, getInterceptorAnnotationType(interceptionType));
+                String methodName = getInterceptorMethod(interceptorClass, getInterceptorAnnotationType(interceptionType));
+                // Validating interceptor that implemented programmatically instead of annotation
+                // we have to look for "intercept" method name explicitly for aroundInvoke interception type.
+                if (methodName == null && ejbInt.getInterceptor() != null && ejbInt.getInterceptor().intercepts(InterceptionType.AROUND_INVOKE)) {
+                    try {
+                        methodName = interceptorClass.getMethod("intercept", InvocationContext.class).getName();
+                    } catch (NoSuchMethodException ignored) {
+                        // ignore
+                    }
+                }
                 if (methodName != null) {
                     LifecycleCallbackDescriptor lifecycleDesc = new LifecycleCallbackDescriptor();
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for https://github.com/payara/Payara/issues/5679 issue.
EJB life-cycle failed to recognize programmatic interceptor regarding fault-tolerance interceptor that is using around invoke interception type

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
N/A

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
None

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
+ Build payara server with build extras profile `-PBuildExtras`
+ Checkout this reproducer https://github.com/ismailsalloo/payara-sample
+ Change `fish.payara.extras:payara-embedded-all` payara-sample's dependency version to fixed payara which is `5.2022.4-SNAPSHOT`
example:
```
<dependency>
  <groupId>fish.payara.extras</groupId>
  <artifactId>payara-embedded-all</artifactId>
  <version>5.2022.4-SNAPSHOT</version>
  <scope>test</scope>
</dependency>
```
+ Run `mvn clean test` 

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, OpenJDK1.8, Maven 3.8.4

## Documentation
<!-- Link documentation if a PR exists -->
None

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
None