### PR TITLE
FISH-6966: Package Opentelemetry into distribution

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -476,11 +476,126 @@
                 <artifactId>jakarta.jws-api</artifactId>
                 <version>${jakarta.jws-api.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- packaged components -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-common</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-metrics</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-logs</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api-logs</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-opentracing-shim</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-context</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-otlp</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-trace</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-otlp-common</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-common</artifactId>
+                <version>${opentelemetry.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
                 <version>${opentracing.version}</version>
+                <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-noop</artifactId>
+                <version>${opentracing.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-util</artifactId>
@@ -758,9 +873,9 @@
                 <version>${istack-commons-runtime.version}</version>
             </dependency>
             <dependency>
-		<groupId>org.eclipse.angus</groupId>
+                <groupId>org.eclipse.angus</groupId>
                 <artifactId>angus-activation</artifactId>
-		<version>${angus.activation.version}</version>
+                <version>${angus.activation.version}</version>
             </dependency>
 
             <!-- Other libraries -->

--- a/api/payara-core-bom/pom.xml
+++ b/api/payara-core-bom/pom.xml
@@ -58,6 +58,7 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- TODO: add, and version-manage any external components packaged by core modules -->
             <dependency>
                 <groupId>fish.payara.server.core.admin</groupId>
                 <artifactId>admin-cli</artifactId>
@@ -289,6 +290,12 @@
             <dependency>
                 <groupId>fish.payara.server.core.packager</groupId>
                 <artifactId>opentracing-repackaged</artifactId>
+                <version>${payara.core.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>fish.payara.server.core.packager</groupId>
+                <artifactId>opentelemetry-repackaged</artifactId>
                 <version>${payara.core.version}</version>
             </dependency>
 

--- a/appserver/ejb/ejb-full-container/pom.xml
+++ b/appserver/ejb/ejb-full-container/pom.xml
@@ -72,6 +72,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
         </dependency>

--- a/appserver/monitoring-console/core/pom.xml
+++ b/appserver/monitoring-console/core/pom.xml
@@ -89,5 +89,9 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
+++ b/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
@@ -122,6 +122,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>provided</scope>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/pom.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/pom.xml
@@ -83,5 +83,10 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
@@ -117,5 +117,10 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/multiple-keystores/pom.xml
+++ b/appserver/tests/payara-samples/samples/multiple-keystores/pom.xml
@@ -50,5 +50,11 @@
 
     <artifactId>multiple-keystore</artifactId>
     <name>Payara Samples - Payara - Multiple Keystores</name>
-
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/opentelemetry/pom.xml
+++ b/appserver/tests/payara-samples/samples/opentelemetry/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>6.2023.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opentelemetry</artifactId>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/InitializeOtel.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/InitializeOtel.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.otel.manual;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+@WebListener
+@Dependent
+public class InitializeOtel implements ServletContextListener {
+
+    @Inject
+    ManualTracing tracing;
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        tracing.initOtel();
+
+        Span span = tracing.getTracer().spanBuilder("otel init").startSpan();
+        try(Scope scope = span.makeCurrent()) {
+            span.addEvent("ApplicationStarted");
+        } finally {
+            span.end();
+        }
+    }
+
+
+}

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManualTracing.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManualTracing.java
@@ -1,0 +1,144 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.otel.manual;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class ManualTracing {
+    private OpenTelemetrySdk openTelemetry;
+
+    private Tracer tracer;
+
+    @Inject
+    @ConfigProperty(name = "autoconfig", defaultValue = "false")
+    boolean autoConfig;
+
+    void initOtelManually() {
+        Resource resource = Resource.getDefault()
+                .merge(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "manual-otel-app")));
+
+        SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder().build()).build())
+                .setResource(resource)
+                .build();
+
+        SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder()
+                .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build())
+                .setResource(resource)
+                .build();
+
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(sdkTracerProvider)
+                //.setMeterProvider(sdkMeterProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        tracer = openTelemetry.getTracer("fish.payara.opentelemetry");
+    }
+
+    void initOtel() {
+        if (autoConfig) {
+            initOtelAutoConfig();
+        } else {
+            initOtelManually();
+        }
+    }
+
+    @Inject
+    Config config;
+
+    void initOtelAutoConfig() {
+        Map<String,String> mpconfigProperties = new HashMap<>();
+
+        config.getPropertyNames().forEach(
+                name -> {
+                    if (name.startsWith("otel.")) {
+                        mpconfigProperties.put(name, config.getValue(name, String.class));
+                    }
+                }
+        );
+        AutoConfiguredOpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropertiesSupplier(() -> mpconfigProperties)
+                .setServiceClassLoader(Thread.currentThread().getContextClassLoader())
+                .build();
+        tracer = sdk.getOpenTelemetrySdk().getTracer("fish.payara.opentelemetry");
+    }
+
+    public Tracer getTracer() {
+        return tracer;
+    }
+
+    @Produces
+    @RequestScoped
+    Span makeSpan() {
+        return tracer.spanBuilder("request").startSpan();
+    }
+
+    void endSpan(@Disposes Span span) {
+        span.end();
+    }
+}

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManuallyTracingServlet.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManuallyTracingServlet.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.otel.manual;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet("/manual/*")
+@Dependent
+public class ManuallyTracingServlet extends HttpServlet {
+    @Inject
+    Span span;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try(Scope scope = span.makeCurrent()) {
+            span.setAttribute(SemanticAttributes.HTTP_METHOD, "GET");
+            span.setAttribute(SemanticAttributes.HTTP_URL, req.getRequestURI());
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(ThreadLocalRandom.current().nextInt(1000)));
+        }
+    }
+}

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/resources/META-INF/microprofile-config.properties
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,47 @@
+#
+#
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#  The contents of this file are subject to the terms of either the GNU
+#  General Public License Version 2 only ("GPL") or the Common Development
+#  and Distribution License("CDDL") (collectively, the "License").  You
+#  may not use this file except in compliance with the License.  You can
+#  obtain a copy of the License at
+#  https://github.com/payara/Payara/blob/master/LICENSE.txt
+#  See the License for the specific
+#  language governing permissions and limitations under the License.
+#
+#  When distributing the software, include this License Header Notice in each
+#  file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#  GPL Classpath Exception:
+#  The Payara Foundation designates this particular file as subject to the "Classpath"
+#  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#  file that accompanied this code.
+#
+#  Modifications:
+#  If applicable, add the following below the License Header, with the fields
+#  enclosed by brackets [] replaced by your own identifying information:
+#  "Portions Copyright [year] [name of copyright owner]"
+#
+#  Contributor(s):
+#  If you wish your version of this file to be governed by only the CDDL or
+#  only the GPL Version 2, indicate your decision by adding "[Contributor]
+#  elects to include this software in this distribution under the [CDDL or GPL
+#  Version 2] license."  If you don't indicate a single choice of license, a
+#  recipient has the option to distribute your version of this file under
+#  either the CDDL, the GPL Version 2 or to extend the choice of license to
+#  its licensees as provided above.  However, if you add GPL Version 2 code
+#  and therefore, elected the GPL Version 2 license, then the option applies
+#  only if the new code is made subject to such option by the copyright
+#  holder.
+#
+
+autoconfig=true
+#Place exporter jar into domaindir/lib to enable
+#otel.traces.exporter=logging
+#Not supported in Jaeger, only GRPC
+#otel.exporter.otlp.traces.protocol=http/protobuf
+otel.service.name=manual-otel-app-autoconfig

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -88,16 +88,8 @@
         <!--module>microprofile-rest-client</module-->
         <module>concurrency</module>
         <module>reproducers</module>
