### PR TITLE
FISH-6588 Add Extra Run Levels for Post-Boot and Deployment and Resolve Payara Micro Variable Expansion Error (Payara6)

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1028,7 +1028,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             gfproperties.setConfigFileURI(runtimeDir.getDomainXML().toURI().toString());
 
             try {
-                configurePreBootCommandFiles();
+                parsePreBootCommandFiles();
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "Unable to load command file", ex);
             }
@@ -1055,7 +1055,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
             // Parse and execute post boot commands
             try {
-                configurePostBootCommandFiles();
+                parsePostBootCommandFiles();
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "Unable to load command file", ex);
             }
@@ -1070,7 +1070,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
             // Parse and execute post deploy commands
             try {
-                configurePostDeployCommandFiles();
+                parsePostDeployCommandFiles();
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "Unable to load command file", ex);
             }
@@ -1848,7 +1848,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      *
      * @throws IOException
      */
-    private void configurePreBootCommandFiles() throws IOException {
+    private void parsePreBootCommandFiles() throws IOException {
         parseCommandFiles("MICRO-INF/pre-boot-commands.txt", preBootFileName, preBootCommands, false);
     }
 
@@ -1857,7 +1857,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      *
      * @throws IOException
      */
-    private void configurePostBootCommandFiles() throws IOException {
+    private void parsePostBootCommandFiles() throws IOException {
         parseCommandFiles("MICRO-INF/post-boot-commands.txt", postBootFileName, postBootCommands, true);
     }
 
@@ -1866,7 +1866,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
      *
      * @throws IOException
      */
-    private void configurePostDeployCommandFiles() throws IOException {
+    private void parsePostDeployCommandFiles() throws IOException {
         parseCommandFiles("MICRO-INF/post-deploy-commands.txt", postDeployFileName, postDeployCommands, true);
     }
 

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1028,7 +1028,7 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             gfproperties.setConfigFileURI(runtimeDir.getDomainXML().toURI().toString());
 
             try {
-                configureCommandFiles();
+                configurePreBootCommandFiles();
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "Unable to load command file", ex);
             }
@@ -1053,7 +1053,12 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             callHandler(preBootHandler);
             gf.start();
 
-            // Execute post boot commands
+            // Parse and execute post boot commands
+            try {
+                configurePostBootCommandFiles();
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, "Unable to load command file", ex);
+            }
             postBootCommands.executeCommands(gf.getCommandRunner());
             callHandler(postBootHandler);
             this.runtime = new PayaraMicroRuntimeImpl(gf, gfruntime);
@@ -1063,6 +1068,12 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
             // These steps are separated in case any steps need to be done in between
             gf.getCommandRunner().run("initialize-all-applications");
 
+            // Parse and execute post deploy commands
+            try {
+                configurePostDeployCommandFiles();
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, "Unable to load command file", ex);
+            }
             postDeployCommands.executeCommands(gf.getCommandRunner());
 
             long end = System.currentTimeMillis();
@@ -1832,33 +1843,53 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
         return new ByteArrayInputStream(writer.getBuffer().toString().getBytes());
     }
 
