### PR TITLE
FISH-6686 Update ASM to 9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <javax.cache-api.version>1.1.1</javax.cache-api.version>
         <mail.version>1.6.7.payara-p1</mail.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-        <hk2.version>2.6.1.payara-p7</hk2.version>
+        <hk2.version>2.6.1.payara-p8</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jackson.version>2.13.4</jackson.version>
@@ -223,7 +223,7 @@
         <websocket-api.version>1.1.2</websocket-api.version>
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.1.payara-p1</concurrent.version>
-        <asm.version>9.3</asm.version>
+        <asm.version>9.4</asm.version>
         <monitoring-console-api.version>1.2</monitoring-console-api.version>
         <monitoring-console-process.version>1.8.1</monitoring-console-process.version>
         <monitoring-console-webapp.version>1.8.1</monitoring-console-webapp.version>


### PR DESCRIPTION
## Description
Updates ASM to 9.4 and HK2 to 2.6.1.payara-p8 which had ASM incremented to 9.4

## Important Info
### Blockers
~Blocked by https://github.com/payara/patched-src-hk2/pull/25 being approved and published to Nexus~

## Testing
### New tests
None

### Testing Performed
Started the server, created and instance and deployed an application

### Testing Environment
JDK 8, Maven 3.6.3, Windows 10

## Documentation
None

## Notes for Reviewers
None
