### PR TITLE
FISH-1413 (P6) Perform variable substitution for create-connector-connection-pool

### DIFF
--- a/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/ConnectorConnectionPoolManager.java
+++ b/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/ConnectorConnectionPoolManager.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright (c) 2022 Payara Foundation and/or affiliates
 
 package org.glassfish.connectors.admin.cli;
 
@@ -47,6 +48,7 @@ import com.sun.enterprise.config.serverbeans.*;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import org.glassfish.api.I18n;
 import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.config.support.TranslatedConfigView;
 import org.glassfish.connectors.config.ConnectorConnectionPool;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.resources.admin.cli.ResourceManager;
@@ -273,6 +275,9 @@ public class ConnectorConnectionPoolManager implements ResourceManager {
     }
 
     public void setParams(HashMap attrList) {
+        //Perform variable replacement for all properties before they are set
+        attrList.forEach((key, value) -> attrList.put(key, TranslatedConfigView.expandConfigValue((String) value)));
+
         raname = (String) attrList.get(RES_ADAPTER_NAME);
         connectiondefinition = (String) attrList.get(CONN_DEF_NAME);
         steadypoolsize = (String) attrList.get(STEADY_POOL_SIZE);


### PR DESCRIPTION
## Description
When the `create-connector-connection-pool` command is executed currently it fails when environment variables are used as there is no substitution in place. With this change before the properties are set a full variable replacement check is performed.

## Important Info

## Testing
### Testing Performed
Started the server, set the NUM environment variable to 20, ran the relevant command below:

**Windows (cmd)**
 `asadmin create-connector-connection-pool --connectiondefinition=jakarta.jms.ConnectionFactory --transactionSupport=NoTransaction --resourceAdapterName=jmsra --maxpoolsize=${ENV=NUM}`

**Windows (Windows Terminal / Poweshell)**
_Remove the spaces in ${ENV=NUM} - These were necessary to keep the backticks_ 
``asadmin create-connector-connection-pool --connectiondefinition=jakarta.jms.ConnectionFactory --transactionSupport=NoTransaction --resourceAdapterName=jmsra --maxpoolsize=`$` {ENV=NUM` }``

**Linux**
`asadmin create-connector-connection-pool --connectiondefinition=jakarta.jms.ConnectionFactory --transactionSupport=NoTransaction --resourceAdapterName=jmsra --maxpoolsize=\${ENV=NUM}`

### Testing Environment
Windows 10, Ubuntu 20.04 (WSL), Maven 3.6.3, Zulu JDK 11

## Documentation
Coming soon...

## Notes for Reviewers
Using proper escaping is important depending on the terminal / OS you are using.
**Windows CMD**: No escaping required
**Windows Powershell / Windows Terminal**: Escape $ and { } characters with a backtick
**Linux**: Escape $ with a backslash
