### PR TITLE
Set Jakarta Version to 10.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright 2017-2022 Payara Foundation and/or affiliates
+    Portions Copyright 2017-2023 Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -219,8 +219,7 @@
         <parsson.version>1.1.1.payara-p1</parsson.version>
         <jsonp-api.version>2.1.0</jsonp-api.version>
         <jbi.version>1.0</jbi.version>
-        <!--<jakarta-platform.version>10.0.0-SNAPSHOT</jakarta-platform.version>-->
-        <jakarta-platform.version>9.1.0</jakarta-platform.version>
+        <jakarta-platform.version>10.0.0</jakarta-platform.version>
         <microprofile-release.version>5.0</microprofile-release.version>
         <microprofile-opentracing.version>3.0</microprofile-opentracing.version>
         <microprofile-config.version>3.0</microprofile-config.version>


### PR DESCRIPTION
## Description
Sets the Jakarta version to 10.0.0 for the platform and web APIs in the BOM/API.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the server, maven didn't complain.

### Testing Environment
Windows 11, Zulu JDK 11.

## Documentation
N/A

## Notes for Reviewers
None
