### PR TITLE
FISH-6556 Concurrency Fix Web Profile

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -388,7 +388,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
         if (handle.getSecurityContext() != null) {
             SecurityContext.setCurrent(handle.getSecurityContext());
         }
-        if (handle.getInvocation() != null /*&& !handle.isUseTransactionOfExecutionThread()*/) {
+        if (handle.getInvocation() != null) {
             invocationManager.postInvoke(((InvocationContext) contextHandle).getInvocation());
         }
         if (contextClear.contains(CONTEXT_TYPE_WORKAREA) && transactionManager != null) {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceConfig.java
@@ -41,6 +41,8 @@
 
 package org.glassfish.concurrent.runtime.deployer;
 
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -60,14 +62,14 @@ public class ContextServiceConfig extends BaseConfig {
         super(jndiName, null, "true");
         this.propagatedContexts = parseContextInfo(this.contextInfo, this.isContextInfoEnabledBoolean());
         this.clearedContexts = new HashSet<>();
-        this.uchangedContexts = new HashSet<>();
+        this.uchangedContexts = new HashSet<>(Arrays.asList(ContextServiceDefinition.ALL_REMAINING));
     }
 
     public ContextServiceConfig(ContextService config) {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         this.propagatedContexts = parseContextInfo(this.contextInfo, this.isContextInfoEnabledBoolean());
         this.clearedContexts = new HashSet<>();
-        this.uchangedContexts = new HashSet<>();
+        this.uchangedContexts = new HashSet<>(Arrays.asList(ContextServiceDefinition.ALL_REMAINING));
     }
 
     public ContextServiceConfig(String jndiName, String contextInfo, String contextInfoEnabled, Set<String> propagatedContexts, Set<String> clearedContexts, Set<String> uchangedContexts) {

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <h2db.version>2.1.212</h2db.version>
         <websocket-api.version>2.1.0</websocket-api.version>
         <concurrent-api.version>3.0.1</concurrent-api.version>
-        <concurrent.version>3.0.0.payara-p1</concurrent.version>
+        <concurrent.version>3.0.0.payara-p2</concurrent.version>
         <asm.version>9.2</asm.version>
         <monitoring-console-api.version>2.0.1</monitoring-console-api.version>
         <monitoring-console-process.version>2.0.1</monitoring-console-process.version>


### PR DESCRIPTION
## Description
Payara failed the Concurrency TCK 3.0.2. It is fixed now:
* properly handle context lists during context switch (fix in ContextSetupProviderImpl.java)
* cancel scheduled Future (upgrade of patched Concurrency RI)

## Important Info
### Blockers
This patch depends on new version of patched Concurrency RI: https://github.com/payara/patched-src-concurrency-ri/pull/2 
The version 3.0.0.payara-p2 is uploaded to Payara's nexus.

## Testing
### Testing Performed
Run latest Concurrency TCK, version 3.0.2. Updated runner: https://github.com/payara/jakartaee-10-tck-runners/pull/44

### Testing Environment
OpenJDK 11, Linux

## Notes for Reviewers

