### PR TITLE
FISH-5828 Connection Pool Metrics Exposed as MicroProfile Metrics

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckCounter.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.metrics.healthcheck;
 
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import java.util.Set;
 import org.eclipse.microprofile.metrics.Counter;
 
 /**
@@ -80,12 +81,7 @@ public class HealthCheckCounter implements Counter, HealthCheckStatsProvider {
 
     @Override
     public long getCount() {
-        return getValue(Long.class, expression.getAttributeName());
-    }
-
-    @Override
-    public <Long> Long getValue(Class<Long> type, String attributeName) {
-        return healthCheck.getValue(type, attributeName);
+        return getValue(Long.class, expression.getAttributeName(), expression.getSubAttributeName());
     }
 
     @Override
@@ -93,4 +89,18 @@ public class HealthCheckCounter implements Counter, HealthCheckStatsProvider {
        return healthCheck.isEnabled();
     }
 
+    @Override
+    public <T> T getValue(Class<T> type, String attribute, String subAttribute) {
+        return healthCheck.getValue(type, attribute, subAttribute);
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+        return healthCheck.getAttributes();
+    }
+
+    @Override
+    public Set<String> getSubAttributes() {
+        return healthCheck.getSubAttributes();
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/HealthCheckGauge.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.metrics.healthcheck;
 
 import fish.payara.nucleus.healthcheck.HealthCheckStatsProvider;
+import java.util.Set;
 import org.eclipse.microprofile.metrics.Gauge;
 
 /**
@@ -59,7 +60,7 @@ public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider
 
     @Override
     public Number getValue() {
-        return getValue(Number.class, expression.getAttributeName());
+        return getValue(Number.class, expression.getAttributeName(), expression.getSubAttributeName());
     }
 
     @Override
@@ -68,8 +69,18 @@ public class HealthCheckGauge implements Gauge<Number>, HealthCheckStatsProvider
     }
 
     @Override
-    public <Number> Number getValue(Class<Number> type, String attributeName) {
-        return healthCheck.getValue(type, attributeName);
+    public <T> T getValue(Class<T> type, String attribute, String subAttribute) {
+        return healthCheck.getValue(type, attribute, subAttribute);
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+        return healthCheck.getAttributes();
+    }
+    
+        @Override
+    public Set<String> getSubAttributes() {
+        return healthCheck.getSubAttributes();
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/ServiceExpression.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/healthcheck/ServiceExpression.java
@@ -39,24 +39,38 @@
  */
 package fish.payara.microprofile.metrics.healthcheck;
 
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.ATTRIBUTE_SEPARATOR;
+import static fish.payara.microprofile.metrics.jmx.MetricsMetadataHelper.SUB_ATTRIBUTE_SEPARATOR;
+
 public class ServiceExpression {
 
     private String service;
 
     private String attributeName;
+    private String subAttributeName;
 
-    private static final String ATTRIBUTE_SEPARATOR = "#";
 
     public ServiceExpression(String expression) {
         if (expression == null || expression.trim().isEmpty()) {
             throw new IllegalArgumentException("Service Expression is null");
         }
         int slashIndex = expression.lastIndexOf(ATTRIBUTE_SEPARATOR);
-        if (slashIndex < 0) {
-            throw new IllegalArgumentException("MBean Expression is invalid : " + expression);
+        if (slashIndex >= 0) {
+            service = expression.substring(0, slashIndex);
+            attributeName = expression.substring(slashIndex + 1);
+            if (attributeName.contains(SUB_ATTRIBUTE_SEPARATOR)) {
+                int hashIndex = attributeName.indexOf(SUB_ATTRIBUTE_SEPARATOR);
+                subAttributeName = attributeName.substring(hashIndex + 1);
+                attributeName = attributeName.substring(0, hashIndex);
+            }
+        } else {
+            slashIndex = expression.lastIndexOf(SUB_ATTRIBUTE_SEPARATOR);
+            if (slashIndex < 0) {
+                throw new IllegalArgumentException("Service Expression is invalid : " + expression);
+            }
+            service = expression.substring(0, slashIndex);
+            subAttributeName = expression.substring(slashIndex + 1);
         }
-        service = expression.substring(0, slashIndex);
-        attributeName = expression.substring(slashIndex + 1);
     }
 
     public String getServiceId() {
@@ -65,6 +79,10 @@ public class ServiceExpression {
 
     public String getAttributeName() {
         return attributeName;
+    }
+
+    public String getSubAttributeName() {
+        return subAttributeName;
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadata.java
@@ -118,6 +118,15 @@ public class MetricsMetadata implements Metadata {
         this.unit = unit;
     }
 
+    public MetricsMetadata(String name, String displayName, String description, MetricType typeRaw, String unit) {
+        this();
+        this.name = name;
+        this.displayName = displayName;
+        this.description = description;
+        this.type = typeRaw.toString();
+        this.unit = unit;
+    }
+
     public String getMBean() {
         return mBean;
     }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataHelper.java
@@ -221,12 +221,75 @@ public class MetricsMetadataHelper {
                 } finally {
                     removedMetadataList.add(metadata);
                 }
+            } else if (metadata.getService() != null
+                    && (metadata.getService().contains(SPECIFIER)
+                    || metadata.getService().contains(ATTRIBUTE)
+                    || metadata.getService().contains(SUB_ATTRIBUTE)
+                    || metadata.getService().contains(INSTANCE))) {
+                ServiceExpression expression = new ServiceExpression(
+                        metadata.getService().replace(SPECIFIER, "*")
+                );
+                if (expression.getAttributeName() != null
+                        && (expression.getAttributeName().equals("*") || expression.getAttributeName().equals(ATTRIBUTE))) {
+                    removedMetadataList.add(metadata);
+                    resolvedMetadataList.addAll(
+                            loadAttribute(expression, metadata)
+                    );
+                } else if (expression.getSubAttributeName() != null
+                        && (expression.getSubAttributeName().equals("*") || expression.getSubAttributeName().equals(SUB_ATTRIBUTE))) {
+                    removedMetadataList.add(metadata);
+                    resolvedMetadataList.addAll(
+                            loadSubAttribute(expression, metadata, expression.getAttributeName())
+                    );
+                }
             }
         }
 
         metadataList.removeAll(removedMetadataList);
         metadataList.addAll(resolvedMetadataList);
         return unresolvedMetadataList;
+    }
+    
+    private List<MetricsMetadata> loadAttribute(
+            ServiceExpression expression,
+            MetricsMetadata metadata) {
+
+        List<MetricsMetadata> metadataList = new ArrayList<>();
+        String instanceName = serverEnv.getInstanceName();
+        HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, expression.getServiceId());
+        if (healthCheck != null) {
+            for (String attribute : healthCheck.getAttributes()) {
+                if (expression.getSubAttributeName() != null
+                        && (expression.getSubAttributeName().equals("*") || expression.getSubAttributeName().equals(SUB_ATTRIBUTE))) {
+                    metadataList.addAll(
+                            loadSubAttribute(expression, metadata, attribute)
+                    );
+                } else {
+                    metadataList.add(createMetadata(metadata, expression.getServiceId(), null, attribute, expression.getSubAttributeName(), instanceName));
+                }
+            }
+        } else {
+            LOGGER.log(WARNING, "Health-Check service not found : {0}", expression.getServiceId());
+        }
+        return metadataList;
+    }
+
+    private List<MetricsMetadata> loadSubAttribute(
+            ServiceExpression expression,
+            MetricsMetadata metadata,
+            String attribute) {
+
+        List<MetricsMetadata> metadataList = new ArrayList<>();
+        String instanceName = serverEnv.getInstanceName();
+        HealthCheckStatsProvider healthCheck = habitat.getService(HealthCheckStatsProvider.class, expression.getServiceId());
+        if (healthCheck != null) {
+            for (String subAttribute : healthCheck.getSubAttributes()) {
+                metadataList.add(createMetadata(metadata, expression.getServiceId(), null, attribute, subAttribute, instanceName));
+            }
+        } else {
+            LOGGER.log(WARNING, "Health-Check service not found : {0}", expression.getServiceId());
+        }
+        return metadataList;
     }
 
     private static List<MetricsMetadata> loadAttribute(
@@ -341,7 +404,7 @@ public class MetricsMetadataHelper {
             builder.append(SUB_ATTRIBUTE_SEPARATOR);
             builder.append(subAttribute);
         }
-        MetricsMetadata newMetaData =  new MetricsMetadata(builder.toString(),
+        MetricsMetadata newMetaData =  new MetricsMetadata(
                 formatMetadata(
                         metadata.getName(),
                         key,
@@ -366,6 +429,11 @@ public class MetricsMetadataHelper {
                 metadata.getTypeRaw(),
                 metadata.unit().orElse(null)
         );
+        if(metadata.getMBean() != null) {
+            newMetaData.setMBean(builder.toString());
+        } else {
+            newMetaData.setService(builder.toString());
+        }
         for (XmlTag oldTag: metadata.getTags()) {
             XmlTag newTag = new XmlTag();
             newTag.setName(formatMetadata(oldTag.getName(), key, attribute, subAttribute, instanceName));
@@ -398,5 +466,9 @@ public class MetricsMetadataHelper {
         }
         return metadata;
     }
+    
+
+
+
 
 }

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/resources/metrics.xml
@@ -218,6 +218,14 @@ holder.
             <unit>none</unit>
             <displayName>Stuck Thread Max Duration</displayName>
             <description>Displays the maximum duration of stuck thread which is blocked, and can't return to the threadpool for a certain amount of time.</description>
+        </metadata>>
+        <metadata>
+            <name>connection.pool.${attribute}.${subattribute}</name>
+            <service>healthcheck-cpool/${attribute}#${subattribute}</service>
+            <type>counter</type>
+            <unit>none</unit>
+            <displayName>${attribute} ${subattribute}</displayName>
+            <description>Displays the number of ${subattribute} in the Connection Pool ${attribute}.</description>
         </metadata>
     </vendor>
 </config>

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/jmx/MetricsMetadataTest.java
@@ -122,4 +122,19 @@ public class MetricsMetadataTest {
         metadata.addTags(tags);
         Assert.assertTrue(metadata.isValid());
     }
+
+    @Test
+    public void isValid_Service() {
+        MetricsMetadata metadata = new MetricsMetadata(
+                "jdbc.connection.pool.${attribute}.pool.instance.free.connections"
+                , "Free Connections (Instance)"
+                , "The total number of free connections in the pool as of the last sampling"
+                , MetricType.GAUGE, "none");
+        metadata.setService("healthcheck-cpool/${attribute}#freeConnection");
+        List<XmlTag> tags = new ArrayList<>();
+        tags.add(new XmlTag("test", "JUnit"));
+        metadata.addTags(tags);
+        Assert.assertTrue(metadata.isValid());
+    }
+
 }

--- a/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
+++ b/nucleus/payara-modules/healthcheck-core/src/main/java/fish/payara/nucleus/healthcheck/HealthCheckStatsProvider.java
@@ -39,12 +39,17 @@
  */
 package fish.payara.nucleus.healthcheck;
 
+import java.util.Set;
 import org.jvnet.hk2.annotations.Contract;
 
 @Contract
 public interface HealthCheckStatsProvider {
 
-    public <T extends Object> T getValue(Class<T> type, String attributeName);
+    <T extends Object> T getValue(Class<T> type, String attribute, String subAttribute);
+
+    Set<String> getAttributes();
+
+    Set<String> getSubAttributes();
 
     boolean isEnabled();
 }


### PR DESCRIPTION
## Description
This PR integrates Connection Pool Helthcheck with Microprofile Metrics.

New config added to `metrics.xml`
````
        <metadata>
            <name>${attribute}.${subattribute}</name>
            <service>healthcheck-cpool/${attribute}#${subattribute}</service>
            <type>gauge</type>
            <unit>none</unit>
            <displayName>${attribute} ${subattribute}</displayName>
            <description>Displays the number of ${subattribute} of ${attribute}.</description>
        </metadata>
````

## Testing
### New tests
Unit test

To verify the feature enable HealthCheck and Connection Pool HealthCheck from the Admin console.
![image](https://user-images.githubusercontent.com/15934072/194505406-7c8553f9-0920-4de8-9237-8c6e17909120.png)


## Documentation
[https://github.com/payara/Payara-Documentation/pull/107](https://github.com/payara/Payara-Documentation/pull/107)


## Related PR
https://github.com/payara/Payara/pull/5974