### PR TITLE
FISH-7063: Use only single property for Jakarta API version

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -138,19 +138,33 @@
                 <artifactId>jakarta.jakartaee-api</artifactId>
                 <version>${jakartaee.api.version}</version>
                 <scope>provided</scope>
+                <!-- https://github.com/eclipse-ee4j/jakartaee-api/issues/133 -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-web-api</artifactId>
-                <version>${jakarta-platform.version}</version>
+                <version>${jakartaee.api.version}</version>
                 <scope>provided</scope>
+                <!-- https://github.com/eclipse-ee4j/jakartaee-api/issues/133 -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Jakarta BOM. May be used in import scope by client instead of aggregate -->
             <dependency>
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-bom</artifactId>
-                <version>${jakarta-platform.version}</version>
+                <version>${jakarta.api.version}</version>
                 <type>pom</type>
             </dependency>
 

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -120,12 +120,6 @@
             </dependency>
 
             <dependency>
-                <groupId>fish.payara.security.connectors</groupId>
-                <artifactId>security-connectors-api</artifactId>
-                <version>${payara.security-connectors.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>fish.payara.server.appclient</groupId>
                 <artifactId>payara-client</artifactId>
                 <version>${project.version}</version>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -136,10 +136,5 @@
             <groupId>org.glassfish.expressly</groupId>
             <artifactId>expressly</artifactId>
         </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.admingui</groupId>
-            <artifactId>faces-compat</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/appserver/packager/microprofile-package/pom.xml
+++ b/appserver/packager/microprofile-package/pom.xml
@@ -251,19 +251,6 @@
             <artifactId>rest-client-ssl</artifactId>
             <version>${project.version}</version>
         </dependency>
-            
-
-        <!-- MicroProfile Rest Client Extensions-->
-        <dependency>
-            <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
-            <artifactId>microprofile-rest-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
-            <artifactId>rest-client-ssl</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <!-- OpenTracing -->
         <dependency>
@@ -274,10 +261,6 @@
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
             <artifactId>microprofile-opentracing</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
         </dependency>
 
         <!-- Admin MicroProfile Admin GUI -->

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>${jakarta-platform.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -129,7 +128,6 @@
                                 <artifactItem>
                                     <groupId>jakarta.platform</groupId>
                                     <artifactId>jakarta.jakartaee-web-api</artifactId>
-                                    <version>${jakarta-platform.version}</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/appserver/security/core-ee/pom.xml
+++ b/appserver/security/core-ee/pom.xml
@@ -243,11 +243,6 @@
             <artifactId>jakarta.security.enterprise-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.security.enterprise</groupId>
-            <artifactId>jakarta.security.enterprise-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
          <dependency>
             <groupId>fish.payara.server.core.security</groupId>
             <artifactId>jaspic.provider.framework</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
         <parsson.version>1.1.1.payara-p1</parsson.version>
         <jsonp-api.version>2.1.0</jsonp-api.version>
         <jbi.version>1.0</jbi.version>
-        <jakarta-platform.version>10.0.0</jakarta-platform.version>
         <microprofile-release.version>5.0</microprofile-release.version>
         <microprofile-opentracing.version>3.0</microprofile-opentracing.version>
         <microprofile-config.version>3.0</microprofile-config.version>


### PR DESCRIPTION

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

Payara BOM declared `jakarta-web-api` version of 9.1.0, as well as for Platform BOM. This was an oversight where we in fact had two properties for platform version.

It also address eclipse-ee4j/jakartaee-api#133, where we exclude the transitional dependencies by default.

