### PR TITLE
FISH-6721 : dbschema version upgraded to 6.7

### DIFF
--- a/appserver/packager/glassfish-cmp/pom.xml
+++ b/appserver/packager/glassfish-cmp/pom.xml
@@ -39,6 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portion Copyright [2022] Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -169,7 +170,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>dbschema-repackaged</artifactId>
+            <artifactId>dbschema</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>

--- a/appserver/persistence/cmp/generator-database/pom.xml
+++ b/appserver/persistence/cmp/generator-database/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portion Copyright [2018-2019] Payara Foundation and/or affiliates
+    Portion Copyright [2018-2022] Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>dbschema-repackaged</artifactId>
+            <artifactId>dbschema</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/persistence/cmp/model/pom.xml
+++ b/appserver/persistence/cmp/model/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portion Copyright [2018-2019] Payara Foundation and/or affiliates
+    Portion Copyright [2018-2022] Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
-            <artifactId>dbschema-repackaged</artifactId>
+            <artifactId>dbschema</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -82,8 +82,7 @@
         <install.dir.name>payara${major_version}</install.dir.name>
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
-        <dbschema.version>3.1.1</dbschema.version>
-        <dbschema.osgi.version>6.0</dbschema.osgi.version>
+        <dbschema.version>6.7</dbschema.version>
         <schema2beans.version>6.7</schema2beans.version>
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
@@ -565,7 +564,7 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>
-                <artifactId>dbschema-repackaged</artifactId>
+                <artifactId>dbschema</artifactId>
                 <version>${dbschema.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Description
Upgrade DBSchema from 3.1.1 to 6.7. Note that the package name has changed.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Payara Samples and quicklook tests

### Testing Environment
Zulu JDK 11 on Ubuntu 18.04 with Maven 3.8.4

## Notes for Reviewers
This upgrade was based on this glassfish commit:
https://github.com/javaee/glassfish/commit/cc77df384d17bee7f573f475ac3d4952307a3126
