### PR TITLE
FISH-6567: override createSocket method without arguments to fix ldap connection issue

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/ldap/CustomSocketFactory.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/ldap/CustomSocketFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.security.auth.realm.ldap;
 
@@ -86,6 +86,20 @@ public class CustomSocketFactory extends SocketFactory implements Comparator<Soc
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, SecurityLoggerInfo.securityExceptionError, ex);
         }
+    }
+
+    /**
+     * Overriding createSocket() to fix issue FISH-6567 when having connectTimeout for Ldap Connections.
+     * The cause of the issue is that new implementation from blocking mechanism during creation of socket connections
+     * is setting a positive value for the parameter connectTimeout instead of using -1 (as previous versions did)
+     * to control the creation. For more information about the changes please check
+     * @see < href="https://github.com/openjdk/jdk/pull/6568">jdk connection timeout pr</>
+     * @return Socket instance with default ssl context
+     * @throws IOException
+     */
+    @Override
+    public Socket createSocket() throws IOException {
+        return socketFactory.createSocket();
     }
 
     /**


### PR DESCRIPTION


<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Override createSocket method without arguments to fix ldap connection issue
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for an invalid behaviour when trying to create LDAPs connections
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
manual testing with different versions of JDK, please check comments on the following ticket: https://payara.atlassian.net/browse/FISH-6567?focusedCommentId=64300
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11 and ubuntu 20.04, JDK's used: Azul JDK 8, Oracle JDK 8,Azul jdk 11.0.13, Azul jdk 11.0.17, Oracle jdk 11.0.15, Azul jdk 17.30.15,  Azul jdk 17.0.4,  OpenJDK 11.0.12, Azul jdk 11.0.15, maven 3.8.6
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
