### PR TITLE
FISH-6588 Embedded EJB Container NPE Fix

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2022 Payara Foundation and/or its affiliates.
 
 package org.glassfish.api.event;
 

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
@@ -57,11 +57,13 @@ public final class EventTypes<T> {
     private static final Map<String, EventTypes<?>> EVENTS = new ConcurrentHashMap<>();
 
     // stock events.
+    public static final String POST_SERVER_INIT_NAME = "post_server_init";
     public static final String SERVER_STARTUP_NAME = "server_startup";
     public static final String SERVER_READY_NAME = "server_ready";
     public static final String PREPARE_SHUTDOWN_NAME = "prepare_shutdown";
     public static final String SERVER_SHUTDOWN_NAME = "server_shutdown";
 
+    public static final EventTypes<?> POST_SERVER_INIT = create(POST_SERVER_INIT_NAME);
     public static final EventTypes<?> SERVER_STARTUP = create(SERVER_STARTUP_NAME);
     public static final EventTypes<?> SERVER_READY = create(SERVER_READY_NAME);
     public static final EventTypes<?> SERVER_SHUTDOWN = create(SERVER_SHUTDOWN_NAME);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -352,6 +352,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
         }
         
         appInstanceListener.startRecordingFutures();
+        events.send(new Event(EventTypes.POST_SERVER_INIT), false);
         if (!proceedTo(StartupRunLevel.VAL)) {
             appInstanceListener.stopRecordingTimes();
             return false;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -350,9 +350,9 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             logger.log(level, "Init level done in " +
                 (initFinishTime - context.getCreationTime()) + " ms");
         }
+        events.send(new Event(EventTypes.POST_SERVER_INIT), false);
         
         appInstanceListener.startRecordingFutures();
-        events.send(new Event(EventTypes.POST_SERVER_INIT), false);
         if (!proceedTo(StartupRunLevel.VAL)) {
             appInstanceListener.stopRecordingTimes();
             return false;

--- a/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
+++ b/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
@@ -69,7 +69,6 @@ import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.EventTypes;
 import org.glassfish.api.event.Events;
 import org.glassfish.internal.api.Globals;
-import org.glassfish.internal.deployment.Deployment;
 import org.jvnet.hk2.annotations.Optional;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigBeanProxy;
@@ -81,6 +80,8 @@ import org.jvnet.hk2.config.UnprocessedChangeEvents;
 import com.sun.enterprise.config.serverbeans.Config;
 
 /**
+ * Service that provides a shared executor service for server internals rather than all services creating and using
+ * their own.
  *
  * @author Andrew Pielage
  */
@@ -130,7 +131,7 @@ public class PayaraExecutorService implements ConfigListener, EventListener {
      */
     @Override
     public void event(Event event) {
-        if (event.is(Deployment.ALL_APPLICATIONS_LOADED)) {
+        if (event.is(EventTypes.POST_SERVER_INIT)) {
             // Embedded containers can be started and stopped multiple times.
             // Thus we need to initialize anytime the server instance is started.
             if (null == threadPoolExecutor) {

--- a/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
+++ b/nucleus/payara-modules/payara-executor-service/src/main/java/fish/payara/nucleus/executorservice/PayaraExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
## Description
Bug fix for the `PayaraExecutorService` encountering NPEs during use in an Embedded EJB Container.

With `ApplicationLoaderService` now starting at run level 15 rather tha 10, this meant the `ALL_APPLICATIONS_LOADED` event was firing later than before, leading to the thread pools in the `PayaraExecutorService` still being _null_ during the "half-restarts" that occur when using the Embedded EJB Container.

These "half-restarts" only re-initialise **some** services, not all, which was leading to the thread pools in `PayaraExecutorService` being nulled from receiving the `SERVER_SHUTDOWN` event, but never being reinitialised.

Since the `SERVER_START` event doesn't get fired until _after_ run-level 10 (our NPE happens _at_ run-level 10), I've created a new event to get fired after run-level 1.

## Important Info
### Blockers
None

## Testing
See https://github.com/payara/Payara/pull/6007

## Documentation
N/A

## Notes for Reviewers
See https://github.com/payara/Payara/pull/6007