### PR TITLE
FISH-6506: enable preprocessing for ENV placeholder on micro logging properties

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1822,10 +1822,13 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private ByteArrayInputStream replaceEnvProperties(InputStream is) throws IOException {
         //preprocessing the properties read from the custom properties file
         Properties configuration = new Properties();
+        Properties environment = new Properties();
         configuration.load(is);
         //set the System.getProperties to be used for the replacement process. The desired property to be mapped
         //should need to be available on the System properties
-        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(System.getProperties()),
+        environment.putAll(System.getProperties());
+        environment.putAll(System.getenv());
+        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(environment),
                 PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
         StringWriter writer = new StringWriter();
         configuration.store(new PrintWriter(writer), null);

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -62,7 +62,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,7 +87,6 @@ import com.sun.enterprise.server.logging.ODLLogFormatter;
 
 import fish.payara.deployment.util.JavaArchiveUtils;
 import fish.payara.deployment.util.URIUtils;
-import java.util.stream.Collectors;
 import org.glassfish.embeddable.BootstrapProperties;
 import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.Deployer;
@@ -1822,29 +1820,15 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     private ByteArrayInputStream replaceEnvProperties(InputStream is) throws IOException {
         //preprocessing the properties read from the custom properties file
         Properties configuration = new Properties();
-        Properties environment = new Properties();
         configuration.load(is);
-        //set the System.getProperties to be used for the replacement process. The desired property to be mapped
-        //should need to be available on the System properties
-        environment.putAll(System.getProperties());
-        environment.putAll(System.getenv());
-        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(environment),
+        //set the System.getenv() to be used for the replacement process. The desired property to be mapped
+        //should need to be available on the System.getenv() Map
+        configuration = new PropertyPlaceholderHelper(System.getenv(),
                 PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
         StringWriter writer = new StringWriter();
         configuration.store(new PrintWriter(writer), null);
         //here is added the new inputStream with the preprocessed properties solving the replacement issues
         return new ByteArrayInputStream(writer.getBuffer().toString().getBytes());
-    }
-
-    /**
-     * Method to convert Properties to Map<String, String>
-     * @param properties to be processed
-     * @return a Map<String, String>
-     */
-    private Map<String, String> convertPropertiesToMap(Properties  properties) {
-        return properties.entrySet().stream().collect(Collectors.toMap(
-                e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue()),
-                (p , n) -> n, HashMap::new));
     }
 
     private void configureCommandFiles() throws IOException {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -39,6 +39,9 @@
  */
 package fish.payara.micro.impl;
 
+import com.sun.enterprise.util.JDK;
+import com.sun.enterprise.util.PropertyPlaceholderHelper;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -47,6 +50,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -57,6 +62,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -80,9 +86,9 @@ import com.sun.enterprise.glassfish.bootstrap.Constants;
 import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
 import com.sun.enterprise.server.logging.ODLLogFormatter;
 
-import com.sun.enterprise.util.JDK;
 import fish.payara.deployment.util.JavaArchiveUtils;
 import fish.payara.deployment.util.URIUtils;
+import java.util.stream.Collectors;
 import org.glassfish.embeddable.BootstrapProperties;
 import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.Deployer;
@@ -1741,10 +1747,11 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
             System.setProperty("java.util.logging.config.file", runtimeDir.getLoggingProperties().getAbsolutePath());
             try (InputStream is = new FileInputStream(runtimeDir.getLoggingProperties())) {
-                LogManager.getLogManager().readConfiguration(is);
+                LogManager.getLogManager().readConfiguration(replaceEnvProperties(is));
 
                 // go through all root handlers and set formatters based on properties
                 Logger rootLogger = LogManager.getLogManager().getLogger("");
+
                 for (Handler handler : rootLogger.getHandlers()) {
                     String formatter = LogManager.getLogManager().getProperty(handler.getClass().getCanonicalName() + ".formatter");
                     if (formatter != null) {
@@ -1785,7 +1792,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             }
             System.setProperty("java.util.logging.config.file", runtimeDir.getLoggingProperties().getAbsolutePath());
             try (InputStream is = new FileInputStream(runtimeDir.getLoggingProperties())) {
-                LogManager.getLogManager().readConfiguration(is);
+                LogManager.getLogManager().readConfiguration(replaceEnvProperties(is));
 
                 // reset the formatters on the two handlers
                 //Logger rootLogger = Logger.getLogger("");
@@ -1804,6 +1811,37 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
                 LOGGER.log(Level.SEVERE, "Unable to reset the log manager", ex);
             }
         }
+    }
+
+    /**
+     * Method to replace Env properties with corresponding value from System properties
+     * @param is InputStream from File with properties
+     * @return an instance of ByteArrayInputStream with the preprocessed properties
+     * @throws IOException
+     */
+    private ByteArrayInputStream replaceEnvProperties(InputStream is) throws IOException {
+        //preprocessing the properties read from the custom properties file
+        Properties configuration = new Properties();
+        configuration.load(is);
+        //set the System.getProperties to be used for the replacement process. The desired property to be mapped
+        //should need to be available on the System properties
+        configuration = new PropertyPlaceholderHelper(convertPropertiesToMap(System.getProperties()),
+                PropertyPlaceholderHelper.ENV_REGEX).replacePropertiesPlaceholder(configuration);
+        StringWriter writer = new StringWriter();
+        configuration.store(new PrintWriter(writer), null);
+        //here is added the new inputStream with the preprocessed properties solving the replacement issues
+        return new ByteArrayInputStream(writer.getBuffer().toString().getBytes());
+    }
+
+    /**
+     * Method to convert Properties to Map<String, String>
+     * @param properties to be processed
+     * @return a Map<String, String>
+     */
+    private Map<String, String> convertPropertiesToMap(Properties  properties) {
+        return properties.entrySet().stream().collect(Collectors.toMap(
+                e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue()),
+                (p , n) -> n, HashMap::new));
     }
 
     private void configureCommandFiles() throws IOException {


### PR DESCRIPTION

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
This is a bug fix for an issue to map system properties to placeholders added on a logging.properties file for payara micro
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing using the following command line for payara micro:
java -Dloglevel=FINE -jar payara-micro.jar --logProperties logging.properties

and using the attached logging.properties file attached on the ticket: [FISH-6506](https://payara.atlassian.net/browse/FISH-6506)

`~/projects/Payara/appserver/extras/payara-micro/payara-micro-distribution/target$ java -Dloglevel=FINE -jar payara-micro.jar --logProperties logging.properties

Sep 20, 2022 9:15:18 PM fish.payara.micro.impl.RuntimeDirectory processDirectoryInformation
WARNING: Payara Micro Runtime directory is located in a temporary file location which can be cleaned by system processes.

Sep 20, 2022 9:15:18 PM fish.payara.micro.impl.RuntimeDirectory processDirectoryInformation
INFO: Payara Micro Runtime directory is located at /tmp/payaramicro-rt16404627346335840359tmp

Sep 20, 2022 9:15:18 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = com.sun.enterprise.glassfish.bootstrap.osgi.OSGiGlassFishRuntimeBuilder@76c3e77a

Sep 20, 2022 9:15:18 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = com.sun.enterprise.glassfish.bootstrap.StaticGlassFishRuntimeBuilder@53fdffa1

Sep 20, 2022 9:15:18 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = com.sun.enterprise.glassfish.bootstrap.osgi.EmbeddedOSGiGlassFishRuntimeBuilder@73e22a3d

Sep 20, 2022 9:15:18 PM GlassFishRuntime getRuntimeBuilder
FINE: builder = fish.payara.micro.boot.runtime.PayaraMicroRuntimeBuilder@169e6180

Sep 20, 2022 9:15:18 PM fish.payara.micro.boot.runtime.PayaraMicroRuntimeBuilder build
INFO: Built Payara Micro Runtime`

now the logs are not showing any error to set the ${ENV=loglevel} value

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, Azul JDK 8, Maven 3.8.6
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
