### PR TITLE
FISH-6495 : setting hazelcast property when passed

### DIFF
--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishRuntime.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishRuntime.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2009-2012 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009-2022 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -93,6 +93,10 @@ public abstract class GlassFishRuntime {
      * @throws GlassFishException
      */
     public static GlassFishRuntime bootstrap(BootstrapProperties bootstrapProperties) throws GlassFishException {
+        String hazelcastProperty = bootstrapProperties.getProperty("hazelcast.config");
+        if (hazelcastProperty != null) {
+            System.setProperty("hazelcast.config", hazelcastProperty);
+        }
         return bootstrap(bootstrapProperties, GlassFishRuntime.class.getClassLoader());
     }
 

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -308,16 +308,11 @@ public class HazelcastCore implements EventListener, ConfigListener {
     private Config buildConfiguration() {
         Config config = new Config();
         String hazelcastFilePath = "";
-        URL serverConfigURL;
         try {
-            serverConfigURL = new URL(context.getServerConfigURL());
             Boolean isChangeToDefault = Boolean.valueOf(configuration.getChangeToDefault());
-            File serverConfigFile = new File(serverConfigURL.getPath());
-            if (new File(configuration.getHazelcastConfigurationFile()).exists()) {
+            hazelcastFilePath = System.getProperty("hazelcast.config");
+            if (hazelcastFilePath == null || hazelcastFilePath.isEmpty()) {
                 hazelcastFilePath = configuration.getHazelcastConfigurationFile();
-            } else {
-                hazelcastFilePath = serverConfigFile.getParentFile().getAbsolutePath() + File.separator
-                        + configuration.getHazelcastConfigurationFile();
             }
             File file = new File(hazelcastFilePath);
             if (file.exists()) {


### PR DESCRIPTION
## Description
A customer would like to provide a path to a hazelcast configuration file when using Payara Embedded with Arquillian.

## Testing
### New tests
None

### Testing Performed
1. Download the attached reproducer application & hazelcast-config.xml
2. Modify the embedded arquillian configuration in arquillian.xml to specify a path to the hazelcast-text.xml file:
    <?xml version="1.0"?>
<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://jboss.org/schema/arquillian"
            xsi:schemaLocation="http://jboss.org/schema/arquillian
                http://jboss.org/schema/arquillian/arquillian_1_0.xsd">

    <container qualifier="payara-embedded" default="true">
        <configuration>
            <property name="bindHttpPort">9990</property>
            <property name="hazelcastConfigurationFile">C:/Users/luise/Downloads/hazelcast-test.xml</property>
        </configuration>
    </container>
</arquillian>
3. Run the test with mvn clean install and the test should pass

### Testing Environment
Zulu JDK 1.8_212 on Windows 10 with Maven 3.8.4