### PR TITLE
FISH-6151 Resolve ContextResourceDecorator Compilation Errors

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/deploy/ContextResourceDecorator.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/deploy/ContextResourceDecorator.java
@@ -37,12 +37,13 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2023] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.web.deploy;
 
 
 import com.sun.enterprise.deployment.ResourceReferenceDescriptor;
-import org.apache.catalina.deploy.ContextResource;
+import org.apache.tomcat.util.descriptor.web.ContextResource;
 
 
 /**


### PR DESCRIPTION
Resolves compilation error in ContextResourceDecorator where ContextResource appears to have been moved to https://github.com/apache/tomcat/blob/main/java/org/apache/tomcat/util/descriptor/web/ContextResource.java. The very core of this appears to be identical with a few new fields with the respective getter and setter methods