### PR TITLE
FISH-6969: Use OpenTelemetry as basis for OpenTracing Support

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/cdi/TracedInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/src/main/java/fish/payara/microprofile/opentracing/cdi/TracedInterceptor.java
@@ -138,7 +138,7 @@ public class TracedInterceptor implements Serializable {
         final String operationName = getOperationName(invocationContext, traced);
         Span parentSpan = tracer.activeSpan();
 
-        final Span span = tracer.buildSpan(operationName).start();
+        final Span span = tracer.buildSpan(operationName).asChildOf(parentSpan).start();
         try (Scope scope = tracer.scopeManager().activate(span)) {
             try {
                 return invocationContext.proceed();

--- a/appserver/tests/payara-samples/samples/opentelemetry/README.adoc
+++ b/appserver/tests/payara-samples/samples/opentelemetry/README.adoc
@@ -1,0 +1,10 @@
+# OpenTelemetry samples
+
+So far there is no API to get server-managed OTEL traces beyond using OpenTracing APIs.
+
+Therefore there are no automated tests yet.
+OpenTracing part is exercised by other tests (such as Remote EJB tracing).
+
+The sample application just makes used of distributed OpenTelemetry APIs to create SDK on its own, either manual or in autoconfiguration mode.
+
+It is also possible to put implementations of e. g. exporters into `domaindir/lib` and have them discovered by the autoconfiguration sdk.

--- a/appserver/tests/payara-samples/samples/opentelemetry/pom.xml
+++ b/appserver/tests/payara-samples/samples/opentelemetry/pom.xml
@@ -51,6 +51,7 @@
         <version>6.2023.1-SNAPSHOT</version>
     </parent>
 
+    <name>Payara Samples - OpenTelemetry</name>
     <artifactId>opentelemetry</artifactId>
     <packaging>war</packaging>
 

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManualTracing.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManualTracing.java
@@ -124,6 +124,7 @@ public class ManualTracing {
         AutoConfiguredOpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder()
                 .addPropertiesSupplier(() -> mpconfigProperties)
                 .setServiceClassLoader(Thread.currentThread().getContextClassLoader())
+                .setResultAsGlobal(false)
                 .build();
         tracer = sdk.getOpenTelemetrySdk().getTracer("fish.payara.opentelemetry");
     }

--- a/nucleus/packager/external/opentracing-repackaged/pom.xml
+++ b/nucleus/packager/external/opentracing-repackaged/pom.xml
@@ -72,7 +72,10 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package>io.opentracing,io.opentracing.propagation,io.opentracing.tag,io.opentracing.log,io.opentracing.util</Export-Package>
+                        <Export-Package>
+                            io.opentracing,
+                            io.opentracing.*
+                        </Export-Package>
                         <Private-Package>*</Private-Package>
                         <Include-Resource>META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/</Include-Resource>
                     </instructions>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -72,7 +72,10 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-opentracing-shim</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -110,7 +110,9 @@ public class OpenTracingService implements EventListener {
         if (event.is(Deployment.APPLICATION_UNLOADED)) {
             ApplicationInfo info = (ApplicationInfo) event.hook();
             Tracer tracer = tracers.remove(info.getName());
-            tracer.close();
+            if (tracer != null) {
+                tracer.close();
+            }
         }
     }
 

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/OpenTracingService.java
@@ -39,11 +39,6 @@
  */
 package fish.payara.opentracing;
 
-import fish.payara.nucleus.requesttracing.RequestTracingService;
-import io.opentracing.Tracer;
-//import io.opentracing.mock.MockTracer;
-import io.opentracing.util.ThreadLocalScopeManager;
-
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -52,9 +47,14 @@ import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jakarta.annotation.PostConstruct;
-import jakarta.interceptor.InvocationContext;
 
+import fish.payara.nucleus.requesttracing.RequestTracingService;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.interceptor.InvocationContext;
 import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.Events;
 import org.glassfish.api.invocation.ComponentInvocation;
@@ -75,47 +75,42 @@ import org.jvnet.hk2.annotations.Service;
 @Service(name = "opentracing-service")
 public class OpenTracingService implements EventListener {
 
-    // The tracer instances
-    private static final Map<String, Tracer> tracers = new ConcurrentHashMap<>();
-    
     // The name of the Corba RMI Tracer
     public static final String PAYARA_CORBA_RMI_TRACER_NAME = "__PAYARA_CORBA_RMI";
 
+    // The tracer instances
+    private static final Map<String, Tracer> tracers = new ConcurrentHashMap<>();
+
     private static final Logger logger = Logger.getLogger(OpenTracingService.class.getName());
 
-    // Initialised from ServiceHandle - use getRequestTracingService() rather than directly accessing this variable
-    private RequestTracingService requestTracingService;
+    @Inject
+    ServiceLocator locator;
+
+    @Inject
+    OpenTelemetryService otel;
+
+    @Inject
+    Events events;
 
     @PostConstruct
     void postConstruct() {
-        // Listen for events
-        Events events = getFromServiceHandle(Globals.getDefaultBaseServiceLocator(), Events.class);
-
         if (events != null) {
             events.register(this);
         } else {
             logger.log(Level.WARNING, "OpenTracing service not registered to Payara Events: "
                     + "The Tracer for an application won't be removed upon undeployment");
         }
-
-        getRequestTracingService();
     }
 
     @Override
     public void event(Event<?> event) {
-        // Eagerly create tracer if request tracing is enabled
-        if (event.is(Deployment.APPLICATION_LOADED)) {
-            if (getRequestTracingService() != null && requestTracingService.isRequestTracingEnabled()) {
-                ApplicationInfo info = (ApplicationInfo) event.hook();
-                createTracer(info.getName());
-            }
-        }
 
         // Listen for application unloaded events (happens during undeployment), so that we remove the tracer instance
         // registered to that application (if there is one)
         if (event.is(Deployment.APPLICATION_UNLOADED)) {
             ApplicationInfo info = (ApplicationInfo) event.hook();
-            tracers.remove(info.getName());
+            Tracer tracer = tracers.remove(info.getName());
+            tracer.close();
         }
     }
 
@@ -141,32 +136,36 @@ public class OpenTracingService implements EventListener {
         return tracer;
     }
 
-    private synchronized Tracer createTracer(String applicationName) {
-        // Does this NEED to be synchronised? Tracers don't store state, and Scopes are ThreadLocal
-
+    private Tracer createTracer(String applicationName) {
         // Double-checked locking - potentially naughty
         Tracer tracer = tracers.computeIfAbsent(applicationName, (appName) -> {
-            Tracer newTracer = null;
-
-            // Check which type of Tracer to create
-            try {//See if an alternate implementation of Tracer is available in a library.
-                ServiceLoader<Tracer> tracerLoader = ServiceLoader.load(Tracer.class);
-                Iterator<Tracer> loadedTracer = tracerLoader.iterator();
-                if (loadedTracer.hasNext()) {
-                    newTracer = loadedTracer.next();
-                }
-            } catch (NoClassDefFoundError ex) {
-                logger.log(Level.SEVERE, "Unable to find Tracer implementation", ex);
+            // required for direct interaction with OpenTracing, i. e. in MP TCK
+            Tracer installedTracer = findTracerViaServiceLoader();
+            if (installedTracer != null) {
+                return installedTracer;
             }
-
-            if (newTracer == null) {
-                newTracer = new fish.payara.opentracing.tracer.Tracer(appName, getRequestTracingService());
+            if (otel == null) {
+                return null;
             }
-
-            return newTracer;
+            // create default implementation (env / system property based) for the application
+            otel.ensureAppInitialized(appName, null);
+            return otel.getSdk(applicationName).map(OpenTracingShim::createTracerShim).orElse(NoopTracerFactory.create());
         });
 
         return tracer;
+    }
+
+    private Tracer findTracerViaServiceLoader() {
+        try {
+            ServiceLoader<Tracer> tracerLoader = ServiceLoader.load(Tracer.class);
+            Iterator<Tracer> loadedTracer = tracerLoader.iterator();
+            if (loadedTracer.hasNext()) {
+                return loadedTracer.next();
+            }
+        } catch (NoClassDefFoundError ex) {
+            logger.log(Level.SEVERE, "Unable to find Tracer implementation", ex);
+        }
+        return null;
     }
 
     /**
@@ -175,22 +174,19 @@ public class OpenTracingService implements EventListener {
      * @return True if the Request Tracing Service is enabled
      */
     public boolean isEnabled() {
-        if (getRequestTracingService() != null) {
-            return requestTracingService.isRequestTracingEnabled();
-        }
-        return false;
+        RequestTracingService requestTracingService = getFromServiceHandle(locator, RequestTracingService.class);
+        return requestTracingService != null && requestTracingService.isRequestTracingEnabled();
     }
 
-    /**
-     * Gets the {@link RequestTracingService}, looking up the active service from HK2 if necessary.
-     * @return The {@link RequestTracingService}, or null.
-     */
-    private RequestTracingService getRequestTracingService() {
-        if (requestTracingService == null) {
-            requestTracingService = getFromServiceHandle(Globals.getDefaultBaseServiceLocator(),
-                    RequestTracingService.class);
+    private <T> T getFromServiceHandle(ServiceLocator serviceLocator, Class<T> serviceClass) {
+        if (serviceLocator != null) {
+            ServiceHandle<T> serviceHandle = serviceLocator.getServiceHandle(serviceClass);
+            if (serviceHandle != null && serviceHandle.isActive()) {
+                return serviceHandle.getService();
+            }
         }
-        return requestTracingService;
+
+        return null;
     }
 
     /**
@@ -274,16 +270,5 @@ public class OpenTracingService implements EventListener {
                 + "#" + annotatedMethod.getName()
                 + "(" + Arrays.toString(annotatedMethod.getParameterTypes()) + ")"
                 + ">" + annotatedMethod.getReturnType().getSimpleName();
-    }
-
-    private <T> T getFromServiceHandle(ServiceLocator serviceLocator, Class<T> serviceClass) {
-        if (serviceLocator != null) {
-            ServiceHandle<T> serviceHandle = serviceLocator.getServiceHandle(serviceClass);
-            if (serviceHandle != null && serviceHandle.isActive()) {
-                return serviceHandle.getService();
-            }
-        }
-
-        return null;
     }
 }

--- a/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/PayaraRequestTracingExporter.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/main/java/fish/payara/opentracing/PayaraRequestTracingExporter.java
@@ -1,0 +1,141 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.opentracing;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import fish.payara.notification.requesttracing.EventType;
+import fish.payara.notification.requesttracing.RequestTraceSpan;
+import fish.payara.nucleus.requesttracing.RequestTracingService;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+class PayaraRequestTracingExporter implements SpanExporter {
+    private static final Logger LOGGER = Logger.getLogger(PayaraRequestTracingExporter.class.getName());
+
+    private static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+
+    private final RequestTracingService requestTracingService;
+
+    private final ExecutorService executorService;
+
+    public PayaraRequestTracingExporter(RequestTracingService requestTracingService, ExecutorService payaraExecutorService) {
+        this.requestTracingService = requestTracingService;
+        this.executorService = payaraExecutorService;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> collection) {
+        CompletableResultCode result = new CompletableResultCode();
+        this.executorService.submit(() -> {
+            try {
+                collection.forEach((data) -> requestTracingService.traceSpan(convert(data)));
+                result.succeed();
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "Failed to export OpenTelemetry span to Payara Request Tracing", e);
+                result.fail();
+            }
+        });
+        return result;
+    }
+
+    RequestTraceSpan convert(SpanData data) {
+        RequestTraceSpan result = new RequestTraceSpan(EventType.PROPAGATED_TRACE, data.getName());
+        result.getSpanContext().setTraceId(parseTraceId(data));
+        // we cannot set spanId
+        result.setStartInstant(Instant.ofEpochSecond(
+                data.getStartEpochNanos() / NANOS_PER_SECOND,
+                data.getStartEpochNanos() % NANOS_PER_SECOND));
+        result.setSpanDuration(data.getEndEpochNanos() - data.getStartEpochNanos());
+        data.getAttributes().forEach((key, value) -> result.addSpanTag(key.getKey(), value.toString()));
+        // exporter has no access to baggage, that goes to propagators only.
+        return result;
+    }
+
+    private UUID parseTraceId(SpanData data) {
+        return parseTraceId(data.getTraceId());
+    }
+
+    static UUID parseTraceId(String traceId) {
+        if (traceId.length() >= 32) {
+            // Long.parseLong does not like unsigned data
+            // we trim everything beyond 32nd byte
+            long high = parseUnsignedHex(traceId, 0, 0);
+            long low = parseUnsignedHex(traceId, 16, 0);
+            return new UUID(high, low);
+        } else {
+            long high = 0;
+            if (traceId.length() > 16) {
+                high = parseUnsignedHex(traceId, 0, 32 - traceId.length());
+            }
+            long low = parseUnsignedHex(traceId, Math.max(traceId.length() - 16, 0), Math.max(16 - traceId.length(), 0));
+            return new UUID(high, low);
+        }
+    }
+
+    static long parseUnsignedHex(CharSequence input, int start, int padding) {
+        long result = 0;
+        for (int i = start, shift = 60 - 4 * padding; shift >= 0; i++, shift -= 4) {
+            long digit = Character.digit(input.charAt(i), 16);
+            result |= digit << shift;
+        }
+        return result;
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        return CompletableResultCode.ofSuccess();
+    }
+}

--- a/nucleus/payara-modules/opentracing-adapter/src/test/java/fish/payara/opentracing/OpenTelemetryTraceConversionTest.java
+++ b/nucleus/payara-modules/opentracing-adapter/src/test/java/fish/payara/opentracing/OpenTelemetryTraceConversionTest.java
@@ -1,0 +1,82 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.opentracing;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OpenTelemetryTraceConversionTest {
+    @Test
+    public void testLargeNegativeNumber() {
+        long result = PayaraRequestTracingExporter.parseUnsignedHex("bf0cf4c8ddd9ae8b", 0, 0);
+        assertEquals(0xbf0cf4c8ddd9ae8bL, result);
+        result = PayaraRequestTracingExporter.parseUnsignedHex("bf0cf4c8ddd9ae8bbf0cf4c8ddd9ae8b", 16, 0);
+        assertEquals(0xbf0cf4c8ddd9ae8bL, result);
+    }
+
+    // Long.parseLong will not parse longs that would translate to negative ones
+    @Test(expected = NumberFormatException.class)
+    public void testStandardParser() {
+        long result = Long.parseLong("bf0cf4c8ddd9ae8b", 16);
+        assertEquals(0xbf0cf4c8ddd9ae8bL, result);
+    }
+
+    @Test
+    public void testShorterTraceId() {
+        test(0,0, "0");
+        test(0,0, "00");
+        test(0,0, "0000000000000000");
+        test(0,0, "00000000000000000");
+        test(1, 0,"10000000000000000");
+        test(0, 0, "");
+        // long input gets truncated at 32 characters
+        test(0x1234_1234_1234_1234L, 0xABCD_ABCD_ABCD_ABCDL, "1234123412341234abcdabcdabcdabcde");
+    }
+
+    private void test(long high, long low, String input) {
+        assertEquals(new UUID(high, low), PayaraRequestTracingExporter.parseTraceId(input));
+    }
+}


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
As transitional step, we use OpenTracing shim to bridge all use of opentracing in the server with OpenTelemetry.

Whenever OpenTracing is used, OpenTelemetry SDK is auto-configured on per-application basis respecting system properties and environment variables.

## Testing
### New tests
So far there is no application API beyond using OpenTracing to get to OTEL, so they will arrive later

### Testing Performed
Payara Samples and OpenTracing TCKs should still pass without problems, let's see what Jenkins thinks about it.

