### PR TITLE
FISH-5828 Connection Pool HealthCheck exposed to MicroProfile Metrics

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.metrics.healthcheck;
 
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import java.util.Set;
 import org.eclipse.microprofile.metrics.Counter;
 
 /**
@@ -80,12 +81,7 @@ public class HealthCheckCounter implements Counter, HealthCheckStatsProvider {
 
     @Override
     public long getCount() {
-        return getValue(Long.class, expression.getAttributeName());
-    }
-
-    @Override
-    public <Long> Long getValue(Class<Long> type, String attributeName) {
-        return healthCheck.getValue(type, attributeName);
+        return getValue(Long.class, expression.getAttributeName(), expression.getSubAttributeName());
     }
 
     @Override
@@ -93,4 +89,18 @@ public class HealthCheckCounter implements Counter, HealthCheckStatsProvider {
        return healthCheck.isEnabled();
     }
 
+    @Override
+    public <T> T getValue(Class<T> type, String attribute, String subAttribute) {
+        return healthCheck.getValue(type, attribute, subAttribute);
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+        return healthCheck.getAttributes();
+    }
+
+    @Override
+    public Set<String> getSubAttributes() {
+        return healthCheck.getSubAttributes();
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.metrics.healthcheck;
 
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import java.util.Set;
 import org.eclipse.microprofile.metrics.Gauge;
 
 /**
@@ -59,7 +60,7 @@ public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider
 
     @Override
     public Number getValue() {
-        return getValue(Number.class, expression.getAttributeName());
+        return getValue(Number.class, expression.getAttributeName(), expression.getSubAttributeName());
     }
 
     @Override
@@ -68,8 +69,18 @@ public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider
     }
 
     @Override
-    public <Number> Number getValue(Class<Number> type, String attributeName) {
-        return healthCheck.getValue(type, attributeName);
+    public <T> T getValue(Class<T> type, String attribute, String subAttribute) {
+        return healthCheck.getValue(type, attribute, subAttribute);
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+        return healthCheck.getAttributes();
+    }
+    
+        @Override
+    public Set<String> getSubAttributes() {
+        return healthCheck.getSubAttributes();
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/ServiceExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/ServiceExpression.java
@@ -39,24 +39,38 @@
  */
 package fish.payara.microprofile.metrics.healthcheck;
 
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.ATTRIBUTE_SEPARATOR;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SUB_ATTRIBUTE_SEPARATOR;
+
 public class ServiceExpression {
 
     private String service;
 
     private String attributeName;
+    private String subAttributeName;
 
-    private static final String ATTRIBUTE_SEPARATOR = "#";
 
     public ServiceExpression(String expression) {
         if (expression == null || expression.trim().isEmpty()) {
             throw new IllegalArgumentException("Service Expression is null");
         }
         int slashIndex = expression.lastIndexOf(ATTRIBUTE_SEPARATOR);
-        if (slashIndex < 0) {
-            throw new IllegalArgumentException("MBean Expression is invalid : " + expression);
+        if (slashIndex >= 0) {
+            service = expression.substring(0, slashIndex);
+            attributeName = expression.substring(slashIndex + 1);
+            if (attributeName.contains(SUB_ATTRIBUTE_SEPARATOR)) {
+                int hashIndex = attributeName.indexOf(SUB_ATTRIBUTE_SEPARATOR);
+                subAttributeName = attributeName.substring(hashIndex + 1);
+                attributeName = attributeName.substring(0, hashIndex);
+            }
+        } else {
+            slashIndex = expression.lastIndexOf(SUB_ATTRIBUTE_SEPARATOR);
+            if (slashIndex < 0) {
+                throw new IllegalArgumentException("Service Expression is invalid : " + expression);
+            }
+            service = expression.substring(0, slashIndex);
+            subAttributeName = expression.substring(slashIndex + 1);
         }
-        service = expression.substring(0, slashIndex);
-        attributeName = expression.substring(slashIndex + 1);
     }
 
     public String getServiceId() {
@@ -65,6 +79,10 @@ public class ServiceExpression {
 
     public String getAttributeName() {
         return attributeName;
+    }
+
+    public String getSubAttributeName() {
+        return subAttributeName;
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
@@ -118,6 +118,15 @@ public class MetricsMetadata implements Metadata {
         this.unit = unit;
     }
 
+    public MetricsMetadata(String name, String displayName, String description, MetricType typeRaw, String unit) {
+        this();
+        this.name = name;
+        this.displayName = displayName;
+        this.description = description;
+        this.type = typeRaw.toString();
+        this.unit = unit;
+    }
+
     public String getMBean() {
         return mBean;
     }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
@@ -257,17 +257,20 @@ public class MetricsMetadataHelper {
         List<MetricsMetadata> metadataList = new ArrayList<>();
         String instanceName = serverEnv.getInstanceName();
         HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, expression.getServiceId());
-        for (String attribute : healthCheck.getAttributes()) {
-            if (expression.getSubAttributeName() != null
-                    && (expression.getSubAttributeName().equals("*") || expression.getSubAttributeName().equals(SUB_ATTRIBUTE))) {
-                metadataList.addAll(
-                        loadSubAttribute(expression, metadata, attribute)
-                );
-            } else {
-                metadataList.add(createMetadata(metadata, expression.getServiceId(), null, attribute, expression.getSubAttributeName(), instanceName));
+        if (healthCheck != null) {
+            for (String attribute : healthCheck.getAttributes()) {
+                if (expression.getSubAttributeName() != null
+                        && (expression.getSubAttributeName().equals("*") || expression.getSubAttributeName().equals(SUB_ATTRIBUTE))) {
+                    metadataList.addAll(
+                            loadSubAttribute(expression, metadata, attribute)
+                    );
+                } else {
+                    metadataList.add(createMetadata(metadata, expression.getServiceId(), null, attribute, expression.getSubAttributeName(), instanceName));
+                }
             }
+        } else {
+            LOGGER.log(WARNING, "Health-Check service not found : {0}", expression.getServiceId());
         }
-
         return metadataList;
     }
 
@@ -279,10 +282,13 @@ public class MetricsMetadataHelper {
         List<MetricsMetadata> metadataList = new ArrayList<>();
         String instanceName = serverEnv.getInstanceName();
         HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, expression.getServiceId());
-        for (String subAttribute : healthCheck.getSubAttributes()) {
-            metadataList.add(createMetadata(metadata, expression.getServiceId(), null, attribute, subAttribute, instanceName));
+        if (healthCheck != null) {
+            for (String subAttribute : healthCheck.getSubAttributes()) {
+                metadataList.add(createMetadata(metadata, expression.getServiceId(), null, attribute, subAttribute, instanceName));
+            }
+        } else {
+            LOGGER.log(WARNING, "Health-Check service not found : {0}", expression.getServiceId());
         }
-
         return metadataList;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -220,12 +220,12 @@ holder.
             <description>Displays the maximum duration of stuck thread which is blocked, and can't return to the threadpool for a certain amount of time.</description>
         </metadata>>
         <metadata>
-            <name>${attribute}.${subattribute}</name>
+            <name>connection.pool.${attribute}.${subattribute}</name>
             <service>healthcheck-cpool/${attribute}#${subattribute}</service>
-            <type>gauge</type>
+            <type>counter</type>
             <unit>none</unit>
             <displayName>${attribute} ${subattribute}</displayName>
-            <description>Displays the number of ${subattribute} of ${attribute}.</description>
+            <description>Displays the number of ${subattribute} in the Connection Pool ${attribute}.</description>
         </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -218,6 +218,14 @@ holder.
             <unit>none</unit>
             <displayName>Stuck Thread Max Duration</displayName>
             <description>Displays the maximum duration of stuck thread which is blocked, and can't return to the threadpool for a certain amount of time.</description>
+        </metadata>>
+        <metadata>
+            <name>${attribute}.${subattribute}</name>
+            <service>healthcheck-cpool/${attribute}#${subattribute}</service>
+            <type>gauge</type>
+            <unit>none</unit>
+            <displayName>${attribute} ${subattribute}</displayName>
+            <description>Displays the number of ${subattribute} of ${attribute}.</description>
         </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
@@ -122,4 +122,19 @@ public class MetricsMetadataTest {
         metadata.addTags(tags);
         Assert.assertTrue(metadata.isValid());
     }
+
+    @Test
+    public void isValid_Service() {
+        MetricsMetadata metadata = new MetricsMetadata(
+                "jdbc.connection.pool.${attribute}.pool.instance.free.connections"
+                , "Free Connections (Instance)"
+                , "The total number of free connections in the pool as of the last sampling"
+                , MetricType.GAUGE, "none");
+        metadata.setService("healthcheck-cpool/${attribute}#freeConnection");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("test", "JUnit"));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
 }

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
@@ -39,12 +39,17 @@
  */
 package fish.payara.nucleus.healthcheck;
 
+import java.util.Set;
 import org.jvnet.hk2.annotations.Contract;
 
 @Contract
 public interface HealthCheckStatsProvider {
 
-    public <T extends Object> T getValue(Class<T> type, String attributeName);
+    <T extends Object> T getValue(Class<T> type, String attribute, String subAttribute);
+
+    Set<String> getAttributes();
+
+    Set<String> getSubAttributes();
 
     boolean isEnabled();
 }

--- a/nucleus/payara-modules/healthcheck-cpool/src/main/java/fish/payara/nucleus/healthcheck/cpool/ConnectionPoolHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-cpool/src/main/java/fish/payara/nucleus/healthcheck/cpool/ConnectionPoolHealthCheck.java
@@ -52,6 +52,7 @@ import fish.payara.monitoring.collect.MonitoringWatchCollector;
 import fish.payara.monitoring.collect.MonitoringWatchSource;
 import fish.payara.notification.healthcheck.HealthCheckResultEntry;
 import fish.payara.nucleus.healthcheck.HealthCheckResult;
+import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
 import fish.payara.nucleus.healthcheck.cpool.configuration.ConnectionPoolChecker;
 import fish.payara.nucleus.healthcheck.preliminary.BaseThresholdHealthCheck;
 import org.glassfish.hk2.runlevel.RunLevel;
@@ -66,9 +67,14 @@ import org.jvnet.hk2.annotations.Service;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * @author mertcaliskan
@@ -78,7 +84,7 @@ import java.util.function.Consumer;
 @RunLevel(10)
 public class ConnectionPoolHealthCheck
     extends BaseThresholdHealthCheck<HealthCheckConnectionPoolExecutionOptions, ConnectionPoolChecker>
-    implements MonitoringDataSource, MonitoringWatchSource {
+    implements MonitoringDataSource, MonitoringWatchSource, HealthCheckStatsProvider {
 
     @Inject
     private Domain domain;
@@ -89,9 +95,53 @@ public class ConnectionPoolHealthCheck
     @Inject
     private PoolManager poolManager;
 
+    private final Map<String, Long> usedConnections = new ConcurrentHashMap<>();
+    private final Map<String, Long> freeConnections = new ConcurrentHashMap<>();
+    private static final String USED_CONNECTION = "usedConnection";
+    private static final String FREE_CONNECTION = "freeConnection";
+    private static final String TOTAL_CONNECTION = "totalConnection";
+    private static final Set<String> VALID_SUB_ATTRIBUTES = Set.of(USED_CONNECTION, FREE_CONNECTION, TOTAL_CONNECTION);
+
     @PostConstruct
     void postConstruct() {
         postConstruct(this, ConnectionPoolChecker.class);
+    }
+
+    @Override
+    public Object getValue(Class type, String attributeName, String subAttributeName) {
+        if (subAttributeName == null) {
+            throw new IllegalArgumentException("sub-attribute name is required");
+        }
+        if (!VALID_SUB_ATTRIBUTES.contains(subAttributeName)) {
+            throw new IllegalArgumentException("Invalid sub-attribute name: " + subAttributeName + ", supported sub-attributes are " + VALID_SUB_ATTRIBUTES);
+        }
+        if (!Number.class.isAssignableFrom(type)) {
+            throw new IllegalArgumentException("attribute type must be number");
+        }
+        switch (subAttributeName) {
+            case USED_CONNECTION:
+                return usedConnections.getOrDefault(attributeName, 0L);
+            case FREE_CONNECTION:
+                return freeConnections.getOrDefault(attributeName, 0L);
+            case TOTAL_CONNECTION:
+                return usedConnections.getOrDefault(attributeName, 0L) + freeConnections.getOrDefault(attributeName, 0L);
+        }
+        return 0L;
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+       return getAllJdbcResourcesName().stream().map(PoolInfo::getName).collect(toSet());
+    }
+
+    @Override
+    public Set<String> getSubAttributes() {
+        return VALID_SUB_ATTRIBUTES;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.getOptions() != null ? this.getOptions().isEnabled() : false;
     }
 
     @Override
@@ -114,6 +164,8 @@ public class ConnectionPoolHealthCheck
     @Override
     protected HealthCheckResult doCheckInternal() {
         HealthCheckResult result = new HealthCheckResult();
+        freeConnections.clear();
+        usedConnections.clear();
         consumeAllJdbcResources(createConsumer((info, usedPercentage) ->
             result.add(new HealthCheckResultEntry(decideOnStatusWithRatio(usedPercentage),
                     info.getName() + " Usage (%): " + new DecimalFormat("#.00").format(usedPercentage)))
@@ -130,8 +182,10 @@ public class ConnectionPoolHealthCheck
     @MonitoringData(ns = "health", intervalSeconds = 8)
     public void collect(MonitoringDataCollector collector) {
         if (options != null && options.isEnabled()) {
-            consumeAllJdbcResources(createConsumer((info, usedPercentage) ->
-                collector.group(info.getName()).collect("PoolUsage", usedPercentage.longValue())
+            freeConnections.clear();
+            usedConnections.clear();
+            consumeAllJdbcResources(createConsumer((info, usedPercentage)
+                    -> collector.group(info.getName()).collect("PoolUsage", usedPercentage.longValue())
             ));
         }
     }
@@ -153,6 +207,8 @@ public class ConnectionPoolHealthCheck
                         double usedPercentage = 100d * usedConnection / totalConnection;
                         poolUsageConsumer.accept(poolInfo, usedPercentage);
                     }
+                    freeConnections.put(poolInfo.getName(), freeConnection);
+                    usedConnections.put(poolInfo.getName(), usedConnection);
                 }
             }
         };
@@ -184,5 +240,39 @@ public class ConnectionPoolHealthCheck
                 }
             }
         }
+    }
+    
+    private List<PoolInfo> getAllJdbcResourcesName() {
+        List<PoolInfo> poolInfos = new ArrayList<>();
+        poolInfos.addAll(getJdbcResourcesInfo(domain.getResources()));
+        for (Application app : applications.getApplications()) {
+            if (ResourcesUtil.createInstance().isEnabled(app)) {
+                poolInfos.addAll(getJdbcResourcesInfo(app.getResources()));
+                List<Module> modules = app.getModule();
+                if (modules != null) {
+                    for (Module module : modules) {
+                        poolInfos.addAll(getJdbcResourcesInfo(module.getResources()));
+                    }
+                }
+            }
+        }
+        return poolInfos; 
+    }
+
+    private List<PoolInfo> getJdbcResourcesInfo(Resources resources) {
+        List<PoolInfo> poolInfos = new ArrayList<>();
+        if (resources != null) {
+            List<Resource> list = resources.getResources();
+            if (list != null) {
+                for (Resource resource : list) {
+                    if (JdbcResource.class.isInstance(resource)) {
+                        ResourceInfo resourceInfo = ResourceUtil.getResourceInfo((JdbcResource)resource);
+                        JdbcConnectionPool pool = JdbcResourcesUtil.createInstance().getJdbcConnectionPoolOfResource(resourceInfo);
+                        poolInfos.add(ResourceUtil.getPoolInfo(pool));
+                    }
+                }
+            }
+        }
+        return poolInfos;   
     }
 }

--- a/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-stuck/src/main/java/fish/payara/nucleus/healthcheck/stuck/StuckThreadsHealthCheck.java
@@ -63,6 +63,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.glassfish.api.StartupRunLevel;
@@ -83,7 +85,7 @@ public class StuckThreadsHealthCheck extends
     private final Map<String, Number> stuckThreadResult = new ConcurrentHashMap<>();
     private static final String STUCK_THREAD_COUNT = "count";
     private static final String STUCK_THREAD_MAX_DURATION = "maxDuration";
-    private static final Set<String> VALID_ATTRIBUTES = Set.of(STUCK_THREAD_COUNT, STUCK_THREAD_MAX_DURATION);
+    private static final Set<String> VALID_SUB_ATTRIBUTES = Set.of(STUCK_THREAD_COUNT, STUCK_THREAD_MAX_DURATION);
 
     @FunctionalInterface
     private interface StuckThreadConsumer {
@@ -102,17 +104,27 @@ public class StuckThreadsHealthCheck extends
     }
 
     @Override
-    public Object getValue(Class type, String attributeName) {
-        if (attributeName == null) {
-            throw new IllegalArgumentException("attribute name is required");
+    public Object getValue(Class type, String attributeName, String subAttributeName) {
+        if (subAttributeName == null) {
+            throw new IllegalArgumentException("sub-attribute name is required");
         }
-        if (!VALID_ATTRIBUTES.contains(attributeName)) {
-            throw new IllegalArgumentException("Invalid attribute name, supported attributes are " + VALID_ATTRIBUTES);
+        if (!VALID_SUB_ATTRIBUTES.contains(subAttributeName)) {
+            throw new IllegalArgumentException("Invalid sub-attribute name, supported sub-attributes are " + VALID_SUB_ATTRIBUTES);
         }
         if (!Number.class.isAssignableFrom(type)) {
-            throw new IllegalArgumentException("attribute type must be number");
+            throw new IllegalArgumentException("sub-attribute type must be number");
         }
-        return stuckThreadResult.getOrDefault(attributeName, 0);
+        return stuckThreadResult.getOrDefault(subAttributeName, 0);
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public Set<String> getSubAttributes() {
+        return VALID_SUB_ATTRIBUTES;
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR integrates Connection Pool Helthcheck with Microprofile Metrics.

New config added to `metrics.xml`
````
        <metadata>
            <name>${attribute}.${subattribute}</name>
            <service>healthcheck-cpool/${attribute}#${subattribute}</service>
            <type>gauge</type>
            <unit>none</unit>
            <displayName>${attribute} ${subattribute}</displayName>
            <description>Displays the number of ${subattribute} of ${attribute}.</description>
        </metadata>
````

## Testing
### New tests
Unit test

To verify the feature enable HealthCheck and Connection Pool HealthCheck from the Admin console.
![image](https://user-images.githubusercontent.com/15934072/194505406-7c8553f9-0920-4de8-9237-8c6e17909120.png)


## Documentation
[https://github.com/payara/Payara-Documentation/pull/107](https://github.com/payara/Payara-Documentation/pull/107)
