### PR TITLE
FISH-6644 (P6) Remove OpenSSL from Docker Images

### DIFF
--- a/appserver/extras/docker-images/basic/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/basic/src/main/docker/Dockerfile
@@ -21,6 +21,8 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
 
 RUN true \
     && apt-get update \
+    # OpenSSL contains security vulnerabilities and is unused by Payara. To prevent recurring issues simply remove OpenSSL
+    && apt-get remove -y openssl \
     && apt-get install -y gpg \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p ${HOME_DIR} \

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraMicroTest.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2020-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development
@@ -43,6 +43,7 @@ package fish.payara.distributions.docker;
 import fish.payara.distributions.docker.war.TestServlet;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -127,5 +128,11 @@ public class PayaraMicroTest {
             }
         }
         return fail("Expected input stream, but received this: " + object.toString());
+    }
+
+    @Test
+    public void testOpenSslIsRemoved() throws IOException, InterruptedException {
+        String openSslVersionOutput = container.execInContainer("/bin/sh","-c","openssl","version").getStderr();
+        assertTrue(openSslVersionOutput.contains("openssl: not found"));
     }
 }

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerFullTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerFullTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLHandshakeException;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -83,7 +84,6 @@ public class PayaraServerFullTest {
         CONTAINER.followOutput(new Slf4jLogConsumer(LOG));
     }
 
-
     @Test
     public void testStartedServerEndpoints() throws Exception {
         assertTrue(CONTAINER.isRunning(), "server is running");
@@ -107,6 +107,12 @@ public class PayaraServerFullTest {
             assertThat("e.message", e.getMessage(),
                 containsString("unable to find valid certification path to requested target"));
         }
+    }
+
+    @Test
+    public void testOpenSslIsRemoved() throws IOException, InterruptedException {
+        String openSslVersionOutput = CONTAINER.execInContainer("/bin/sh","-c","openssl","version").getStderr();
+        assertTrue(openSslVersionOutput.contains("openssl: not found"));
     }
 
 

--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerWebTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/distributions/docker/PayaraServerWebTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -109,6 +109,11 @@ public class PayaraServerWebTest {
         }
     }
 
+    @Test
+    public void testOpenSslIsRemoved() throws IOException, InterruptedException {
+        String openSslVersionOutput = CONTAINER.execInContainer("/bin/sh","-c","openssl","version").getStderr();
+        assertTrue(openSslVersionOutput.contains("openssl: not found"));
+    }
 
     private String getPageContent(final URL url) throws IOException {
         final URLConnection conn = url.openConnection();


### PR DESCRIPTION
## Description
https://nvd.nist.gov/vuln/detail/CVE-2022-2068 and https://nvd.nist.gov/vuln/detail/CVE-2022-1292 are present in OpenSSL 1.1.1f, the version present in the Payara docker images. As Payara doesn't use OpenSSL, simply removing it will prevent this from happening in the future.

## Important Info
### Blockers
None

## Testing
### New tests
New tests in PayaraServerFullTest, PayaraServerWebTest and PayaraMicroTest to confirm openssl isn't installed in those containers.

### Testing Performed
Started docker image and ran openssl in terminal. Confirmed it's not installed.

### Testing Environment
Zulu JDK 8, Maven 3.6.3, Windows 10

## Documentation
Security Fix PRs Pending

## Notes for Reviewers
None