+        <module>opentelemetry</module>
     </modules>
-
-    <dependencies>
-        <dependency>
-            <groupId>fish.payara.samples</groupId>
-            <artifactId>ejb-invoker-secure-endpoint</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
-    </dependencies>
 
     <dependencyManagement>
         <dependencies>

--- a/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
@@ -126,6 +126,11 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- This is required for remote EJB clients on JDK17+ to prevent IllegalReflectiveAccess caused by org.glassfish.pfl.basic.reflection.Bridge -->

--- a/appserver/tests/payara-samples/samples/reproducers/pom.xml
+++ b/appserver/tests/payara-samples/samples/reproducers/pom.xml
@@ -77,7 +77,11 @@
             <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
@@ -108,5 +108,10 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.server.internal.packager</groupId>
+        <artifactId>nucleus-external</artifactId>
+        <version>6.2023.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>fish.payara.server.core.packager</groupId>
+    <artifactId>opentelemetry-repackaged</artifactId>
+    <name>Repackaged OpenTelemetry</name>
+    <description>OpenTelemetry API and SDK repackaged as OSGi bundle</description>
+
+    <properties>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <!-- we will rely on transitive dependencies of our leaf ones -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-opentracing-shim</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <!-- okhttp3 version 4 is kotlin-based, bring in kotlin stdlib -->
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Not a perfect solution to the problem, but we need to wait for OTEL project
+             to decouple their exporter from OkHttp so that we can replace HTTP transport -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.9</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <!-- next we need to relocate okhttp, and add OSGi manifest -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            io.opentelemetry.*;version=${opentelemetry.version}
+                        </Export-Package>
+                        <!-- Import API classes, not bundled okhttp -->
+                        <Import-Package>
+                            !okhttp.*, !fish.payara.shaded.*, !android.*,
+                            !com.google.common.*,
+                            io.grpc.*;resolution:=optional,
+                            io.netty.*;resolution:=optional,
+                            !*.shaded.*,
+                            !org.checkerframework.checker.nullness.qual,
+                            !org.conscrypt,sun.misc;version=!,
+                            !javax.annotation.*,
+                            *
+                        </Import-Package>
+                        <!-- Embed the dependencies and then shade them in next step -->
+                        <Embed-Dependency>
+                            *;groupId=com.squareup.*;inline=true,
+                            *;groupId=io.opentelemetry;inline=true,
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <createSourcesJar>true</createSourcesJar>
+                    <artifactSet>
+                        <includes>
+                            <include>com.squareup.*:*</include>
+                        </includes>
+                    </artifactSet>
+                    <filters>
+                        <!-- bundle plugin already inlined the classes, so we can skip the contents -->
+                        <filter>
+                            <artifact>com.squareup.*:*</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <relocations>
+                        <relocation>
+                            <pattern>okhttp3.</pattern>
+                            <shadedPattern>fish.payara.shaded.okhttp3.</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>okio.</pattern>
+                            <shadedPattern>fish.payara.shaded.okio.</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/nucleus/packager/external/pom.xml
+++ b/nucleus/packager/external/pom.xml
@@ -72,8 +72,9 @@
         <module>vboxjws</module>
         <module>trilead-ssh2</module>
         <module>j-interop</module>
