### PR TITLE
FISH-6769 OpenApi Support for 'extensions'

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ComponentsImpl.java
@@ -83,6 +83,7 @@ public class ComponentsImpl extends ExtensibleImpl<Components> implements Compon
 
     public static Components createInstance(AnnotationModel annotation, ApiContext context) {
         Components from = new ComponentsImpl();
+        from.setExtensions(parseExtensions(annotation));
         extractAnnotations(annotation, context, "schemas", "name", SchemaImpl::createInstance, from::addSchema);
         extractAnnotations(annotation, context, "responses", "name", APIResponseImpl::createInstance, from::addResponse);
         extractAnnotations(annotation, context, "parameters", "name", ParameterImpl::createInstance, from::addParameter);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleImpl.java
@@ -49,11 +49,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.openapi.models.Extensible;
+import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 
 public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensible<T> {
 
@@ -97,6 +100,19 @@ public abstract class ExtensibleImpl<T extends Extensible<T>> implements Extensi
             LOGGER.log(Level.WARNING, "extension name not starting with `x-` cause invalid Open API documents: {0}", name);
         }
         return name;
+    }
+
+    public static Map<String, Object> parseExtensions(AnnotationModel annotation) {
+        List<AnnotationModel> extensions = annotation.getValue("extensions", List.class);
+        Map<String, Object> parsedExtensions = new HashMap<>();
+        if (extensions != null) {
+            for (AnnotationModel extension : extensions) {
+                String name = extension.getValue("name", String.class);
+                String value = extension.getValue("value", String.class);
+                parsedExtensions.put(name, value);
+            }
+        }
+        return parsedExtensions;
     }
 
     public static void merge(Extensible<?> from, Extensible<?> to, boolean override) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExtensibleTreeMap.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2019-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.microprofile.openapi.impl.model;
 
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createMap;
@@ -22,7 +61,7 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
         implements Extensible<T> {
 
     @JsonIgnore
-    protected Map<String, Object> extensions = createMap();
+    protected Map<String, Object> extensions = null; // null means not specified, empty map means specified empty extensions
 
     protected ExtensibleTreeMap() {
         super();
@@ -39,9 +78,13 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
 
     @Override
     public final void setExtensions(Map<String, Object> extensions) {
-        this.extensions.clear();
-        for (Entry<String, Object> entry : extensions.entrySet()) {
-            this.extensions.put(extensionName(entry.getKey()), entry.getValue());
+        if (extensions == null) {
+            this.extensions = null;
+        } else {
+            this.extensions = createMap();
+            for (Entry<String, Object> entry : extensions.entrySet()) {
+                this.extensions.put(extensionName(entry.getKey()), entry.getValue());
+            }
         }
     }
 
@@ -49,6 +92,9 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
     @Override
     public final T addExtension(String name, Object value) {
         if (value != null) {
+            if (extensions == null) {
+                extensions = createMap();
+            }
             this.extensions.put(extensionName(name), value);
         }
         return (T) this;
@@ -56,7 +102,9 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
 
     @Override
     public final void removeExtension(String name) {
-        this.extensions.remove(extensionName(name));
+        if (extensions != null) {
+            this.extensions.remove(extensionName(name));
+        }
     }
 
     /**
@@ -64,7 +112,7 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
      * {@link ExtensibleTreeMap#extensions} map to the output object unless the value represents a {@link Reference} in
      * which case only the {@link Reference#getRef()} is added.
      */
-    static class ExtensibleTreeMapSerializer extends JsonSerializer<ExtensibleTreeMap<?,?>> {
+    static class ExtensibleTreeMapSerializer extends JsonSerializer<ExtensibleTreeMap<?, ?>> {
 
         @Override
         public void serialize(ExtensibleTreeMap<?,?> value, JsonGenerator gen, SerializerProvider serializers)
@@ -88,10 +136,12 @@ public abstract class ExtensibleTreeMap<V, T extends Extensible<T>> extends Tree
                 gen.writeFieldName(entry.getKey());
                 valueSerializer.serialize(entry.getValue(), gen, serializers);
             }
-            for (Map.Entry<String, Object> extension : value.getExtensions().entrySet()) {
-                gen.writeFieldName(extension.getKey());
-                Object extensionValue = extension.getValue();
-                serializers.findValueSerializer(extensionValue.getClass()).serialize(extensionValue, gen, serializers);
+            if (value.getExtensions() != null) {
+                for (Map.Entry<String, Object> extension : value.getExtensions().entrySet()) {
+                    gen.writeFieldName(extension.getKey());
+                    Object extensionValue = extension.getValue();
+                    serializers.findValueSerializer(extensionValue.getClass()).serialize(extensionValue, gen, serializers);
+                }
             }
             gen.writeEndObject();
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExternalDocumentationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExternalDocumentationImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExternalDocumentationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/ExternalDocumentationImpl.java
@@ -52,6 +52,7 @@ public class ExternalDocumentationImpl extends ExtensibleImpl<ExternalDocumentat
         org.eclipse.microprofile.openapi.models.ExternalDocumentation from = new ExternalDocumentationImpl();
         from.setDescription(annotation.getValue("description", String.class));
         from.setUrl(annotation.getValue("url", String.class));
+        from.setExtensions(parseExtensions(annotation));
         return from;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -100,6 +100,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         if (components != null) {
             from.setComponents(ComponentsImpl.createInstance(components, context));
         }
+        from.setExtensions(parseExtensions(annotation));
         return from;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -298,6 +298,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
             }
             ExternalDocumentationImpl.merge(from.getExternalDocs(), to.getExternalDocs(), override);
         }
+        ExtensibleImpl.merge(from, to, override);
         // Handle @SecurityRequirement
         if (from.getSecurity() != null) {
             for (SecurityRequirement requirement : from.getSecurity()) {
@@ -349,6 +350,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         clonedObj.setTags(new ArrayList<>(this.tags));
         clonedObj.setPaths(new PathsImpl(this.paths.getPathItems()));
         clonedObj.setComponents(this.components);
+        clonedObj.setExtensions(this.extensions);
         ((OpenAPIImpl) clonedObj).setEndpoints(new TreeMap<>(this.getEndpoints()));
         return clonedObj;
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -105,10 +105,6 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
         List<AnnotationModel> responses = annotation.getValue("responses", List.class);
         if (responses != null) {
             APIResponsesImpl apiResponsesImpl = APIResponsesImpl.createInstance(annotation, context);
-// FIXME: implement!
-//            for (AnnotationModel response : responses) {
-//                from.getResponses().addAPIResponse(response.getValue("responseCode", String.class), apiResponsesImpl);
-//            }
         }
         from.setExtensions(parseExtensions(annotation));
         extractAnnotations(annotation, context, "callbacks", "name", CallbackImpl::createInstance, from::addCallback);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fish.payara.microprofile.openapi.impl.model.responses.APIResponseImpl;
 
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.models.Operation;
@@ -101,11 +102,7 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
         if (requestBody != null) {
             from.setRequestBody(RequestBodyImpl.createInstance(requestBody, context));
         }
-        //extractAnnotations(annotation, context, "responses", "responseCode", APIResponseImpl::createInstance, from.responses::addAPIResponse);
-        List<AnnotationModel> responses = annotation.getValue("responses", List.class);
-        if (responses != null) {
-            APIResponsesImpl apiResponsesImpl = APIResponsesImpl.createInstance(annotation, context);
-        }
+        extractAnnotations(annotation, context, "responses", "responseCode", APIResponseImpl::createInstance, from.responses::addAPIResponse);
         from.setExtensions(parseExtensions(annotation));
         extractAnnotations(annotation, context, "callbacks", "name", CallbackImpl::createInstance, from::addCallback);
         from.setDeprecated(annotation.getValue("deprecated", Boolean.class));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -49,7 +49,6 @@ import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.callbacks.CallbackImpl;
 import fish.payara.microprofile.openapi.impl.model.parameters.ParameterImpl;
 import fish.payara.microprofile.openapi.impl.model.parameters.RequestBodyImpl;
-import fish.payara.microprofile.openapi.impl.model.responses.APIResponseImpl;
 import fish.payara.microprofile.openapi.impl.model.responses.APIResponsesImpl;
 import fish.payara.microprofile.openapi.impl.model.security.SecurityRequirementImpl;
 import fish.payara.microprofile.openapi.impl.model.servers.ServerImpl;
@@ -102,7 +101,16 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
         if (requestBody != null) {
             from.setRequestBody(RequestBodyImpl.createInstance(requestBody, context));
         }
-        extractAnnotations(annotation, context, "responses", "responseCode", APIResponseImpl::createInstance, from.responses::addAPIResponse);
+        //extractAnnotations(annotation, context, "responses", "responseCode", APIResponseImpl::createInstance, from.responses::addAPIResponse);
+        List<AnnotationModel> responses = annotation.getValue("responses", List.class);
+        if (responses != null) {
+            APIResponsesImpl apiResponsesImpl = APIResponsesImpl.createInstance(annotation, context);
+// FIXME: implement!
+//            for (AnnotationModel response : responses) {
+//                from.getResponses().addAPIResponse(response.getValue("responseCode", String.class), apiResponsesImpl);
+//            }
+        }
+        from.setExtensions(parseExtensions(annotation));
         extractAnnotations(annotation, context, "callbacks", "name", CallbackImpl::createInstance, from::addCallback);
         from.setDeprecated(annotation.getValue("deprecated", Boolean.class));
         extractAnnotations(annotation, context, "security", SecurityRequirementImpl::createInstance, from::addSecurityRequirement);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -75,6 +75,7 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
     public static PathItem createInstance(AnnotationModel annotation, ApiContext context) {
         PathItem from = new PathItemImpl();
         extractAnnotations(annotation, context, "servers", ServerImpl::createInstance, from::addServer);
+        from.setExtensions(parseExtensions(annotation));
         return from;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/examples/ExampleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/examples/ExampleImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/examples/ExampleImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/examples/ExampleImpl.java
@@ -62,6 +62,7 @@ public class ExampleImpl extends ExtensibleImpl<Example> implements Example {
         from.setValue(annotation.getValue("value", Object.class));
         from.setExternalValue(annotation.getValue("externalValue", String.class));
         String ref = annotation.getValue("ref", String.class);
+        from.setExtensions(parseExtensions(annotation));
         if (ref != null && !ref.isEmpty()) {
             from.setRef(ref);
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
@@ -99,6 +99,7 @@ public class HeaderImpl extends ExtensibleImpl<Header> implements Header {
         if (ref != null && !ref.isEmpty()) {
             from.setRef(ref);
         }
+        from.setExtensions(parseExtensions(annotation));
         from.setDescription(annotation.getValue("description", String.class));
         from.setRequired(annotation.getValue("required", Boolean.class));
         from.setDeprecated(annotation.getValue("deprecated", Boolean.class));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/headers/HeaderImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/ContactImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/ContactImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/ContactImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/ContactImpl.java
@@ -56,6 +56,7 @@ public class ContactImpl extends ExtensibleImpl<Contact> implements Contact {
         from.setName(annotation.getValue("name", String.class));
         from.setUrl(annotation.getValue("url", String.class));
         from.setEmail(annotation.getValue("email", String.class));
+        from.setExtensions(parseExtensions(annotation));
         return from;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/InfoImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/InfoImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/InfoImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/InfoImpl.java
@@ -59,6 +59,7 @@ public class InfoImpl extends ExtensibleImpl<Info> implements Info {
         Info from = new InfoImpl();
         from.setTitle(annotation.getValue("title", String.class));
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setTermsOfService(annotation.getValue("termsOfService", String.class));
         AnnotationModel contact = annotation.getValue("contact", AnnotationModel.class);
         if (contact != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
@@ -53,6 +53,7 @@ public class LicenseImpl extends ExtensibleImpl<License> implements License {
         License from = new LicenseImpl();
         from.setName(annotation.getValue("name", String.class));
         from.setUrl(annotation.getValue("url", String.class));
+        from.setExtensions(parseExtensions(annotation));
         return from;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/links/LinkImpl.java
@@ -82,6 +82,7 @@ public class LinkImpl extends ExtensibleImpl<Link> implements Link {
         }
         from.setRequestBody(annotation.getValue("requestBody", String.class));
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         String ref = annotation.getValue("ref", String.class);
         if (ref != null && !ref.isEmpty()) {
             from.setRef(ref);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -46,7 +46,6 @@ import fish.payara.microprofile.openapi.impl.model.examples.ExampleImpl;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
-import java.util.HashMap;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -62,7 +61,7 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
 
     private static final long serialVersionUID = 1575356277308242221L;
 
-    private Map<String, Object> extensions = new HashMap<>(); // workaround as Content doesn't extend Extendable!
+    private Map<String, Object> extensions = null; // workaround as Content doesn't extend Extendable!
 
     public ContentImpl() {
         super();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -40,11 +40,13 @@
 package fish.payara.microprofile.openapi.impl.model.media;
 
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
+import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.examples.ExampleImpl;
 
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
+import java.util.HashMap;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -60,6 +62,8 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
 
     private static final long serialVersionUID = 1575356277308242221L;
 
+    private Map<String, Object> extensions = new HashMap<>(); // workaround as Content doesn't extend Extendable!
+
     public ContentImpl() {
         super();
     }
@@ -74,6 +78,7 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
         if (typeName == null || typeName.isEmpty()) {
             typeName = jakarta.ws.rs.core.MediaType.WILDCARD;
         }
+        from.setExtensions(ExtensibleImpl.parseExtensions(annotation));
         MediaType mediaType = new MediaTypeImpl();
         from.addMediaType(typeName, mediaType);
         extractAnnotations(annotation, context, "examples", "name", ExampleImpl::createInstance, mediaType::addExample);
@@ -160,6 +165,14 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
                 SchemaImpl.merge(fromMediaType.getSchema(), schema, true, context);
             }
         }
+    }
+
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -164,6 +164,9 @@ public class ContentImpl extends LinkedHashMap<String, MediaType> implements Con
                 Schema schema = toMediaType.getSchema();
                 SchemaImpl.merge(fromMediaType.getSchema(), schema, true, context);
             }
+
+            // extensions
+            ExtensibleImpl.merge(fromMediaType, toMediaType, override);
         }
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/ContentImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
@@ -72,6 +72,7 @@ public class EncodingImpl extends ExtensibleImpl<Encoding> implements Encoding {
         }
         from.setExplode(annotation.getValue("explode", Boolean.class));
         from.setAllowReserved(annotation.getValue("allowReserved", Boolean.class));
+        from.setExtensions(parseExtensions(annotation));
 
         return from;
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -161,6 +161,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
         from.setDefaultValue(annotation.getValue("defaultValue", Object.class));
         from.setName(annotation.getValue("name", String.class));
         from.setTitle(annotation.getValue("title", String.class));
+        from.setExtensions(parseExtensions(annotation));
         Double multipleOf = annotation.getValue("multipleOf", Double.class);
         if (multipleOf != null) {
             from.setMultipleOf(BigDecimal.valueOf(multipleOf));
@@ -200,6 +201,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
         }
 
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setFormat(annotation.getValue("format", String.class));
         from.setNullable(annotation.getValue("nullable", Boolean.class));
         from.setReadOnly(annotation.getValue("readOnly", Boolean.class));
@@ -806,6 +808,8 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
             applyReference(to, from.getRef());
             return;
         }
+        // process extensions attributes
+        ExtensibleImpl.merge(from, to, override);
         if (from.getType() != null) {
             to.setType(mergeProperty(to.getType(), from.getType(), override));
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/ParameterImpl.java
@@ -88,6 +88,7 @@ public class ParameterImpl extends ExtensibleImpl<Parameter> implements Paramete
             from.setIn(In.valueOf(inEnum.getValue()));
         }
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setRequired(annotation.getValue("required", Boolean.class));
         from.setDeprecated(annotation.getValue("deprecated", Boolean.class));
         from.setAllowEmptyValue(annotation.getValue("allowEmptyValue", Boolean.class));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/RequestBodyImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/RequestBodyImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/RequestBodyImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/parameters/RequestBodyImpl.java
@@ -63,6 +63,7 @@ public class RequestBodyImpl extends ExtensibleImpl<RequestBody> implements Requ
     public static RequestBodyImpl createInstance(AnnotationModel annotation, ApiContext context) {
         RequestBodyImpl from = new RequestBodyImpl();
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setRequired(annotation.getValue("required", Boolean.class));
         String ref = annotation.getValue("ref", String.class);
         if (ref != null && !ref.isEmpty()) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -216,6 +216,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
             return;
         }
         to.setDescription(mergeProperty(to.getDescription(), from.getDescription(), override));
+        ExtensibleImpl.merge(from, to, override);
         if (from.getContent() != null) {
             if (to.getContent() == null) {
                 to.setContent(new ContentImpl());

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -97,6 +97,8 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
         extractAnnotations(annotation, context, "content", ContentImpl::createInstance, contents::add);
         for (ContentImpl content : contents) {
             content.getMediaTypes().forEach(from.content::addMediaType);
+            // copy extensions down to media types
+            content.getExtensions().forEach((extKey, extValue) -> content.getMediaTypes().forEach((mtKey, mtValue) -> from.content.getMediaType(mtKey).addExtension(extKey, extValue)));
         }
 
         extractAnnotations(annotation, context, "links", "name", LinkImpl::createInstance, from::addLink);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -78,6 +78,7 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
     public static APIResponseImpl createInstance(AnnotationModel annotation, ApiContext context) {
         APIResponseImpl from = new APIResponseImpl();
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         HeaderImpl.createInstances(annotation, context).forEach(from::addHeader);
 
         final List<ContentImpl> contents = createList();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponseImpl.java
@@ -98,7 +98,9 @@ public class APIResponseImpl extends ExtensibleImpl<APIResponse> implements APIR
         for (ContentImpl content : contents) {
             content.getMediaTypes().forEach(from.content::addMediaType);
             // copy extensions down to media types
-            content.getExtensions().forEach((extKey, extValue) -> content.getMediaTypes().forEach((mtKey, mtValue) -> from.content.getMediaType(mtKey).addExtension(extKey, extValue)));
+            if (content.getExtensions() != null) {
+                content.getExtensions().forEach((extKey, extValue) -> content.getMediaTypes().forEach((mtKey, mtValue) -> from.content.getMediaType(mtKey).addExtension(extKey, extValue)));
+            }
         }
 
         extractAnnotations(annotation, context, "links", "name", LinkImpl::createInstance, from::addLink);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -68,10 +68,6 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
     public static APIResponsesImpl createInstance(AnnotationModel annotation, ApiContext context) {
         APIResponsesImpl from = new APIResponsesImpl();
         from.setExtensions(parseExtensions(annotation));
-//        List<AnnotationModel> extensions = annotation.getValue("extensions", List.class);
-//        if (extensions != null) {
-//            extensions.stream().forEach(e -> from.addExtension(e.getValue("name", String.class), e.getValue("value", String.class)));
-//        }
         ModelUtils.extractAnnotations(annotation, context, "responses", "responseCode", APIResponseImpl::createInstance, from::addAPIResponse);
         return from;
     }
@@ -115,8 +111,6 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
         if (from == null) {
             return;
         }
-        // process extensions attribute
-        ExtensibleImpl.merge(from, to, override);
         // Get the response name
         String responseName = null;
         if (from instanceof APIResponseImpl) {
@@ -130,8 +124,14 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
                 .getAPIResponses()
                 .getOrDefault(responseName, new APIResponseImpl());
         to.addAPIResponse(responseName, response);
+        // process extensions attribute
+        ExtensibleImpl.merge(from, response, override);
 
         APIResponseImpl.merge(from, response, override, context);
+    }
+
+    public static void merge(APIResponses from, APIResponses to, boolean override, ApiContext context) {
+        ExtensibleImpl.merge(from, to, override);
     }
 
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/responses/APIResponsesImpl.java
@@ -68,7 +68,7 @@ public class APIResponsesImpl extends ExtensibleTreeMap<APIResponse, APIResponse
     public static APIResponsesImpl createInstance(AnnotationModel annotation, ApiContext context) {
         APIResponsesImpl from = new APIResponsesImpl();
         from.setExtensions(parseExtensions(annotation));
-        ModelUtils.extractAnnotations(annotation, context, "responses", "responseCode", APIResponseImpl::createInstance, from::addAPIResponse);
+        ModelUtils.extractAnnotations(annotation, context, "value", "responseCode", APIResponseImpl::createInstance, from::addAPIResponse);
         return from;
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowImpl.java
@@ -64,6 +64,7 @@ public class OAuthFlowImpl extends ExtensibleImpl<OAuthFlow> implements OAuthFlo
         from.setAuthorizationUrl(annotation.getValue("authorizationUrl", String.class));
         from.setTokenUrl(annotation.getValue("tokenUrl", String.class));
         from.setRefreshUrl(annotation.getValue("refreshUrl", String.class));
+        from.setExtensions(parseExtensions(annotation));
         List<AnnotationModel> scopesAnnotation = annotation.getValue("scopes", List.class);
         if (scopesAnnotation != null) {
             Map<String, String> scopes = createMap();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowsImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/OAuthFlowsImpl.java
@@ -54,6 +54,7 @@ public class OAuthFlowsImpl extends ExtensibleImpl<OAuthFlows> implements OAuthF
 
     public static OAuthFlows createInstance(AnnotationModel annotation) {
         OAuthFlows from = new OAuthFlowsImpl();
+        from.setExtensions(parseExtensions(annotation));
         AnnotationModel implicitAnnotation = annotation.getValue("implicit", AnnotationModel.class);
         if (implicitAnnotation != null) {
             from.setImplicit(OAuthFlowImpl.createInstance(implicitAnnotation));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecuritySchemeImpl.java
@@ -70,6 +70,7 @@ public class SecuritySchemeImpl extends ExtensibleImpl<SecurityScheme> implement
             from.setType(SecurityScheme.Type.valueOf(type.getValue()));
         }
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setName(annotation.getValue("apiKeyName", String.class));
         String ref = annotation.getValue("ref", String.class);
         if (ref != null && !ref.isEmpty()) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerImpl.java
@@ -62,6 +62,7 @@ public class ServerImpl extends ExtensibleImpl<Server> implements Server {
     public static Server createInstance(AnnotationModel annotation, ApiContext context) {
         Server from = new ServerImpl();
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setUrl(annotation.getValue("url", String.class));
         extractAnnotations(annotation, context, "variables", "name", ServerVariableImpl::createInstance, from::addVariable);
         return from;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/servers/ServerVariableImpl.java
@@ -60,6 +60,7 @@ public class ServerVariableImpl extends ExtensibleImpl<ServerVariable> implement
     public static ServerVariable createInstance(AnnotationModel annotation, ApiContext context) {
         ServerVariable from = new ServerVariableImpl();
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         from.setDefaultValue(annotation.getValue("defaultValue", String.class));
         List<String> enumeration = annotation.getValue("enumeration", List.class);
         if (enumeration != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/tags/TagImpl.java
@@ -61,6 +61,7 @@ public class TagImpl extends ExtensibleImpl<Tag> implements Tag {
         TagImpl from = new TagImpl();
         from.setName(annotation.getValue("name", String.class));
         from.setDescription(annotation.getValue("description", String.class));
+        from.setExtensions(parseExtensions(annotation));
         AnnotationModel externalDocs = annotation.getValue("externalDocs", AnnotationModel.class);
         if (externalDocs != null) {
             from.setExternalDocs(ExternalDocumentationImpl.createInstance(externalDocs));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -531,7 +531,7 @@ public final class ModelUtils {
     public static <T> void extractAnnotations(
             AnnotationModel annotationModel,
             ApiContext context,
-            String type,
+            String parameterName,
             String key,
             BiFunction<AnnotationModel, ApiContext, T> factory,
             BiConsumer<String, T> wrapperAddFunction) {
@@ -539,7 +539,7 @@ public final class ModelUtils {
         if (wrapperAddFunction == null) {
             throw new IllegalArgumentException("null wrapperAddFunction. This is required to modify OpenAPI documents");
         }
-        List<AnnotationModel> annotations = annotationModel.getValue(type, List.class);
+        List<AnnotationModel> annotations = annotationModel.getValue(parameterName, List.class);
         if (annotations != null) {
             for (AnnotationModel annotation : annotations) {
                 wrapperAddFunction.accept(

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -875,7 +875,9 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
         if (responses != null) {
             responses.forEach(response -> visitAPIResponse(response, element, context));
         }
-        APIResponsesImpl.merge(from, context.getWorkingOperation().getResponses(), true, context);
+        if (context.getWorkingOperation() != null) {
+            APIResponsesImpl.merge(from, context.getWorkingOperation().getResponses(), true, context);
+        }
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -838,7 +838,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             } else if (element instanceof ClassModel) {
                 // this is fine, class-based annotation is reflected in methods as well
             } else {
-                LOGGER.warning("Unrecognised @APIResponse annotation position at: " + element.shortDesc());
+                LOGGER.warning(() -> "Unrecognised @APIResponse annotation position at: " + element.shortDesc());
             }
             return;
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -747,7 +747,6 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
         if (name != null && !name.isEmpty()
                 && value != null && !value.isEmpty()) {
             Object parsedValue = ExtensibleImpl.convertExtensionValue(value, parseValue);
-//            context.addExtension(name, parsedValue);
             if (element instanceof MethodModel) {
                 context.getWorkingOperation().addExtension(name, parsedValue);
             } else {
@@ -872,14 +871,11 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     @Override
     public void visitAPIResponses(AnnotationModel annotation, AnnotatedElement element, ApiContext context) {
         APIResponsesImpl from = APIResponsesImpl.createInstance(annotation, context);
-        List<AnnotationModel> extensions = annotation.getValue("extensions", List.class);
-        if (extensions != null && context.getWorkingOperation() != null) {
-            extensions.forEach(extension -> visitExtension(extension, element, context)); // FIXME: this must put he extension to APIResponse, not Operation!!!
-        }
         List<AnnotationModel> responses = annotation.getValue("value", List.class);
         if (responses != null) {
             responses.forEach(response -> visitAPIResponse(response, element, context));
         }
+        APIResponsesImpl.merge(from, context.getWorkingOperation().getResponses(), true, context);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -42,6 +42,7 @@ package fish.payara.microprofile.openapi.impl.visitor;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor;
 import fish.payara.microprofile.openapi.api.visitor.ApiVisitor.VisitorFunction;
 import fish.payara.microprofile.openapi.api.visitor.ApiWalker;
+import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
 import fish.payara.microprofile.openapi.impl.model.media.SchemaImpl;
 import java.lang.annotation.Annotation;
 import java.util.Comparator;
@@ -180,6 +181,31 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
                 if (context.getPath() != null) {
                     annotationFunction.apply(annotations.getAnnotation(annotationClass), element, context);
                 }
+            }
+        }
+        // at the end, propagate @Extension defined on method to the @APIResponses (see javadoc of propagateExtension).
+        if (element instanceof MethodModel && annotations.isAnnotationPresent(Extension.class, element)) {
+            OpenApiContext methodContext = new OpenApiContext(context, element);
+            propagateExtension(methodContext);
+        }
+    }
+
+    /**
+     * Propagate @Extension from method-level down to @APIResponses as required
+     * by MP OpenApi TCK (testExtensionPlacement,
+     * <verbatim><code>
+     * vr.body(opPath + ".responses.'503'", hasEntry(equalTo(X_OPERATION_EXT),
+     * equalTo(TEST_OPERATION_EXT)));
+     * </code></verbatim>
+     *
+     * This is nonsense, when this test will be removed, remove also this
+     * method!
+     */
+    private void propagateExtension(OpenApiContext methodContext) {
+        for (org.eclipse.microprofile.openapi.models.responses.APIResponse apiResponse : methodContext.getWorkingOperation().getResponses().getAPIResponses().values()) {
+            if (apiResponse.getExtensions() == null) {
+                // only if empty
+                ExtensibleImpl.merge(methodContext.getWorkingOperation(), apiResponse, true);
             }
         }
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -156,6 +156,7 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
         for (Class<? extends Annotation> annotationClass : getAnnotationVisitor(visitor).keySet()) {
             VisitorFunction<AnnotationModel, E> annotationFunction = getAnnotationVisitor(visitor).get(annotationClass);
             Class<? extends Annotation> alternative = getAnnotationAlternatives().get(annotationClass);
+
             // If it's just the one annotation class
             // Check the element
             if (annotations.isAnnotationPresent(annotationClass, element)) {
@@ -173,6 +174,13 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
                         }
                     }
                 } else {
+                    // if annotation requires merging from both class and method (like APIResponse(s) does, call class first
+                    if (element instanceof MethodModel && (annotationClass == APIResponse.class || annotationClass == APIResponses.class)) {
+                        if (annotations.isAnnotationPresent(annotationClass)) {
+                            annotationFunction.apply(annotations.getAnnotation(annotationClass), element, context);
+                        }
+                    }
+                    // process the annotation by its function
                     annotationFunction.apply(annotations.getAnnotation(annotationClass, element), element, context);
                 }
             } else if (element instanceof MethodModel && annotations.isAnnotationPresent(annotationClass)

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/model/ModelInvariantsTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/model/ModelInvariantsTest.java
@@ -112,7 +112,7 @@ public class ModelInvariantsTest {
 
     @Test
     public void addKeyValueIgnoresNull() {
-        BiPredicate<Extensible<?>, String> hasExtension = (obj, key) -> obj.getExtensions().containsKey(key);
+        BiPredicate<Extensible<?>, String> hasExtension = (obj, key) -> obj.getExtensions() != null && obj.getExtensions().containsKey(key);
         assertAddIgnoresNull(new CallbackImpl(), Callback::addPathItem, Callback::hasPathItem);
         assertAddIgnoresNull(new CallbackImpl(), Callback::addExtension, hasExtension);
         assertAddIgnoresNull(new ExampleImpl(), Example::addExtension,  hasExtension);


### PR DESCRIPTION
## Description
Adding support

## Testing
### Testing Performed
Going through MP OpenApi TCK -- test, which deploy (yes, the TCK is broken) pass!

There is a setup required -- disable https (Configurations, server-config, Network Config, edit http-listener-2, set disabled; this is registered as second server, tests expectat only one server, specifically `testStaticDocument`).

### Testing Environment
Linux, OpenJDK

## Note for reviewer
It was necessary to distinguish between "no extensions defined" and "empty extensions defined". The TCK requires, that annotation `@Extension` is propagated to `@APIResponses/@APIResponse`, but only if not defined. In the next code:

```
    @APIResponses(extensions = @Extension(name = "x-responses-ext", value = "test-responses-ext"), value = {
        @APIResponse(responseCode = "200", description = "successful operation",
                extensions = @Extension(name = "x-response-ext", value = "test-response-ext")),
        @APIResponse(responseCode = "500", description = "server error", extensions = {}),
        @APIResponse(responseCode = "503", description = "service not available",
                content = @Content(extensions = @Extension(name = "x-notavailable-ext", value = "true"))),})
    @Operation(summary = "Returns pet inventories by status",
            description = "Returns a map of status codes to quantities")
    @Extension(name = "x-operation-ext", value = "test-operation-ext")
    public java.util.Map<String, Integer> getInventory() {
```

The extension "x-operation-ext" is propagated to code 503 (no other extension is defined), but not to 200  (extension "x-response-ext" defined), nor to 500 (empty extensions!).