### PR TITLE
FISH-6486 Support legacy handling of empty beans.xml

### DIFF
--- a/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/pom.xml
+++ b/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>legacy-mode-empty-beans-xml</artifactId>
+    <packaging>war</packaging>
+
+    <name>Payara Samples - Legacy mode of empty beans.xml</name>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>6.2022.1.Alpha5-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/main/java/fish/payara/samples/cdi/legacymode/beans/AnnotatedBean.java
+++ b/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/main/java/fish/payara/samples/cdi/legacymode/beans/AnnotatedBean.java
@@ -1,0 +1,49 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.cdi.legacymode.beans;
+
+import jakarta.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class AnnotatedBean {
+    public String sayHello(String name) {
+        return "Hello " + name;
+    }
+}

--- a/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/main/java/fish/payara/samples/cdi/legacymode/beans/NotAnnotatedBean.java
+++ b/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/main/java/fish/payara/samples/cdi/legacymode/beans/NotAnnotatedBean.java
@@ -1,0 +1,46 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.cdi.legacymode.beans;
+
+public class NotAnnotatedBean {
+    public String sayHello(String name) {
+        return "Hello " + name;
+    }
+}

--- a/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/main/resources/arquillian.xml
+++ b/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/main/resources/arquillian.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian" xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="Servlet 5.0"/>
+
+     <container qualifier="payara" default="true">
+        <configuration>
+            <property name="domain">${payara.domain.name}</property>
+            <property name="debug">${payara.debug}</property>
+            <property name="adminHost">${payara.adminHost}</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="properties">emptyBeansXmlModeALL=true</property>
+        </configuration>
+     </container>
+
+</arquillian>

--- a/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/test/java/fish/payara/samples/cdi/legacymode/beans/EnableLegacyModeTest.java
+++ b/appserver/tests/payara-samples/samples/legacy-mode-empty-beans-xml/src/test/java/fish/payara/samples/cdi/legacymode/beans/EnableLegacyModeTest.java
@@ -1,0 +1,79 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.cdi.legacymode.beans;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import jakarta.enterprise.inject.Instance;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class EnableLegacyModeTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClasses(AnnotatedBean.class, NotAnnotatedBean.class)
+                .addAsManifestResource("beans.xml");
+    }
+
+    @Inject
+    AnnotatedBean annotatedBean;
+
+    @Inject
+    Instance<NotAnnotatedBean> notAnnotatedBean;
+
+    @Test
+    public void should_be_injected() throws Exception {
+        assertThat(annotatedBean, is(notNullValue()));
+        assertTrue(notAnnotatedBean.isResolvable());
+    }
+}

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -65,6 +65,7 @@
         <module>jaxrs-rolesallowed-servlet</module>
         <module>jaxws-security</module>
         <!--module>jaxws-tracing</module-->
+        <module>legacy-mode-empty-beans-xml</module>
         <module>microprofile-config</module>
         <module>microprofile-endpoints</module>
         <module>microprofile-healthcheck</module>

