### PR TITLE
Fish 6907 configure samesite cookie attribute

### DIFF
--- a/appserver/admingui/web/src/main/resources/grizzly/http.layout
+++ b/appserver/admingui/web/src/main/resources/grizzly/http.layout
@@ -39,7 +39,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates.] -->
+<!-- Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates.] -->
 
 <!-- grizzly/http.jsf -->
 
@@ -81,7 +81,7 @@
         setPageSessionAttribute(key="valueMap" value="#{pageSession.httpMap}");
         setPageSessionAttribute(key="convertToFalseList" 
             value={"uploadTimeoutEnabled", "cometSupportEnabled", "dnsLookupEnabled", "rcmSupportEnabled", "traceEnabled", "authPassThroughEnabled", 
-            "chunkingEnabled", "encodedSlashEnabled", "websocketsSupport", "xpoweredBy", "serverHeader", "xframeOptions", "http2Enabled", "http2DisableCipherCheck", "http2PushEnabled" });
+            "chunkingEnabled", "encodedSlashEnabled", "websocketsSupportEnabled", "xpoweredBy", "serverHeader", "xframeOptions", "cookieSameSiteEnabled", "http2Enabled", "http2DisableCipherCheck", "http2PushEnabled" });
 
         //set the following for including buttons.inc
         

--- a/appserver/admingui/web/src/main/resources/grizzly/httpAttr.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/httpAttr.inc
@@ -40,7 +40,7 @@
 
 -->
 
-<!-- Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates.] -->
+<!-- Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates.] -->
 
 <!-- grizzly/httpAttr.inc -->
 
@@ -247,8 +247,8 @@
             <sun:checkbox id="encodedSlashEnabled" label="$resource{i18n_web.common.enabled}" selected="#{pageSession.httpMap['encodedSlashEnabled']}" selectedValue="true" />
         </sun:property>
 
-        <sun:property id="websockets"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.WebsocketsSupport}" helpText="$resource{i18n_web.http.WebsocketsSupportHelp}" >
-            <sun:checkbox id="websocketsEnabled" label="$resource{i18n_web.common.enabled}" selected="#{pageSession.httpMap['websocketsSupportEnabled']}" selectedValue="true" />
+        <sun:property id="websocketsSupportEnabled"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.WebsocketsSupport}" helpText="$resource{i18n_web.http.WebsocketsSupportHelp}" >
+            <sun:checkbox id="websocketsSupportEnabled" label="$resource{i18n_web.common.enabled}" selected="#{pageSession.httpMap['websocketsSupportEnabled']}" selectedValue="true" />
         </sun:property>
     
         <sun:property id="SchemeMapping"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.SchemeMapping}" helpText="$resource{i18n_web.http.SchemeMappingHelp}" >
@@ -259,5 +259,12 @@
             <sun:textField id="RemoteUserMapping"  columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.http.ForcedResponseType']}" text="#{pageSession.httpMap['remoteUserMapping']}" />
         </sun:property>
 
+        <sun:property id="cookieSameSiteEnabled"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.EnableCookieSameSite}" helpText="$resource{i18n_web.http.EnableCookieSameSiteHelp}">
+            <sun:checkbox id="cookieSameSiteEnabled" label="$resource{i18n_web.common.enabled}" selected="#{pageSession.httpMap['cookieSameSiteEnabled']}" selectedValue="true" />
+        </sun:property>
+
+        <sun:property id="CookieSameSiteValue"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.CookieSameSiteValue}" helpText="$resource{i18n_web.http.CookieSameSiteValueHelp}">
+            <sun:dropDown id="cookieSameSiteValue" selected="#{pageSession.httpMap['cookieSameSiteValue']}" labels={"Strict","Lax","None"} />
+        </sun:property>
 "<br /><br />
 </sun:propertySheetSection>

--- a/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
+++ b/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates.]
+# Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates.]
 
 button.GetStatistics=Get Statistics
 
@@ -341,6 +341,10 @@ http.SchemeMappingHelp=HTTP Header Name used for identifying the originating pro
 http.RemoteUserMapping=Remote User Mapping
 http.RemoteUserMappingHelp=HTTP Header Name used for identifying the originating user of an HTTP request
 
+http.EnableCookieSameSite=Enable Cookie SameSite
+http.CookieSameSiteValue=Cookie SameSite Value
+http.EnableCookieSameSiteHelp=Enabling to set all cookies to use the SameSite value
+http.CookieSameSiteValueHelp=Lax: Cookies are not sent on normal cross-site subrequests, Strict: Cookies will only be sent in a first-party context, None: Cookies will be sent in all contexts
 
 http.listPortHelp=Can be 1-65535; ports 1-1024 require superuser privileges
 #http.acceptorLabel=Acceptor Threads:

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016,2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016,2023] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.v3.services.impl;
 
 import com.sun.appserv.server.util.Version;
@@ -281,7 +281,9 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
                 keepAlive,
                 delayedExecutor,
                 maxRequestHeaders,
