### PR TITLE
FISH-6506: enable preprocessing for ENV placeholder on micro logging properties

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1823,10 +1823,13 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private ByteArrayInputStream replaceEnvProperties(InputStream is) throws IOException {
         //preprocessing the properties read from the custom properties file
         Properties configuration = new Properties();
+        Properties environment = new Properties();
         configuration.load(is);
         //set the System.getProperties to be used for the replacement process. The desired property to be mapped
         //should need to be available on the System properties
-        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(System.getProperties()),
+        environment.putAll(System.getProperties());
+        environment.putAll(System.getenv());
+        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(environment),
                 PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
         StringWriter writer = new StringWriter();
         configuration.store(new PrintWriter(writer), null);

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -62,7 +62,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,7 +87,6 @@ import com.sun.enterprise.server.logging.ODLLogFormatter;
 
 import fish.payara.deployment.util.JavaArchiveUtils;
 import fish.payara.deployment.util.URIUtils;
-import java.util.stream.Collectors;
 import org.glassfish.embeddable.BootstrapProperties;
 import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.Deployer;
@@ -1823,29 +1821,15 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private ByteArrayInputStream replaceEnvProperties(InputStream is) throws IOException {
         //preprocessing the properties read from the custom properties file
         Properties configuration = new Properties();
-        Properties environment = new Properties();
         configuration.load(is);
-        //set the System.getProperties to be used for the replacement process. The desired property to be mapped
-        //should need to be available on the System properties
-        environment.putAll(System.getProperties());
-        environment.putAll(System.getenv());
-        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(environment),
+        //set the System.getenv() to be used for the replacement process. The desired property to be mapped
+        //should need to be available on the System.getenv() Map
+        configuration = new PropertyPlaceholderHelper(System.getenv(),
                 PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
         StringWriter writer = new StringWriter();
         configuration.store(new PrintWriter(writer), null);
         //here is added the new inputStream with the preprocessed properties solving the replacement issues
         return new ByteArrayInputStream(writer.getBuffer().toString().getBytes());
-    }
-
-    /**
-     * Method to convert Properties to Map<String, String>
-     * @param properties to be processed
-     * @return a Map<String, String>
-     */
-    private Map<String, String> convertPropertiesToMap(Properties  properties) {
-        return properties.entrySet().stream().collect(Collectors.toMap(
-                e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue()),
-                (p , n) -> n, HashMap::new));
     }
 
     private void configureCommandFiles() throws IOException {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Enabling preprocessing for ENV placeholder on micro logging properties

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a bug fix for an issue to map system properties to placeholders added on a logging.properties file for payara micro
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing using the following command line for payara micro:
java -Dloglevel=FINE -jar payara-micro.jar --logProperties logging.properties

and using the attached logging.properties file attached on the ticket: [FISH-6506](https://payara.atlassian.net/browse/FISH-6506)

`~/projects/Payara/appserver/extras/payara-micro/payara-micro-distribution/target$ java -Dloglevel=FINE -jar payara-micro.jar --logProperties logging.properties

Sep 20, 2022 8:04:59 PM fish.payara.micro.impl.RuntimeDirectory processDirectoryInformation
WARNING: Payara Micro Runtime directory is located in a temporary file location which can be cleaned by system processes.

Sep 20, 2022 8:04:59 PM fish.payara.micro.impl.RuntimeDirectory processDirectoryInformation
INFO: Payara Micro Runtime directory is located at /tmp/payaramicro-rt5470083545123475589tmp

Sep 20, 2022 8:04:59 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = com.sun.enterprise.glassfish.bootstrap.osgi.OSGiGlassFishRuntimeBuilder@1ee807c6

Sep 20, 2022 8:04:59 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = com.sun.enterprise.glassfish.bootstrap.StaticGlassFishRuntimeBuilder@11c20519

Sep 20, 2022 8:04:59 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = com.sun.enterprise.glassfish.bootstrap.osgi.EmbeddedOSGiGlassFishRuntimeBuilder@365c30cc

Sep 20, 2022 8:04:59 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = fish.payara.micro.boot.runtime.PayaraMicroRuntimeBuilder@5e25a92e

Sep 20, 2022 8:04:59 PM fish.payara.micro.boot.runtime.PayaraMicroRuntimeBuilder build
INFO: Built Payara Micro Runtime`

now the logs are not showing any error to set the ${ENV=loglevel} value

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, Azul JDK 8, Maven 3.8.6
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
