### PR TITLE
FISH-6975 OpenAPI Scanning Rules

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018 - 2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
@@ -248,9 +248,8 @@ public class OpenApiConfiguration {
 
     /**
      * @param types the list of classes to filter.
-     * @return a filtered list of classes, using {@link #getScanClasses()},
-     *         {@link #getExcludeClasses()}, {@link #getScanPackages()} and
-     *         {@link #getExcludePackages()}.
+     * @return a filtered list of classes, using scanClasses,
+     *         scanExcludeClasses, scanPackages and scanExcludePackages.
      */
     public Set<Type> getValidClasses(Collection<Type> types) {
         return types.stream()

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018 - 2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -270,7 +270,8 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
                     try {
                         Class<?> oneOfClass = context.getApplicationClassLoader().loadClass(schemaClassName);
                         return (Schema) oneOfClass.getDeclaredConstructor().newInstance();
-                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
+                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                            | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
                         LOGGER.log(WARNING, "Unable to create Schema class instance.", ex);
                     }
                 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/util/ModelUtils.java
@@ -714,7 +714,8 @@ public final class ModelUtils {
                     } else {
                         f.set(to, mergeProperty(f.get(to), f.get(from), override));
                     }
-                } catch (IllegalArgumentException | IllegalAccessException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException e) {
+                } catch (IllegalArgumentException | IllegalAccessException | InstantiationException
+                        | NoSuchMethodException | SecurityException | InvocationTargetException e) {
                     // Ignore errors
                 }
             }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
@@ -92,7 +92,8 @@ public class FilterProcessor implements OASProcessor {
             if (filter == null && config.getFilter() != null) {
                 filter = config.getFilter().getDeclaredConstructor().newInstance();
             }
-        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
+        } catch (InstantiationException | IllegalAccessException
+                | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
             LOGGER.log(WARNING, "Error creating OASFilter instance.", ex);
         }
         if (filter != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ModelReaderProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ModelReaderProcessor.java
@@ -66,7 +66,8 @@ public class ModelReaderProcessor implements OASProcessor {
             if (config.getModelReader() != null) {
                 reader = config.getModelReader().getDeclaredConstructor().newInstance();
             }
-        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
+        } catch (InstantiationException | IllegalAccessException
+                | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
             LOGGER.log(WARNING, "Error creating OASModelReader instance.", ex);
         }
         if (reader != null) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
@@ -196,7 +196,9 @@ public class OpenApiContext implements ApiContext {
                                 .map(allTypes::getBy)
                                 .filter(Objects::nonNull)
                                 .collect(toSet()));
-                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException ex) {
+                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                            | NoSuchMethodException | IllegalArgumentException
+                            | SecurityException | InvocationTargetException ex) {
                         LOGGER.log(WARNING, "Unable to initialise application class.", ex);
                     }
                 } else {


### PR DESCRIPTION
## Description
OpenAPI refined the rules for usage of lists, specifying scanning or excluding classes for OpenAPI.

## Testing
### Testing Performed
OpenAPI TCK, all tests (which deploy) for the scanning rules pass, total number of failing issues decreased from 18 to 4.

### Testing Environment
Linux, OpenJDK

## Notes for Reviewers
The first commit is functional, the other just code formatting, removing majority of compiler warnings.
Getters and setters were removed as they are not used and the data is only internal.