### PR TITLE
FISH-6167 Resolve Compilation Errors in CacheModule

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/CacheModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/CacheModule.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2023] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.web;
 
@@ -47,16 +48,17 @@ import com.sun.appserv.web.cache.mapping.Field;
 import com.sun.appserv.web.cache.mapping.ValueConstraint;
 import com.sun.enterprise.config.serverbeans.ConfigBeansUtilities;
 import com.sun.enterprise.deployment.runtime.web.SunWebApp;
-import org.glassfish.web.LogFacade;
-import org.glassfish.web.deployment.runtime.*;
-import org.apache.tomcat.util.descriptor.web.FilterDef;
-import org.apache.tomcat.util.descriptor.web.FilterMap;
-
-import jakarta.servlet.DispatcherType;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.tomcat.util.descriptor.web.FilterDef;
+import org.apache.tomcat.util.descriptor.web.FilterMap;
+import org.glassfish.web.LogFacade;
+import org.glassfish.web.deployment.runtime.Cache;
+import org.glassfish.web.deployment.runtime.CacheHelper;
+import org.glassfish.web.deployment.runtime.DefaultHelper;
+import org.glassfish.web.deployment.runtime.SunWebAppImpl;
+import org.glassfish.web.deployment.runtime.WebProperty;
 
 /**
  * configures the cache for the application

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/CacheModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/CacheModule.java
@@ -49,8 +49,8 @@ import com.sun.enterprise.config.serverbeans.ConfigBeansUtilities;
 import com.sun.enterprise.deployment.runtime.web.SunWebApp;
 import org.glassfish.web.LogFacade;
 import org.glassfish.web.deployment.runtime.*;
-import org.apache.catalina.deploy.FilterDef;
-import org.apache.catalina.deploy.FilterMap;
+import org.apache.tomcat.util.descriptor.web.FilterDef;
+import org.apache.tomcat.util.descriptor.web.FilterMap;
 
 import jakarta.servlet.DispatcherType;
 import java.util.EnumSet;
@@ -195,7 +195,7 @@ public final class CacheModule {
             // setup the ias CachingFilter definition with the context
             FilterDef filterDef = new FilterDef();
             filterDef.setFilterName(filterName);
-            filterDef.setFilterClassName(CACHING_FILTER_CLASSNAME);
+            filterDef.setFilterClass(CACHING_FILTER_CLASSNAME);
 
             if (mapping.getServletName() != null) {
                 filterDef.addInitParameter("servletName",
@@ -210,22 +210,14 @@ public final class CacheModule {
 
             // setup the mapping for the specified servlet-name or url-pattern
             FilterMap filterMap = new FilterMap();
-            filterMap.setServletName(mapping.getServletName());
-            filterMap.setURLPattern(mapping.getURLPattern());
+            filterMap.addServletName(mapping.getServletName());
+            filterMap.addURLPattern(mapping.getURLPattern());
             String[] dispatchers = mapConfig.getDispatcher();
             if (dispatchers != null) {
-                EnumSet<DispatcherType> dispatcherTypes = null;
                 for (String dispatcher : dispatchers) {
                     // calls to FilterMap.setDispatcher are cumulative
-                    if (dispatcherTypes == null) {
-                        dispatcherTypes = EnumSet.of(
-                            Enum.valueOf(DispatcherType.class, dispatcher));
-                    } else {
-                        dispatcherTypes.add(
-                            Enum.valueOf(DispatcherType.class, dispatcher));
-                    }
+                    filterMap.setDispatcher(dispatcher);
                 }
-                filterMap.setDispatcherTypes(dispatcherTypes);
             }
             filterMap.setFilterName(filterName);
             app.addFilterMap(filterMap);


### PR DESCRIPTION
Resolves the compilation errors in CacheModule. FilterDef and FilterMap were part of `web-core` which was removed, I believe these changes will maintain the original behaviour although they are different.

FilterDef `setFilterClassName` was replaced with `setFilterClass` however these both take strings and appear to be doing the same function. A null check is lost, however `CACHING_FILTER_CLASSNAME` is a static final string so could never be null hence I didn't feel the need to re-implement this.

Rather than a FilterMap having one servlet name and URL pattern, it instead has two lists which I have modified by adding rather than setting these properties. `setDispatcherTypes` with an EnumSet of DispatcherType is completely removed, being replaced with `setDispatcher` requiring a string. This new method then performs a similar action to the removed code, getting the DispatcherType in the `setDispatcher` method. As the comment indicates, these calls are cumulative and should still work within the loop as expected.