-	<module>antlr</module>
+	    <module>antlr</module>
         <module>opentracing-repackaged</module>
+        <module>opentelemetry-repackaged</module>
         <module>tiger-types</module>
     </modules>
     <build>

--- a/nucleus/packager/requesttracing-package/pom.xml
+++ b/nucleus/packager/requesttracing-package/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>opentracing-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.server.core.packager</groupId>
+            <artifactId>opentelemetry-repackaged</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -65,8 +65,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>fish.payara.server.core.packager</groupId>
+            <artifactId>opentelemetry-repackaged</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>
@@ -82,5 +88,6 @@
             <artifactId>opentracing-util</artifactId>
             <scope>provided</scope>
         </dependency>
+
     </dependencies>
 </project>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -65,6 +65,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
         </dependency>

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTelemetryService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTelemetryService.java
@@ -1,0 +1,307 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.opentracing;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import fish.payara.notification.requesttracing.EventType;
+import fish.payara.notification.requesttracing.RequestTraceSpan;
+import fish.payara.nucleus.executorservice.PayaraExecutorService;
+import fish.payara.nucleus.requesttracing.RequestTracingService;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import org.glassfish.api.event.EventListener;
+import org.glassfish.api.event.Events;
+import org.glassfish.internal.data.ApplicationInfo;
+import org.glassfish.internal.deployment.Deployment;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ * Service class for the OpenTracing integration.
+ *
+ * @author Andrew Pielage <andrew.pielage@payara.fish>
+ */
+@Service(name = "opentelemetry-service")
+public class OpenTelemetryService implements EventListener {
+
+    public static final String INSTRUMENTATION_SCOPE_NAME = "payara";
+
+    // The tracer instances
+    private static final Map<String, OpenTelemetryAppInfo> appTelemetries = new ConcurrentHashMap<>();
+
+    private static final Logger logger = Logger.getLogger(OpenTelemetryService.class.getName());
+
+    private static long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+
+    @Inject
+    Events events;
+
+    @Inject
+    PayaraExecutorService executorService;
+
+    @Inject
+    private RequestTracingService requestTracingService;
+
+    @PostConstruct
+    void postConstruct() {
+        if (events != null) {
+            events.register(this);
+        } else {
+            logger.log(Level.WARNING, "OpenTracing service not registered to Payara Events: "
+                    + "The Tracer for an application won't be removed upon undeployment");
+        }
+    }
+
+    @Override
+    public void event(Event<?> event) {
+        // Listen for application unloaded events (happens during undeployment), so that we remove the tracer instance
+        // registered to that application (if there is one)
+        if (event.is(Deployment.APPLICATION_UNLOADED)) {
+            ApplicationInfo info = (ApplicationInfo) event.hook();
+            OpenTelemetryAppInfo otel = appTelemetries.remove(info.getName());
+            if (otel != null) {
+                otel.shutdown();
+            }
+        }
+    }
+
+    /**
+     * Return existing tracer for a given application.
+     * <p>Because Telemetry SDKs are configurable per app, the tracer need to be explicitly created for an application</p>
+     *
+     * @param applicationName
+     * @return
+     */
+    public Optional<Tracer> getTracer(String applicationName) {
+        return get(applicationName, OpenTelemetryAppInfo::tracer);
+    }
+
+    private <T> Optional<T> get(String applicationName, Function<OpenTelemetryAppInfo, T> getter) {
+        if (applicationName == null) {
+            return Optional.empty();
+        }
+        OpenTelemetryAppInfo appInfo = appTelemetries.get(applicationName);
+        if (appInfo == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(getter.apply(appInfo));
+    }
+
+    /**
+     * Return Meter builder for given application
+     *
+     * @param applicationName
+     * @return
+     */
+    public Optional<Meter> getMeter(String applicationName) {
+        return get(applicationName, OpenTelemetryAppInfo::meter);
+    }
+
+    /**
+     * Return logger for given application.
+     *
+     * @param applicationName
+     * @return
+     */
+    public Optional<io.opentelemetry.api.logs.Logger> getLogger(String applicationName) {
+        return get(applicationName, OpenTelemetryAppInfo::logger);
+    }
+
+    public OpenTelemetrySdk initializeApplication(String applicationName, Map<String, String> configProperties) {
+        Supplier<Map<String, String>> supplier = configProperties == null ? () -> Map.of() : () -> configProperties;
+
+        AutoConfiguredOpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder()
+                .setServiceClassLoader(Thread.currentThread().getContextClassLoader())
+
+                .addSpanExporterCustomizer((exporter, c) -> {
+                    if (isPayaraTracingEnabled()) {
+                        return SpanExporter.composite(exporter, new PayaraRequestTracingForwarder());
+                    } else {
+                        return exporter;
+                    }
+                })
+                .addPropertiesSupplier(supplier)
+                .addResourceCustomizer((resource, config) -> {
+                    if (resource.getAttributes().get(ResourceAttributes.SERVICE_NAME) == null) {
+                        // there are few more attributes to add later to identify domain, payara version, etc.
+                        return resource.toBuilder().put(ResourceAttributes.SERVICE_NAME, applicationName).build();
+                    } else {
+                        return resource;
+                    }
+                })
+                .build();
+        OpenTelemetryAppInfo previous = appTelemetries.put(applicationName, new OpenTelemetryAppInfo(sdk.getOpenTelemetrySdk()));
+        if (previous != null) {
+            previous.shutdown();
+        }
+        ;
+        return sdk.getOpenTelemetrySdk();
+    }
+
+    /**
+     * Pass-through method that checks if Request Tracing is enabled.
+     *
+     * @return True if the Request Tracing Service is enabled
+     */
+    public boolean isPayaraTracingEnabled() {
+        return requestTracingService.isRequestTracingEnabled();
+    }
+
+    static class OpenTelemetryAppInfo {
+
+        private final OpenTelemetrySdk sdk;
+
+        private Tracer tracer;
+
+        private Meter meter;
+
+        private io.opentelemetry.api.logs.Logger logger;
+
+        OpenTelemetryAppInfo(OpenTelemetrySdk sdk) {
+            this.sdk = sdk;
+        }
+
+        Tracer tracer() {
+            if (this.tracer == null) {
+                this.tracer = sdk.getTracerProvider().get(INSTRUMENTATION_SCOPE_NAME);
+            }
+            return this.tracer;
+        }
+
+        Meter meter() {
+            if (this.meter == null) {
+                this.meter = sdk.getMeterProvider().get(INSTRUMENTATION_SCOPE_NAME);
+            }
+            return this.meter;
+        }
+
+        io.opentelemetry.api.logs.Logger logger() {
+            if (this.logger == null) {
+                this.logger = sdk.getSdkLoggerProvider().get(INSTRUMENTATION_SCOPE_NAME);
+            }
+            return this.logger;
+        }
+
+        void shutdown() {
+            // we need to shut it down properly. SDK providers offer both async shutdown meter as well as implement
+            // Closeable, where shutdown is invoked in sync fashion. Let's be optimistic and start with async shutdown
+            SdkTracerProvider tracerProvider = this.sdk.getSdkTracerProvider();
+            if (tracerProvider != null) {
+                tracerProvider.shutdown();
+            }
+            SdkMeterProvider meterProvider = this.sdk.getSdkMeterProvider();
+            if (meterProvider != null) {
+                meterProvider.shutdown();
+            }
+            SdkLoggerProvider logProvider = this.sdk.getSdkLoggerProvider();
+            if (logProvider != null) {
+                logProvider.shutdown();
+            }
+        }
+    }
+
+    class PayaraRequestTracingForwarder implements SpanExporter {
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> collection) {
+            CompletableResultCode result = new CompletableResultCode();
+            executorService.submit(() -> {
+                try {
+                    collection.forEach(this::convert);
+                    result.succeed();
+                } catch (RuntimeException e) {
+                    logger.log(Level.WARNING, "Failed to export OpenTelemetry span to Payara Request Tracing", e);
+                    result.fail();
+                }
+            });
+            return result;
+        }
+
+
+        RequestTraceSpan convert(SpanData data) {
+            RequestTraceSpan result = new RequestTraceSpan(EventType.PROPAGATED_TRACE, data.getName());
+            result.getSpanContext().setTraceId(parseTraceId(data));
+            // we cannot set spanId
+            result.setStartInstant(Instant.ofEpochSecond(data.getStartEpochNanos() / NANOS_PER_SECOND, data.getStartEpochNanos() % NANOS_PER_SECOND));
+            result.setSpanDuration(data.getEndEpochNanos() - data.getStartEpochNanos());
+            data.getAttributes().forEach((key, value) -> result.addSpanTag(key.getKey(), value.toString()));
+            // exporter has no access to baggage, that goes to propagators only.
+            return result;
+        }
+
+        private UUID parseTraceId(SpanData data) {
+            long high = Long.parseLong(data.getTraceId().substring(0, 16), 16);
+            long low = Long.parseLong(data.getTraceId().substring(16), 16);
+            return new UUID(high, low);
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,8 @@
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <payara.security-connectors.version>3.0.alpha6</payara.security-connectors.version>
         <opentracing.version>0.33.0</opentracing.version>
+        <opentelemetry.version>1.22.0</opentelemetry.version>
+        <opentelemetry.alpha.version>1.22.0-alpha</opentelemetry.alpha.version>
         <h2db.version>2.1.212</h2db.version>
         <websocket-api.version>2.1.0</websocket-api.version>
         <concurrent-api.version>3.0.1</concurrent-api.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This brings OpenTelemetry APIs and default implementations into server as basis for implementing MP Telemetry and redoing opentracing support via shim.

Applications can now manually bootstrap OTEL SDK and use the tracer. OTLP export via GRPC and HTTP works. It is possible to add additional components into `domaindir/lib` and have autoconfiguration bootstrap them properly.

## Testing
### New tests
New samples module will be basis for adding arquillian tests. So far the test has been only manual using this exact application.

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
* Deploy the sample application, observe OTLP traces appearing in Jaeger (via its native OTLP collection endpoint)
* Configure tracing via API
* Configure tracing via autoconfiguration, providing properties from MP config (one of MP Tracing requriements)
* Add jar for logging exporter into domaindir/lib, configure it via microprofile config.
