### PR TITLE
FISH-6066 Invalid property 'default-web-xml' on instance start-up

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -1548,6 +1548,8 @@ public class WebModule extends PwcWebModule implements Context {
             setUseMyFaces(ConfigBeansUtilities.toBoolean(value));
         } else if("default-role-mapping".equalsIgnoreCase(name)) {
             wmInfo.getDescriptor().setDefaultGroupPrincipalMapping(ConfigBeansUtilities.toBoolean(value));
+        } else if("default-web-xml".equalsIgnoreCase(name)) {
+            vs.setDefaultWebXmlLocation(value);
         } else if(name.startsWith("alternatedocroot_")) {
             parseAlternateDocBase(name, value);
         } else if(name.startsWith("valve_") ||


### PR DESCRIPTION
## Description
When starting a new instance, the following warning is logged: 
`Ignoring invalid property default-web-xml = /home/james/workspace/payara5/glassfish/nodes/localhost-domain1/Dull-Piranha/config/default-web.xml`

This fix prevents this from happening and sets the default-web.xml property. This changes nothing functionally, as this property is already correctly configured by the time it reaches `vs.setDefaultWebXmlLocation(value);`. This also explains why it was observed this warning doesn't impact any functionality on the server.

## Important Info
### Blockers
N/A

## Testing
### New tests
N/A

### Testing Performed
Started the server, created a new instance and observed the logs.

### Testing Environment
Windows 10, Maven 3.6.3, JDK 11

## Documentation
N/A
