### PR TITLE
FISH-6501 Fix App Loading After Reboot

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -150,6 +150,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import java.net.URISyntaxException;
 import org.glassfish.hk2.classmodel.reflect.util.ParsingConfig;
+import org.glassfish.hk2.utilities.BuilderHelper;
 
 /**
  * Application Loader is providing useful methods to load applications
@@ -228,6 +229,11 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
     public void postConstruct() {
         deploymentLifecycleProbeProvider = new DeploymentLifecycleProbeProvider();
         alcInterceptors = habitat.getAllServices(ApplicationLifecycleInterceptor.class);
+
+        // initialize listening services before application startup
+        habitat.getAllServices(BuilderHelper.createNameFilter("ManagedBeanManagerImpl"));
+        habitat.getAllServices(BuilderHelper.createNameFilter("ResourceManager"));
+        habitat.getAllServices(BuilderHelper.createNameFilter("ApplicationScopedResourcesManager"));
     }
 
     /**

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -337,7 +337,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         events.send(new Event<>(Deployment.ALL_APPLICATIONS_LOADED, null), false);
 
         for (Deployment.ApplicationDeployment depl : appDeployments) {
-            if (!depl.appInfo.isLoaded()) {
+            if (!depl.appInfo.isRunning()) {
                 // it may be loaded by postbootcommandfile
                 deployment.initialize(depl.appInfo, depl.appInfo.getSniffers(), depl.context);
             }


### PR DESCRIPTION
## Description
The previous changes FISH-6501 introduced a problem with app loading during restart. This fix corrects the way, how is already loaded app checked.

An application can be loaded via postbootcommand file, e.g. ApplicationLoaderService will try to load this application later again. The former test was using isLoaded flag, but it is set for the application during server reboot. This new fix uses isRunning.

## Important Info
## Testing
### Testing Performed
Download the jolokia war file from the ticket. The test can be done with clusterjsp.war as well.

Create file postboot.asadmin with content:
`deploy /path/to/jolokia-war-1.7.1.war`

Run this command from Payara:
`/asadmin start-domain --postbootcommandfile /path/to/postboot.asadmin`

Expected output: deployed app (it asks for password when opened).

Stop the server and start again without parameters.

Expected output: app still works.

It is possible to retry the same with CDIReproducer (simple app with CDI) and MyEar-1.0-SNAPSHOT.ear (ear consisting from two war files), which I added to the Jira ticket.

### Testing Environment
OpenJDK, Linux