### PR TITLE
Fish 6766 : Support new security requirement constructs for MP OpenAPI 3.1

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiVisitor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiVisitor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -137,4 +137,9 @@ public interface ApiVisitor {
     void visitSecurityRequirements(AnnotationModel securityRequirements, AnnotatedElement element,
             ApiContext context);
 
+    void visitSecurityRequirementSet(AnnotationModel securityRequirement, AnnotatedElement element,
+                                  ApiContext context);
+
+    void visitSecurityRequirementSets(AnnotationModel securityRequirements, AnnotatedElement element,
+                                   ApiContext context);
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -49,11 +49,13 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.create
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.extractAnnotations;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.mergeProperty;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
+
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.Set;
+
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -91,6 +93,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
             from.setExternalDocs(ExternalDocumentationImpl.createInstance(externalDocs));
         }
         extractAnnotations(annotation, context, "security", SecurityRequirementImpl::createInstance, from::addSecurityRequirement);
+        extractAnnotations(annotation, context, "securitySets", SecurityRequirementImpl::createInstances, from::addSecurityRequirements);
         extractAnnotations(annotation, context, "servers", ServerImpl::createInstance, from::addServer);
         extractAnnotations(annotation, context, "tags", TagImpl::createInstance, from::addTag);
         AnnotationModel components = annotation.getValue("components", AnnotationModel.class);
@@ -99,7 +102,11 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         }
         return from;
     }
-    
+
+    private void addSecurityRequirements(List<SecurityRequirement> securityRequirements) {
+        securityRequirements.forEach(this::addSecurityRequirement);
+    }
+
     public final ApiContext getContext() {
         return context;
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -44,11 +44,13 @@ import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOn
 
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 
@@ -117,4 +119,16 @@ public class SecurityRequirementImpl extends LinkedHashMap<String, List<String>>
         }
     }
 
+    public static <T> List<SecurityRequirement> createInstances(AnnotationModel annotationModel, ApiContext context) {
+        List<SecurityRequirement> securityRequirements = new ArrayList<>();
+        List<AnnotationModel> annotations = annotationModel.getValue("value", ArrayList.class);
+        for (AnnotationModel annotation : annotations) {
+            SecurityRequirement securityRequirement = new SecurityRequirementImpl();
+            String name = annotation.getValue("name", String.class);
+            List<String> scopes = annotation.getValue("scopes", List.class);
+            securityRequirement.addScheme(name, scopes != null ? scopes : Collections.emptyList());
+            securityRequirements.add(securityRequirement);
+        }
+        return securityRequirements;
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -1153,7 +1153,26 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     public void visitSecurityRequirements(AnnotationModel annotation, AnnotatedElement element, ApiContext context) {
         List<AnnotationModel> securityRequirements = annotation.getValue("value", List.class);
         if (securityRequirements != null) {
-            securityRequirements.forEach(securityRequirement -> visitSecurityRequirement(securityRequirement, element, context));
+            securityRequirements.forEach(securityRequirement ->
+                    visitSecurityRequirement(securityRequirement, element, context));
+        }
+    }
+
+    @Override
+    public void visitSecurityRequirementSet(AnnotationModel annotation, AnnotatedElement element, ApiContext context) {
+        List<AnnotationModel> securityRequirements = annotation.getValue("value", List.class);
+        if (securityRequirements != null) {
+            securityRequirements.forEach(securityRequirement ->
+                    visitSecurityRequirement(securityRequirement, element, context));
+        }
+    }
+
+    @Override
+    public void visitSecurityRequirementSets(AnnotationModel annotation, AnnotatedElement element, ApiContext context) {
+        List<AnnotationModel> securityRequirementSetList = annotation.getValue("value", List.class);
+        if (securityRequirementSetList != null) {
+            securityRequirementSetList.forEach(securityRequirementSet ->
+                    visitSecurityRequirementSet(securityRequirementSet, element, context));
         }
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -82,7 +82,12 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBodySchema
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.openapi.annotations.security.*;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSets;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.servers.Servers;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -82,10 +82,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBodySchema
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
-import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
+import org.eclipse.microprofile.openapi.annotations.security.*;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.servers.Servers;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -237,6 +234,8 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
             annotationVisitor.put(SecuritySchemes.class, visitor::visitSecuritySchemes);
             annotationVisitor.put(SecurityRequirement.class, visitor::visitSecurityRequirement);
             annotationVisitor.put(SecurityRequirements.class, visitor::visitSecurityRequirements);
+            annotationVisitor.put(SecurityRequirementsSet.class, visitor::visitSecurityRequirementSet);
+            annotationVisitor.put(SecurityRequirementsSets.class, visitor::visitSecurityRequirementSets);
 
             // JAX-RS response
             annotationVisitor.put(Produces.class, visitor::visitProduces);
@@ -268,6 +267,8 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
             annotationAlternatives.put(SecuritySchemes.class, SecurityScheme.class);
             annotationAlternatives.put(SecurityRequirement.class, SecurityRequirements.class);
             annotationAlternatives.put(SecurityRequirements.class, SecurityRequirement.class);
+            annotationAlternatives.put(SecurityRequirementsSet.class, SecurityRequirementsSets.class);
+            annotationAlternatives.put(SecurityRequirementsSets.class, SecurityRequirementsSet.class);
         }
         return annotationAlternatives;
     }


### PR DESCRIPTION
## Description
Handling annotation @SecurityRequirementSet and property securitySet

## Testing
### New tests
None

### Testing Performed

1. Deploy the reproducer-6766.zip attached on https://payara.atlassian.net/browse/FISH-6766
2. Poke localhost:8080/openapi
3. Check the yaml result... It should contain:

security:
- airlinesRatingApp_auth: []
**- testScheme1: []
- testScheme2: []**
into openapi and also into /user/login -> get

it also should have:
      security:
      - httpSchemeForTest: []
      **- userApiKey: []
      - userBearerHttp: []**
inside /user/{username} -> patch

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.6

## Notes for Reviewers
The tests where based in TCK: 
https://github.com/eclipse/microprofile-open-api/pull/519/files#diff-0b001a0b97f0f3eecd10d2d39d7de2a15716bd7b95885244e0f3802f36d7cb3d