--- a/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
+++ b/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
@@ -694,7 +694,7 @@ public class WeldUtils {
 
         if (beanDiscoveryMode == null) {
             //when empty beans.xml or bean-discovery-mode not specified
-            return "all";
+            return "annotated";
         }
 
         if (beanDiscoveryMode.equals("")) {

--- a/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
+++ b/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
@@ -88,6 +88,8 @@ public class WeldUtils {
 
     private static Logger logger = Logger.getLogger(WeldUtils.class.getName());
 
+    private static final String EMPTY_BEANS_XML_MODE_ALL = "fish.payara.deployment.emptyBeansXmlModeALL";
+
     public static final char SEPARATOR_CHAR = '/';
     public static final String WEB_INF = "WEB-INF";
     public static final String WEB_INF_CLASSES = WEB_INF + SEPARATOR_CHAR + "classes";
@@ -584,6 +586,14 @@ public class WeldUtils {
     public static void setCDIDevMode(DeploymentContext context, boolean enabled) {
        context.getAppProps().setProperty(ServerTags.CDI_DEV_MODE_ENABLED_PROP, String.valueOf(enabled));
     }
+    
+    public static boolean isEmptyBeansXmlModeALL(DeploymentContext context) {
+        if(Boolean.getBoolean(EMPTY_BEANS_XML_MODE_ALL)) {
+            return true;
+        }
+        Object propValue = context.getAppProps().get(ServerTags.EMPTY_BEANS_XML_MODE_ALL_PROP);
+        return propValue != null && Boolean.parseBoolean((String) propValue);
+    }
 
   public static InputStream getBeansXmlInputStream(DeploymentContext context) {
     return getBeansXmlInputStream( context.getSource() );
@@ -684,7 +694,7 @@ public class WeldUtils {
 
         if (beanDiscoveryMode == null) {
             //when empty beans.xml or bean-discovery-mode not specified
-            return "annotated";
+            return "all";
         }
 
         if (beanDiscoveryMode.equals("")) {

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -84,7 +84,6 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <includes>
-                    <include>beans-all.xml</include>
                     <include>**/faces-config.xml</include>
                     <include>**/com.sun.faces.spi.FacesConfigResourceProvider</include>
                     <include>**/jakarta.enterprise.inject.spi.Extension</include>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -84,6 +84,7 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <includes>
+                    <include>beans-all.xml</include>
                     <include>**/faces-config.xml</include>
                     <include>**/com.sun.faces.spi.FacesConfigResourceProvider</include>
                     <include>**/jakarta.enterprise.inject.spi.Extension</include>

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -777,7 +777,9 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                     url = this.getClass().getResource("/beans-all.xml");
                 }
             } catch (URISyntaxException ex) {
-                Logger.getLogger(BeanDeploymentArchiveImpl.class.getName()).log(Level.SEVERE, null, ex);
+                if (logger.isLoggable(Level.SEVERE)) {
+                    logger.log(Level.SEVERE, null, ex);
+                }
             }
         }
         BeansXml result = weldBootstrap.parse(url);

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -769,10 +769,20 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     @SuppressWarnings("unchecked")
     protected BeansXml parseBeansXML(ReadableArchive archive, String beansXMLPath) throws IOException {
         URL url = getBeansXMLFileURL(archive, beansXMLPath);
-        BeansXml result;
+        BeansXml result = null;
         if (WeldUtils.isEmptyBeansXmlModeALL(context)) {
-            result = weldBootstrap.parse(url, BeanDiscoveryMode.ALL);
-        } else {
+            try {
+                File beansxml = new File(url.toURI());
+                if (beansxml.length() == 0) {
+                    result = weldBootstrap.parse(url, BeanDiscoveryMode.ALL);
+                }
+            } catch (URISyntaxException ex) {
+                if (logger.isLoggable(Level.SEVERE)) {
+                    logger.log(Level.SEVERE, null, ex);
+                }
+            }
+        }
+        if (result == null) {
             result = weldBootstrap.parse(url);
         }
         JarFileUtils.closeCachedJarFiles();

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -42,6 +42,7 @@
 package org.glassfish.weld;
 
 import com.sun.enterprise.admin.util.JarFileUtils;
+import com.sun.enterprise.config.serverbeans.ServerTags;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import org.glassfish.api.deployment.DeploymentContext;
@@ -63,6 +64,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
@@ -768,7 +770,17 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     @SuppressWarnings("unchecked")
     protected BeansXml parseBeansXML(ReadableArchive archive, String beansXMLPath) throws IOException {
         URL url = getBeansXMLFileURL(archive, beansXMLPath);
-        BeansXml result =  weldBootstrap.parse(url);
+        if (WeldUtils.isEmptyBeansXmlModeALL(context)) {
+            try {
+                File beansxml = new File(url.toURI());
+                if (beansxml.length() == 0) {
+                    url = this.getClass().getResource("/beans-all.xml");
+                }
+            } catch (URISyntaxException ex) {
+                Logger.getLogger(BeanDeploymentArchiveImpl.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        BeansXml result = weldBootstrap.parse(url);
         JarFileUtils.closeCachedJarFiles();
         return result;
     }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -769,19 +769,12 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     @SuppressWarnings("unchecked")
     protected BeansXml parseBeansXML(ReadableArchive archive, String beansXMLPath) throws IOException {
         URL url = getBeansXMLFileURL(archive, beansXMLPath);
+        BeansXml result;
         if (WeldUtils.isEmptyBeansXmlModeALL(context)) {
-            try {
-                File beansxml = new File(url.toURI());
-                if (beansxml.length() == 0) {
-                    url = this.getClass().getResource("/beans-all.xml");
-                }
-            } catch (URISyntaxException ex) {
-                if (logger.isLoggable(Level.SEVERE)) {
-                    logger.log(Level.SEVERE, null, ex);
-                }
-            }
+            result = weldBootstrap.parse(url, BeanDiscoveryMode.ALL);
+        } else {
+            result = weldBootstrap.parse(url);
         }
-        BeansXml result = weldBootstrap.parse(url);
         JarFileUtils.closeCachedJarFiles();
         return result;
     }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -42,7 +42,6 @@
 package org.glassfish.weld;
 
 import com.sun.enterprise.admin.util.JarFileUtils;
-import com.sun.enterprise.config.serverbeans.ServerTags;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import org.glassfish.api.deployment.DeploymentContext;

--- a/appserver/web/weld-integration/src/main/resources/beans-all.xml
+++ b/appserver/web/weld-integration/src/main/resources/beans-all.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/appserver/web/weld-integration/src/main/resources/beans-all.xml
+++ b/appserver/web/weld-integration/src/main/resources/beans-all.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
-</beans>

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/weld/RootBeanDeploymentArchiveTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/weld/RootBeanDeploymentArchiveTest.java
@@ -104,6 +104,7 @@ public class RootBeanDeploymentArchiveTest {
         expect(readableArchive.exists(WeldUtils.WEB_INF_CLASSES_META_INF_BEANS_XML)).andReturn(false).anyTimes();
 
         // in BeanDeploymentArchiveImpl.populate
+        expect(deploymentContext.getAppProps()).andReturn(new Properties()).anyTimes();
         expect(deploymentContext.getTransientAppMetadata()).andReturn(null).anyTimes();
         expect(deploymentContext.getModuleMetaData(Application.class)).andReturn(null).anyTimes();
         expect(deploymentContext.getTransientAppMetaData(WeldDeployer.WELD_BOOTSTRAP, WeldBootstrap.class)).andReturn(wb).anyTimes();

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/ServerTags.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/ServerTags.java
@@ -196,6 +196,7 @@ public class ServerTags  {
     //public static final String ENABLED = "enabled";
     public static final String VIRTUAL_SERVERS = "virtual-servers";
     public static final String CDI_DEV_MODE_ENABLED_PROP = "cdiDevModeEnabled";
+    public static final String EMPTY_BEANS_XML_MODE_ALL_PROP = "emptyBeansXmlModeALL";
     
     //public static final String LB_ENABLED = "lb-enabled";
     //public static final String DISABLE_TIMEOUT_IN_MINUTES = "disable-timeout-in-minutes";

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationConfigListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationConfigListener.java
@@ -177,7 +177,8 @@ public class ApplicationConfigListener implements TransactionListener, PostConst
                     } else if (ServerTags.CONTEXT_ROOT.equals(propertyName)
                             || ServerTags.VIRTUAL_SERVERS.equals(propertyName)
                             || ServerTags.AVAILABILITY_ENABLED.equals(propertyName)
-                            || ServerTags.CDI_DEV_MODE_ENABLED_PROP.equals(propertyName)) {
+                            || ServerTags.CDI_DEV_MODE_ENABLED_PROP.equals(propertyName)
+                            || ServerTags.EMPTY_BEANS_XML_MODE_ALL_PROP.equals(propertyName)) {
                         // for other changes, reload the application
                         handleOtherAppConfigChanges(event.getSource(), appName);
                     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationConfigListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationConfigListener.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.server;
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -538,6 +538,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                         return;
                     }
 
+                    deploymentContext.getAppProps().setProperty(ServerTags.EMPTY_BEANS_XML_MODE_ALL_PROP, Boolean.TRUE.toString());
                     deploymentContext.setSource((FileArchive)archiveFactory.createArchive(output));
 
                     // reset transient and module data of orignal deployed archive


### PR DESCRIPTION
## Description
Starting with CDI 4.0, bean archives with empty beans.xml have discovery mode `annotated`. This PR adds a compatibility configuration option that users can leverage to switch this back to `all` discovery mode. 

Application level configuration: `asadmin deploy  --properties=emptyBeansXmlModeALL=true my_app.war`
Global configuration: `asadmin create-system-properties fish.payara.deployment.emptyBeansXmlModeALL=true `

### Docs
[https://github.com/payara/Payara-Documentation/pull/90](https://github.com/payara/Payara-Documentation/pull/90)
