### PR TITLE
FISH-5798 : casting explode parameter to EnumModel

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -99,7 +99,10 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
         if (styleEnum != null) {
             from.setStyle(Style.valueOf(styleEnum.getValue()));
         }
-        from.setExplode(annotation.getValue("explode", Boolean.class));
+        EnumModel explodeEnum = annotation.getValue("explode", EnumModel.class);
+        if (explodeEnum != null) {
+            from.setExplode("TRUE".equals(explodeEnum.getValue()));
+        }
         from.setAllowReserved(annotation.getValue("allowReserved", Boolean.class));
         AnnotationModel schemaAnnotation = annotation.getValue("schema", AnnotationModel.class);
         if (schemaAnnotation != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/QueryParamTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/QueryParamTest.java
@@ -1,0 +1,92 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.microprofile.openapi.test.app.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
+import org.eclipse.microprofile.openapi.annotations.enums.Explode;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
+import org.junit.Test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.util.List;
+
+import static fish.payara.microprofile.openapi.test.util.JsonUtils.path;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TCK lacks tests for parameter annotations being used on fields which should add such parameters to all methods of the
+ * bean.
+ */
+@Path("/query-params")
+public class QueryParamTest extends OpenApiApplicationTest {
+
+    @GET
+    @Parameters({
+            @Parameter(name = "name", description = "The name(s)", required = false,
+                    schema = @Schema(type = SchemaType.ARRAY, implementation = String.class),
+                    explode = Explode.TRUE)
+    })
+    public Response get(@QueryParam("name") List<String> names) {
+        return Response.ok(Instant.now().toString()).build();
+    }
+
+    @Test
+    public void fieldParamsWithExplodeTrue() {
+        JsonNode parameters = path(getOpenAPIJson(), "paths./test/query-params.get.parameters");
+        assertTrue(parameterWithExplode(true, parameters));
+    }
+
+    private boolean parameterWithExplode(boolean explode, JsonNode parameters) {
+        for (JsonNode parameter : parameters) {
+            if (parameter.get("explode").booleanValue() == explode) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Description
When using OpenAPI annotation @Parameter(... explode = Explode.TRUE) (see code snippet), it is resulting in an exception in the 5.2021.7 version whereas for the 5.31.0 version OpenAPI document is not getting generated.

## Important Info
### Blockers
None

## Testing
### New tests
`fish.payara.microprofile.openapi.test.app.application.QueryParamTest`

### Testing Performed
1. **mvn clean install -T 3C -DskipTests**
2. .\appserver\distributions\payara\target\stage\payara5\bin\asadmin start-domain
3. **download** war file **payara-openapi-explode-issue-1.0-Payara6.war** from https://payara.atlassian.net/browse/FISH-5798
5. \asadmin deploy .\payara-openapi-explode-issue-1.0-SNAPSHOT.war
6. Poke http://localhost:8080/openapi
It should show: 

```
...
paths:
  /rest/ping:
    get:
      operationId: ping
      parameters:
      - name: name
        in: query
        description: The name(s)
        required: false
        deprecated: false
        allowEmptyValue: false
        explode: true
...
```

### Testing Environment
Zulu JDK 11 on Windows 10 with Maven 3.8.4

## Documentation
None

## Notes for Reviewers
None