### PR TITLE
FISH-6748 (P6) Add JDK 17 support to README

### DIFF
--- a/appserver/packager/appserver-base/src/main/docs/README.txt
+++ b/appserver/packager/appserver-base/src/main/docs/README.txt
@@ -8,9 +8,14 @@ Here are a few short steps to get you started...
 
 Payara Server currently supports the following Java Virtual Machines:
 
-* Oracle JDK 11 (11.0.5+)
-* Azul Zulu JDK 11 (11.0.5u10+)
-* OpenJDK 11 (11.0.5+)
+* Azul Zulu JDK: 11 (11.0.5u10+), 17 (17.34/17.0.3+)
+* Oracle JDK: 11 (11.0.5+), 17 (17.0.3+)
+* Amazon Corretto: 11 (11.0.5+), 17 (17.0.3+)
+* Adopt Open JDK: 11 (11.0.5+), 17 (17.0.3+)
+* Adopt Open JDK with Eclipse Open J9: 11 (11.0.5+), 17 (17.0.3+)
+* Any other JVM based on OpenJDK 11.0.5+ or 17.0.3+
+
+The Payara Platform runs on the x64 and arm64 variants of the above JVMs.
 
 1. Installing Payara Server
 ===========================


### PR DESCRIPTION
## Description
Adds mention of JDK 17 support to README file in Payara distribution, taken from https://docs.payara.fish/community/docs/6.2022.1/General%20Info/Supported%20Platforms.html

Addresses https://github.com/payara/Payara/issues/6059

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Compiled Payara, checked README is correct in distributions

### Testing Environment
Zulu JDK 11, Maven 3.6.3, Windows 10

## Documentation
N/A