-                maxResponseHeaders);
+                maxResponseHeaders,
+                http == null || Boolean.parseBoolean(http.getCookieSameSiteEnabled()),
+                http.getCookieSameSiteValue());
 
         if (http != null) { // could be null for HTTP redirect
             httpCodecFilter.setMaxPayloadRemainderToSkip(
@@ -379,6 +381,7 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
         private final String serverVersion;
         private final String xPoweredBy;
         private final String xFrameOptions;
+        private final String cookieSameSiteValue;
 
         public GlassfishHttpCodecFilter(
                 final boolean isXPoweredByEnabled,
@@ -388,7 +391,9 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
                 final int maxHeadersSize,
                 final String defaultResponseContentType,
                 final KeepAlive keepAlive, final DelayedExecutor executor,
-                final int maxRequestHeaders, final int maxResponseHeaders) {
+                final int maxRequestHeaders, final int maxResponseHeaders,
+                final boolean cookieSameSiteEnabled,
+                final String cookieSameSiteValue) {
             super(chunkingEnabled, maxHeadersSize, defaultResponseContentType,
                     keepAlive, executor, maxRequestHeaders, maxResponseHeaders);
 
@@ -430,6 +435,12 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
             } else {
                 xFrameOptions = null;
             }
+
+            if (cookieSameSiteEnabled) {
+                this.cookieSameSiteValue = cookieSameSiteValue;
+            } else {
+                this.cookieSameSiteValue = null;
+            }
         }
 
         @Override
@@ -451,6 +462,10 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
             // Set response "X-Powered-By" header
             if (xPoweredBy != null) {
                 response.addHeader(Header.XPoweredBy, xPoweredBy);
+            }
+
+            if (this.cookieSameSiteValue != null) {
+                response.addHeader(Header.SetCookie, "SameSite=" + this.cookieSameSiteValue);
             }
 
             return result;

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Http.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Http.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+ * Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates]
  */
 
 
@@ -75,8 +75,8 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     boolean XPOWERED_BY = true;
     boolean SERVER_HEADER = true;
     boolean XFRAME_OPTIONS = true;
+    boolean COOKIE_SAME_SITE_ENABLED = false;
     boolean ALLOW_PAYLOAD_FOR_UNDEFINED_HTTP_METHODS = false;
-
     int COMPRESSION_MIN_SIZE = 2048;
     int COMPRESSION_LEVEL = -1;
     int CONNECTION_UPLOAD_TIMEOUT = 300000;
@@ -98,6 +98,8 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     String COMPRESSION_PATTERN = "on|off|force|\\d+";
     String COMPRESSION_STRATEGY = "Default";
     String COMPRESSION_STRATEGY_PATTERN = "Filtered|Default|Huffman Only|\\d+";
+    String COOKIE_SAME_SITE_VALUE = "None";
+    String COOKIE_SAME_SITE_VALUE_PATTERN = "Strict|Lax|None|\\d+";
     String DEFAULT_ADAPTER = "org.glassfish.grizzly.http.server.StaticHttpHandler";
     String URI_ENCODING = "UTF-8";
     String SCHEME_PATTERN = "http|https";
@@ -163,6 +165,12 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     String getCompressionStrategy();
 
     void setCompressionStrategy(String compressionStrategy);
+
+    @Attribute(defaultValue = COOKIE_SAME_SITE_VALUE, dataType = String.class)
+    @Pattern(regexp = COOKIE_SAME_SITE_VALUE_PATTERN)
+    String getCookieSameSiteValue();
+
+    void setCookieSameSiteValue(String cookieSameSiteValue);
 
     @Attribute(defaultValue = "" + COMPRESSION_MIN_SIZE, dataType = Integer.class)
     String getCompressionMinSizeBytes();
@@ -374,6 +382,8 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
 
     void setRemoteUserMapping(final String remoteUserMapping);
 
+
+
     @Attribute(defaultValue = "" + WEBSOCKET_SUPPORT_ENABLED, dataType = Boolean.class)
     String getWebsocketsSupportEnabled();
 
@@ -454,6 +464,11 @@ public interface Http extends ConfigBeanProxy, PropertyBag {
     String getXframeOptions();
 
     void setXframeOptions(String xframeOptions);
+
+    @Attribute(defaultValue = "" + COOKIE_SAME_SITE_ENABLED, dataType = Boolean.class)
+    String getCookieSameSiteEnabled();
+
+    void setCookieSameSiteEnabled(String enabled);
 
     /**
      * @return <tt>true</tt>, if payload will be allowed for HTTP methods, for


### PR DESCRIPTION
## Description
Several customers have requested the ability have an easy way to configure ALL cookies generated by web applications deployed in Payara Server to set up their SameSite attribute to a specific value.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. mvn clean install -DskipTests
2. .\appserver\distributions\payara\target\stage\payara6\bin\asadmin start-domain -v
3. Open http://localhost:4848
4. Go into Configuration -> server-config -> Network Config -> Network Listeners -> http-listener-1
5. Choose HTTP Tab
6. Scroll down to the end of the page
7. Mark "Enable Cookie SameSite" checkbox
8. Select "Cookie SameSite Value" as Strict
9. Click on Save button
10. Deploy the war application attached in https://payara.atlassian.net/browse/FISH-6907
11. Poke http://alienware:8080/openapi-3-1-1.0-SNAPSHOT/user/name/Bob1
12. Open chrome dev tools (Ctrl+Shift+i)
13. Go to Network Tab
14. Click on "Bob" file
15. Check if SameSite=Strict was added in "Response Headers".Set-Cookie attribute

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.6

## Documentation
None

## Notes for Reviewers
None