### PR TITLE
FISH-5808 : handling single @Path on methods

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -257,7 +257,7 @@ public class OpenApiContext implements ApiContext {
     private String getResourcePath(MethodModel method) {
         AnnotationInfo annotations = getAnnotationInfo(method.getDeclaringType());
         if (annotations.isAnyAnnotationPresent(method,
-                GET.class, POST.class, PUT.class, DELETE.class, HEAD.class, OPTIONS.class, PATCH.class)) {
+                GET.class, POST.class, PUT.class, DELETE.class, HEAD.class, OPTIONS.class, PATCH.class, Path.class)) {
             if (annotations.isAnnotationPresent(Path.class, method)) {
                 // If the method is a valid resource
                 return ModelUtils.normaliseUrl(getResourcePath(method.getDeclaringType()) + "/"

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -61,6 +61,7 @@ import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
@@ -196,6 +197,14 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
             annotationVisitor.put(HEAD.class, (annot, element, con) -> visitor.visitHEAD(annot, (MethodModel) element, con));
             annotationVisitor.put(OPTIONS.class, (annot, element, con) -> visitor.visitOPTIONS(annot, (MethodModel) element, con));
             annotationVisitor.put(PATCH.class, (annot, element, con) -> visitor.visitPATCH(annot, (MethodModel) element, con));
+            annotationVisitor.put(Path.class, (annot, element, con) -> {
+                if (element instanceof MethodModel && element.getAnnotations().size() == 1) {
+                    AnnotationModel annotationModel = element.getAnnotations().iterator().next();
+                    if ("Path".equals(annotationModel.getType().getSimpleName())) {
+                        visitor.visitGET(annot, (MethodModel) element, con);
+                    }
+                }
+            });
 
             // JAX-RS parameters
             annotationVisitor.put(QueryParam.class, visitor::visitQueryParam);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/DependantClassesTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/DependantClassesTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2021-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import fish.payara.microprofile.openapi.resource.rule.ApplicationProcessedDocument;
 import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
 import fish.payara.microprofile.openapi.test.app.TestApplication;
+import fish.payara.microprofile.openapi.test.app.application.schema.Child;
 import fish.payara.microprofile.openapi.test.app.application.schema.Schema1Depending;
 import fish.payara.microprofile.openapi.test.app.application.schema.Schema2Simple;
 import fish.payara.microprofile.openapi.test.app.application.schema.Schema2Simple1;
@@ -53,6 +54,8 @@ import java.util.Iterator;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -71,6 +74,8 @@ import org.junit.Test;
  */
 @Path("/serversDependant")
 public class DependantClassesTest extends OpenApiApplicationTest {
+    @Context
+    private ResourceContext rc;
 
     // add multiple classes to be processed, simulate component scan
     @Before
@@ -90,6 +95,11 @@ public class DependantClassesTest extends OpenApiApplicationTest {
                     schema = @Schema(implementation = Schema1Depending.class)
             )) Schema1Depending schema1Depending) {
         return new Schema1Depending();
+    }
+
+    @Path("child")
+    public Child sub() {
+        return rc.getResource(Child.class);
     }
 
     /**
@@ -126,5 +136,11 @@ public class DependantClassesTest extends OpenApiApplicationTest {
         assertEquals("schema2SimpleRef", requiredElements.next().asText());
         // no more than two results
         assertFalse(requiredElements.hasNext());
+    }
+
+    @Test
+    public void dependantClassSinglePathAnnotation() {
+        JsonNode operationSubMethod = path(getOpenAPIJson(),"paths./test/serversDependant/child.get");
+        assertEquals("sub", operationSubMethod.findValue("operationId").asText());
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/schema/Child.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/schema/Child.java
@@ -1,0 +1,51 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.openapi.test.app.application.schema;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.core.Response;
+
+public class Child {
+
+    @GET
+    public Response childMethod() {
+        return Response.ok().entity("child").build();
+    }
+}


### PR DESCRIPTION
## Description
JAX-RS Subresources don't Appear in OpenAPI Document

## Important Info
### Blockers
None

## Testing
### New tests
new test **dependantClassSinglePathAnnotation** in `fish.payara.microprofile.openapi.test.app.application.DependantClassesTest`

### Testing Performed
1. mvn clean install -T 3C -DskipTests
2. .\appserver\distributions\payara\target\stage\payara5\bin\asadmin start-domain
3. cd C:\Dev\reproducers\FISH-5808
4. C:\Dev\reproducers\FISH-5808\mvn clean install
5. C:\Users\luise\git\Payara\appserver\distributions\payara\target\stage\payara5\bin\asadmin deploy .\openapi-test.war
6. Poke http://localhost:8080/openapi
7. It should show: /resources/foo/bar into **paths** & **endpoints**

### Testing Environment
Zulu JDK 1.8_212 on Windows 10 with Maven 3.8.4
