### PR TITLE
FISH-6775 Authorization Constraints Ignored When Using Path Traversal Penetration Using Default Virtual Module

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -428,6 +428,13 @@ public class CoyoteAdapter extends HttpHandler {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URI");
             return false;
         }
+
+        // Normalize Decoded URI
+        if (!normalize(decodedURI)) {
+            res.setStatus(400);
+            res.setDetailMessage(("Invalid URI"));
+            return false;
+        }
         
         if (compatWithTomcat || !v3Enabled) {
 //            decodedURI.duplicate(req.requestURI());
@@ -660,22 +667,22 @@ public class CoyoteAdapter extends HttpHandler {
      * return false when trying to go above the root, or if the URI contains
      * a null byte.
      * 
-     * @param uriMB URI to be normalized
+     * @param uriDC URI DataChunk to be normalized
      */
-    public static boolean normalize(MessageBytes uriMB) {
+    public static boolean normalize(DataChunk uriDC) {
 
-        int type = uriMB.getType();
-        if (type == MessageBytes.T_CHARS) {
-            return normalizeChars(uriMB);
+        DataChunk.Type type = uriDC.getType();
+        if (type == DataChunk.Type.Chars) {
+            return normalizeChars(uriDC);
         } else {
-            return normalizeBytes(uriMB);
+            return normalizeBytes(uriDC);
         }
     }
 
 
-    private static boolean normalizeBytes(MessageBytes uriMB) {
+    private static boolean normalizeBytes(DataChunk uriDC) {
 
-        ByteChunk uriBC = uriMB.getByteChunk();
+        ByteChunk uriBC = uriDC.getByteChunk();
         byte[] b = uriBC.getBytes();
         int start = uriBC.getStart();
         int end = uriBC.getEnd();
@@ -780,9 +787,9 @@ public class CoyoteAdapter extends HttpHandler {
     }
 
 
-    private static boolean normalizeChars(MessageBytes uriMB) {
+    private static boolean normalizeChars(DataChunk uriDC) {
 
-        CharChunk uriCC = uriMB.getCharChunk();
+        CharChunk uriCC = uriDC.getCharChunk();
         char[] c = uriCC.getChars();
         int start = uriCC.getStart();
         int end = uriCC.getEnd();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -666,7 +666,7 @@ public class CoyoteAdapter extends HttpHandler {
      * Normalize URI.
      * <p>
      * This method normalizes "\", "//", "/./" and "/../". This method will
-     * return false when trying to go above the root, or if the URI contains
+     * throw an error when trying to go above the root, or if the URI contains
      * a null byte.
      * 
      * @param uriDC URI DataChunk to be normalized


### PR DESCRIPTION
## Description
Security fix.

It was possible to circumvent JACC authentication using a `./` traversal, since the request normalisation which normally stops these attacks actually happens _after_ the JACC check has occurred. So while the path is normalised as expected, the actual JACC check has already occurred and passed when it would fail against the normalised path.

This PR reactivates the old normalisation in the CoyoteAdapater which was commented out many many moons ago without explanation when integrating Grizzly with the forked Tomcat in the days of GlassFish 2 & 3.

What happens now is that if a request which would fail its normalisation checks occur, a HTTP 400 request is returned. This is, from a quick scan of their code, in line with how Tomcat / Catalina functions today.
The criteria for failing normalisation are:

* Request not starting with a "/"
* Request with backslashes in (if a property is not enabled: `org.glassfish.grizzly.tcp.tomcat5.CoyoteAdapter.ALLOW_BACKSLASH`)
* Request with null bytes in
* Requests which try to escape the context

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Ran the reproducer for FISH-6775
* Ran the reproducer for FISH-6603

I also ran the Jakarta TCK and it seemed to work, with the exception of some tests which seem to be complaining about not being able to render stuff on a headless server (they pass locally)

### Testing Environment
WSL, JDK 8

## Documentation
None - no CVE

## Notes for Reviewers
None
