### PR TITLE
FISH-6432 Applications Take Longer To Deploy on JDK 11 and 17

### DIFF
--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionImpl.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionImpl.java
@@ -52,7 +52,7 @@ import com.sun.jdo.spi.persistence.support.sqlstore.ejb.EJBHelper;
 import com.sun.jdo.spi.persistence.utility.Linkable;
 import com.sun.jdo.spi.persistence.utility.logging.Logger;
 import com.sun.jdo.spi.persistence.support.sqlstore.LogHelperSQLStore;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 
 
 import java.sql.*;
@@ -874,7 +874,7 @@ public class ConnectionImpl implements Connection, Linkable {
     }
 
     public final void registerCloseEvent() {
-        Cleaner.create().register(this, () -> {
+        CleanerFactory.create().register(this, () -> {
             try {
                 this.connection.close();
                 logger.finest("sqlstore.connectionimpl.finalize"); // NOI18N

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionImpl.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionImpl.java
@@ -52,6 +52,7 @@ import com.sun.jdo.spi.persistence.support.sqlstore.ejb.EJBHelper;
 import com.sun.jdo.spi.persistence.utility.Linkable;
 import com.sun.jdo.spi.persistence.utility.logging.Logger;
 import com.sun.jdo.spi.persistence.support.sqlstore.LogHelperSQLStore;
+import java.lang.ref.Cleaner;
 
 
 import java.sql.*;
@@ -142,6 +143,7 @@ public class ConnectionImpl implements Connection, Linkable {
         this.freePending = false;
         //		this.resource = null;
         this.connectionManager = connMgr;
+        registerCloseEvent();
     }
 
     //----------------------------------------------------------------------
@@ -871,13 +873,14 @@ public class ConnectionImpl implements Connection, Linkable {
         return buffer;
     }
 
-    protected void finalize() {
-        try {
-            this.connection.close();
-            logger.finest("sqlstore.connectionimpl.finalize"); // NOI18N
-        } catch (SQLException se) {
-            ;
-        }
+    public final void registerCloseEvent() {
+        Cleaner.create().register(this, () -> {
+            try {
+                this.connection.close();
+                logger.finest("sqlstore.connectionimpl.finalize"); // NOI18N
+            } catch (SQLException se) {
+            }
+        });
     }
 
     public void setSchema(String schema) throws SQLException {

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionManager.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionManager.java
@@ -53,7 +53,7 @@ import com.sun.jdo.spi.persistence.utility.Linkable;
 import com.sun.jdo.spi.persistence.support.sqlstore.utility.StringScanner;
 import com.sun.jdo.spi.persistence.utility.logging.Logger;
 import com.sun.jdo.spi.persistence.support.sqlstore.LogHelperSQLStore;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 
 
 import java.sql.Connection;
@@ -1513,7 +1513,7 @@ public class ConnectionManager {
      *
      */
     public final void registerCloseEvent() {
-        Cleaner.create().register(this, () -> {
+        CleanerFactory.create().register(this, () -> {
             try {
                 shutDown();
             } catch (SQLException se) {

--- a/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionManager.java
+++ b/appserver/persistence/cmp/support-sqlstore/src/main/java/com/sun/jdo/spi/persistence/support/sqlstore/connection/ConnectionManager.java
@@ -53,6 +53,7 @@ import com.sun.jdo.spi.persistence.utility.Linkable;
 import com.sun.jdo.spi.persistence.support.sqlstore.utility.StringScanner;
 import com.sun.jdo.spi.persistence.utility.logging.Logger;
 import com.sun.jdo.spi.persistence.support.sqlstore.LogHelperSQLStore;
+import java.lang.ref.Cleaner;
 
 
 import java.sql.Connection;
@@ -822,6 +823,7 @@ public class ConnectionManager {
         this.busyList = null;
         this.xactConnections = null;
         this.initialized = false;
+        registerCloseEvent();
     }
 
     // --------------- Overloaded Constructors -----------------
@@ -1510,12 +1512,14 @@ public class ConnectionManager {
      * or rolledback.
      *
      */
-    protected void finalize() {
-        try {
-            shutDown();
-        } catch (SQLException se) {
-            ; // Ignore it.
-        }
+    public final void registerCloseEvent() {
+        Cleaner.create().register(this, () -> {
+            try {
+                shutDown();
+            } catch (SQLException se) {
+                // Ignore it.
+            }
+        });
     }
 
     // ----------- Public Methods to get and set properties --------------

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/LogFileHandle.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/LogFileHandle.java
@@ -66,6 +66,8 @@ package com.sun.jts.CosTransactions;
 
 import com.sun.enterprise.util.i18n.StringManager;
 import java.io.*;
+import java.lang.ref.Cleaner;
+import java.sql.SQLException;
 
 /**This class encapsulates file I/O operations and the file handle.
  *
@@ -163,7 +165,7 @@ class LogFileHandle {
     LogFileHandle() {
         fhandle = null;
         fd      = null;                                                       //@MA
-
+        registerDestroyEvent();
     }
 
     /**Creates a new file handle for the given file.
@@ -189,16 +191,18 @@ class LogFileHandle {
         }
 
         // Change the OpenOptions to the format expected by CLOSE
-
-        if( (openOptions & OPEN_RDONLY) != 0 )
-            fileOpen(file,MODE_READONLY);
-        else
+        if ((openOptions & OPEN_RDONLY) != 0) {
+            fileOpen(file, MODE_READONLY);
+        } else {
             try {
-                fileOpen(file,MODE_READWRITEOLD);
-            } catch( LogException e ) {
-                if( (openOptions & OPEN_CREAT) != 0 )
-                    fileOpen(file,MODE_READWRITENEW);
+                fileOpen(file, MODE_READWRITEOLD);
+            } catch (LogException e) {
+                if ((openOptions & OPEN_CREAT) != 0) {
+                    fileOpen(file, MODE_READWRITENEW);
+                }
             }
+        }
+        registerDestroyEvent();
     }
 
     /**Destroys the FileHandle, closing the file, if open.
@@ -222,10 +226,10 @@ class LogFileHandle {
             fileClose();
     }
 
-    protected void finalize()
-        throws LogException {
-
-        destroy();
+    public final void registerDestroyEvent() {
+        Cleaner.create().register(this, () -> {
+            destroy();
+        });
     }
 
     /**Reads from the file.

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/LogFileHandle.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/LogFileHandle.java
@@ -66,7 +66,7 @@ package com.sun.jts.CosTransactions;
 
 import com.sun.enterprise.util.i18n.StringManager;
 import java.io.*;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.sql.SQLException;
 
 /**This class encapsulates file I/O operations and the file handle.
@@ -227,8 +227,12 @@ class LogFileHandle {
     }
 
     public final void registerDestroyEvent() {
-        Cleaner.create().register(this, () -> {
-            destroy();
+        CleanerFactory.create().register(this, () -> {
+            try {
+                destroy();
+            } catch(LogException ex) {
+                // Ignore it
+            }
         });
     }
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/PartItem.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/PartItem.java
@@ -65,7 +65,7 @@ import org.apache.catalina.util.RequestUtil;
 
 import jakarta.servlet.http.Part;
 import java.io.*;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.*;
@@ -622,7 +622,7 @@ class PartItem
      * Removes the file contents from the temporary storage.
      */
     public final void registerCleanupEvent() {
-        Cleaner.create().register(this, () -> {
+        CleanerFactory.create().register(this, () -> {
             File outputFile = dfos.getFile();
 
             if (outputFile != null && outputFile.exists()) {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/PartItem.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/PartItem.java
@@ -65,7 +65,9 @@ import org.apache.catalina.util.RequestUtil;
 
 import jakarta.servlet.http.Part;
 import java.io.*;
+import java.lang.ref.Cleaner;
 import java.nio.charset.Charset;
+import java.sql.SQLException;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -227,6 +229,7 @@ class PartItem
         this.requestCharEncoding = requestCharEncoding;
         this.sizeThreshold = multipart.getFileSizeThreshold();
         this.repository = multipart.getRepository();
+        registerCleanupEvent();
     }
 
 
@@ -618,14 +621,15 @@ class PartItem
     /**
      * Removes the file contents from the temporary storage.
      */
-    protected void finalize() {
-        File outputFile = dfos.getFile();
+    public final void registerCleanupEvent() {
+        Cleaner.create().register(this, () -> {
+            File outputFile = dfos.getFile();
 
-        if (outputFile != null && outputFile.exists()) {
-            deleteFile(outputFile);
-        }
+            if (outputFile != null && outputFile.exists()) {
+                deleteFile(outputFile);
+            }
+        });
     }
-
 
     /**
      * Creates and returns a {@link java.io.File File} representing a uniquely

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
@@ -52,7 +52,7 @@ import org.glassfish.hk2.api.PreDestroy;
 import java.io.*;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.net.*;
 import java.nio.file.Path;
 import java.security.*;
@@ -923,7 +923,7 @@ public class ASURLClassLoader extends CurrentBeforeParentClassLoader
         }
 
         public final void registerCloseEvent() {
-            Cleaner.create().register(this, () -> {
+            CleanerFactory.create().register(this, () -> {
                 try {
                     reallyClose();
                 } catch (IOException ex) {
@@ -1123,7 +1123,7 @@ public class ASURLClassLoader extends CurrentBeforeParentClassLoader
          * relates to _close() is unclear.
          */
         public final void registerStopEvent() {
-            Cleaner.create().register(this, () -> {
+            CleanerFactory.create().register(this, () -> {
                 if (!closed && this.in != null) {
                     try {
                         in.close();

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
@@ -50,7 +50,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -340,7 +340,7 @@ public abstract class PayloadFilesManager {
         }
 
         public final void registerCleanupEvent() {
-            Cleaner.create().register(this, () -> {
+            CleanerFactory.create().register(this, () -> {
                 cleanup();
             });
         }

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
@@ -50,7 +50,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.ref.Cleaner;
 import java.net.URI;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -306,6 +308,7 @@ public abstract class PayloadFilesManager {
                       logger),
                   report,
                   logger);
+            registerCleanupEvent();
         }
         /**
          * Creates a new PayloadFilesManager for temporary files.
@@ -336,10 +339,10 @@ public abstract class PayloadFilesManager {
             }
         }
 
-        @Override
-        protected void finalize() throws Throwable {
-            super.finalize();
-            cleanup();
+        public final void registerCleanupEvent() {
+            Cleaner.create().register(this, () -> {
+                cleanup();
+            });
         }
 
         @Override

--- a/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/InputJarArchive.java
+++ b/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/InputJarArchive.java
@@ -49,7 +49,7 @@ import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 
 import java.io.*;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -543,7 +543,7 @@ public class InputJarArchive extends JarArchive implements ReadableArchive {
         }
 
         public final void registerCloseEvent() {
-            Cleaner.create().register(this, () -> {
+            CleanerFactory.create().register(this, () -> {
                 close();
             });
         }

--- a/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/InputJarArchive.java
+++ b/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/InputJarArchive.java
@@ -49,6 +49,7 @@ import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 
 import java.io.*;
+import java.lang.ref.Cleaner;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -488,6 +489,7 @@ public class InputJarArchive extends JarArchive implements ReadableArchive {
 
         private EntryEnumeration(final JarEntrySource jarEntrySource) {
             this.jarEntrySource = jarEntrySource;
+            registerCloseEvent();
         }
 
         /**
@@ -540,10 +542,10 @@ public class InputJarArchive extends JarArchive implements ReadableArchive {
             entryEnumerations.remove(this);
         }
 
-        @Override
-        protected void finalize() throws Throwable {
-            super.finalize();
-            close();
+        public final void registerCloseEvent() {
+            Cleaner.create().register(this, () -> {
+                close();
+            });
         }
     }
 

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/ClientArtifactsManager.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/ClientArtifactsManager.java
@@ -42,6 +42,7 @@ package org.glassfish.deployment.common;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.ref.Cleaner;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -122,6 +123,10 @@ public class ClientArtifactsManager {
      * here.
      */
     private final Map<URI,JarFile> jarFiles = new HashMap<URI,JarFile>();
+
+    public ClientArtifactsManager() {
+        registerCloseEvent();
+    }
 
     /**
      * Retrieves the client artifacts store from the provided deployment 
@@ -347,12 +352,12 @@ public class ClientArtifactsManager {
         return MessageFormat.format(format, args);
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize(); //To change body of generated methods, choose Tools | Templates.
-        if ( ! isArtifactSetConsumed) {
-            closeOpenedJARs();
-        }
+    public final void registerCloseEvent() {
+        Cleaner.create().register(this, () -> {
+            if (!isArtifactSetConsumed) {
+                closeOpenedJARs();
+            }
+        });
     }
 
     /**

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/ClientArtifactsManager.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/ClientArtifactsManager.java
@@ -42,7 +42,7 @@ package org.glassfish.deployment.common;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.ref.Cleaner;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -353,7 +353,7 @@ public class ClientArtifactsManager {
     }
 
     public final void registerCloseEvent() {
-        Cleaner.create().register(this, () -> {
+        CleanerFactory.create().register(this, () -> {
             if (!isArtifactSetConsumed) {
                 closeOpenedJARs();
             }

--- a/nucleus/payara-modules/healthcheck-cpool/src/main/java/fish/payara/nucleus/healthcheck/cpool/ConnectionPoolHealthCheck.java
+++ b/nucleus/payara-modules/healthcheck-cpool/src/main/java/fish/payara/nucleus/healthcheck/cpool/ConnectionPoolHealthCheck.java
@@ -75,6 +75,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import static java.util.stream.Collectors.toSet;
+import com.sun.enterprise.config.serverbeans.Module;
 
 /**
  * @author mertcaliskan

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <mail.version>2.1.0</mail.version>
         <angus.mail.version>1.0.0</angus.mail.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
-        <hk2.version>3.0.1.payara-p1</hk2.version>
+        <hk2.version>3.0.1.payara-p2</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jackson.version>2.14.1</jackson.version>


### PR DESCRIPTION
## Description
In this PR, a few performance optimizations have been done.

- The finalize methods of FileInputStream, FileOutputStream, Zip Inflator, and Deflator were deprecated for removal in JDK 9. They have been removed in JDK12 release, which may cause resources are not cleaned and leaked.
- File canonicalization cache is disabled by default in JDK 12 which helps in performance optimizations for file name canonicalization. In HK2, TypeImpl#addDefiningURI duplicate uri is added so canonicalization is not required.

## Testing

### Testing Performed
Manually with reproducer

### Testing Environment
Windows 11, and WSL
JDK 11, 12, and 17

## Depends on
https://github.com/payara/patched-src-hk2/pull/28

