### PR TITLE
FISH-6596 Upgrade Mojarra to Patched Source 4.0.0-p2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <jstl-api.version>3.0.0</jstl-api.version>
         <jstl-impl.version>3.0.0</jstl-impl.version>
         <jakarta.faces-api.version>4.0.1</jakarta.faces-api.version>
-        <mojarra.version>4.0.0.payara-p1</mojarra.version>
+        <mojarra.version>4.0.0.payara-p2</mojarra.version>
         <tyrus.version>2.1.0.payara-p1</tyrus.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <json.bind-api.version>3.0.0</json.bind-api.version>


### PR DESCRIPTION
## Description
This change of Mojarra uses regex for jakarta/javax copy of POST headers.
Using startsWith failed in Faces TCK, when some option was in fact an event.

## Important Info
## Testing
### Testing Performed
Faces TCK

### Testing Environment
OpenJDK, Linux
