### PR TITLE
FISH-6715 (P6) Update BCEL to 6.6.1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -62,7 +62,7 @@
         <jakarta.faces-spec.version>4.0.0</jakarta.faces-spec.version>
         <jsftemplating.version>3.0.0</jsftemplating.version>
         <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
-        <apache.bcel.version>6.5.0</apache.bcel.version>
+        <apache.bcel.version>6.6.1</apache.bcel.version>
         <!-- Java EE Security API -->
         <jakarta.security.enterprise-spec.version>1.0</jakarta.security.enterprise-spec.version>
         <jna.version>5.2.0</jna.version>


### PR DESCRIPTION
## Description
Update BCEL to 6.6.1. This also fixes CVE-2022-42920

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the server, created an instance and deployed an application

### Testing Environment
Windows 10, Maven 3.6.3, JDK 11

## Documentation
None

## Notes for Reviewers
None
