### PR TITLE
Fish 6767 schema hide true

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -1214,7 +1214,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             mediaType.schema(createSchema(context, bodyType));
         }
 
-        requestBody.getContent().addMediaType(jakarta.ws.rs.core.MediaType.WILDCARD, mediaType);
+        requestBody.getContent().addMediaType(jakarta.ws.rs.core.MediaType.APPLICATION_JSON, mediaType);
 
         operation.setRequestBody(requestBody);
         return requestBody;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -443,7 +443,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
         newParameter.setRequired(required);
 
         Boolean isSchemaHidden = false;
-        AnnotationModel annotation = element.getAnnotation("org.eclipse.microprofile.openapi.annotations.media.Schema");
+        AnnotationModel annotation = element.getAnnotation(org.eclipse.microprofile.openapi.annotations.media.Schema.class.getName());
         if (annotation != null) {
             isSchemaHidden = annotation.getValue("hidden", Boolean.class);
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -356,16 +356,20 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             if (requestBody != null) {
                 // Find the wildcard return type
                 if (requestBody.getContent() != null
-                        && requestBody.getContent().getMediaType(jakarta.ws.rs.core.MediaType.WILDCARD) != null) {
-                    MediaType wildcardMedia = requestBody.getContent().getMediaType(jakarta.ws.rs.core.MediaType.WILDCARD);
+                        && requestBody.getContent().getMediaType(
+                                jakarta.ws.rs.core.MediaType.APPLICATION_JSON) != null) {
+                    MediaType jsonMedia = requestBody.getContent().getMediaType(
+                            jakarta.ws.rs.core.MediaType.APPLICATION_JSON);
 
                     // Copy the wildcard return type to the valid request body types
                     List<String> mediaTypes = consumes.getValue("value", List.class);
                     for (String mediaType : mediaTypes) {
-                        requestBody.getContent().addMediaType(getContentType(mediaType), wildcardMedia);
+                        requestBody.getContent().addMediaType(getContentType(mediaType), jsonMedia);
                     }
-                    // If there is an @Consumes, remove the wildcard
-                    requestBody.getContent().removeMediaType(jakarta.ws.rs.core.MediaType.WILDCARD);
+                    // If there is an @Consumes, removes the default
+                    if (!mediaTypes.contains(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)) {
+                        requestBody.getContent().removeMediaType(jakarta.ws.rs.core.MediaType.APPLICATION_JSON);
+                    }
                 }
             }
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/EnumTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/test/app/application/EnumTest.java
@@ -72,7 +72,7 @@ public class EnumTest extends OpenApiApplicationTest {
     @Test
     public void testSchemaReferenceCreated() {
         assertEquals("#/components/schemas/Data",
-                path(getOpenAPIJson(), "paths./test/enum/add.post.requestBody.content.*/*.schema.$ref").asText());
+                path(getOpenAPIJson(), "paths./test/enum/add.post.requestBody.content.application/json.schema.$ref").asText());
     }
 
     @Test


### PR DESCRIPTION
## Description
Check conformance with @Schema(hide=true) for MP OpenAPI 3.1

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1.  C:\Users\luise\git\Payara> git remote set-url origin https://github.com/luiseufrasio/Payara/ 
2. git fetch
3. git checkout -b FISH-6767-schema-hide-true origin/FISH-6767-schema-hide-true
4. mvn clean install -DskipTests
5. ./appserver/distributions/payara/target/stage/payara6/bin/asadmin start-domain -v
6. poke localhost:4848
7. deploy the reproducer attached here: https://payara.atlassian.net/browse/FISH-6767 
8. open another terminal
9. curl http://localhost:8080/openapi?format=json | jq '.paths."/user/special".post.requestBody.content."application/json".schema'
10. curl http://localhost:8080/openapi?format=json | jq '.paths."/user/special".post.requestBody.content."application/json"'
11. curl http://localhost:8080/openapi?format=json | jq '.paths."/user/special".post.parameters[0].schema'
12. Both commands on lines 10 and 11 should return null

### Testing Environment
Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.8.6

## Notes for Reviewers
You can play with the reproducer by removing the hidden property or setting false value and check if the results from commands on lines 10 and 11 change.
