### PR TITLE
FISH-1418 FISH-6470 Support TLS 1.2 & 1.3 on JMX Listener + GCM Cipher Suites Not Being Recognised 

### DIFF
--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
@@ -419,6 +419,8 @@ final class RMIConnectorStarter extends ConnectorStarter {
         sslParams.setKeyStorePassword(keyStorePwd);
         sslParams.setKeyStoreType(keyStoreType);
         sslParams.setSsl3TlsCiphers(sslConfig.getSsl3TlsCiphers());
+        sslParams.setTls12Enabled(sslConfig.getTls12Enabled());
+        sslParams.setTls13Enabled(sslConfig.getTls13Enabled());
         sslParams.setTlsRollbackEnabled(sslConfig.getTlsRollbackEnabled());
         sslParams.setHstsEnabled(sslConfig.getHstsEnabled());
 

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLClientConfigurator.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLClientConfigurator.java
@@ -55,6 +55,9 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.glassfish.grizzly.config.dom.Ssl.TLS12;
+import static org.glassfish.grizzly.config.dom.Ssl.TLS13;
+
 /**
  * This class is a utility class that would configure a client socket factory using
  * either the SSL defaults for GlassFish  or via params supplied.
@@ -431,6 +434,12 @@ public class SSLClientConfigurator {
         List<String> tmpSSLArtifactsList = new LinkedList<>();
         // first configure the protocols
         System.out.println("SSLParams ="+ sslParams);
+        if (sslParams.getTls12Enabled()) {
+            tmpSSLArtifactsList.add(TLS12);
+        }
+        if (sslParams.getTls13Enabled()) {
+            tmpSSLArtifactsList.add(TLS13);
+        }
         if (tmpSSLArtifactsList.isEmpty()) {
             _logger.log(Level.WARNING, allVariantsDisabled);
         } else {

--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/ssl/SSLParams.java
@@ -81,6 +81,8 @@ public class SSLParams {
     private String clientAuth;
     private String crlFile;
     private String ssl3TlsCiphers;
+    private Boolean tls12Enabled=true;
+    private Boolean tls13Enabled=true;
     private Boolean tlsRollBackEnabled=false;
     private Boolean hstsEnabled = false;
     private Boolean hstsSubDomains = false;
@@ -267,6 +269,28 @@ public class SSLParams {
 
     public void setSsl3TlsCiphers(String ssl3TlsCiphers) {
         this.ssl3TlsCiphers  = ssl3TlsCiphers;
+    }
+
+    /**
+     * Determines whether TLSv1.2 is enabled.
+     */
+    public Boolean getTls12Enabled() {
+        return tls12Enabled;
+    }
+
+    public void setTls12Enabled(String tls12Enabled) {
+        this.tls12Enabled = Boolean.parseBoolean(tls12Enabled);
+    }
+
+    /**
+     * Determines whether TLSv1.3 is enabled.
+     */
+    public Boolean getTls13Enabled() {
+        return tls13Enabled;
+    }
+
+    public void setTls13Enabled(String tls13Enabled) {
+        this.tls13Enabled = Boolean.parseBoolean(tls13Enabled);
     }
 
     /**

--- a/nucleus/tests/quicklook/pom.xml
+++ b/nucleus/tests/quicklook/pom.xml
@@ -87,6 +87,12 @@ utilities are in the NucleusTestUtils class.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>glassfish-mbeanserver</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils-ng</artifactId>
             <version>${project.version}</version>

--- a/nucleus/tests/quicklook/src/test/java/org/glassfish/nucleus/quicklook/JceCipherSuitesTest.java
+++ b/nucleus/tests/quicklook/src/test/java/org/glassfish/nucleus/quicklook/JceCipherSuitesTest.java
@@ -1,0 +1,59 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.nucleus.quicklook;
+
+import org.glassfish.admin.mbeanserver.ssl.*;
+import static org.testng.AssertJUnit.assertTrue;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+@Test
+public class JceCipherSuitesTest
+{
+  @Test
+  public void testSslDefaultCipherSuitesShouldIncludeGcm() {
+    Map<String, ?>  ciphers = SSLClientConfigurator.getInstance().getSupportedCipherSuites();
+    assertTrue (ciphers.containsKey("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"));
+    assertTrue (ciphers.containsKey("TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256"));
+    assertTrue (ciphers.containsKey("TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"));
+    assertTrue (ciphers.containsKey("TLS_DHE_DSS_WITH_AES_128_GCM_SHA256"));
+  }
+}


### PR DESCRIPTION
## Description
Port of https://github.com/payara/Payara/pull/5932
Also includes missed required port of https://github.com/payara/Payara/pull/5283

## Important Info
### Blockers
None

## Testing
### New tests
See main PR.

### Testing Performed
* Started server
* Changed admin password
* Enabled secure admin
* Restarted server
* Loaded Admin Console
* Enabled GCM cipher suites on JMX listener:  Configurations > server-config > Admin Service > SSL
* Did the same for admin-listener and http-listener-2
* Restarted server
* No warnings about `All SSL cipher suites disabled` in log.

### Testing Environment
Windows 10, Zulu JDK 11.0.16.

## Documentation
N/A

## Notes for Reviewers
I didn't port across the getters/setters for TLS 1.0 and 1.1, since we previously made efforts to disable & remove support for these from Payara 6.
