### PR TITLE
FISH-6722 : schema2beans upgraded to version 6.7

### DIFF
--- a/appserver/load-balancer/admin/pom.xml
+++ b/appserver/load-balancer/admin/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2019-2022] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -125,7 +125,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>schema2beans-repackaged</artifactId>
+            <artifactId>schema2beans</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.security</groupId>

--- a/appserver/packager/glassfish-common-web/pom.xml
+++ b/appserver/packager/glassfish-common-web/pom.xml
@@ -178,7 +178,7 @@
         <!-- schema2beans - both CMP and LB admin now depend on it -->
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>schema2beans-repackaged</artifactId>
+            <artifactId>schema2beans</artifactId>
         </dependency>          
         <dependency>
             <groupId>fish.payara.server.internal.extras</groupId>

--- a/appserver/persistence/cmp/ejb-mapping/pom.xml
+++ b/appserver/persistence/cmp/ejb-mapping/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portion Copyright [2018-2019] Payara Foundation and/or affiliates
+    Portion Copyright [2018-2022] Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>schema2beans-repackaged</artifactId>
+            <artifactId>schema2beans</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/persistence/cmp/support-ejb/pom.xml
+++ b/appserver/persistence/cmp/support-ejb/pom.xml
@@ -39,6 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portion Copyright 2022 Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -144,7 +145,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>schema2beans-repackaged</artifactId>
+            <artifactId>schema2beans</artifactId>
         </dependency>
     </dependencies>
     

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -84,8 +84,7 @@
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
         <dbschema.version>3.1.1</dbschema.version>
         <dbschema.osgi.version>6.0</dbschema.osgi.version>
-        <schema2beans.version>3.1.1</schema2beans.version>
-        <schema2beans.osgi.version>5.5</schema2beans.osgi.version>
+        <schema2beans.version>6.7</schema2beans.version>
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
         <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
@@ -571,7 +570,7 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>
-                <artifactId>schema2beans-repackaged</artifactId>
+                <artifactId>schema2beans</artifactId>
                 <version>${schema2beans.version}</version>
             </dependency>
             <dependency>
@@ -594,7 +593,7 @@
             <dependency>
                 <groupId>org.netbeans.external</groupId>
                 <artifactId>ddl</artifactId>
-                <version>RELEASE65</version>
+                <version>RELEASE82</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Upgrade Schema2Beans to 6.7. Note that the package name has changed.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Payara Samples and quicklook tests

### Testing Environment
Zulu JDK 11 on Ubuntu 18.04 with Maven 3.8.4

## Notes for Reviewers
This upgrade was based on this glassfish commit:
https://github.com/javaee/glassfish/commit/cc77df384d17bee7f573f475ac3d4952307a3126
