### PR TITLE
FISH-5827 Stuck Thread count as MicroProfile Metric Gauge

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
@@ -1,0 +1,93 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ * 
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ * 
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.microprofile.metrics.healthcheck;
+
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import org.eclipse.microprofile.metrics.Counter;
+
+/**
+ * Implementation of a counter based off an HealthCheck. As this is just a proxy
+ * for the HealthCheck calling the {@link #inc() } method will throw an
+ * {@link UnsupportedOperationException}. Just use the {@link #getCount()}
+ * method to get the value of the HealthCheck backing this.
+ */
+public class HealthCheckCounter implements Counter, HealthCheckStatsProvider<Integer> {
+
+    private final HealthCheckStatsProvider<Integer> healthCheck;
+
+    public HealthCheckCounter(HealthCheckStatsProvider<Integer> healthCheck) {
+        this.healthCheck = healthCheck;
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException} - this is all dealt with by
+     * the backing HealthCheck
+     */
+    @Override
+    public void inc() {
+        throw new UnsupportedOperationException("Not supported - use getCount() to get value from HealthCheck directly.");
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException} - this is all dealt with by
+     * the backing HealthCheck
+     * @param n the increment value
+     */
+    @Override
+    public void inc(long n) {
+        throw new UnsupportedOperationException("Not supported - use getCount() to get value from HealthCheck directly.");
+    }
+
+    @Override
+    public long getCount() {
+        return healthCheck.getValue();
+    }
+    
+    @Override
+    public Integer getValue() {
+       return healthCheck.getValue();
+    }
+
+    @Override
+    public boolean isEnabled() {
+       return healthCheck.isEnabled();
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
@@ -1,0 +1,67 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ * 
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ * 
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.microprofile.metrics.healthcheck;
+
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import org.eclipse.microprofile.metrics.Gauge;
+
+/**
+ * Implementation of a gauge based off an HealthCheck.
+ *
+ */
+public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider<Number> {
+
+    private final HealthCheckStatsProvider<Number> healthCheck;
+
+    public HealthCheckGauge(HealthCheckStatsProvider<Number> healthCheck) {
+        this.healthCheck = healthCheck;
+    }
+
+    @Override
+    public Number getValue() {
+        return healthCheck.getValue();
+    }
+
+    @Override
+    public boolean isEnabled() {
+       return healthCheck.isEnabled();
+    }
+
+}

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MBeanExpression.java
@@ -40,8 +40,8 @@
 
 package fish.payara.microprofile.metrics.jmx;
 
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.ATTRIBUTE_SEPARATOR;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SUB_ATTRIBUTE_SEPARATOR;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.ATTRIBUTE_SEPARATOR;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SUB_ATTRIBUTE_SEPARATOR;
 import java.lang.management.ManagementFactory;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
@@ -40,10 +40,10 @@
 
 package fish.payara.microprofile.metrics.jmx;
 
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.ATTRIBUTE;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.KEY;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SPECIFIER;
-import static fish.payara.microprofile.metrics.jmx.MBeanMetadataHelper.SUB_ATTRIBUTE;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.ATTRIBUTE;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.KEY;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SPECIFIER;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SUB_ATTRIBUTE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -64,12 +64,15 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-public class MBeanMetadata implements Metadata {
+public class MetricsMetadata implements Metadata {
 
-    private static final Logger LOGGER = Logger.getLogger(MBeanMetadata.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(MetricsMetadata.class.getName());
 
     @XmlElement(name = "mbean")
     private String mBean;
+
+    @XmlElement(name = "service")
+    private String service;
 
     @XmlElement
     private boolean dynamic = true;
@@ -97,15 +100,15 @@ public class MBeanMetadata implements Metadata {
     private List<XmlTag> tags;
 
 
-    public MBeanMetadata() {
+    public MetricsMetadata() {
         tags = new ArrayList<>();
     }
 
-    public MBeanMetadata(Metadata metadata) {
+    public MetricsMetadata(Metadata metadata) {
         this(null, metadata.getName(), metadata.getDisplayName(), metadata.description().orElse(null), metadata.getTypeRaw(), metadata.unit().orElse(null));
     }
 
-    public MBeanMetadata(String mBean, String name, String displayName, String description, MetricType typeRaw, String unit) {
+    public MetricsMetadata(String mBean, String name, String displayName, String description, MetricType typeRaw, String unit) {
         this();
         this.mBean = mBean;
         this.name = name;
@@ -121,6 +124,14 @@ public class MBeanMetadata implements Metadata {
 
     public void setMBean(String mBean) {
         this.mBean = mBean;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
     }
 
     public boolean isDynamic() {
@@ -184,14 +195,14 @@ public class MBeanMetadata implements Metadata {
 
     private boolean validateMetadata() {
         boolean validationResult = true;
-        MBeanMetadata metadata = this;
+        MetricsMetadata metadata = this;
 
         if (isNull(metadata.getName())) {
             LOGGER.log(WARNING, "'name' property not defined in " + metadata.getMBean() + " mbean metadata", new Exception());
             validationResult = false;
         }
-        if (isNull(metadata.getMBean())) {
-            LOGGER.log(WARNING, "'mbean' property not defined in {0} metadata", metadata.getName());
+        if (isNull(metadata.getMBean()) && isNull(metadata.getService())) {
+            LOGGER.log(WARNING, "'mbean' or 'service' property not defined in {0} metadata", metadata.getName());
             validationResult = false;
         }
         if (isNull(metadata.getType())) {
@@ -275,7 +286,7 @@ public class MBeanMetadata implements Metadata {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", MBeanMetadata.class.getSimpleName() + "[", "]")
+        return new StringJoiner(", ", MetricsMetadata.class.getSimpleName() + "[", "]")
                 .add("mBean='" + mBean + "'")
                 .add("dynamic=" + dynamic)
                 .add("name='" + name + "'")

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataConfig.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataConfig.java
@@ -46,39 +46,39 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 @XmlRootElement(name = "config")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class MBeanMetadataConfig {
+public class MetricsMetadataConfig {
 
     @XmlElementWrapper(name = "base")
     @XmlElement(name = "metadata")
-    private final List<MBeanMetadata> baseMetadata = new CopyOnWriteArrayList<>();
+    private final List<MetricsMetadata> baseMetadata = new CopyOnWriteArrayList<>();
 
     @XmlElementWrapper(name = "vendor")
     @XmlElement(name = "metadata")
-    private final List<MBeanMetadata> vendorMetadata = new CopyOnWriteArrayList<>();
+    private final List<MetricsMetadata> vendorMetadata = new CopyOnWriteArrayList<>();
 
-    public List<MBeanMetadata> getBaseMetadata() {
+    public List<MetricsMetadata> getBaseMetadata() {
         return baseMetadata;
     }
 
-    public void setBaseMetadata(List<MBeanMetadata> baseMetadata) {
+    public void setBaseMetadata(List<MetricsMetadata> baseMetadata) {
         this.baseMetadata.clear();
         this.addBaseMetadata(baseMetadata);
     }
 
-    public void addBaseMetadata(List<MBeanMetadata> baseMetadata) {
+    public void addBaseMetadata(List<MetricsMetadata> baseMetadata) {
         this.baseMetadata.addAll(baseMetadata);
     }
 
-    public List<MBeanMetadata> getVendorMetadata() {
+    public List<MetricsMetadata> getVendorMetadata() {
         return vendorMetadata;
     }
 
-    public void setVendorMetadata(List<MBeanMetadata> vendorMetadata) {
+    public void setVendorMetadata(List<MetricsMetadata> vendorMetadata) {
         this.vendorMetadata.clear();
         this.addVendorMetadata(vendorMetadata);
     }
 
-    public void addVendorMetadata(List<MBeanMetadata> vendorMetadata) {
+    public void addVendorMetadata(List<MetricsMetadata> vendorMetadata) {
         this.vendorMetadata.addAll(vendorMetadata);
     }
 

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
@@ -58,6 +58,7 @@ import fish.payara.microprofile.metrics.MetricsService.MetricsContext;
 import fish.payara.microprofile.metrics.exception.NoSuchMetricException;
 import fish.payara.microprofile.metrics.exception.NoSuchRegistryException;
 import fish.payara.microprofile.metrics.impl.MetricRegistryImpl;
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 
 public class MetricsWriterImpl implements MetricsWriter {
 
@@ -121,6 +122,10 @@ public class MetricsWriterImpl implements MetricsWriter {
         Metadata metadata = registry.getMetadata(metricName);
         for (Entry<MetricID, Metric> metric : registry.getMetrics(metricName).entrySet()) {
             MetricID metricID = metric.getKey();
+            if (metric.getValue() instanceof HealthCheckStatsProvider
+                    && !((HealthCheckStatsProvider) metric.getValue()).isEnabled()) {
+                continue;
+            }
             if (globalTags.length > 0) {
                 Tag[]  tagsWithoutGlobal = metricID.getTagsAsArray();
                 Tag[] tags = new Tag[tagsWithoutGlobal.length +  globalTags.length];

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -126,7 +126,7 @@ holder.
             <type>gauge</type>
             <unit>none</unit>
             <displayName>System Load Average</displayName>
-            <description>Displays the system load average for the last minute. The system load average is the sum of the number of runnable entities queued to the available processors and the number of runnable entities running on the available processors averaged over a period of time. The way in which the load average is calculated is operating system specific but is typically a damped time-dependent average. If the load average is not available, a negative value is displayed. This attribute is designed to provide a hint about the system load and may be queried frequently. The load average may be unavailable on some platform where it is expensive to implement this method.</description>
+            <description>Displays the system load average for the last minute. The system load average is the sum of the number of runnable entities queued to the available processors and the number of runnable entities running on the available processors averaged over a period of time. The way in which the load average is calculated is operating system specific but is typically a damped time-dependent average. If the load average is not available, a negative value is displayed. This attribute is designed to provide a hint about the system load and may be queried frequently. The load average may be unavailable on some platforms where it is expensive to implement this method.</description>
         </metadata>
         <metadata>
             <name>jvm.uptime</name>
@@ -201,7 +201,15 @@ holder.
             <type>gauge</type>
             <unit>none</unit>
             <displayName>System Cpu Load</displayName>
-            <description>Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values betweens 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.</description>
+            <description>Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values between 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.</description>
+        </metadata>
+        <metadata>
+            <name>thread.stuck.count</name>
+            <service>healthcheck-stuck</service>
+            <type>gauge</type>
+            <unit>none</unit>
+            <displayName>Stuck Thread Count</displayName>
+            <description>Displays the stuck thread count which is blocked, and can't return to the threadpool for a certain amount of time.</description>
         </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -49,11 +49,11 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MBeanMetadataTest {
+public class MetricsMetadataTest {
 
     @Test
     public void isValid_basic() {
-        MBeanMetadata metadata = new MBeanMetadata("m", "name"
+        MetricsMetadata metadata = new MetricsMetadata("m", "name"
                 , "Display", "description", MetricType.COUNTER, "none");
         List<XmlTag> tags = new ArrayList<>();
         tags.add(new XmlTag("test", "JUnit"));
@@ -63,7 +63,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_EmptyTag() {
-        MBeanMetadata metadata = new MBeanMetadata("m", "name", "Display", "description"
+        MetricsMetadata metadata = new MetricsMetadata("m", "name", "Display", "description"
                 , MetricType.COUNTER, "none");
         List<XmlTag> tags = new ArrayList<>();
         tags.add(new XmlTag("test", "JUnit"));
@@ -73,7 +73,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_PlaceHolder() {
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.%s.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"
@@ -85,7 +85,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_PlaceHolderSomeTag() {
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.%s.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"
@@ -98,7 +98,7 @@ public class MBeanMetadataTest {
 
     @Test
     public void isValid_PlaceHolderPlaceHolderTag() {
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"
@@ -112,7 +112,7 @@ public class MBeanMetadataTest {
     @Test
     public void isValid_PlaceHolderEmptyTag() {
         // FISH-5801
-        MBeanMetadata metadata = new MBeanMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
+        MetricsMetadata metadata = new MetricsMetadata("amx:type=jdbc-connection-pool-mon,pp=/mon/server-mon[local-instance],name=resources/%sPool/numconnfree#current"
                 , "jdbc.connection.pool.%s.pool.instance.free.connections"
                 , "Free Connections (Instance)"
                 , "The total number of free connections in the pool as of the last sampling"

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
@@ -1,0 +1,50 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *    Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * 
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ * 
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ * 
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ * 
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ * 
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.nucleus.healthcheck;
+
+import org.jvnet.hk2.annotations.Contract;
+
+@Contract
+public interface HealthCheckStatsProvider<T extends Object> {
+
+    public T getValue();
+
+    boolean isEnabled();
+}

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.nucleus.healthcheck.stuck;
 
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 import fish.payara.nucleus.healthcheck.HealthCheckResult;
 import fish.payara.monitoring.collect.MonitoringData;
 import fish.payara.monitoring.collect.MonitoringDataCollector;
@@ -75,7 +76,17 @@ import org.jvnet.hk2.annotations.Service;
 @RunLevel(StartupRunLevel.VAL)
 public class StuckThreadsHealthCheck extends
         BaseHealthCheck<HealthCheckStuckThreadExecutionOptions, StuckThreadsChecker>
-        implements MonitoringDataSource, MonitoringWatchSource {
+        implements MonitoringDataSource, MonitoringWatchSource, HealthCheckStatsProvider<Integer> {
+
+    @Override
+    public Integer getValue() {
+       return this.stuckThreadsStore.getThreads().size();
+    }
+
+    @Override
+    public boolean isEnabled() {
+       return this.getOptions() != null ? this.getOptions().isEnabled() : false;
+    }
 
     @FunctionalInterface
     private interface StuckThreadConsumer {


### PR DESCRIPTION
## Description
This PR adds HealthCheck stats (Stuck thread count) to MicroProfile Metrics.


## Payara 6 PR:
https://github.com/payara/Payara/pull/5952


## Testing
### Testing Performed
````
asadmin start-domain
asadmin set-healthcheck-service-configuration --serviceName=stuck-thread --enabled=true
asadmin restart-domain
````
Open `http://localhost:8080/metrics/vendor` URL which so=houl contains the following result:
````
# TYPE vendor_system_cpu_load gauge
# HELP vendor_system_cpu_load Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values between 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.
vendor_system_cpu_load 0.2421606522975489
# TYPE vendor_thread_stuck_count gauge
# HELP vendor_thread_stuck_count Displays the stuck thread count which is blocked, and can't return to the threadpool for a certain amount of time.
vendor_thread_stuck_count 1
````
Now disable health check stuck-thread:
````
asadmin set-healthcheck-service-configuration --serviceName=stuck-thread --enabled=false
asadmin restart-domain
````
Open `http://localhost:8080/metrics/vendor` URL which so=houl contains the following result:
````
# TYPE vendor_system_cpu_load gauge
# HELP vendor_system_cpu_load Display the "recent cpu usage" for the whole system. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs were idle during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running 100% of the time during the recent period being observed. All values between 0.0 and 1.0 are possible depending of the activities going on in the system. If the system recent cpu usage is not available, the method returns a negative value.
vendor_system_cpu_load 0.2421606522975489
````

### Testing Environment
Windows 11, JDK 11.0.16
