### PR TITLE
FISH-6432 Applications Take Longer To Deploy on JDK 11 and 17 (Payara 5.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <javax.cache-api.version>1.1.1</javax.cache-api.version>
         <mail.version>1.6.7.payara-p1</mail.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-        <hk2.version>2.6.1.payara-p8</hk2.version>
+        <hk2.version>2.6.1.payara-p9</hk2.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jackson.version>2.13.4</jackson.version>


### PR DESCRIPTION
## Description
In this PR, a few performance optimizations have been done.
- File canonicalization cache is disabled by default in JDK 12 which helps in performance optimizations for file name canonicalization. In HK2, TypeImpl#addDefiningURI duplicate uri is added so canonicalization is not required.

## Testing

### Testing Performed
Manually with reproducer

### Testing Environment
Windows 11, and WSL
JDK 11, 12, and 17

## Depends on
https://github.com/payara/patched-src-hk2/pull/29

