### PR TITLE
FISH-5971 Upgrade Catalina to 10.1.1

### DIFF
--- a/appserver/web/web-core/src/main/java/com/sun/enterprise/web/connector/grizzly/CoyoteConnectorLauncher.java
+++ b/appserver/web/web-core/src/main/java/com/sun/enterprise/web/connector/grizzly/CoyoteConnectorLauncher.java
@@ -236,11 +236,6 @@ public class CoyoteConnectorLauncher implements ProtocolHandler
     }
 
     @Override
-    public boolean isAprRequired() {
-        return false;
-    }
-
-    @Override
     public boolean isSendfileSupported() {
         return false;
     }

--- a/appserver/web/web-core/src/main/java/fish/payara/appserver/web/core/CatalinaRequest.java
+++ b/appserver/web/web-core/src/main/java/fish/payara/appserver/web/core/CatalinaRequest.java
@@ -487,11 +487,6 @@ public class CatalinaRequest extends org.apache.catalina.connector.Request {
     }
 
     @Override
-    public String getRealPath(String path) {
-        return super.getRealPath(path);
-    }
-
-    @Override
     public String getRemoteAddr() {
         return grizzlyRequest.getRemoteAddr();
     }
@@ -875,11 +870,6 @@ public class CatalinaRequest extends org.apache.catalina.connector.Request {
     @Override
     public boolean isRequestedSessionIdFromURL() {
         return grizzlyRequest.isRequestedSessionIdFromURL();
-    }
-
-    @Override
-    public boolean isRequestedSessionIdFromUrl() {
-        return super.isRequestedSessionIdFromUrl();
     }
 
     @Override

--- a/appserver/web/web-core/src/main/java/fish/payara/appserver/web/core/CatalinaResponse.java
+++ b/appserver/web/web-core/src/main/java/fish/payara/appserver/web/core/CatalinaResponse.java
@@ -580,12 +580,6 @@ public class CatalinaResponse extends org.apache.catalina.connector.Response {
     }
 
     @Override
-    public void setStatus(int status, String message) {
-        setStatus(status);
-        grizzlyResponse.setDetailMessage(message);
-    }
-
-    @Override
     protected boolean isEncodeable(String location) {
         return super.isEncodeable(location);
     }

--- a/appserver/web/web-core/src/main/java/fish/payara/appserver/web/core/GrizzlyCatalinaBridge.java
+++ b/appserver/web/web-core/src/main/java/fish/payara/appserver/web/core/GrizzlyCatalinaBridge.java
@@ -42,6 +42,7 @@
 
 package fish.payara.appserver.web.core;
 
+import jakarta.servlet.ServletConnection;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -299,7 +300,7 @@ public class GrizzlyCatalinaBridge extends HttpHandler {
     /**
      * Processor is three-way junction between grizzly, coyote and Catalina, which keeps all classes bound together
      * in sync.
-     * Grzilly doesn't do good job at limiting allocations, therefore processor can be recycled to serve other grizzly
+     * Grizzly doesn't do good job at limiting allocations, therefore processor can be recycled to serve other grizzly
      * request/response pair
      */
     final class Processor extends AbstractProcessor {
@@ -418,6 +419,11 @@ public class GrizzlyCatalinaBridge extends HttpHandler {
         @Override
         protected boolean isTrailerFieldsReady() {
             return grizzlyRequest.areTrailersAvailable();
+        }
+
+        @Override
+        protected ServletConnection getServletConnection() {
+            return catalinaRequest.getServletConnection();
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <payara.deployment.transformer.version>1.1.1</payara.deployment.transformer.version>
         <osgi.version>7.0.0</osgi.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>
-        <catalina.version>10.1.2</catalina.version>
+        <catalina.version>10.1.1</catalina.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <payara.deployment.transformer.version>1.1.1</payara.deployment.transformer.version>
         <osgi.version>7.0.0</osgi.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>
-        <catalina.version>10.0.16</catalina.version>
+        <catalina.version>10.1.2</catalina.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Updates Catalina to 10.1.1, fixing new compilation errors in `web-core`, `web-glue` and `websecurity`. Unable to test this further as the branch doesn't compile.

Can't upgrade to Catalina 10.1.2 as this bug is present https://bz-he-de.apache.org/bugzilla/show_bug.cgi?id=66353 causing test failures. 10.1.3 will fix this when it's released