### PR TITLE
FISH-6578 (P6) added jna required dependency to packager and upgraded it to latest

### DIFF
--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -74,12 +74,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara-ml"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -76,12 +76,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara-web-ml"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -77,12 +77,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara-web"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -89,12 +89,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="distribution"
                                           value="payara"/>
                                 <ant antfile="../distributions.xml"
                                      target="set-distribution"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -139,7 +139,7 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk11">
                                             <filterset>
                                                 <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk11.tag}"/>
@@ -151,7 +151,7 @@
                                                 <filter token="docker.payara.tag" value="${docker.payara.tag}-jdk17"/>
                                             </filterset>
                                         </copy>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>

--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] -->
 
 <project name="glassfish-embedded-all" default="create.distribution" basedir=".">
     <property name="rootdir" value="target"/>
@@ -126,7 +126,7 @@
         <defaultexcludes add="META-INF/**.inf"/>
         <defaultexcludes add="META-INF/**.SF"/>
 
-        <rejar destfile="${finaljar}" duplicate="preserve" >
+        <rejar destfile="${finaljar}" duplicate="preserve" zip64Mode="always">
             <manifest>
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="com.sun.enterprise.glassfish.bootstrap.UberMain"/>

--- a/appserver/packager/external/libpam4j/pom.xml
+++ b/appserver/packager/external/libpam4j/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
 
@@ -55,7 +55,7 @@
     <description>libpam4j (Java binding for libpam.so) repackaged as a module</description>
 
     <properties>
-      <libpam4j.jna.version>4.5.2</libpam4j.jna.version>
+      <libpam4j.jna.version>${jna.version}</libpam4j.jna.version>
     </properties>
 
     <build>
@@ -123,6 +123,12 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>libpam4j</artifactId>
             <version>1.11</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${libpam4j.jna.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -65,7 +65,7 @@
         <apache.bcel.version>6.6.1</apache.bcel.version>
         <!-- Java EE Security API -->
         <jakarta.security.enterprise-spec.version>1.0</jakarta.security.enterprise-spec.version>
-        <jna.version>5.2.0</jna.version>
+        <jna.version>5.12.1</jna.version>
 
         <!-- Application Server / Implementation -->
         <product.name>Payara Server</product.name>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -103,7 +103,7 @@
 
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
-        <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
+        <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
         <maven.remote.resources.plugin.version>1.6.0</maven.remote.resources.plugin.version>
         <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
         <maven.invoker.plugin.version>3.1.0</maven.invoker.plugin.version>
@@ -364,7 +364,7 @@
                 <plugin>
                     <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
                     <artifactId>maven-antrun-extended-plugin</artifactId>
-                    <version>1.43</version>
+                    <version>1.43.payara-p1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.updatecenter2</groupId>


### PR DESCRIPTION
## Description
Pam4j is missing the required JNA dependency in the packager
Latest JNA so it runs on apple silicon.
Only other possibility is to put JNA in modules/ putting it in lib/ doesn’t work

Needs additional commit 6f1b7b1 which community did not need to prevent `error creating jar archive contains more than 65535 entries`

Payara 6 port of community contribution: https://github.com/payara/Payara/pull/5961
Fixes: https://github.com/payara/Payara/issues/5581

## Testing

### New tests
None

### Testing Performed
Tested server starts as expected, created new instance and deployed application


### Testing Environment
Maven 3.6.3, JDK 11, Windows 10

## Documentation
N/A

## Notes for Reviewers
N/A