### PR TITLE
FISH-6047: Fix Single Sing On handling for Jaspic applications, Single Sign Off for all SSO-enabled apps

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -768,6 +768,9 @@ public abstract class AuthenticatorBase extends ValveBase
         assert (realm != null);
         sso.register(value, principal, authType, username, password, realm);
         // END S1AS8 PE 4856080,4918627
+        if (session != null) {
+            sso.associate(value, 0, session);
+        }
 
         request.setNote(Constants.REQ_SSOID_NOTE, value);
         if (sso.isVersioningSupported()) {
@@ -807,6 +810,9 @@ public abstract class AuthenticatorBase extends ValveBase
         if (session != null) {
             session.setPrincipal(null);
             session.setAuthType(null);
+            if (session.getSsoId() != null) {
+                session.expire();
+            }
         }
 
         // principal and authType set to null in the following

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
@@ -337,7 +337,7 @@ public class GlassFishSingleSignOn extends SingleSignOn
         }
 
         String realmName = realm.getRealmName();
-        if (realmName == null) {
+        if (realmName == null || realmName.isEmpty()) {
             // S1AS8 6155481 START
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, LogFacade.NO_REALM_CONFIGURED);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Fixes #5551. The session that estabilishes SSO ID is now added into SSO tracking object.

Upon logout, the session is now explicitly invalidated before new SSO ID is generated. 

Empty realm is now handled the same as `null` realm. Therefore to enable SSO between Jaspic, or Jakarta EE Security, following must be present in `web.xml`:

```
<login-config>
  <realm-name>anything</realm-name>
</login-config>
```
This doesn't need to refer to any existing realm name, it's a mean to enable applications to opt-in to SSO feature. Otherwise any two applications would be treated as SSO ones, regardless of their identity store or even authentication mechanism.

## Testing


### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Test project per our internal JIRA now behaves as expected (after making the change to `web.xml`).

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->
```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: C:\ProgramData\chocolatey\lib\maven\apache-maven-3.8.6
Java version: 11.0.12, vendor: Azul Systems, Inc., runtime: C:\Program Files\Zulu\zulu-11
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```
