### PR TITLE
FISH-6598: Upgrade soteria to fix broken Multiple Auth Mechanisms in EAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <weld.version>3.1.8.Final</weld.version>
         <weld-api.version>3.1.SP4</weld-api.version>
         <jakarta.security.enterprise-api.version>1.0.2</jakarta.security.enterprise-api.version>
-        <jakarta.security.enterprise.version>1.1-b01.payara-p4</jakarta.security.enterprise.version>
+        <jakarta.security.enterprise.version>1.1-b01.payara-p5</jakarta.security.enterprise.version>
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
         <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
         <jms-api.version>2.0.2</jms-api.version>


### PR DESCRIPTION
## Description
Upgrades soteria implementation to one from payara/patched-src-security-soteria#4, which is already deployed to payara-artifacts.

What was described as "spurious warning" was in fact manifesting, that OpenID security connectors changed and they no longer ship Authentication Mechanism per OpenId provider, rather there is single mechanisms that can be activated by one of definition annotations.

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
All integrations tests in soteria pass against updated Payara. They weren't run before.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: C:\ProgramData\chocolatey\lib\maven\apache-maven-3.8.6
Java version: 11.0.12, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-11
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```

## Documentation
payara/Payara-Documentation#153
