### PR TITLE
FISH-6501 Gix BootCommandService Runlevel

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/BootCommandService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/BootCommandService.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.SEVERE;
 
 @Service
-@RunLevel(value = StartupRunLevel.IMPLICITLY_RELIED_ON)
+@RunLevel(value = StartupRunLevel.VAL)
 public class BootCommandService implements PostConstruct {
 
     private static final Logger LOGGER = Logger.getLogger(BootCommandService.class.getName());

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -45,6 +45,7 @@ import com.sun.enterprise.config.serverbeans.*;
 import com.sun.enterprise.deploy.shared.ArchiveFactory;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.admin.report.HTMLActionReporter;
+import com.sun.enterprise.v3.bootstrap.BootCommandService;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -124,6 +125,10 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
 
     @Inject
     ApplicationRegistry appRegistry;
+
+    // Explicit dependency, boot command file can contain setup for already deployed applications
+    @Inject
+    private BootCommandService bootCommandService;
 
     @Inject
     Events events;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -336,8 +336,11 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         }
         events.send(new Event<>(Deployment.ALL_APPLICATIONS_LOADED, null), false);
 
-        for(Deployment.ApplicationDeployment depl : appDeployments) {
-            deployment.initialize(depl.appInfo, depl.appInfo.getSniffers(), depl.context);
+        for (Deployment.ApplicationDeployment depl : appDeployments) {
+            if (!depl.appInfo.isLoaded()) {
+                // it may be loaded by postbootcommandfile
+                deployment.initialize(depl.appInfo, depl.appInfo.getSniffers(), depl.context);
+            }
         }
 
         events.send(new Event<>(Deployment.ALL_APPLICATIONS_PROCESSED, null));

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -107,7 +107,7 @@ import java.util.logging.Logger;
  * @since 4.1.151
  */
 @Service(name = "hazelcast-core")
-@RunLevel(StartupRunLevel.IMPLICITLY_RELIED_ON)
+@RunLevel(StartupRunLevel.VAL)
 public class HazelcastCore implements EventListener, ConfigListener {
 
     public final static String INSTANCE_ATTRIBUTE_MAP = "payara-instance-map";

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/store/ClusteredStore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/store/ClusteredStore.java
@@ -72,7 +72,7 @@ import org.glassfish.internal.api.JavaEEContextUtil.Context;
  * @author steve
  */
 @Service(name = "payara-cluster-store")
-@RunLevel(StartupRunLevel.IMPLICITLY_RELIED_ON)
+@RunLevel(StartupRunLevel.VAL)
 public class ClusteredStore implements EventListener, MonitoringDataSource {
     private static final Logger logger = Logger.getLogger(ClusteredStore.class.getCanonicalName());
 


### PR DESCRIPTION
## Description
Fixes the issue with using DEPLOY command in postbootcommand file.

Set the BootCommandService to 10. Return HazelcastCore and ClusteredStore back to level 10 as they don't need to be started earlier. And add an explicit dependency from ApplicationLoaderService for cases, that postbootcommanfile contains setup for already deployed apps.
Add check during application loading service, if it was already loaded via postbootcommandfile.

## Important Info
## Testing
### Testing Performed
Download the jolokia war file from the ticket (can be tested by any application, e.g. clusterjsp.war).

Create file postboot.asadmin with content:
`deploy /path/to/jolokia-war-1.7.1.war`

Run this command from Payara:
`/asadmin start-domain --postbootcommandfile /path/to/postboot.asadmin`

Expected output: deployed app (it asks for password when opened).

### Testing Environment
OpenJDK, Linux

## Description
Fix after previous FISH 6501 change, add check during application loading service, if it was already loaded via postbootcommandfile.

## Important Info
## Testing
### Testing Performed
Download the jolokia war file from the ticket.

Create file postboot.asadmin with content:
`deploy /path/to/jolokia-war-1.7.1.war`

Run this command from Payara:
`/asadmin start-domain --postbootcommandfile /path/to/postboot.asadmin`

Expected output: deployed app (it asks for password when opened).

### Testing Environment
OpenJDK, Linux

