### PR TITLE
FISH-6152 Resolve Compilation Errors in ErrorPageDecorator

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/deploy/ErrorPageDecorator.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/deploy/ErrorPageDecorator.java
@@ -37,11 +37,12 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2023] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.web.deploy;
 
-import org.apache.catalina.deploy.ErrorPage;
-import org.apache.catalina.util.RequestUtil;
+import org.apache.tomcat.util.buf.UDecoder;
+import org.apache.tomcat.util.descriptor.web.ErrorPage;
 import org.glassfish.web.deployment.descriptor.ErrorPageDescriptor;
 
 /**
@@ -65,6 +66,6 @@ public class ErrorPageDecorator extends ErrorPage {
             setExceptionType(decoree.getExceptionType());
         }
 
-        setLocation(RequestUtil.urlDecode(decoree.getLocation()));
+        setLocation(UDecoder.URLDecode(decoree.getLocation(), null));
     }
 }


### PR DESCRIPTION
## Description
Resolves compilation errors in ErrorPageDecorator. 

ErrorPage has moved to https://github.com/apache/tomcat/blob/10.1.x/java/org/apache/tomcat/util/descriptor/web/ErrorPage.java

RequestUtil.urlDecode has been replaced with UDecoder.URLDecode. This always requires a charset so to maintain previous behaviour I have set this to null as was previously happening https://github.com/apache/tomcat/blob/7.0.x/java/org/apache/catalina/util/RequestUtil.java#L178 
The same null charset behaviour was maintained https://github.com/apache/tomcat/blob/10.1.x/java/org/apache/tomcat/util/buf/UDecoder.java#L186