### PR TITLE
Embedded Use Zip64 Format

### DIFF
--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] -->
 
 <project name="glassfish-embedded-all" default="create.distribution" basedir=".">
     <property name="rootdir" value="target"/>
@@ -126,7 +126,7 @@
         <defaultexcludes add="META-INF/**.inf"/>
         <defaultexcludes add="META-INF/**.SF"/>
 
-        <rejar destfile="${finaljar}" duplicate="preserve" >
+        <rejar destfile="${finaljar}" duplicate="preserve" zip64Mode="always">
             <manifest>
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="com.sun.enterprise.glassfish.bootstrap.UberMain"/>


### PR DESCRIPTION
## Description
As found in FISH-6578, the jar limit is 65535 entries. Payara 6 and Payara Enterprise both exceeded this limit and so required this property for https://github.com/payara/Payara-Enterprise/pull/719 and https://github.com/payara/Payara/pull/6082 respectively to compile. This same error was not observed in Payara 5 Community, but this PR keeps the distributions aligned.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Unable to test this as the error doesn't yet occur on Community

### Testing Environment
Maven 3.6.3, Windows 10, JDK 8

## Documentation
N/A

## Notes for Reviewers
N/A
