### PR TITLE
FISH-7025 accessors-smart 2.4.8

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -86,7 +86,7 @@
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
 
         <nimbus-jose-jwt.version>9.25</nimbus-jose-jwt.version>
-        <accessors-smart.version>2.4.2.payara-p1</accessors-smart.version>
+        <accessors-smart.version>2.4.8</accessors-smart.version>
         <json-smart.version>2.4.8</json-smart.version>
         <reactor-core.version>3.4.4</reactor-core.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>


### PR DESCRIPTION
## Description
Title.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built server, started DAS.

### Testing Environment
Windows 11, Zulu JDK 11.0.17 and 17.0.5

## Documentation
N/A

## Notes for Reviewers
Whomever previously patched accessors-smart forgot to make a maintenance branch and tag, so I have no way of knowing what was actually changed - my best guess is increasing the version of ASM used (which should no longer be required, 2.4.8 uses 9.1)
