### PR TITLE
FISH-5827 Stuck Thread count as MicroProfile Metric Gauge

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
@@ -1,0 +1,93 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ * 
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ * 
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.microprofile.metrics.healthcheck;
+
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import org.eclipse.microprofile.metrics.Counter;
+
+/**
+ * Implementation of a counter based off an HealthCheck. As this is just a proxy
+ * for the HealthCheck calling the {@link #inc() } method will throw an
+ * {@link UnsupportedOperationException}. Just use the {@link #getCount()}
+ * method to get the value of the HealthCheck backing this.
+ */
+public class HealthCheckCounter implements Counter, HealthCheckStatsProvider<Integer> {
+
+    private final HealthCheckStatsProvider<Integer> healthCheck;
+
+    public HealthCheckCounter(HealthCheckStatsProvider<Integer> healthCheck) {
+        this.healthCheck = healthCheck;
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException} - this is all dealt with by
+     * the backing HealthCheck
+     */
+    @Override
+    public void inc() {
+        throw new UnsupportedOperationException("Not supported - use getCount() to get value from HealthCheck directly.");
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException} - this is all dealt with by
+     * the backing HealthCheck
+     * @param n the increment value
+     */
+    @Override
+    public void inc(long n) {
+        throw new UnsupportedOperationException("Not supported - use getCount() to get value from HealthCheck directly.");
+    }
+
+    @Override
+    public long getCount() {
+        return healthCheck.getValue();
+    }
+    
+    @Override
+    public Integer getValue() {
+       return healthCheck.getValue();
+    }
+
+    @Override
+    public boolean isEnabled() {
+       return healthCheck.isEnabled();
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
@@ -48,12 +48,15 @@ import org.eclipse.microprofile.metrics.Counter;
  * {@link UnsupportedOperationException}. Just use the {@link #getCount()}
  * method to get the value of the HealthCheck backing this.
  */
-public class HealthCheckCounter implements Counter, HealthCheckStatsProvider<Integer> {
+public class HealthCheckCounter implements Counter, HealthCheckStatsProvider {
 
-    private final HealthCheckStatsProvider<Integer> healthCheck;
+    private final HealthCheckStatsProvider healthCheck;
+    
+    private final ServiceExpression expression;
 
-    public HealthCheckCounter(HealthCheckStatsProvider<Integer> healthCheck) {
+    public HealthCheckCounter(HealthCheckStatsProvider healthCheck, ServiceExpression expression) {
         this.healthCheck = healthCheck;
+        this.expression = expression;
     }
 
     /**
@@ -77,12 +80,12 @@ public class HealthCheckCounter implements Counter, HealthCheckStatsProvider<Int
 
     @Override
     public long getCount() {
-        return healthCheck.getValue();
+        return getValue(Long.class, expression.getAttributeName());
     }
-    
+
     @Override
-    public Integer getValue() {
-       return healthCheck.getValue();
+    public <Long> Long getValue(Class<Long> type, String attributeName) {
+        return healthCheck.getValue(type, attributeName);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
@@ -1,8 +1,8 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- *
- *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
- *
+ * 
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
  *     and Distribution License("CDDL") (collectively, the "License").  You
@@ -11,20 +11,20 @@
  *     https://github.com/payara/Payara/blob/master/LICENSE.txt
  *     See the License for the specific
  *     language governing permissions and limitations under the License.
- *
+ * 
  *     When distributing the software, include this License Header Notice in each
  *     file and include the License file at glassfish/legal/LICENSE.txt.
- *
+ * 
  *     GPL Classpath Exception:
  *     The Payara Foundation designates this particular file as subject to the "Classpath"
  *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  *     file that accompanied this code.
- *
+ * 
  *     Modifications:
  *     If applicable, add the following below the License Header, with the fields
  *     enclosed by brackets [] replaced by your own identifying information:
  *     "Portions Copyright [year] [name of copyright owner]"
- *
+ * 
  *     Contributor(s):
  *     If you wish your version of this file to be governed by only the CDDL or
  *     only the GPL Version 2, indicate your decision by adding "[Contributor]
@@ -37,49 +37,31 @@
  *     only if the new code is made subject to such option by the copyright
  *     holder.
  */
+package fish.payara.microprofile.metrics.healthcheck;
 
-package fish.payara.microprofile.metrics.jmx;
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import org.eclipse.microprofile.metrics.Gauge;
 
-import jakarta.xml.bind.annotation.*;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+/**
+ * Implementation of a gauge based off an HealthCheck.
+ *
+ */
+public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider<Number> {
 
-@XmlRootElement(name = "config")
-@XmlAccessorType(XmlAccessType.FIELD)
-public class MBeanMetadataConfig {
+    private final HealthCheckStatsProvider<Number> healthCheck;
 
-    @XmlElementWrapper(name = "base")
-    @XmlElement(name = "metadata")
-    private final List<MBeanMetadata> baseMetadata = new CopyOnWriteArrayList<>();
-
-    @XmlElementWrapper(name = "vendor")
-    @XmlElement(name = "metadata")
-    private final List<MBeanMetadata> vendorMetadata = new CopyOnWriteArrayList<>();
-
-    public List<MBeanMetadata> getBaseMetadata() {
-        return baseMetadata;
+    public HealthCheckGauge(HealthCheckStatsProvider<Number> healthCheck) {
+        this.healthCheck = healthCheck;
     }
 
-    public void setBaseMetadata(List<MBeanMetadata> baseMetadata) {
-        this.baseMetadata.clear();
-        this.addBaseMetadata(baseMetadata);
+    @Override
+    public Number getValue() {
+        return healthCheck.getValue();
     }
 
-    public void addBaseMetadata(List<MBeanMetadata> baseMetadata) {
-        this.baseMetadata.addAll(baseMetadata);
-    }
-
-    public List<MBeanMetadata> getVendorMetadata() {
-        return vendorMetadata;
-    }
-
-    public void setVendorMetadata(List<MBeanMetadata> vendorMetadata) {
-        this.vendorMetadata.clear();
-        this.addVendorMetadata(vendorMetadata);
-    }
-
-    public void addVendorMetadata(List<MBeanMetadata> vendorMetadata) {
-        this.vendorMetadata.addAll(vendorMetadata);
+    @Override
+    public boolean isEnabled() {
+       return healthCheck.isEnabled();
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
@@ -46,22 +46,30 @@ import org.eclipse.microprofile.metrics.Gauge;
  * Implementation of a gauge based off an HealthCheck.
  *
  */
-public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider<Number> {
+public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider {
 
-    private final HealthCheckStatsProvider<Number> healthCheck;
+    private final HealthCheckStatsProvider healthCheck;
+    
+    private final ServiceExpression expression;
 
-    public HealthCheckGauge(HealthCheckStatsProvider<Number> healthCheck) {
+    public HealthCheckGauge(HealthCheckStatsProvider healthCheck, ServiceExpression expression) {
         this.healthCheck = healthCheck;
+        this.expression = expression;
     }
 
     @Override
     public Number getValue() {
-        return healthCheck.getValue();
+        return getValue(Number.class, expression.getAttributeName());
     }
 
     @Override
     public boolean isEnabled() {
        return healthCheck.isEnabled();
+    }
+
+    @Override
+    public <Number> Number getValue(Class<Number> type, String attributeName) {
+        return healthCheck.getValue(type, attributeName);
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/ServiceExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/ServiceExpression.java
@@ -37,14 +37,34 @@
  *     only if the new code is made subject to such option by the copyright
  *     holder.
  */
-package fish.payara.nucleus.healthcheck;
+package fish.payara.microprofile.metrics.healthcheck;
 
-import org.jvnet.hk2.annotations.Contract;
+public class ServiceExpression {
 
-@Contract
-public interface HealthCheckStatsProvider {
+    private String service;
 
-    public <T extends Object> T getValue(Class<T> type, String attributeName);
+    private String attributeName;
 
-    boolean isEnabled();
+    private static final String ATTRIBUTE_SEPARATOR = "#";
+
+    public ServiceExpression(String expression) {
+        if (expression == null || expression.trim().isEmpty()) {
+            throw new IllegalArgumentException("Service Expression is null");
+        }
+        int slashIndex = expression.lastIndexOf(ATTRIBUTE_SEPARATOR);
+        if (slashIndex < 0) {
+            throw new IllegalArgumentException("MBean Expression is invalid : " + expression);
+        }
+        service = expression.substring(0, slashIndex);
+        attributeName = expression.substring(slashIndex + 1);
+    }
+
+    public String getServiceId() {
+        return service;
+    }
+
+    public String getAttributeName() {
+        return attributeName;
+    }
+
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricsServiceImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/impl/MetricsServiceImpl.java
@@ -95,6 +95,7 @@ import fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper;
 import fish.payara.monitoring.collect.MonitoringDataCollector;
 import fish.payara.monitoring.collect.MonitoringDataSource;
 import fish.payara.nucleus.executorservice.PayaraExecutorService;
+import fish.payara.nucleus.healthcheck.HealthCheckService;
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 import java.util.logging.Level;
 
@@ -103,6 +104,9 @@ import java.util.logging.Level;
 public class MetricsServiceImpl implements MetricsService, ConfigListener, MonitoringDataSource {
 
     private static final Logger LOGGER = Logger.getLogger(MetricsService.class.getName());
+
+    @Inject
+    private HealthCheckService healthCheckService;
 
     @Inject
     private MetricsServiceConfiguration configuration;
@@ -246,7 +250,7 @@ public class MetricsServiceImpl implements MetricsService, ConfigListener, Monit
         }
     }
 
-    private static void collectRegistry(String contextName, MetricRegistry registry, MonitoringDataCollector collector) {
+    private void collectRegistry(String contextName, MetricRegistry registry, MonitoringDataCollector collector) {
 
         // OBS: this way of iterating the metrics in the registry is optimal because of its internal data organisation
         for (String name : registry.getNames()) {
@@ -255,9 +259,9 @@ public class MetricsServiceImpl implements MetricsService, ConfigListener, Monit
                 Metric metric = entry.getValue();
                 try {
                     MonitoringDataCollector metricCollector = tagCollector(contextName, metricID, collector);
-                    if(metric instanceof HealthCheckStatsProvider
-                                && !((HealthCheckStatsProvider)metric).isEnabled()) {
-                            continue;
+                    if (metric instanceof HealthCheckStatsProvider
+                            && (!((HealthCheckStatsProvider) metric).isEnabled() || !healthCheckService.isEnabled())) {
+                        continue;
                     }
                     if (metric instanceof Counting) {
                         metricCollector.collect(toName(metricID, "Count"), ((Counting) metric).getCount());

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
@@ -40,8 +40,8 @@
 
 package fish.payara.microprofile.metrics.jmx;
 
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.ATTRIBUTE_SEPARATOR;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SUB_ATTRIBUTE_SEPARATOR;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.ATTRIBUTE_SEPARATOR;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SUB_ATTRIBUTE_SEPARATOR;
 import java.lang.management.ManagementFactory;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
@@ -40,10 +40,10 @@
 
 package fish.payara.microprofile.metrics.jmx;
 
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.ATTRIBUTE;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.KEY;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SPECIFIER;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SUB_ATTRIBUTE;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.ATTRIBUTE;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.KEY;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SPECIFIER;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SUB_ATTRIBUTE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -64,12 +64,15 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-public class MBeanMetadata implements Metadata {
+public class MetricsMetadata implements Metadata {
 
-    private static final Logger LOGGER = Logger.getLogger(MBeanMetadata.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(MetricsMetadata.class.getName());
 
     @XmlElement(name = "mbean")
     private String mBean;
+
+    @XmlElement(name = "service")
+    private String service;
 
     @XmlElement
     private boolean dynamic = true;
@@ -97,15 +100,15 @@ public class MBeanMetadata implements Metadata {
     private List<XmlTag> tags;
 
 
-    public MBeanMetadata() {
+    public MetricsMetadata() {
         tags = new ArrayList<>();
     }
 
-    public MBeanMetadata(Metadata metadata) {
+    public MetricsMetadata(Metadata metadata) {
         this(null, metadata.getName(), metadata.getDisplayName(), metadata.description().orElse(null), metadata.getTypeRaw(), metadata.unit().orElse(null));
     }
 
-    public MBeanMetadata(String mBean, String name, String displayName, String description, MetricType typeRaw, String unit) {
+    public MetricsMetadata(String mBean, String name, String displayName, String description, MetricType typeRaw, String unit) {
         this();
         this.mBean = mBean;
         this.name = name;
@@ -121,6 +124,14 @@ public class MBeanMetadata implements Metadata {
 
     public void setMBean(String mBean) {
         this.mBean = mBean;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
     }
 
     public boolean isDynamic() {
@@ -184,14 +195,14 @@ public class MBeanMetadata implements Metadata {
 
     private boolean validateMetadata() {
         boolean validationResult = true;
-        MBeanMetadata metadata = this;
+        MetricsMetadata metadata = this;
 
         if (isNull(metadata.getName())) {
             LOGGER.log(WARNING, "'name' property not defined in " + metadata.getMBean() + " mbean metadata", new Exception());
             validationResult = false;
         }
-        if (isNull(metadata.getMBean())) {
-            LOGGER.log(WARNING, "'mbean' property not defined in {0} metadata", metadata.getName());
+        if (isNull(metadata.getMBean()) && isNull(metadata.getService())) {
+            LOGGER.log(WARNING, "'mbean' or 'service' property not defined in {0} metadata", metadata.getName());
             validationResult = false;
         }
         if (isNull(metadata.getType())) {
@@ -275,7 +286,7 @@ public class MBeanMetadata implements Metadata {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", MBeanMetadata.class.getSimpleName() + "[", "]")
+        return new StringJoiner(", ", MetricsMetadata.class.getSimpleName() + "[", "]")
                 .add("mBean='" + mBean + "'")
                 .add("dynamic=" + dynamic)
                 .add("name='" + name + "'")

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataConfig.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataConfig.java
@@ -1,0 +1,85 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+
+package fish.payara.microprofile.metrics.jmx;
+
+import jakarta.xml.bind.annotation.*;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@XmlRootElement(name = "config")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class MetricsMetadataConfig {
+
+    @XmlElementWrapper(name = "base")
+    @XmlElement(name = "metadata")
+    private final List<MetricsMetadata> baseMetadata = new CopyOnWriteArrayList<>();
+
+    @XmlElementWrapper(name = "vendor")
+    @XmlElement(name = "metadata")
+    private final List<MetricsMetadata> vendorMetadata = new CopyOnWriteArrayList<>();
+
+    public List<MetricsMetadata> getBaseMetadata() {
+        return baseMetadata;
+    }
+
+    public void setBaseMetadata(List<MetricsMetadata> baseMetadata) {
+        this.baseMetadata.clear();
+        this.addBaseMetadata(baseMetadata);
+    }
+
+    public void addBaseMetadata(List<MetricsMetadata> baseMetadata) {
+        this.baseMetadata.addAll(baseMetadata);
+    }
+
+    public List<MetricsMetadata> getVendorMetadata() {
+        return vendorMetadata;
+    }
+
+    public void setVendorMetadata(List<MetricsMetadata> vendorMetadata) {
+        this.vendorMetadata.clear();
+        this.addVendorMetadata(vendorMetadata);
+    }
+
+    public void addVendorMetadata(List<MetricsMetadata> vendorMetadata) {
+        this.vendorMetadata.addAll(vendorMetadata);
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
@@ -41,6 +41,7 @@ package fish.payara.microprofile.metrics.jmx;
 
 import fish.payara.microprofile.metrics.healthcheck.HealthCheckCounter;
 import fish.payara.microprofile.metrics.healthcheck.HealthCheckGauge;
+import fish.payara.microprofile.metrics.healthcheck.ServiceExpression;
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +65,6 @@ import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Tag;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.internal.api.Globals;
 import org.jvnet.hk2.annotations.Service;
 
 @Service
@@ -130,14 +130,15 @@ public class MetricsMetadataHelper {
                     }
                     metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
                 } else {
-                    HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, beanMetadata.getService());
+                    ServiceExpression expression = new ServiceExpression(beanMetadata.getService());
+                    HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, expression.getServiceId());
                     if (healthCheck != null) {
                         switch (beanMetadata.getTypeRaw()) {
                             case COUNTER:
-                                type = new HealthCheckCounter(healthCheck);
+                                type = new HealthCheckCounter(healthCheck, expression);
                                 break;
                             case GAUGE:
-                                type = new HealthCheckGauge(healthCheck);
+                                type = new HealthCheckGauge(healthCheck, expression);
                                 break;
                             default:
                                 throw new IllegalStateException("Unsupported type : " + beanMetadata);

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
@@ -127,17 +127,21 @@ public class MetricsMetadataHelper {
                     metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
                 } else {
                     HealthCheckStatsProvider healthCheck = Globals.getDefaultHabitat().getService(HealthCheckStatsProvider.class, beanMetadata.getService());
-                    switch (beanMetadata.getTypeRaw()) {
-                        case COUNTER:
-                            type = new HealthCheckCounter(healthCheck);
-                            break;
-                        case GAUGE:
-                            type = new HealthCheckGauge(healthCheck);
-                            break;
-                        default:
-                            throw new IllegalStateException("Unsupported type : " + beanMetadata);
+                    if (healthCheck != null) {
+                        switch (beanMetadata.getTypeRaw()) {
+                            case COUNTER:
+                                type = new HealthCheckCounter(healthCheck);
+                                break;
+                            case GAUGE:
+                                type = new HealthCheckGauge(healthCheck);
+                                break;
+                            default:
+                                throw new IllegalStateException("Unsupported type : " + beanMetadata);
+                        }
+                        metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
+                    } else {
+                        throw new IllegalStateException("Health-Check service not found : " + beanMetadata.getService());
                     }
-                    metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
                 }
             } catch (IllegalArgumentException ex) {
                 LOGGER.log(WARNING, ex.getMessage(), ex);

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
@@ -39,6 +39,9 @@
  */
 package fish.payara.microprofile.metrics.jmx;
 
+import fish.payara.microprofile.metrics.healthcheck.HealthCheckCounter;
+import fish.payara.microprofile.metrics.healthcheck.HealthCheckGauge;
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 import java.util.ArrayList;
 import java.util.List;
 import static java.util.Objects.nonNull;
@@ -60,10 +63,11 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Tag;
 import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.internal.api.Globals;
 import org.jvnet.hk2.annotations.Service;
 
 @Service
-public class MBeanMetadataHelper {
+public class MetricsMetadataHelper {
 
     public static final String SPECIFIER = "%s"; // microprofile-metrics specification defined specifier
     public static final String KEY = "${key}";
@@ -73,7 +77,7 @@ public class MBeanMetadataHelper {
     public static final String SUB_ATTRIBUTE_SEPARATOR = "#";
     public static final String INSTANCE = "${instance}";
 
-    private static final Logger LOGGER = Logger.getLogger(MBeanMetadataHelper.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(MetricsMetadataHelper.class.getName());
 
     @Inject
     private ServerEnvironment serverEnv;
@@ -82,22 +86,22 @@ public class MBeanMetadataHelper {
      * Registers metrics as MBeans
      *
      * @param metricRegistry Registry to add metrics to
-     * @param metadataList List of all {@link MBeanMetadata} representing a
+     * @param metadataList List of all {@link MetricsMetadata} representing a
      * {@link Metric}
      * @param globalTags
      * @param isRetry true if this is not initial registration, this is used to
      * register lazy-loaded MBeans
      * @return the list of unresolved MBean Metadata
      */
-    public List<MBeanMetadata> registerMetadata(MetricRegistry metricRegistry,
-            List<MBeanMetadata> metadataList, boolean isRetry) {
+    public List<MetricsMetadata> registerMetadata(MetricRegistry metricRegistry,
+            List<MetricsMetadata> metadataList, boolean isRetry) {
 
         if (!metricRegistry.getNames().isEmpty() && !isRetry) {
             metricRegistry.removeMatching(MetricFilter.ALL);
         }
 
-        List<MBeanMetadata> unresolvedMetadataList = resolveDynamicMetadata(metadataList);
-        for (MBeanMetadata beanMetadata : metadataList) {
+        List<MetricsMetadata> unresolvedMetadataList = resolveDynamicMetadata(metadataList);
+        for (MetricsMetadata beanMetadata : metadataList) {
             List<Tag> tags = new ArrayList<>();
             for (XmlTag tag : beanMetadata.getTags()) {
                 tags.add(new Tag(tag.getName(), tag.getValue()));
@@ -108,18 +112,33 @@ public class MBeanMetadataHelper {
                     continue;
                 }
                 Metric type;
-                MBeanExpression mBeanExpression = new MBeanExpression(beanMetadata.getMBean());
-                switch (beanMetadata.getTypeRaw()) {
-                    case COUNTER:
-                        type = new MBeanCounterImpl(mBeanExpression);
-                        break;
-                    case GAUGE:
-                        type = new MBeanGuageImpl(mBeanExpression);
-                        break;
-                    default:
-                        throw new IllegalStateException("Unsupported type : " + beanMetadata);
+                if (beanMetadata.getMBean() != null) {
+                    MBeanExpression mBeanExpression = new MBeanExpression(beanMetadata.getMBean());
+                    switch (beanMetadata.getTypeRaw()) {
+                        case COUNTER:
+                            type = new MBeanCounterImpl(mBeanExpression);
+                            break;
+                        case GAUGE:
+                            type = new MBeanGuageImpl(mBeanExpression);
+                            break;
+                        default:
+                            throw new IllegalStateException("Unsupported type : " + beanMetadata);
+                    }
+                    metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
+                } else {
+                    HealthCheckStatsProvider healthCheck = Globals.getDefaultHabitat().getService(HealthCheckStatsProvider.class, beanMetadata.getService());
+                    switch (beanMetadata.getTypeRaw()) {
+                        case COUNTER:
+                            type = new HealthCheckCounter(healthCheck);
+                            break;
+                        case GAUGE:
+                            type = new HealthCheckGauge(healthCheck);
+                            break;
+                        default:
+                            throw new IllegalStateException("Unsupported type : " + beanMetadata);
+                    }
+                    metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
                 }
-                metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
             } catch (IllegalArgumentException ex) {
                 LOGGER.log(WARNING, ex.getMessage(), ex);
             }
@@ -133,20 +152,21 @@ public class MBeanMetadataHelper {
      * @param metadataList list of MBean Metadata
      * @return the list of unresolved MBean Metadata
      */
-    public List<MBeanMetadata> resolveDynamicMetadata(List<MBeanMetadata> metadataList) {
-        List<MBeanMetadata> unresolvedMetadataList = new ArrayList<>();
-        List<MBeanMetadata> resolvedMetadataList = new ArrayList<>();
+    public List<MetricsMetadata> resolveDynamicMetadata(List<MetricsMetadata> metadataList) {
+        List<MetricsMetadata> unresolvedMetadataList = new ArrayList<>();
+        List<MetricsMetadata> resolvedMetadataList = new ArrayList<>();
         List<Metadata> removedMetadataList = new ArrayList<>(metadataList.size());
-        for (MBeanMetadata metadata : metadataList) {
+        for (MetricsMetadata metadata : metadataList) {
             if (!metadata.isValid()) {
                 removedMetadataList.add(metadata);
                 continue;
             }
-            if (metadata.getMBean().contains(SPECIFIER)
+            if (metadata.getMBean() != null
+                    && (metadata.getMBean().contains(SPECIFIER)
                     || metadata.getMBean().contains(KEY)
                     || metadata.getMBean().contains(ATTRIBUTE)
                     || metadata.getMBean().contains(SUB_ATTRIBUTE)
-                    || metadata.getMBean().contains(INSTANCE)) {
+                    || metadata.getMBean().contains(INSTANCE))) {
                 try {
                     String instanceName = serverEnv.getInstanceName();
                     // set (optional) instance the query expression
@@ -200,14 +220,14 @@ public class MBeanMetadataHelper {
         return unresolvedMetadataList;
     }
 
-    private static List<MBeanMetadata> loadAttribute(
+    private static List<MetricsMetadata> loadAttribute(
             ObjectName objName,
             MBeanExpression mBeanExpression,
-            MBeanMetadata metadata,
+            MetricsMetadata metadata,
             String key,
             String instanceName) {
 
-        List<MBeanMetadata> metadataList = new ArrayList<>();
+        List<MetricsMetadata> metadataList = new ArrayList<>();
         String attributeName;
 
         if (ATTRIBUTE.equals(mBeanExpression.getAttributeName())) {
@@ -243,15 +263,15 @@ public class MBeanMetadataHelper {
         return metadataList;
     }
 
-    private static List<MBeanMetadata> loadSubAttribute(
+    private static List<MetricsMetadata> loadSubAttribute(
             ObjectName objName,
             MBeanExpression mBeanExpression,
-            MBeanMetadata metadata,
+            MetricsMetadata metadata,
             String key,
             String attribute,
             String instanceName,
             boolean isDynamicAttribute) {
-        List<MBeanMetadata> metadataList = new ArrayList<>();
+        List<MetricsMetadata> metadataList = new ArrayList<>();
         String exp = objName.getCanonicalName();
         String subAttribute = mBeanExpression.getSubAttributeName();
         if (subAttribute != null) {
@@ -276,7 +296,7 @@ public class MBeanMetadataHelper {
                             newMetadataBuilder = newMetadataBuilder.withUnit((String) compositeData.get(subAttribute));
                         }
                     }
-                    MBeanMetadata newMbeanMetadata = new MBeanMetadata(newMetadataBuilder.build());
+                    MetricsMetadata newMbeanMetadata = new MetricsMetadata(newMetadataBuilder.build());
                     newMbeanMetadata.addTags(metadata.getTags());
                     metadataList.add(createMetadata(newMbeanMetadata, exp, key, attribute, subAttribute, instanceName));
                 }
@@ -297,8 +317,8 @@ public class MBeanMetadataHelper {
         return metadataList;
     }
 
-    private static MBeanMetadata createMetadata(
-            MBeanMetadata metadata,
+    private static MetricsMetadata createMetadata(
+            MetricsMetadata metadata,
             String exp,
             String key,
             String attribute,
@@ -312,7 +332,7 @@ public class MBeanMetadataHelper {
             builder.append(SUB_ATTRIBUTE_SEPARATOR);
             builder.append(subAttribute);
         }
-        MBeanMetadata newMetaData =  new MBeanMetadata(builder.toString(),
+        MetricsMetadata newMetaData =  new MetricsMetadata(builder.toString(),
                 formatMetadata(
                         metadata.getName(),
                         key,

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
@@ -63,6 +63,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Tag;
 import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.Globals;
 import org.jvnet.hk2.annotations.Service;
 
@@ -81,6 +82,9 @@ public class MetricsMetadataHelper {
 
     @Inject
     private ServerEnvironment serverEnv;
+
+    @Inject
+    private ServiceLocator habitat;
 
     /**
      * Registers metrics as MBeans
@@ -126,7 +130,7 @@ public class MetricsMetadataHelper {
                     }
                     metricRegistry.register(beanMetadata, type, tags.toArray(new Tag[tags.size()]));
                 } else {
-                    HealthCheckStatsProvider healthCheck = Globals.getDefaultHabitat().getService(HealthCheckStatsProvider.class, beanMetadata.getService());
+                    HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, beanMetadata.getService());
                     if (healthCheck != null) {
                         switch (beanMetadata.getTypeRaw()) {
                             case COUNTER:

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
@@ -58,6 +58,7 @@ import fish.payara.microprofile.metrics.MetricsService.MetricsContext;
 import fish.payara.microprofile.metrics.exception.NoSuchMetricException;
 import fish.payara.microprofile.metrics.exception.NoSuchRegistryException;
 import fish.payara.microprofile.metrics.impl.MetricRegistryImpl;
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 
 public class MetricsWriterImpl implements MetricsWriter {
 
@@ -121,6 +122,10 @@ public class MetricsWriterImpl implements MetricsWriter {
         Metadata metadata = registry.getMetadata(metricName);
         for (Entry<MetricID, Metric> metric : registry.getMetrics(metricName).entrySet()) {
             MetricID metricID = metric.getKey();
+            if (metric.getValue() instanceof HealthCheckStatsProvider
+                    && !((HealthCheckStatsProvider) metric.getValue()).isEnabled()) {
+                continue;
+            }
             if (globalTags.length > 0) {
                 Tag[]  tagsWithoutGlobal = metricID.getTagsAsArray();
                 Tag[] tags = new Tag[tagsWithoutGlobal.length +  globalTags.length];

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
@@ -58,7 +58,9 @@ import fish.payara.microprofile.metrics.MetricsService.MetricsContext;
 import fish.payara.microprofile.metrics.exception.NoSuchMetricException;
 import fish.payara.microprofile.metrics.exception.NoSuchRegistryException;
 import fish.payara.microprofile.metrics.impl.MetricRegistryImpl;
+import fish.payara.nucleus.healthcheck.HealthCheckService;
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import org.glassfish.internal.api.Globals;
 
 public class MetricsWriterImpl implements MetricsWriter {
 
@@ -66,6 +68,7 @@ public class MetricsWriterImpl implements MetricsWriter {
     private final Set<String> contextNames;
     private final Function<String, MetricsContext> getContextByName;
     private final Tag[] globalTags;
+    private final HealthCheckService healthCheckService;
 
     public MetricsWriterImpl(MetricExporter exporter, Set<String> contextNames,
             Function<String, MetricsContext> getContextByName, Tag... globalTags) {
@@ -73,6 +76,7 @@ public class MetricsWriterImpl implements MetricsWriter {
         this.contextNames = contextNames;
         this.getContextByName = getContextByName;
         this.globalTags = globalTags;
+        this.healthCheckService = Globals.getDefaultBaseServiceLocator().getService(HealthCheckService.class);
     }
 
     @Override
@@ -123,7 +127,7 @@ public class MetricsWriterImpl implements MetricsWriter {
         for (Entry<MetricID, Metric> metric : registry.getMetrics(metricName).entrySet()) {
             MetricID metricID = metric.getKey();
             if (metric.getValue() instanceof HealthCheckStatsProvider
-                    && !((HealthCheckStatsProvider) metric.getValue()).isEnabled()) {
+                    && (!((HealthCheckStatsProvider) metric.getValue()).isEnabled() || !healthCheckService.isEnabled())) {
                 continue;
             }
             if (globalTags.length > 0) {

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -205,11 +205,19 @@ holder.
         </metadata>
         <metadata>
             <name>thread.stuck.count</name>
-            <service>healthcheck-stuck</service>
+            <service>healthcheck-stuck#count</service>
             <type>gauge</type>
             <unit>none</unit>
             <displayName>Stuck Thread Count</displayName>
             <description>Displays the stuck thread count which is blocked, and can't return to the threadpool for a certain amount of time.</description>
+        </metadata>
+        <metadata>
+            <name>thread.stuck.maxDuration</name>
+            <service>healthcheck-stuck#maxDuration</service>
+            <type>gauge</type>
+            <unit>none</unit>
+            <displayName>Stuck Thread Max Duration</displayName>
+            <description>Displays the maximum duration of stuck thread which is blocked, and can't return to the threadpool for a certain amount of time.</description>
         </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -203,5 +203,13 @@ holder.
             <displayName>System Cpu Load</displayName>
             <description>Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values betweens 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.</description>
         </metadata>
+        <metadata>
+            <name>thread.stuck.count</name>
+            <service>healthcheck-stuck</service>
+            <type>gauge</type>
+            <unit>none</unit>
+            <displayName>Stuck Thread Count</displayName>
+            <description>Displays the stuck thread count which are blocked, and can't return to the threadpool for a certain amout of time.</description>
+        </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -126,7 +126,7 @@ holder.
             <type>gauge</type>
             <unit>none</unit>
             <displayName>System Load Average</displayName>
-            <description>Displays the system load average for the last minute. The system load average is the sum of the number of runnable entities queued to the available processors and the number of runnable entities running on the available processors averaged over a period of time. The way in which the load average is calculated is operating system specific but is typically a damped time-dependent average. If the load average is not available, a negative value is displayed. This attribute is designed to provide a hint about the system load and may be queried frequently. The load average may be unavailable on some platform where it is expensive to implement this method.</description>
+            <description>Displays the system load average for the last minute. The system load average is the sum of the number of runnable entities queued to the available processors and the number of runnable entities running on the available processors averaged over a period of time. The way in which the load average is calculated is operating system specific but is typically a damped time-dependent average. If the load average is not available, a negative value is displayed. This attribute is designed to provide a hint about the system load and may be queried frequently. The load average may be unavailable on some platforms where it is expensive to implement this method.</description>
         </metadata>
         <metadata>
             <name>jvm.uptime</name>
@@ -201,7 +201,7 @@ holder.
             <type>gauge</type>
             <unit>none</unit>
             <displayName>System Cpu Load</displayName>
-            <description>Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values betweens 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.</description>
+            <description>Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values between 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.</description>
         </metadata>
         <metadata>
             <name>thread.stuck.count</name>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -209,7 +209,7 @@ holder.
             <type>gauge</type>
             <unit>none</unit>
             <displayName>Stuck Thread Count</displayName>
-            <description>Displays the stuck thread count which are blocked, and can't return to the threadpool for a certain amout of time.</description>
+            <description>Displays the stuck thread count which is blocked, and can't return to the threadpool for a certain amount of time.</description>
         </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -49,11 +49,11 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MBeanMetadataTest {
+public class MetricsMetadataTest {
 
     @Test
     public void isValid_basic() {
-        MBeanMetadata metadata = new MBeanMetadata("m", "name"
+        MetricsMetadata metadata = new MetricsMetadata("m", "name"
                 , "Display", "description", MetricType.COUNTER, "none");
         List<XmlTag> tags = new ArrayList<>();
         tags.add(new XmlTag("test", "JUnit"));
@@ -63,7 +63,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_EmptyTag() {
-        MBeanMetadata metadata = new MBeanMetadata("m", "name", "Display", "description"
+        MetricsMetadata metadata = new MetricsMetadata("m", "name", "Display", "description"
                 , MetricType.COUNTER, "none");
         List<XmlTag> tags = new ArrayList<>();
         tags.add(new XmlTag("test", "JUnit"));
@@ -73,7 +73,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_PlaceHolder() {
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.%s.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"
@@ -85,7 +85,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_PlaceHolderSomeTag() {
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.%s.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"
@@ -98,7 +98,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_PlaceHolderPlaceHolderTag() {
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"
@@ -112,7 +112,7 @@ public class MBeanMetadataTest {
     @Test
     public void isValid_PlaceHolderEmptyTag() {
         // FISH-5801
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.%s.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
@@ -1,0 +1,50 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ * 
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ * 
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.nucleus.healthcheck;
+
+import org.jvnet.hk2.annotations.Contract;
+
+@Contract
+public interface HealthCheckStatsProvider<T extends Object> {
+
+    public T getValue();
+
+    boolean isEnabled();
+}

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.nucleus.healthcheck.stuck;
 
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 import fish.payara.nucleus.healthcheck.HealthCheckResult;
 import fish.payara.monitoring.collect.MonitoringData;
 import fish.payara.monitoring.collect.MonitoringDataCollector;
@@ -75,7 +76,17 @@ import org.jvnet.hk2.annotations.Service;
 @RunLevel(StartupRunLevel.VAL)
 public class StuckThreadsHealthCheck extends
         BaseHealthCheck<HealthCheckStuckThreadExecutionOptions, StuckThreadsChecker>
-        implements MonitoringDataSource, MonitoringWatchSource {
+        implements MonitoringDataSource, MonitoringWatchSource, HealthCheckStatsProvider<Integer> {
+
+    @Override
+    public Integer getValue() {
+       return this.stuckThreadsStore.getThreads().size();
+    }
+
+    @Override
+    public boolean isEnabled() {
+       return this.getOptions() != null ? this.getOptions().isEnabled() : false;
+    }
 
     @FunctionalInterface
     private interface StuckThreadConsumer {

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -63,6 +63,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Set;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
@@ -76,17 +78,12 @@ import org.jvnet.hk2.annotations.Service;
 @RunLevel(StartupRunLevel.VAL)
 public class StuckThreadsHealthCheck extends
         BaseHealthCheck<HealthCheckStuckThreadExecutionOptions, StuckThreadsChecker>
-        implements MonitoringDataSource, MonitoringWatchSource, HealthCheckStatsProvider<Integer> {
+        implements MonitoringDataSource, MonitoringWatchSource, HealthCheckStatsProvider {
 
-    @Override
-    public Integer getValue() {
-       return this.stuckThreadsStore.getThreads().size();
-    }
-
-    @Override
-    public boolean isEnabled() {
-       return this.getOptions() != null ? this.getOptions().isEnabled() : false;
-    }
+    private final Map<String, Number> stuckThreadResult = new ConcurrentHashMap<>();
+    private static final String STUCK_THREAD_COUNT = "count";
+    private static final String STUCK_THREAD_MAX_DURATION = "maxDuration";
+    private static final Set<String> VALID_ATTRIBUTES = Set.of(STUCK_THREAD_COUNT, STUCK_THREAD_MAX_DURATION);
 
     @FunctionalInterface
     private interface StuckThreadConsumer {
@@ -94,14 +91,33 @@ public class StuckThreadsHealthCheck extends
     }
 
     @Inject
-    StuckThreadsStore stuckThreadsStore;
+    private StuckThreadsStore stuckThreadsStore;
 
     @Inject
-    StuckThreadsChecker checker;
+    private StuckThreadsChecker checker;
 
     @PostConstruct
     void postConstruct() {
         postConstruct(this, StuckThreadsChecker.class);
+    }
+
+    @Override
+    public Object getValue(Class type, String attributeName) {
+        if (attributeName == null) {
+            throw new IllegalArgumentException("attribute name is required");
+        }
+        if (!VALID_ATTRIBUTES.contains(attributeName)) {
+            throw new IllegalArgumentException("Invalid attribute name, supported attributes are " + VALID_ATTRIBUTES);
+        }
+        if (!Number.class.isAssignableFrom(type)) {
+            throw new IllegalArgumentException("attribute type must be number");
+        }
+        return stuckThreadResult.getOrDefault(attributeName, 0);
+    }
+
+    @Override
+    public boolean isEnabled() {
+       return this.getOptions() != null ? this.getOptions().isEnabled() : false;
     }
 
     @Override
@@ -137,6 +153,8 @@ public class StuckThreadsHealthCheck extends
         });
         collector.collect("StuckThreadDuration", maxDuration);
         collector.collect("StuckThreadCount", count);
+        stuckThreadResult.put(STUCK_THREAD_MAX_DURATION, maxDuration.get());
+        stuckThreadResult.put(STUCK_THREAD_COUNT, count.get());
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR adds HealthCheck stats (Stuck thread count) to MicroProfile Metrics.


## Important Info
`StuckThreadsHealthCheck` required by `MetricsServiceImpl`.
`MetricsServiceImpl` required by `FaultToleranceServiceImpl` and `MicroProfileMetricsChecker`.
All of these services started at `@RunLevel(StartupRunLevel.VAL)`.
The enable status of HealthCheck can not be checked during registration of Metrics metadata which is by default registered and during response writer operation, health check status is checked.


## Testing
### Testing Performed
````
asadmin start-domain
asadmin set-healthcheck-service-configuration --serviceName=stuck-thread --enabled=true
asadmin restart-domain
````
Open `http://localhost:8080/metrics/vendor` URL which so=houl contains the following result:
````
# TYPE vendor_system_cpu_load gauge
# HELP vendor_system_cpu_load Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values between 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.
vendor_system_cpu_load 0.2421606522975489
# TYPE vendor_thread_stuck_count gauge
# HELP vendor_thread_stuck_count Displays the stuck thread count which is blocked, and can't return to the threadpool for a certain amount of time.
vendor_thread_stuck_count 1
````
Now disable health check stuck-thread:
````
asadmin set-healthcheck-service-configuration --serviceName=stuck-thread --enabled=false
asadmin restart-domain
````
Open `http://localhost:8080/metrics/vendor` URL which so=houl contains the following result:
````
# TYPE vendor_system_cpu_load gauge
# HELP vendor_system_cpu_load Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values between 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.
vendor_system_cpu_load 0.2421606522975489
````

### Testing Environment
Windows 11, JDK 11.0.16
