### PR TITLE
FISH-6715 Update BCEL to 6.6.1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -62,7 +62,7 @@
         <jakarta.faces-spec.version>2.3.1</jakarta.faces-spec.version>
         <jsftemplating.version>2.1.4</jsftemplating.version>
         <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
-        <apache.bcel.version>6.2</apache.bcel.version>
+        <apache.bcel.version>6.6.1</apache.bcel.version>
         
         <!-- Java EE Security API -->
         <javax.security.enterprise-spec.version>1.0</javax.security.enterprise-spec.version>


### PR DESCRIPTION
## Description
Update BCEL to 6.6.1. This also fixes CVE-2022-42920

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the server, created an instance and deployed an application

### Testing Environment
Windows 10, Maven 3.6.3, JDK 8

## Documentation
https://github.com/payara/Payara-Documentation/pull/157

## Notes for Reviewers
None
