### PR TITLE
FISH-6578 added jna required dependency to packager and upgraded it to latest

### DIFF
--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -74,12 +74,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara-ml"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -76,12 +76,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara-web-ml"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -77,12 +77,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara-web"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -89,12 +89,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -142,7 +142,7 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk8">
                                             <filterset>
                                                 <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk8.tag}"/>
@@ -154,7 +154,7 @@
                                                 <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk11"/>
                                             </filterset>
                                         </copy>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>
@@ -237,14 +237,14 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk17">
                                             <filterset>
                                                 <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk17.tag}"/>
                                                 <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk17"/>
                                             </filterset>
                                         </copy>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>

--- a/appserver/packager/appserver-base/pom.xml
+++ b/appserver/packager/appserver-base/pom.xml
@@ -109,7 +109,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <replace token="@@@FULL_VERSION@@@" value="${project.version}" dir="${stage.dir}">
                                     <include name="README.txt"/>
                                 </replace>
@@ -122,7 +122,7 @@
                                 <replace token="@@@UPDATE_VERSION@@@" value="${update_version}" dir="${stage.dir}">
                                     <include name="README.txt"/>
                                 </replace>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/packager/external/libpam4j/pom.xml
+++ b/appserver/packager/external/libpam4j/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
 
@@ -55,7 +55,7 @@
     <description>libpam4j (Java binding for libpam.so) repackaged as a module</description>
 
     <properties>
-      <libpam4j.jna.version>4.5.2</libpam4j.jna.version>
+      <libpam4j.jna.version>${jna.version}</libpam4j.jna.version>
     </properties>
 
     <build>
@@ -123,6 +123,12 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>libpam4j</artifactId>
             <version>1.11</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${libpam4j.jna.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -66,7 +66,7 @@
         
         <!-- Java EE Security API -->
         <javax.security.enterprise-spec.version>1.0</javax.security.enterprise-spec.version>
-        <jna.version>5.2.0</jna.version>
+        <jna.version>5.12.1</jna.version>
 
         <!-- Application Server / Implementation -->
         <product.name>Payara Server</product.name>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -89,7 +89,7 @@
 
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
-        <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
+        <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
         <maven.remote.resources.plugin.version>1.6.0</maven.remote.resources.plugin.version>
         <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
         <maven.invoker.plugin.version>3.1.0</maven.invoker.plugin.version>
@@ -361,7 +361,7 @@
                 <plugin>
                     <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
                     <artifactId>maven-antrun-extended-plugin</artifactId>
-                    <version>1.43</version>
+                    <version>1.45</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.updatecenter2</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -361,7 +361,7 @@
                 <plugin>
                     <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
                     <artifactId>maven-antrun-extended-plugin</artifactId>
-                    <version>1.45</version>
+                    <version>1.43.payara-p1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.updatecenter2</groupId>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Pam4j is missing the required JNA dependency in the packager 
Latest JNA so it runs on apple silicon.
Only other possibility is to put JNA in modules/ putting it in lib/ doesn’t work 

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
fixes #5581 

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Mac, Linux
