### PR TITLE
Fish-6430: skipping BdId TransactionalExtension type to not generate error logs

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -106,6 +106,7 @@ public class InjectionServicesImpl implements InjectionServices {
     private DeploymentImpl deployment;
 
     private Predicate<BackedAnnotatedType> availableAnnotatedType = n -> n != null && n.getIdentifier() != null;
+    
     private Predicate<AnnotatedTypeIdentifier> isTransactionExtension = t -> t.getBdaId().equals(TRANSACTIONAL_EXTENSION_NAME)
             || t.getBdaId().equals(TRANSACTION_EXTENSION_NAME);
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -92,18 +92,18 @@ import org.glassfish.api.invocation.ComponentInvocation;
  */
 public class InjectionServicesImpl implements InjectionServices {
 
+    private static final Logger logger = Logger.getLogger(InjectionServicesImpl.class.getName());
+
+    private static final String TRANSACTIONAL_EXTENSION_NAME = "org.glassfish.cdi.transaction.TransactionalExtension";
+
+    private static final String TRANSACTION_EXTENSION_NAME = "org.glassfish.cdi.transaction.TransactionScopedContextExtension";
+
     private InjectionManager injectionManager;
 
     // Associated bundle context
     private BundleDescriptor bundleContext;
 
     private DeploymentImpl deployment;
-    
-    private static final Logger logger = Logger.getLogger(InjectionServicesImpl.class.getName());
-
-    private static final String TRANSACTIONAL_EXTENSION_NAME = "org.glassfish.cdi.transaction.TransactionalExtension";
-
-    private static final String TRANSACTION_EXTENSION_NAME = "org.glassfish.cdi.transaction.TransactionScopedContextExtension";
 
     private Predicate<BackedAnnotatedType> availableAnnotatedType = n -> n != null && n.getIdentifier() != null;
     private Predicate<AnnotatedTypeIdentifier> isTransactionExtension = t -> t.getBdaId().equals(TRANSACTIONAL_EXTENSION_NAME)

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -172,8 +172,9 @@ public class InjectionServicesImpl implements InjectionServices {
                 }
 
                 if (componentEnv == null) {
-                    logger.log(Level.SEVERE, "No valid EE environment for injection of {0}",
-                            new Object[]{targetClass});
+                    logger.log(Level.FINE,
+                            "No valid EE environment for injection of {0}. The methods that is missing the context is {1}",
+                            new Object[] {targetClass, injectionContext.getAnnotatedType().getMethods()});
                     injectionContext.proceed();
                     return;
                 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -101,8 +101,6 @@ public class InjectionServicesImpl implements InjectionServices {
     
     private static final Logger logger = Logger.getLogger(InjectionServicesImpl.class.getName());
 
-    private static final Logger logger = Logger.getLogger(InjectionServicesImpl.class.getName());
-
     public InjectionServicesImpl(InjectionManager injectionMgr, BundleDescriptor context, DeploymentImpl deployment) {
         injectionManager = injectionMgr;
         bundleContext = context;

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -158,8 +158,10 @@ public class InjectionServicesImpl implements InjectionServices {
                     //for the TransactionalScoped CDI Bean
                     if (backedAnnotatedType != null
                             && backedAnnotatedType.getIdentifier() != null
-                            && backedAnnotatedType.getIdentifier().getBdaId()
+                            && (backedAnnotatedType.getIdentifier().getBdaId()
                             .equals("org.glassfish.cdi.transaction.TransactionalExtension")
+                            || backedAnnotatedType.getIdentifier().getBdaId()
+                            .equals("org.glassfish.cdi.transaction.TransactionScopedContextExtension"))
                             && componentEnv == null) {
                         injectionContext.proceed();
                         return;

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -48,6 +48,13 @@ import com.sun.enterprise.deployment.InjectionCapable;
 import com.sun.enterprise.deployment.InjectionInfo;
 import com.sun.enterprise.deployment.JndiNameEnvironment;
 import com.sun.enterprise.deployment.ManagedBeanDescriptor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.enterprise.inject.spi.InjectionTarget;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.ejb.api.EjbContainerServices;
 import org.glassfish.internal.api.Globals;
@@ -65,8 +72,6 @@ import com.sun.enterprise.container.common.spi.util.InjectionManager;
 import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.*;
-import javax.enterprise.inject.spi.InjectionTarget;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceContext;
@@ -90,6 +95,8 @@ public class InjectionServicesImpl implements InjectionServices {
     private BundleDescriptor bundleContext;
 
     private DeploymentImpl deployment;
+
+    private static final Logger logger = Logger.getLogger(InjectionServicesImpl.class.getName());
 
     public InjectionServicesImpl(InjectionManager injectionMgr, BundleDescriptor context, DeploymentImpl deployment) {
         injectionManager = injectionMgr;
@@ -160,8 +167,8 @@ public class InjectionServicesImpl implements InjectionServices {
                 }
 
                 if (componentEnv == null) {
-                    //throw new IllegalStateException("No valid EE environment for injection of " + targetClassName);
-                    System.err.println("No valid EE environment for injection of " + targetClassName);
+                    logger.log(Level.SEVERE, "No valid EE environment for injection of {0}",
+                            new Object[]{targetClass});
                     injectionContext.proceed();
                     return;
                 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -157,7 +157,9 @@ public class InjectionServicesImpl implements InjectionServices {
                         injectionContext.proceed();
                         return;
                     }
-                } else if (componentEnv == null) {
+                }
+
+                if (componentEnv == null) {
                     //throw new IllegalStateException("No valid EE environment for injection of " + targetClassName);
                     System.err.println("No valid EE environment for injection of " + targetClassName);
                     injectionContext.proceed();

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -37,16 +37,23 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld.services;
 
-import com.sun.enterprise.deployment.*;
+import com.sun.enterprise.deployment.BundleDescriptor;
+import com.sun.enterprise.deployment.EjbBundleDescriptor;
+import com.sun.enterprise.deployment.EjbDescriptor;
+import com.sun.enterprise.deployment.InjectionCapable;
+import com.sun.enterprise.deployment.InjectionInfo;
+import com.sun.enterprise.deployment.JndiNameEnvironment;
+import com.sun.enterprise.deployment.ManagedBeanDescriptor;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.ejb.api.EjbContainerServices;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.weld.DeploymentImpl;
 import org.glassfish.weld.connector.WeldUtils;
+import org.jboss.weld.annotated.slim.backed.BackedAnnotatedType;
 import org.jboss.weld.injection.spi.InjectionContext;
 import org.jboss.weld.injection.spi.InjectionServices;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -138,7 +145,14 @@ public class InjectionServicesImpl implements InjectionServices {
               // must use the current jndi component env to lookup the objects to inject
               injectionManager.inject( targetClass, target, injectionEnv, null, false );
             } else {
-              if( componentEnv == null ) {
+                BackedAnnotatedType backedAnnotatedType = ((BackedAnnotatedType) annotatedType);
+                //added condition to skip the failure when the TransactionScopedCDIEventHelperImpl is tried to be used
+                //for the TransactionalScoped CDI Bean
+                if(!(backedAnnotatedType != null
+                        && backedAnnotatedType.getIdentifier() != null
+                        && backedAnnotatedType.getIdentifier().getBdaId()
+                        .equals("org.glassfish.cdi.transaction.TransactionalExtension"))
+                        && componentEnv == null ) {
                 //throw new IllegalStateException("No valid EE environment for injection of " + targetClassName);
                 System.err.println("No valid EE environment for injection of " + targetClassName);
                 injectionContext.proceed();

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -145,19 +145,24 @@ public class InjectionServicesImpl implements InjectionServices {
               // must use the current jndi component env to lookup the objects to inject
               injectionManager.inject( targetClass, target, injectionEnv, null, false );
             } else {
-                BackedAnnotatedType backedAnnotatedType = ((BackedAnnotatedType) annotatedType);
-                //added condition to skip the failure when the TransactionScopedCDIEventHelperImpl is tried to be used
-                //for the TransactionalScoped CDI Bean
-                if(!(backedAnnotatedType != null
-                        && backedAnnotatedType.getIdentifier() != null
-                        && backedAnnotatedType.getIdentifier().getBdaId()
-                        .equals("org.glassfish.cdi.transaction.TransactionalExtension"))
-                        && componentEnv == null ) {
-                //throw new IllegalStateException("No valid EE environment for injection of " + targetClassName);
-                System.err.println("No valid EE environment for injection of " + targetClassName);
-                injectionContext.proceed();
-                return;
-              }
+                if(annotatedType instanceof BackedAnnotatedType) {
+                    BackedAnnotatedType backedAnnotatedType = ((BackedAnnotatedType) annotatedType);
+                    //added condition to skip the failure when the TransactionScopedCDIEventHelperImpl is tried to be used
+                    //for the TransactionalScoped CDI Bean
+                    if(backedAnnotatedType != null
+                            && backedAnnotatedType.getIdentifier() != null
+                            && backedAnnotatedType.getIdentifier().getBdaId()
+                            .equals("org.glassfish.cdi.transaction.TransactionalExtension")
+                            && componentEnv == null ) {
+                        injectionContext.proceed();
+                        return;
+                    }
+                } else if (componentEnv == null) {
+                    //throw new IllegalStateException("No valid EE environment for injection of " + targetClassName);
+                    System.err.println("No valid EE environment for injection of " + targetClassName);
+                    injectionContext.proceed();
+                    return;
+                }
 
               // Perform EE-style injection on the target.  Skip PostConstruct since
               // in this case 299 impl is responsible for calling it.

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/InjectionServicesImpl.java
@@ -145,15 +145,15 @@ public class InjectionServicesImpl implements InjectionServices {
               // must use the current jndi component env to lookup the objects to inject
               injectionManager.inject( targetClass, target, injectionEnv, null, false );
             } else {
-                if(annotatedType instanceof BackedAnnotatedType) {
+                if (annotatedType instanceof BackedAnnotatedType) {
                     BackedAnnotatedType backedAnnotatedType = ((BackedAnnotatedType) annotatedType);
                     //added condition to skip the failure when the TransactionScopedCDIEventHelperImpl is tried to be used
                     //for the TransactionalScoped CDI Bean
-                    if(backedAnnotatedType != null
+                    if (backedAnnotatedType != null
                             && backedAnnotatedType.getIdentifier() != null
                             && backedAnnotatedType.getIdentifier().getBdaId()
                             .equals("org.glassfish.cdi.transaction.TransactionalExtension")
-                            && componentEnv == null ) {
+                            && componentEnv == null) {
                         injectionContext.proceed();
                         return;
                     }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Preventing error logs related to inject TransactionalScopedCDIEventHelperImpl for TransactionScoped CDI Beans
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
this is a bug fix to not add unnecesary error logs for TransactionScoped CDI Beans
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
local testing using the attached reproducer from the ticket [FISH-6430](https://payara.atlassian.net/browse/FISH-6430)

logs looks more cleaned:
`  [#|2022-09-27T13:18:04.654-0500|INFO|Payara 5.2022.4-SNAPSHOT||_ThreadID=129;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1664302684654;_LevelValue=800;|
  TestTransactionalScopeBean initialized. Value is 1664302684654|#]

[#|2022-09-27T13:19:02.527-0500|INFO|Payara 5.2022.4-SNAPSHOT||_ThreadID=129;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1664302742527;_LevelValue=800;|
  ServiceBean:: testTransactionalScope value is 1664302684654|#]

[#|2022-09-27T13:19:02.528-0500|INFO|Payara 5.2022.4-SNAPSHOT||_ThreadID=129;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1664302742528;_LevelValue=800;|
  NestedServiceBean::doWork() called|#]

[#|2022-09-27T13:19:02.530-0500|INFO|Payara 5.2022.4-SNAPSHOT||_ThreadID=129;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1664302742530;_LevelValue=800;|
  NestedServiceBean:: testTransactionalScope value is 1664302684654|#]

[#|2022-09-27T13:20:15.105-0500|INFO|Payara 5.2022.4-SNAPSHOT||_ThreadID=129;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1664302815105;_LevelValue=800;|
  TestTransactionalScopeBean destroyed. Value is 1664302684654|#]`
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, Azul JDK 8, Maven 3.8.6
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