-    private void configureCommandFiles() throws IOException {
-        // load the embedded files
-        URL scriptURL = Thread.currentThread().getContextClassLoader().getResource("MICRO-INF/pre-boot-commands.txt");
+    /**
+     * Helper method to parse the pre-boot command file.
+     *
+     * @throws IOException
+     */
+    private void configurePreBootCommandFiles() throws IOException {
+        parseCommandFiles("MICRO-INF/pre-boot-commands.txt", preBootFileName, preBootCommands, false);
+    }
+
+    /**
+     * Helper method to parse the post-boot command file.
+     *
+     * @throws IOException
+     */
+    private void configurePostBootCommandFiles() throws IOException {
+        parseCommandFiles("MICRO-INF/post-boot-commands.txt", postBootFileName, postBootCommands, true);
+    }
+
+    /**
+     * Helper method to parse the post-deploy command file.
+     *
+     * @throws IOException
+     */
+    private void configurePostDeployCommandFiles() throws IOException {
+        parseCommandFiles("MICRO-INF/post-deploy-commands.txt", postDeployFileName, postDeployCommands, true);
+    }
+
+    /**
+     * Parse the pre-boot, post-boot, or post-deploy command files - both the embedded one in MICRO-INF and the file
+     * provided by the user.
+     *
+     * @param resourcePath The path of the embedded pre-boot, post-boot, or post-deploy command file.
+     * @param fileName The path of the pre-boot, post-boot, or post-deploy command file provided by the user.
+     * @param bootCommands The {@link BootCommands} object to add the parsed commands to.
+     * @param expandValues Whether variable expansion should be attempted - cannot be done during pre-boot.
+     * @throws IOException
+     */
+    private void parseCommandFiles(String resourcePath, String fileName, BootCommands bootCommands,
+            boolean expandValues) throws IOException {
+        // Load the embedded file
+        URL scriptURL = Thread.currentThread().getContextClassLoader().getResource(resourcePath);
         if (scriptURL != null) {
-            preBootCommands.parseCommandScript(scriptURL);
+            bootCommands.parseCommandScript(scriptURL, expandValues);
         }
 
-        if (preBootFileName != null) {
-            preBootCommands.parseCommandScript(new File(preBootFileName));
-        }
-
-        scriptURL = Thread.currentThread().getContextClassLoader().getResource("MICRO-INF/post-boot-commands.txt");
-        if (scriptURL != null) {
-            postBootCommands.parseCommandScript(scriptURL);
-        }
-
-        if (postBootFileName != null) {
-            postBootCommands.parseCommandScript(new File(postBootFileName));
-        }
-
-        scriptURL = Thread.currentThread().getContextClassLoader().getResource("MICRO-INF/post-deploy-commands.txt");
-        if (scriptURL != null) {
-            postDeployCommands.parseCommandScript(scriptURL);
-        }
-
-        if (postDeployFileName != null) {
-            postDeployCommands.parseCommandScript(new File(postDeployFileName));
+        if (fileName != null) {
+            bootCommands.parseCommandScript(new File(fileName), expandValues);
         }
     }
 

--- a/nucleus/admin/config-api/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
+++ b/nucleus/admin/config-api/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
@@ -46,8 +46,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-import fish.payara.boot.runtime.BootCommand;
-import fish.payara.boot.runtime.BootCommands;
 import org.junit.Test;
 
 /**
@@ -61,7 +59,7 @@ public class BootCommandsTest {
         BootCommands bootCommands = new BootCommands();
         String commandText = "create-custom-resource --restype java.lang.String -s v --name='custom-res' --description=\"results \\\"in\\\" error\" --property value=\"${ENV=ini_ws_uri}\" vfp/vfp-menu/ini.ws.uri";
         try (Reader reader = new StringReader(commandText)){
-            bootCommands.parseCommandScript(reader);
+            bootCommands.parseCommandScript(reader, false);
         }
         assertThat(bootCommands.getCommands().size(), is(1));
         

--- a/nucleus/common/internal-api/src/main/java/fish/payara/internal/api/DeployPreviousApplicationsRunLevel.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/internal/api/DeployPreviousApplicationsRunLevel.java
@@ -1,0 +1,69 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.internal.api;
+
+import org.glassfish.hk2.runlevel.RunLevel;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Startup level for deploying applications that have previously been deployed. This is for services that need to
+ * startup after the typical set of dependent services have booted, after any required configuration has been done via
+ * post-boot commands, after any resources and applications specified for deployment via post-boot commands have deployed,
+ * but before autodeploying applications (e.g. applications in the autodeploy directory, or the admin console).
+ * Most prominent use case for this startup level is for applications that have previously been deployed, and are thus
+ * already registered in the domain.xml. We want this to happen after the post-boot phase so that the server and any
+ * resource adaptors can be potentially reconfigured via post-boot commands before they are loaded.
+ *
+ * @author Andrew Pielage
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Inherited
+@RunLevel(15)
+public @interface DeployPreviousApplicationsRunLevel {
+    int VAL = 15;
+}

--- a/nucleus/common/internal-api/src/main/java/fish/payara/internal/api/PostBootRunLevel.java
+++ b/nucleus/common/internal-api/src/main/java/fish/payara/internal/api/PostBootRunLevel.java
@@ -1,0 +1,73 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.internal.api;
+
+import org.glassfish.hk2.runlevel.RunLevel;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Startup level for "post-boot" phase. This is for services that need to startup after the typical set of dependent
+ * services have booted ({@link org.glassfish.api.StartupRunLevel}), but before application deployment has begun.
+ * Most prominent use case for this startup level is for the service that executes post-boot commands
+ * (e.g. {@linkplain com.sun.enterprise.v3.bootstrap.BootCommandService}); post-boot commands are typically asadmin
+ * commands and so require most services to have started (e.g. so they can use
+ * {@link org.glassfish.config.support.TranslatedConfigView} for variable substitution).
+ * <br><br>
+ * Note that post-boot command files can deploy applications themselves. Applications may therefore be getting deployed
+ * at this run level, which will typically be before that of previously deployed applications
+ * ({@link DeployPreviousApplicationsRunLevel}) and autodeploying applications
+ * ({@link org.glassfish.internal.api.PostStartupRunLevel}).
+ *
+ * @author Andrew Pielage
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Inherited
+@RunLevel(12)
+public @interface PostBootRunLevel {
+    int VAL = 12;
+}

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -135,7 +135,8 @@ public class GlassFishMain {
             addShutdownHook();
             gfr = GlassFishRuntime.bootstrap(new BootstrapProperties(ctx), getClass().getClassLoader());
             gf = gfr.newGlassFish(new GlassFishProperties(ctx));
-            doBootCommands(ctx.getProperty("-prebootcommandfile"));
+            // Services required for variable expansion aren't available during pre-boot, so don't expand values
+            doBootCommands(ctx.getProperty("-prebootcommandfile"), false);
             if (Boolean.valueOf(Util.getPropertyOrSystemProperty(ctx, "GlassFish_Interactive", "false"))) {
                 startConsole();
             } else {
@@ -293,14 +294,14 @@ public class GlassFishMain {
          * Runs a series of commands from a file
          * @param file
          */
-        private void doBootCommands(String file) {
+        private void doBootCommands(String file, boolean expandValues) {
             if (file == null) {
                 return;
             }
             try {
                 BootCommands bootCommands = new BootCommands();
                 System.out.println("Reading in commandments from " + file);
-                bootCommands.parseCommandScript(new File(file));
+                bootCommands.parseCommandScript(new File(file), expandValues);
                 bootCommands.executeCommands(gf.getCommandRunner());
             } catch (IOException ex) {
                 LOGGER.log(SEVERE, "Error reading from file");

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/BootCommandService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/BootCommandService.java
@@ -70,14 +70,14 @@ public class BootCommandService implements PostConstruct {
      * Runs a series of commands from a file
      * @param file
      */
-    public void doBootCommands(String file) {
+    public void doBootCommands(String file, boolean expandValues) {
         if (file == null) {
             return;
         }
         try {
             BootCommands bootCommands = new BootCommands();
             System.out.println("Reading in commands from " + file);
-            bootCommands.parseCommandScript(new File(file));
+            bootCommands.parseCommandScript(new File(file), expandValues);
             bootCommands.executeCommands(commandRunner);
         } catch (IOException ex) {
             LOGGER.log(SEVERE, "Error reading from file");
@@ -88,6 +88,6 @@ public class BootCommandService implements PostConstruct {
 
     @Override
     public void postConstruct() {
-        doBootCommands(startupContext.getArguments().getProperty("-postbootcommandfile"));
+        doBootCommands(startupContext.getArguments().getProperty("-postbootcommandfile"), true);
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/BootCommandService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/BootCommandService.java
@@ -40,7 +40,7 @@
 package com.sun.enterprise.v3.bootstrap;
 
 import com.sun.enterprise.module.bootstrap.StartupContext;
-import org.glassfish.api.StartupRunLevel;
+import fish.payara.internal.api.PostBootRunLevel;
 import fish.payara.boot.runtime.BootCommands;
 import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.hk2.api.PostConstruct;
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.SEVERE;
 
 @Service
-@RunLevel(value = StartupRunLevel.VAL)
+@RunLevel(value = PostBootRunLevel.VAL)
 public class BootCommandService implements PostConstruct {
 
     private static final Logger LOGGER = Logger.getLogger(BootCommandService.class.getName());

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.server;
 
@@ -56,8 +56,9 @@ import java.util.logging.Logger;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Provider;
+
+import fish.payara.internal.api.DeployPreviousApplicationsRunLevel;
 import org.glassfish.api.ActionReport;
-import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.UndeployCommandParameters;
@@ -92,11 +93,10 @@ import org.jvnet.hk2.annotations.Service;
  *
  * @author Jerome Dochez
  */
-//@Priority(8) // low priority , should be started last
 @Service(name="ApplicationLoaderService")
-@RunLevel( value=StartupRunLevel.VAL, mode=RunLevel.RUNLEVEL_MODE_NON_VALIDATING)
+@RunLevel(value = DeployPreviousApplicationsRunLevel.VAL, mode = RunLevel.RUNLEVEL_MODE_NON_VALIDATING)
+// In the wake of the introduction of PostBootRunLevel and DeployPreviousApplicationsRunLevel, should this still be non-validating?
 public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestroy, org.glassfish.hk2.api.PostConstruct {
-//public class ApplicationLoaderService implements Startup, org.glassfish.hk2.api.PreDestroy, org.glassfish.hk2.api.PostConstruct {
 
     final Logger logger = KernelLoggerInfo.getLogger();
 


### PR DESCRIPTION
## Description
Port of https://github.com/payara/Payara/pull/5991

This PR attempts to sanitise the boot sequence for services, post-boot commands, and application deployments.

In our previous attempts to allow variable substitution in post-boot command files and make post-boot commands consistent, we ended up frequently causing unintentional side effects typically to do with deployment or command timings.

This PR introduces two new run levels, which are used to hopefully make everything consistent and better space out the server boot lifecycle timings.

Before:
* Run level 10 (in no particular order - all run at the same run level):
  * Previously deployed applications
  * Post-boot commands
  * Startup services (e.g. MicroProfile Config)
* Run level 20:
  * Autodeploy applications (not previously deployed ones)
    * Applications in the autodeploy folder
    * Admin Console

After:
* Run level 10:
  * Startup services (e.g. MicroProfile Config)
* Run level 12:
  * Post-boot commands
* Run level 15: 
  * Previously deployed applications
* Run level 20:
  * Autodeploy applications (not previously deployed ones)
    * Applications in the autodeploy folder
    * Admin Console

Additionally, this PR fixes an issue where Payara Micro attempts to perform variable expansion as it parses the command files during the pre-boot phase - variable expansion is post-boot only.

## Important Info
### Blockers
None

## Testing
### New tests
Pending, will look at automating the manual tests below...

### Testing Performed
Tested the following reproducers against Payara Server:
* [FISH-5976](https://payara.atlassian.net/browse/FISH-5976)
* [FISH-6484](https://payara.atlassian.net/browse/FISH-6484)
* [FISH-6492](https://payara.atlassian.net/browse/FISH-6492)
* [FISH-6501](https://payara.atlassian.net/browse/FISH-6501)

Tested the following reproducer against Payara Micro:
* [FISH-5976](https://payara.atlassian.net/browse/FISH-5976)
* [FISH-6492](https://payara.atlassian.net/browse/FISH-6492)

### Testing Environment
Windows 11, JDK 11.
WSL, JDK 11.

## Documentation
Public: N/A
Internal analysis and solution architecture: [Confluence Page](https://payara.atlassian.net/wiki/spaces/PAYAR/pages/3488448526/Start-up+Post-Boot+Deployment+and+Post-Deploy)

## Notes for Reviewers
I'm not sure if the `ApplicationLoaderService` should still have a non-validating run level. What this means is that if something with a lower run level asks for it (e.g. a startup service of run level 10), it will load _before_ it's nominal run level of 15. If we make it validating, what will happen is that the HK2 service will simply error out (and in all likelihood cause the server to fail to boot).
