### PR TITLE
FISH-6979 Add support for RSA-OAEP-256 for MP JWT 2.1

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/eesecurity/SignedJWTIdentityStore.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/eesecurity/SignedJWTIdentityStore.java
@@ -210,6 +210,6 @@ public class SignedJWTIdentityStore implements IdentityStore {
         optionalConfigProperty = new HashMap<>();
         optionalConfigProperty.put(Names.TOKEN_AGE, readConfigOptional(Names.TOKEN_AGE, properties, config)); // mp.jwt.verify.token.age
         optionalConfigProperty.put(Names.CLOCK_SKEW, readConfigOptional(Names.CLOCK_SKEW, properties, config)); // mp.jwt.verify.clock.skew
-        optionalConfigProperty.put(Names.DECRYPTOR_KEY_ALGORITHM,  readConfigOptional(Names.DECRYPTOR_KEY_ALGORITHM, properties, config)); //mp.jwt.decrypt.key.algorithm
+        optionalConfigProperty.put(Names.DECRYPTOR_KEY_ALGORITHM, readConfigOptional(Names.DECRYPTOR_KEY_ALGORITHM, properties, config)); //mp.jwt.decrypt.key.algorithm
     }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Fix MP JWT TCK `RolesAllowedSignEncryptRsaOaepTest` test by read optional `mp.jwt.decrypt.key.algorithm` config property and validate the key algorithm

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
MP JWT TCK Runner - https://github.com/payara/MicroProfile-TCK-Runners/pull/211

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
New test class added to MP JWT TCK - https://github.com/payara/MicroProfile-TCK-Runners/pull/211

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Build, run and execute MP JWT TCK

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, OpenJDK11, Maven 3.8.4

## Documentation
<!-- Link documentation if a PR exists -->
N/A

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
None
