### PR TITLE
[DEVOPS-745] - Capture server log on test failure

### DIFF
--- a/.jenkins/modules/Test/Test.groovy
+++ b/.jenkins/modules/Test/Test.groovy
@@ -1,9 +1,10 @@
-MPLPostStep('always') {
+MPLModulePostStep('always') {
+    echo "Cleaning up the workspace"
     sh "${pwd()}/${getPayaraDirectoryName(CFG.'build.version')}/bin/asadmin stop-domain ${CFG.domain_name}"
     cleanWs()
 }
 
-MPLPostStep('failure') {
+MPLModulePostStep('failure') {
     echo "There are test failures, archiving server log"
     archiveArtifacts artifacts: "./${${getPayaraDirectoryName}}/glassfish/domains/${getDomainName()}/logs/server.log"
 }

--- a/.jenkins/modules/Test/Test.groovy
+++ b/.jenkins/modules/Test/Test.groovy
@@ -3,6 +3,11 @@ MPLPostStep('always') {
     cleanWs()
 }
 
+MPLPostStep('failure') {
+    echo "There are test failures, archiving server log"
+    archiveArtifacts artifacts: "./${${getPayaraDirectoryName}}/glassfish/domains/${getDomainName()}/logs/server.log"
+}
+
 // Perform suite specific test execution
 if(CFG.suite.suite_name.equals("Payara-Samples")) {
     MPLModule('Payara Samples Test', CFG)

--- a/.jenkins/modules/Test/Test.groovy
+++ b/.jenkins/modules/Test/Test.groovy
@@ -1,10 +1,10 @@
-MPLModulePostStep('always') {
+MPLPostStep('always') {
     echo "Cleaning up the workspace"
     sh "${pwd()}/${getPayaraDirectoryName(CFG.'build.version')}/bin/asadmin stop-domain ${CFG.domain_name}"
     cleanWs()
 }
 
-MPLModulePostStep('failure') {
+MPLPostStep('failure') {
     echo "There are test failures, archiving server log"
     archiveArtifacts artifacts: "./${${getPayaraDirectoryName}}/glassfish/domains/${getDomainName()}/logs/server.log"
 }

--- a/.jenkins/modules/Test/Test.groovy
+++ b/.jenkins/modules/Test/Test.groovy
@@ -9,6 +9,8 @@ MPLModulePostStep('failure') {
     archiveArtifacts artifacts: "./${${getPayaraDirectoryName}}/glassfish/domains/${getDomainName()}/logs/server.log"
 }
 
+error("Temporary forced failure to test failure post step behaviour")
+
 // Perform suite specific test execution
 if(CFG.suite.suite_name.equals("Payara-Samples")) {
     MPLModule('Payara Samples Test', CFG)


### PR DESCRIPTION
## Description
See title

## Notes for Reviewers
Running through Jenkins with forced failure to ensure correct behaviour, will later create a commit to remove this forced failure behaviour
