### PR TITLE
FISH-5778 : handling duplicated field when annotated with @Schema

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -677,6 +677,10 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             parentSchema.addProperty(schemaName, property);
             if (schema.isRequired()) {
                 parentSchema.addRequired(schemaName);
+            }
+            // Removing the original property
+            if (!schemaName.equals(fieldOrMethod.getName()) && parentSchema.getProperties().containsKey(fieldOrMethod.getName())) {
+                parentSchema.removeProperty(fieldOrMethod.getName());
             }
 
             if (property.getRef() == null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/SchemaExampleTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/SchemaExampleTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.openapi.test.app.application;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 import fish.payara.microprofile.openapi.impl.visitor.OpenApiWalker;
 import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
@@ -58,8 +59,12 @@ import org.junit.Test;
  * 
  * These should occur as {@link SchemaImpl#getProperties()}.
  */
+@Schema(name = "SchemaExample")
 @Path("/users")
 public class SchemaExampleTest extends OpenApiApplicationTest {
+
+    @Schema(name = "friendly_name")
+    private String notFriendlyName;
 
     @Schema(maxProperties = 1024, minProperties = 1, requiredProperties = { "password" })
     public static class User {
@@ -83,5 +88,13 @@ public class SchemaExampleTest extends OpenApiApplicationTest {
         assertNotNull(passwordProperties);
         assertEquals("string", passwordProperties.get("type").textValue());
         assertEquals("bobSm37", passwordProperties.get("example").textValue());
+    }
+
+    @Test
+    public void fieldSchemaExampleIsRenamed() {
+        ObjectNode root = getOpenAPIJson();
+        assertEquals(false,
+                JsonUtils.hasPath(root, "components.schemas.SchemaExample.properties.notFriendlyName".split("\\.")));
+        assertNotNull(JsonUtils.path(root,"components.schemas.SchemaExample.properties.friendly_name"));
     }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/util/JsonUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/util/JsonUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -87,5 +87,26 @@ public class JsonUtils {
 
     public static ObjectNode toJson(Constructible node) {
         return OpenApiBuilderTest.JSON_MAPPER.valueToTree(node);
+    }
+
+    public static boolean hasPath(JsonNode root, String... pathElements) {
+        JsonNode current = root;
+        if (pathElements == null || pathElements.length == 0) {
+            return false;
+        }
+        for (int i = 0; i < pathElements.length; i++) {
+            String nameOrIndex = pathElements[i];
+            if (current != null) {
+                if (nameOrIndex.startsWith("[") && nameOrIndex.endsWith("]")) {
+                    current = current.get(Integer.parseInt(nameOrIndex.substring(1, nameOrIndex.length() - 1)));
+                } else {
+                    current = current.get(nameOrIndex);
+                }
+            }
+            if (current == null) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Description
When using OpenAPI annotation @Schema on the Class attribute, it does not rename it instead it appears twice (initial attribute name and the renamed one)

## Important Info
### Blockers
None

## Testing
### New tests
new test **fieldSchemaExampleIsRenamed** in `fish.payara.microprofile.openapi.test.app.application.SchemaExampleTest`

### Testing Performed
1. mvn clean install -T 3C -DskipTests
2. .\appserver\distributions\payara\target\stage\payara5\bin\asadmin start-domain
3. Download and unzip: https://github.com/payara/Payara/files/7254999/payara-openapi-schema-name-error.zip
4. cd C:\Dev\reproducers\payara-openapi-schema-name-error
5. C:\Dev\reproducers\payara-openapi-schema-name-error\mvn clean package
6. C:\Users\luise\git\Payara\appserver\distributions\payara\target\stage\payara5\bin\asadmin deploy .\payara-openapi-schema-name-error.war
7. Poke http://localhost:8080/openapi
8. It should show only: components->schemas->TestModel->properties->friendly_name

### Testing Environment
Zulu JDK 11 on Windows 10 with Maven 3.8.4
