### PR TITLE
FISH-6566 Only create an action report for action report files [Payara6]

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/reader/MultipartProprietaryReader.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/reader/MultipartProprietaryReader.java
@@ -112,7 +112,7 @@ public class MultipartProprietaryReader implements ProprietaryReader<ParamsWithP
                     parameters = new ParameterMap();
                 }
                 parameters.add(cdParams.getProperty("name"), stream2String(mimePart.readOnce()));
-            } else if (mimePart.getContentType() != null && mimePart.getContentType().startsWith("application/json")) {
+            } else if (cd.contains("name=\"ActionReport\"") && mimePart.getContentType() != null && mimePart.getContentType().startsWith("application/json")) {
                 //ACTION REPORT
                 actionReport = actionReportReader.readFrom(mimePart.readOnce(), "application/json");
             } else {

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/reader/MultipartProprietaryReader.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/reader/MultipartProprietaryReader.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+//Portions Copyright [2022] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.admin.remote.reader;
 
 import com.sun.enterprise.admin.remote.ParamsWithPayload;


### PR DESCRIPTION
## Description

On JDK 11.0.16 if a WAR contained a .json file, Payara would create an ActionReport when it is not needed, this change ensures that for only ActionReport files an ActionReport is created. 