### PR TITLE
FISH-6442 Payara Micro Docker Image Test Fails

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/domain/domain.xml
@@ -105,7 +105,7 @@ Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
                 <notifier>eventbus-notifier</notifier>
             </monitoring-service-configuration>
             <microprofile-metrics-configuration></microprofile-metrics-configuration>
-            <security-service activate-default-principal-to-role-mapping="true" jacc="simple">
+            <security-service activate-default-principal-to-role-mapping="true">
                 <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
                     <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
                     <property value="fileRealm" name="jaas-context" />


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix,
`jacc-provider` with `name=simple` is unavailable thus it causes the policy provider lookup failed to collect the defined policy provider from domain.xml.
By removing the jacc identification on tag `security-service` on payara micro's domain.xml it help policy provider to get correct `jacc-provider` config

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
None

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
+ `cd appserver/extras/docker-images`
+ Run `mvn clean install` 

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, OpenJDK11, Maven 3.8.4

## Documentation
<!-- Link documentation if a PR exists -->
None

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
None