### PR TITLE
Bundle payara.version not project.version

### DIFF
--- a/appserver/extras/docker-images/micro/pom.xml
+++ b/appserver/extras/docker-images/micro/pom.xml
@@ -19,6 +19,7 @@
         <dependency>
             <groupId>fish.payara.extras</groupId>
             <artifactId>payara-micro</artifactId>
+            <version>${payara.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/extras/docker-images/server-full/pom.xml
+++ b/appserver/extras/docker-images/server-full/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>fish.payara.distributions</groupId>
             <artifactId>payara</artifactId>
+            <version>${payara.version}</version>
             <type>zip</type>
             <scope>provided</scope>
         </dependency>

--- a/appserver/extras/docker-images/server-node/pom.xml
+++ b/appserver/extras/docker-images/server-node/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>fish.payara.distributions</groupId>
             <artifactId>payara</artifactId>
+            <version>${payara.version}</version>
             <type>zip</type>
             <scope>provided</scope>
         </dependency>

--- a/appserver/extras/docker-images/server-web/pom.xml
+++ b/appserver/extras/docker-images/server-web/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>fish.payara.distributions</groupId>
             <artifactId>payara-web</artifactId>
+            <version>${payara.version}</version>
             <type>zip</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
## Description
The recent change to make the bom use `project.version` meant the docker images were ignoring `payara.version` when determining which version of Payara to bundle.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built images and ran tests using `payara.version=6.2022.1.Alpha2`, checking logs to make sure it actually used 6.2022.1.Alpha2

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None