### PR TITLE
FISH-6768 display additionalProperties if specified

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OASFactoryResolverImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OASFactoryResolverImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -158,7 +158,7 @@ public class OASFactoryResolverImpl extends OASFactoryResolver {
 
         // Return a new instance. Shouldn't throw an exception.
         try {
-            return (T) implClass.newInstance();
+            return (T) implClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new OpenAPIClassCreationException(e);
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -55,6 +55,7 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeI
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
 import fish.payara.microprofile.openapi.impl.rest.app.provider.ObjectMapperFactory;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
@@ -268,8 +269,8 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
                 if (schemaClassModel.isInstanceOf(Schema.class.getName())) {
                     try {
                         Class<?> oneOfClass = context.getApplicationClassLoader().loadClass(schemaClassName);
-                        return (Schema) oneOfClass.newInstance();
-                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+                        return (Schema) oneOfClass.getDeclaredConstructor().newInstance();
+                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
                         LOGGER.log(WARNING, "Unable to create Schema class instance.", ex);
                     }
                 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2021-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -183,6 +183,12 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
         from.setMaxProperties(annotation.getValue("maxProperties", Integer.class));
         from.setMinProperties(annotation.getValue("minProperties", Integer.class));
         from.setRequired(annotation.getValue("requiredProperties", List.class));
+        String additionalPropertiesAttr = annotation.getValue("additionalProperties", String.class);
+        if (Void.class.getName().equals(additionalPropertiesAttr)) {
+            // Void is used as default, e.g. not specified value
+            additionalPropertiesAttr = null;
+        }
+        from.setAdditionalPropertiesBoolean(additionalPropertiesAttr == null ? null : org.eclipse.microprofile.openapi.annotations.media.Schema.True.class.getName().equals(additionalPropertiesAttr));
 
         extractAnnotations(annotation, context, "properties", "name", SchemaImpl::createInstance, from::addProperty);
         for (Entry<String, Schema> property : from.getProperties().entrySet()) {
@@ -892,6 +898,12 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
         }
         if (from.getNot() != null) {
             to.setNot(from.getNot());
+        }
+        if (from.getAdditionalPropertiesBoolean() != null) {
+            to.setAdditionalPropertiesBoolean(mergeProperty(to.getAdditionalPropertiesBoolean(), from.getAdditionalPropertiesBoolean(), override));
+        }
+        if (from.getAdditionalPropertiesSchema() != null) {
+            to.setAdditionalPropertiesSchema(mergeProperty(to.getAdditionalPropertiesSchema(), from.getAdditionalPropertiesSchema(), override));
         }
         mergeImmutableList(from.getAnyOf(), to.getAnyOf(), to::setAnyOf);
         mergeImmutableList(from.getAllOf(), to.getAllOf(), to::setAllOf);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -627,7 +627,8 @@ public final class ModelUtils {
         // For every field except the reference
         for (Field field : referee.getClass().getDeclaredFields()) {
             // Make the field accessible
-            boolean accessible = field.isAccessible();
+            Object objectToTestAccessibility = Modifier.isStatic(field.getModifiers()) ? null : referee;
+            boolean accessible = field.canAccess(objectToTestAccessibility);
             field.setAccessible(true);
             try {
                 Object currentValue = field.get(referee);
@@ -706,14 +707,14 @@ public final class ModelUtils {
                         }
                     } else if (fromValue instanceof Constructible) {
                         if (toValue == null) {
-                            f.set(to, fromValue.getClass().newInstance());
+                            f.set(to, fromValue.getClass().getDeclaredConstructor().newInstance());
                             toValue = f.get(to);
                         }
                         merge(fromValue, toValue, override);
                     } else {
                         f.set(to, mergeProperty(f.get(to), f.get(from), override));
                     }
-                } catch (IllegalArgumentException | IllegalAccessException | InstantiationException e) {
+                } catch (IllegalArgumentException | IllegalAccessException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException e) {
                     // Ignore errors
                 }
             }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -76,7 +76,7 @@ public class BaseProcessor implements OASProcessor {
 
         // Set the OpenAPI version if it hasn't been set
         if (api.getOpenapi() == null) {
-            api.setOpenapi("3.0.0");
+            api.setOpenapi("3.1.0");
         }
 
         // Set the info if it hasn't been set

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/BaseProcessor.java
@@ -76,7 +76,9 @@ public class BaseProcessor implements OASProcessor {
 
         // Set the OpenAPI version if it hasn't been set
         if (api.getOpenapi() == null) {
-            api.setOpenapi("3.1.0");
+            // FIXME: change to 3.1.0 when MP TCK is upgraded
+            // api.setOpenapi("3.1.0");
+            api.setOpenapi("3.0.0");
         }
 
         // Set the info if it hasn't been set

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -43,6 +43,7 @@ import fish.payara.microprofile.openapi.api.processor.OASProcessor;
 import fish.payara.microprofile.openapi.impl.config.OpenApiConfiguration;
 import fish.payara.microprofile.openapi.impl.model.OpenAPIImpl;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -89,9 +90,9 @@ public class FilterProcessor implements OASProcessor {
     public OpenAPI process(OpenAPI api, OpenApiConfiguration config) {
         try {
             if (filter == null && config.getFilter() != null) {
-                filter = config.getFilter().newInstance();
+                filter = config.getFilter().getDeclaredConstructor().newInstance();
             }
-        } catch (InstantiationException | IllegalAccessException ex) {
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
             LOGGER.log(WARNING, "Error creating OASFilter instance.", ex);
         }
         if (filter != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ModelReaderProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ModelReaderProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -41,6 +41,7 @@ package fish.payara.microprofile.openapi.impl.processor;
 
 import fish.payara.microprofile.openapi.api.processor.OASProcessor;
 import fish.payara.microprofile.openapi.impl.config.OpenApiConfiguration;
+import java.lang.reflect.InvocationTargetException;
 import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.openapi.OASModelReader;
@@ -63,9 +64,9 @@ public class ModelReaderProcessor implements OASProcessor {
     public OpenAPI process(OpenAPI api, OpenApiConfiguration config) {
         try {
             if (config.getModelReader() != null) {
-                reader = config.getModelReader().newInstance();
+                reader = config.getModelReader().getDeclaredConstructor().newInstance();
             }
-        } catch (InstantiationException | IllegalAccessException ex) {
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
             LOGGER.log(WARNING, "Error creating OASModelReader instance.", ex);
         }
         if (reader != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -63,6 +63,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Application;
+import java.lang.reflect.InvocationTargetException;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
@@ -186,7 +187,7 @@ public class OpenApiContext implements ApiContext {
                     mapping.put(key, resourceClasses);
                     try {
                         Class<?> clazz = appClassLoader.loadClass(classModel.getName());
-                        Application app = (Application) clazz.newInstance();
+                        Application app = (Application) clazz.getDeclaredConstructor().newInstance();
                         // Add all classes contained in the application
                         resourceClasses.addAll(app.getClasses()
                                 .stream()
@@ -195,7 +196,7 @@ public class OpenApiContext implements ApiContext {
                                 .map(allTypes::getBy)
                                 .filter(Objects::nonNull)
                                 .collect(toSet()));
-                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException ex) {
                         LOGGER.log(WARNING, "Unable to initialise application class.", ex);
                     }
                 } else {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/model/OpenApiBuilderTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/model/OpenApiBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -65,7 +65,7 @@ public abstract class OpenApiBuilderTest {
         info.setTitle("title");
         info.setVersion("version");
         document.setInfo(info);
-        document.setOpenapi("3.0.0");
+        document.setOpenapi("3.1.0");
         setupBaseDocument(document);
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/resource/rule/ApplicationProcessedDocument.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/resource/rule/ApplicationProcessedDocument.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -46,6 +46,7 @@ import fish.payara.microprofile.openapi.impl.processor.FilterProcessor;
 import fish.payara.microprofile.openapi.resource.classloader.ApplicationClassLoader;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import static java.util.Arrays.asList;
 import java.util.Collections;
@@ -80,10 +81,10 @@ public class ApplicationProcessedDocument {
             // Apply application processor
             new ApplicationProcessor(getTypes(), getApplicationTypes(extraClasses), appClassLoader).process(document, null);
             if (filter != null) {
-                new FilterProcessor(filter.newInstance()).process(document, null);
+                new FilterProcessor(filter.getDeclaredConstructor().newInstance()).process(document, null);
             }
             return document;
-        } catch (IOException | IllegalAccessException | InstantiationException | InterruptedException ex) {
+        } catch (IOException | IllegalAccessException | InstantiationException | InterruptedException | NoSuchMethodException | IllegalArgumentException | InvocationTargetException ex) {
             throw new AssertionError("Failed to build document.", ex);
         }
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/spec/NodeType.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/spec/NodeType.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 
 /**
  * Node types and their structure as described by Open API Specification
- * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md}.
+ * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md}.
  */
 public enum NodeType implements Iterable<Field> {
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/SchemaExampleTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/SchemaExampleTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -50,7 +50,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -70,6 +73,16 @@ public class SchemaExampleTest extends OpenApiApplicationTest {
     public static class User {
         @Schema(example = "bobSm37")
         String password;
+    }
+
+    @Schema(additionalProperties = Schema.True.class, maxProperties = 2)
+    public static class WithAdditionalProperties {
+        String data;
+    }
+
+    @Schema(additionalProperties = Schema.False.class)
+    public static class WithoutAdditionalProperties {
+        String data;
     }
 
     /**
@@ -96,5 +109,26 @@ public class SchemaExampleTest extends OpenApiApplicationTest {
         assertEquals(false,
                 JsonUtils.hasPath(root, "components.schemas.SchemaExample.properties.notFriendlyName".split("\\.")));
         assertNotNull(JsonUtils.path(root,"components.schemas.SchemaExample.properties.friendly_name"));
+    }
+
+    @Test
+    public void schemaWithAdditionalProperties() {
+        ObjectNode root = getOpenAPIJson();
+        assertNotNull(JsonUtils.path(root, "components.schemas.WithAdditionalProperties"));
+        assertTrue(JsonUtils.path(root, "components.schemas.WithAdditionalProperties.additionalProperties").asBoolean());
+    }
+
+    @Test
+    public void schemaWithoutAdditionalProperties() {
+        ObjectNode root = getOpenAPIJson();
+        assertNotNull(JsonUtils.path(root, "components.schemas.WithoutAdditionalProperties"));
+        assertFalse(JsonUtils.path(root, "components.schemas.WithoutAdditionalProperties.additionalProperties").asBoolean());
+    }
+
+    @Test
+    public void schemaWithNoAdditionalProperties() {
+        ObjectNode root = getOpenAPIJson();
+        assertNotNull(JsonUtils.path(root, "components.schemas.User"));
+        assertNull(JsonUtils.path(root, "components.schemas.User").findValue("additionalProperties")); // if not specified, the additionalProperties is not displayed in the generated openapi
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2011-2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011-2015 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2011-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011-2023 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -215,7 +215,7 @@
         <microprofile-healthcheck.version>4.0.1</microprofile-healthcheck.version>
         <microprofile-metrics.version>4.0</microprofile-metrics.version>
         <microprofile-rest-client.version>3.0.1</microprofile-rest-client.version>
-        <microprofile-openapi.version>3.0</microprofile-openapi.version>
+        <microprofile-openapi.version>3.1</microprofile-openapi.version>
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <payara.security-connectors.version>3.0.alpha6</payara.security-connectors.version>
         <opentracing.version>0.33.0</opentracing.version>


### PR DESCRIPTION
## Description
Adding support of additionalProperties to the generated OpenApi documentation.
If additionalProperties is not specified in the `@Schema` annotation, it is supposed to be True, but it is not mentioned in the displayed documentation (it's the default value).
If explicitly specified, it is always displayed, either true or false.
Deploy the reproducer attached to the Jira ticket to Payara and open `http://localhost:4848/openapi` in browser.

The key parts of the source:
```
@Schema(description = "no additionalProperties defined, shouldn't appear in OpenApi description")
public static class WithoutAdditionalProperties {

@Schema(additionalProperties = Schema.True.class, description = "additionalProperties defined as true, should appear as 'additionalProperties: true'")
public static class WithAdditionalProperties {

@Schema(additionalProperties = Schema.False.class, description = "additionalProperties defined as false, should appear as 'additionalProperties: false'")
public static class WithNoAdditionalProperties {
```
This output should be displayed (unrelated parts removed):
```
    WithAdditionalProperties:
      description: "additionalProperties defined as true, should appear as 'additionalProperties:\
        \ true'"
      additionalProperties: true
    WithNoAdditionalProperties:
      description: "additionalProperties defined as false, should appear as 'additionalProperties:\
        \ false'"
      additionalProperties: false
    WithoutAdditionalProperties:
      description: "no additionalProperties defined, shouldn't appear in OpenApi description"
```

Last tiny change -- the version in the first line is changed to 3.1.0.

## Testing
### New tests
3 new tests in appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/SchemaExampleTest.java

### Testing Performed
Unit tests, test of reproducer and 4848/openapi

### Testing Environment
Linux, OpenJDK 11

### Info for Reviewers
I split the changes to 3 commits, so it's easier to review. The first one is functional, then change of generated version, then removal of deprecation warnings. The last commit has no functional impact.

