### PR TITLE
FISH-6603 : META-INF must not be always denied

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java
@@ -293,16 +293,11 @@ final class StandardContextValve
         if(rv.indexOf("./") == 0) {
             rv = rv.replaceFirst("./", "/");
         }
-        // has /WEB-INF or /META-INF
+        // has /WEB-INF/ or ends with /WEB-INF
         final String RV = rv.toUpperCase();
         int index = RV.indexOf("/WEB-INF/");
         if (index != -1 || RV.endsWith("/WEB-INF")) {
             return "/WEB-INF";
-        } else {
-            index = RV.indexOf("/META-INF/");
-            if (index != -1 || RV.endsWith("/META-INF")) {
-                return "/META-INF";
-            }
         }
 
         // Normalize the slashes and add leading slash if necessary

--- a/appserver/web/web-core/src/test/java/org/apache/catalina/core/StandardContextValveTest.java
+++ b/appserver/web/web-core/src/test/java/org/apache/catalina/core/StandardContextValveTest.java
@@ -97,7 +97,6 @@ public class StandardContextValveTest extends TestCase {
         String path2 = "/app/./some/./something/./my.jsp";
         String path3 = "./my.jsp";
         String path4 = "../app/WEB-INF/web.xml";
-        String path5 = "../app/META-INF";
 
         String result = standardContextValve.normalize(path1);
 
@@ -114,10 +113,6 @@ public class StandardContextValveTest extends TestCase {
         result = standardContextValve.normalize(path4);
 
         assertEquals("/WEB-INF", result);
-
-        result = standardContextValve.normalize(path5);
-
-        assertEquals("/META-INF", result);
     }
 
     protected void verifyThatResourceIsNotFound(int pipelineResult, int times, HttpRequest httpRequest, HttpResponse httpResponse,


### PR DESCRIPTION
## Description
META-INF folder is necessary to be available for some requests.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps in https://payara.atlassian.net/browse/FISH-6603
using Payara\appserver\extras\payara-micro\payara-micro-distribution\target\payara-micro.jar

### Testing Environment
Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.8.4