### PR TITLE
FISH-6022 FISH-6299: Allow access to unprotected endpoints with invalid JWT

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/cdi/CdiInitEventHandler.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/cdi/CdiInitEventHandler.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -91,8 +91,6 @@ import org.glassfish.soteria.cdi.CdiUtils;
  */
 public class CdiInitEventHandler {
 
-    private final static JsonWebTokenImpl emptyJsonWebToken = new JsonWebTokenImpl(null, Collections.emptyMap());
-
     public static void installAuthenticationMechanism(AfterBeanDiscovery afterBeanDiscovery) {
 
         afterBeanDiscovery.addBean(new CdiProducer<IdentityStore>()
@@ -108,14 +106,6 @@ public class CdiInitEventHandler {
                 .types(Object.class, HttpAuthenticationMechanism.class, JWTAuthenticationMechanism.class)
                 .addToId("mechanism " + LoginConfig.class)
                 .create(e -> new JWTAuthenticationMechanism()));
-
-        // MP-JWT 1.0 7.1.1. Injection of JsonWebToken
-        afterBeanDiscovery.addBean(new CdiProducer<JsonWebToken>()
-                .scope(RequestScoped.class)
-                .beanClass(JsonWebToken.class)
-                .types(Object.class, JsonWebToken.class)
-                .addToId("token " + LoginConfig.class)
-                .create(e -> getJsonWebToken()));
 
         // MP-JWT 1.0 7.1.2
         for (JWTInjectableType injectableType : computeTypes()) {
@@ -237,11 +227,7 @@ public class CdiInitEventHandler {
     }
 
     public static JsonWebTokenImpl getJsonWebToken() {
-        JsonWebTokenImpl jsonWebToken = (JsonWebTokenImpl) CdiUtils.getBeanReference(SecurityContext.class).getCallerPrincipal();
-        if (jsonWebToken == null) {
-            jsonWebToken = emptyJsonWebToken;
-        }
-
+        JsonWebTokenImpl jsonWebToken = CdiUtils.getBeanReference(JsonWebTokenImpl.class);
         return jsonWebToken;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/cdi/JsonWebTokenProducer.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/cdi/JsonWebTokenProducer.java
@@ -1,0 +1,178 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.microprofile.jwtauth.cdi;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Typed;
+import javax.json.JsonValue;
+import javax.security.enterprise.SecurityContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.NotAuthorizedException;
+
+import fish.payara.microprofile.jwtauth.eesecurity.JWTAuthenticationMechanism;
+import fish.payara.microprofile.jwtauth.jwt.JsonWebTokenImpl;
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+@RequestScoped
+class JsonWebTokenProducer {
+    @Produces
+    @RequestScoped
+    @Typed({JsonWebTokenImpl.class, JsonWebToken.class}) // so it's not eligible for injection as Principal
+    JsonWebTokenImpl currentJwt(SecurityContext securityContext, HttpServletRequest request) {
+        Principal principal = securityContext.getCallerPrincipal();
+        if (principal != null && principal instanceof JsonWebTokenImpl) {
+            return (JsonWebTokenImpl) principal;
+        }
+        if (request.getAttribute(JWTAuthenticationMechanism.INVALID_JWT_TOKEN) != null) {
+            return INVALID_JWT_TOKEN;
+        }
+        return EMPTY_JWT_TOKEN;
+    }
+
+    private final static JsonWebTokenImpl EMPTY_JWT_TOKEN = new JsonWebTokenImpl(null, Collections.emptyMap());
+
+    static final JsonWebTokenImpl INVALID_JWT_TOKEN = new JsonWebTokenImpl(null, Collections.emptyMap()) {
+        void throwOnInvalidToken() {
+            throw new NotAuthorizedException("Presented JWT token is invalid");
+        }
+
+        @Override
+        public Map<String, JsonValue> getClaims() {
+            throwOnInvalidToken();
+            return super.getClaims();
+        }
+
+        @Override
+        public <T> T getClaim(String claimName) {
+            throwOnInvalidToken();
+            return super.getClaim(claimName);
+        }
+
+        @Override
+        public Set<String> getClaimNames() {
+            throwOnInvalidToken();
+            return super.getClaimNames();
+        }
+
+        @Override
+        public String getRawToken() {
+            throwOnInvalidToken();
+            return super.getRawToken();
+        }
+
+        @Override
+        public String getIssuer() {
+            throwOnInvalidToken();
+            return super.getIssuer();
+        }
+
+        @Override
+        public Set<String> getAudience() {
+            throwOnInvalidToken();
+            return super.getAudience();
+        }
+
+        @Override
+        public String getSubject() {
+            throwOnInvalidToken();
+            return super.getSubject();
+        }
+
+        @Override
+        public String getTokenID() {
+            throwOnInvalidToken();
+            return super.getTokenID();
+        }
+
+        @Override
+        public long getExpirationTime() {
+            throwOnInvalidToken();
+            return super.getExpirationTime();
+        }
+
+        @Override
+        public long getIssuedAtTime() {
+            throwOnInvalidToken();
+            return super.getIssuedAtTime();
+        }
+
+        @Override
+        public Set<String> getGroups() {
+            throwOnInvalidToken();
+            return super.getGroups();
+        }
+
+        @Override
+        public boolean containsClaim(String claimName) {
+            throwOnInvalidToken();
+            return super.containsClaim(claimName);
+        }
+
+        @Override
+        public <T> T getClaim(Claims claim) {
+            throwOnInvalidToken();
+            return super.getClaim(claim);
+        }
+
+        @Override
+        public <T> Optional<T> claim(String claimName) {
+            throwOnInvalidToken();
+            return super.claim(claimName);
+        }
+
+        @Override
+        public <T> Optional<T> claim(Claims claim) {
+            throwOnInvalidToken();
+            return super.claim(claim);
+        }
+    };
+}

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/cdi/JwtAuthCdiExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/cdi/JwtAuthCdiExtension.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -50,18 +50,8 @@ import java.util.Set;
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.AfterBeanDiscovery;
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.BeforeBeanDiscovery;
-import javax.enterprise.inject.spi.DeploymentException;
-import javax.enterprise.inject.spi.Extension;
-import javax.enterprise.inject.spi.InjectionPoint;
-import javax.enterprise.inject.spi.ProcessBean;
-import javax.enterprise.inject.spi.ProcessInjectionTarget;
-import javax.enterprise.inject.spi.ProcessManagedBean;
-import javax.enterprise.inject.spi.ProcessSessionBean;
+import javax.enterprise.inject.spi.*;
+
 import org.eclipse.microprofile.auth.LoginConfig;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -90,13 +80,14 @@ public class JwtAuthCdiExtension implements Extension {
 
     public void register(@Observes BeforeBeanDiscovery beforeBean, BeanManager beanManager) {
         beforeBean.addAnnotatedType(beanManager.createAnnotatedType(InjectionPointGenerator.class), "JWT InjectionPointGenerator ");
+        beforeBean.addAnnotatedType(beanManager.createAnnotatedType(JsonWebTokenProducer.class), JsonWebTokenProducer.class.getName());
     }
     
     /**
      * This method tries to find the LoginConfig annotation and if does flags that fact.
      * 
      */
-    public <T> void findLoginConfigAnnotation(@Observes ProcessBean<T> eventIn, BeanManager beanManager) {
+    public <T> void findLoginConfigAnnotation(@Observes ProcessBean<T> eventIn) {
         
         ProcessBean<T> event = eventIn; // JDK8 u60 workaround
         
@@ -111,7 +102,7 @@ public class JwtAuthCdiExtension implements Extension {
      * declared later on. 
      * 
      */
-    public <T> void findRoles(@Observes ProcessManagedBean<T> eventIn, BeanManager beanManager) {
+    public <T> void findRoles(@Observes ProcessManagedBean<T> eventIn) {
         
         ProcessManagedBean<T> event = eventIn; // JDK8 u60 workaround
         
@@ -132,7 +123,7 @@ public class JwtAuthCdiExtension implements Extension {
         
     }
     
-    public <T> void checkInjectIntoRightScope(@Observes ProcessInjectionTarget<T> eventIn, BeanManager beanManager) {
+    public <T> void checkInjectIntoRightScope(@Observes ProcessInjectionTarget<T> eventIn) {
 
         ProcessInjectionTarget<T> event = eventIn; // JDK8 u60 workaround
         
@@ -162,7 +153,7 @@ public class JwtAuthCdiExtension implements Extension {
         }
     }
    
-    public void installMechanismIfNeeded(@Observes AfterBeanDiscovery eventIn, BeanManager beanManager) {
+    public void installMechanismIfNeeded(@Observes AfterBeanDiscovery eventIn) {
 
         AfterBeanDiscovery afterBeanDiscovery = eventIn; // JDK8 u60 workaround
 

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/eesecurity/JWTAuthenticationMechanism.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/eesecurity/JWTAuthenticationMechanism.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -64,6 +64,7 @@ import org.eclipse.microprofile.jwt.config.Names;
  * @author Arjan Tijms
  */
 public class JWTAuthenticationMechanism implements HttpAuthenticationMechanism {
+    public static String INVALID_JWT_TOKEN = JWTAuthenticationMechanism.class.getName()+".invalidJwt";
 
     public static final String CONFIG_TOKEN_HEADER_AUTHORIZATION = "Authorization";
     public static final String CONFIG_TOKEN_HEADER_COOKIE = "Cookie";
@@ -89,8 +90,6 @@ public class JWTAuthenticationMechanism implements HttpAuthenticationMechanism {
     @Override
     public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthenticationException {
 
-        // Don't limit processing of JWT to protected pages (httpMessageContext.isProtected())
-        // as MP TCK requires JWT being parsed (if provided) even if not in protected pages.
         IdentityStoreHandler identityStoreHandler = CDI.current().select(IdentityStoreHandler.class).get();
 
         SignedJWTCredential credential = getCredential(request);
@@ -105,7 +104,13 @@ public class JWTAuthenticationMechanism implements HttpAuthenticationMechanism {
                 return httpMessageContext.notifyContainerAboutLogin(result);
             }
 
-            return httpMessageContext.responseUnauthorized();
+
+            if (httpMessageContext.isProtected()) {
+                return httpMessageContext.responseUnauthorized();
+            }
+
+            // put validation result in an attribute in case unauthenticated endpoint want to touch the token
+            request.setAttribute(INVALID_JWT_TOKEN, true);
         }
 
         return httpMessageContext.doNothing();

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JsonWebTokenImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/jwt/JsonWebTokenImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -40,6 +40,8 @@
 package fish.payara.microprofile.jwtauth.jwt;
 
 import static java.util.Collections.singleton;
+
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +62,12 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 public class JsonWebTokenImpl extends CallerPrincipal implements JsonWebToken {
     
     private final Map<String, JsonValue> claims;
+
+    protected JsonWebTokenImpl() {
+        // for proxying request-scoped bean
+        super(null);
+        claims = Collections.EMPTY_MAP;
+    }
 
     public JsonWebTokenImpl(String callerName, Map<String, JsonValue> claims) {
         super(callerName);

--- a/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/src/test/resources/post-boot-commands.txt
+++ b/appserver/tests/payara-samples/samples/microprofile-endpoints/secure/src/test/resources/post-boot-commands.txt
@@ -1,3 +1,3 @@
-set-metrics-configuration --securityenabled=true
-set-microprofile-healthcheck-configuration --securityenabled=true
-set-openapi-configuration --securityenabled=true
+set-metrics-configuration --securityenabled=true --endpoint=mpmetrics
+set-microprofile-healthcheck-configuration --securityenabled=true --endpoint=mphealth
+set-openapi-configuration --securityenabled=true --endpoint=openapi

--- a/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/mpjwt/fish6022/JaxrsApplication.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/mpjwt/fish6022/JaxrsApplication.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.mpjwt.fish6022;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.eclipse.microprofile.auth.LoginConfig;
+
+
+@ApplicationPath("resources")
+@LoginConfig(authMethod = "MP-JWT")
+@ApplicationScoped
+public class JaxrsApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Collections.singleton(RootResource.class);
+    }
+}

--- a/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/mpjwt/fish6022/PublicServlet.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/mpjwt/fish6022/PublicServlet.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.mpjwt.fish6022;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+@WebServlet("/servlet")
+public class PublicServlet extends HttpServlet {
+    @Inject
+    JsonWebToken jwt;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (req.getParameter("token") != null) {
+            resp.getWriter().println(jwt.getRawToken());
+        } else {
+            resp.getWriter().println("ok");
+        }
+    }
+}

--- a/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/mpjwt/fish6022/RootResource.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/main/java/fish/payara/samples/mpjwt/fish6022/RootResource.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.mpjwt.fish6022;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+@Path("/")
+@RequestScoped
+public class RootResource {
+    @Inject
+    JsonWebToken jwt;
+
+    @GET
+    public String get() {
+        return "everything's allright";
+    }
+
+    @Path("token")
+    @GET
+    public String tryReadingToken() {
+        return jwt.getRawToken();
+    }
+}

--- a/appserver/tests/payara-samples/samples/reproducers/src/test/java/fish/payara/samples/mpjwt/fish6022/InvalidTokenOnPublicEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/reproducers/src/test/java/fish/payara/samples/mpjwt/fish6022/InvalidTokenOnPublicEndpointTest.java
@@ -1,0 +1,118 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.mpjwt.fish6022;
+
+
+import java.net.URI;
+
+import javax.persistence.criteria.Root;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class InvalidTokenOnPublicEndpointTest {
+    static final String MPCONFIG = "mp.jwt.verify.issuer=airhacks\n"
+            + "mp.jwt.verify"
+            + ".publickey=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAin3fGoTp6LNzNd5NtITVrQUl2vxnKGr249mRbHw02cZhLStaUMMFt8DR2Z5HfM8upR"
+            + "+0Y6bnlrn3dQdm4kE5ri1vr05mWhjF1wGflKaux54VtXTR8Xuu1zeZzasxgxYeYp680r9pkYJw7kK4QYx4tEMo5FHKsitIOnTxxAT3+mpMVQEOPjTkt2r929p82XYO9WRR"
+            + "/OwLcHH28s9epY+eNfQIjZ2FHawF2NJeyN3fUyJqUdRsrKoodorOoog"
+            + "/mMFimYB1XbctBeZRBE8utLtbyP8hhR2NkvAzGcmy7d7bS9aRbdH236DCcREg5iDpNCt5rDcHLO7ScDKEMMz/jFJ9zwIDAQAB";
+
+    static final String AUTH = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(JaxrsApplication.class, RootResource.class, PublicServlet.class)
+                .addAsManifestResource(new StringAsset(MPCONFIG), "microprofile-config.properties");
+    }
+
+    @ArquillianResource
+    URI base;
+
+    @Test
+    public void passesWithoutTokenAccess() {
+        WebTarget target = ClientBuilder.newClient().target(base).path("resources");
+
+        Response response = target.request().header("Authorization", AUTH).get();
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void unauthorizedOnTokenAccess() {
+        WebTarget target = ClientBuilder.newClient().target(base).path("resources").path("token");
+
+        Response response = target.request().header("Authorization", AUTH).get();
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void servletPassesWithoutTokenAccess() {
+        WebTarget target = ClientBuilder.newClient().target(base).path("servlet");
+
+        Response response = target.request().header("Authorization", AUTH).get();
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void servletUnauthorizedOnTokenAccess() {
+        WebTarget target = ClientBuilder.newClient().target(base).path("servlet");
+
+        Response response = target.queryParam("token", "true").request().header("Authorization", AUTH).get();
+        assertEquals(500, response.getStatus());
+    }
+
+}


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
MP JWT Auth says that it is possible to access unprotected endpoints with invalid JWT token in the header unless application tries to access injected `JsonWebToken`. At the same time, unprotected endpoints should have access to JWT token if it is valid and has been passed in the request.

Therefore there are three possible behaviors upon accessing `JsonWebToken`:
* If token is valid, the class can be injected to access properties of the token. Principal identity is also estabilished
* If token is not present, empty token is injected, all methods return null.
* If token is invalid, any access to the class will result in `NotAuthorizedException`, causing JAX-RS processing to end with status 401.

Spec doesn't specify behavior in servlet container, therefore it was not considered. That results in status 500, as JAX-RS exception is not handled on servlet container level.

## Testing
### New tests
New reproducer demonstrates both processing which does and does not touch `JsonWebToken` in processing.

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
MP JWT Auth TCK passes

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: C:\ProgramData\chocolatey\lib\maven\apache-maven-3.8.6
Java version: 11.0.12, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-11
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```