### PR TITLE
FISH-6578 Use Zip64 as-needed

### DIFF
--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -126,7 +126,7 @@
         <defaultexcludes add="META-INF/**.inf"/>
         <defaultexcludes add="META-INF/**.SF"/>
 
-        <rejar destfile="${finaljar}" duplicate="preserve" zip64Mode="always">
+        <rejar destfile="${finaljar}" duplicate="preserve" zip64Mode="as-needed">
             <manifest>
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="com.sun.enterprise.glassfish.bootstrap.UberMain"/>


### PR DESCRIPTION
## Description
Payara Enterprise Embedded All exceeded the 65,535 file limit for a zip/jar so Zip64 was required. This however caused an invalid cen header / class not found exception for all other embedded distributions. This specifically only impacted Payara 5 on JDK 8. It appears to be related to this JDK bug which was fixed in JDK 10 https://bugs.openjdk.org/browse/JDK-8186464 hence only affecting JDK 8.

Use the 'as-needed' option instead so there is no issue with jars containing fewer than 65,535 files but will use Zip64 for distributions with more files, allowing both to compile and run as expected.

## Important Info

## Testing

### Testing Performed
Tested Embedded Web & Embedded All manual test.

### Testing Environment
Ubuntu 20 (WSL), Zulu JDK 11, Maven 3.6.3

## Documentation
N/A
