### PR TITLE
FISH-1175 Fix Typo in '@Clustered' API

### DIFF
--- a/api/payara-api/src/main/java/fish/payara/cluster/Clustered.java
+++ b/api/payara-api/src/main/java/fish/payara/cluster/Clustered.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2017] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -84,5 +84,5 @@ public @interface Clustered {
      * and this singleton also exists on the other node. (not truly destroyed)
      * Default is true
      */
-    boolean callPreDestoyOnDetach () default true;
+    boolean callPreDestroyOnDetach () default true;
 }

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/annotation/handlers/SingletonHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/annotation/handlers/SingletonHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.ejb.deployment.annotation.handlers;
 
@@ -171,7 +171,7 @@ public class SingletonHandler extends AbstractEjbHandler {
             desc.setClustered(true);
             desc.setClusteredKeyValue(clusteredAnnotation.keyName());
             desc.setDontCallPostConstructOnAttach(!clusteredAnnotation.callPostConstructOnAttach());
-            desc.setDontCallPreDestroyOnDetach(!clusteredAnnotation.callPreDestoyOnDetach());
+            desc.setDontCallPreDestroyOnDetach(!clusteredAnnotation.callPreDestroyOnDetach());
         }
     }
 }

--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopedInterceptor.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/cluster/ClusterScopedInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -108,7 +108,7 @@ public class ClusterScopedInterceptor implements Serializable {
         IAtomicLong count = clusteredLookup.getClusteredUsageCount();
         if (count.decrementAndGet() <= 0) {
             clusteredLookup.destroy();
-        } else if (!clusteredAnnotation.callPreDestoyOnDetach()) {
+        } else if (!clusteredAnnotation.callPreDestroyOnDetach()) {
             return null;
         }
 


### PR DESCRIPTION
## Description
Fixes a typo in the '@Clustered' API.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the server, ran the clustered-singleton test in payara-samples

### Testing Environment
WSL, Zulu JDK 11

## Documentation
PR to Documentation: https://github.com/payara/Payara-Documentation/pull/152
Added to our itnernal documentation of breaking changes: https://payara.atlassian.net/wiki/spaces/PAYAR/pages/3418685483/Breaking+Changes
## Notes for Reviewers
None
