### PR TITLE
FISH-6522 Nimbus-jose upgrade to 9.25

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -89,7 +89,7 @@
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
 
-        <nimbus-jose-jwt.version>9.8.1</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>9.25</nimbus-jose-jwt.version>
         <accessors-smart.version>1.2.payara-p2</accessors-smart.version>
         <json-smart.version>2.4.8</json-smart.version>
         <reactor-core.version>3.4.0</reactor-core.version>


### PR DESCRIPTION
## Description
Nimbus-JOSE-JWT version 9.8.1 uses json-smart version 1.3.2 (affected component) and thus it is needed to be updated. 

## Testing
### New tests
None

### Testing Performed
payara-samples
quicklook

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.8.4
