### PR TITLE
FISH-7078: Tests for span naming configuration

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/OpenTracingHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/OpenTracingHelper.java
@@ -165,6 +165,7 @@ public class OpenTracingHelper {
                 var result = new StringBuilder();
                 result.append(request.getMethod()).append(" ")
                         .append(uriInfo.getBaseUri().getPath());
+                SpanStrategy.trimTrailingSlash(result);
                 appendTemplate(resourceInfo, uriInfo, result);
                 return result.toString();
             }

--- a/appserver/tests/payara-samples/samples/opentelemetry/README.adoc
+++ b/appserver/tests/payara-samples/samples/opentelemetry/README.adoc
@@ -1,10 +1,15 @@
 # OpenTelemetry samples
 
-So far there is no API to get server-managed OTEL traces beyond using OpenTracing APIs.
-
-Therefore there are no automated tests yet.
-OpenTracing part is exercised by other tests (such as Remote EJB tracing).
+Some of telemetry features are exercised by other tests (such as Remote EJB tracing).
 
 The sample application just makes used of distributed OpenTelemetry APIs to create SDK on its own, either manual or in autoconfiguration mode.
 
 It is also possible to put implementations of e. g. exporters into `domaindir/lib` and have them discovered by the autoconfiguration sdk.
+
+Tests validate custom configuration of span naming strategy by means of setting property `payara.telemetry.span-convention`.
+
+To observe the traces deploy the resulting application manually and start Jaeger docker image with
+
+```
+docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:latest
+```

--- a/appserver/tests/payara-samples/samples/opentelemetry/pom.xml
+++ b/appserver/tests/payara-samples/samples/opentelemetry/pom.xml
@@ -80,6 +80,19 @@
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/JaxrsApp.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/JaxrsApp.java
@@ -40,36 +40,12 @@
  *
  */
 
-package fish.payara.samples.otel.manual;
+package fish.payara.samples.otel;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.context.Scope;
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
-import jakarta.servlet.annotation.WebListener;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
 
-@WebListener
-@Dependent
-public class InitializeOtel implements ServletContextListener {
-
-    @Inject
-    ManualTracing tracing;
-
-    @Override
-    public void contextInitialized(ServletContextEvent sce) {
-        tracing.initOtel();
-
-        Span span = tracing.getTracer().spanBuilder("otel init").startSpan();
-        try(Scope scope = span.makeCurrent()) {
-            span.addEvent("ApplicationStarted");
-        } finally {
-            span.setStatus(StatusCode.OK);
-            span.end();
-        }
-    }
-
-
+@ApplicationPath("/jaxrs")
+public class JaxrsApp extends Application {
 }

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/async/AsyncResource.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/async/AsyncResource.java
@@ -1,0 +1,126 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.otel.async;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/async")
+@RequestScoped
+public class AsyncResource {
+    @Resource
+    ManagedExecutorService mes;
+
+
+    @Inject
+    Tracer tracer;
+
+    @Path("/compute")
+    @GET
+    public String computation(@QueryParam("propagation") @DefaultValue("none") String propagation) throws ExecutionException, InterruptedException {
+        List<CompletableFuture<Integer>> tasks = new ArrayList<>();
+        for(int i=0; i<10; i++) {
+            switch (propagation.toLowerCase()) {
+                case "traced":
+                    // with manual span
+                    tasks.add(mes.supplyAsync(this::tracedTask));
+                    break;
+                case "wrap":
+                    // with manual span and context wrapping
+                    tasks.add(mes.supplyAsync(Context.current().wrapSupplier(this::tracedTask)));
+                    break;
+                default:
+                    // without explicit span
+                    tasks.add(mes.supplyAsync(this::task));
+            }
+        }
+        CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new));
+        int result = 0;
+        for (CompletableFuture<Integer> task : tasks) {
+            result += task.get();
+        }
+        return String.valueOf(result);
+    }
+
+    private int task() {
+
+        try {
+            Thread.sleep(ThreadLocalRandom.current().nextInt(200));
+        } catch (InterruptedException e) {
+            // anyway...
+        }
+        return ThreadLocalRandom.current().nextInt();
+    }
+
+    private int tracedTask() {
+        var span = tracer.spanBuilder("tracedTask").startSpan();
+
+        try (var scope = span.makeCurrent()){
+            var sleep = ThreadLocalRandom.current().nextInt(200);
+            Thread.sleep(sleep);
+            span.addEvent("sleep", Attributes.of(AttributeKey.longKey("sleeping"), (long)sleep));
+        } catch (InterruptedException e) {
+            // anyway...
+        }
+        span.setStatus(StatusCode.OK);
+        span.end();
+        return ThreadLocalRandom.current().nextInt();
+    }
+}

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/Manual.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/Manual.java
@@ -42,34 +42,12 @@
 
 package fish.payara.samples.otel.manual;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.context.Scope;
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
-import jakarta.servlet.annotation.WebListener;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
-@WebListener
-@Dependent
-public class InitializeOtel implements ServletContextListener {
+import jakarta.inject.Qualifier;
 
-    @Inject
-    ManualTracing tracing;
-
-    @Override
-    public void contextInitialized(ServletContextEvent sce) {
-        tracing.initOtel();
-
-        Span span = tracing.getTracer().spanBuilder("otel init").startSpan();
-        try(Scope scope = span.makeCurrent()) {
-            span.addEvent("ApplicationStarted");
-        } finally {
-            span.setStatus(StatusCode.OK);
-            span.end();
-        }
-    }
-
-
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Manual {
 }

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManualTracing.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManualTracing.java
@@ -133,13 +133,13 @@ public class ManualTracing {
         return tracer;
     }
 
-    @Produces
+    @Produces @Manual
     @RequestScoped
     Span makeSpan() {
         return tracer.spanBuilder("request").startSpan();
     }
 
-    void endSpan(@Disposes Span span) {
+    void endSpan(@Disposes @Manual Span span) {
         span.end();
     }
 }

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManuallyTracingServlet.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/java/fish/payara/samples/otel/manual/ManuallyTracingServlet.java
@@ -61,7 +61,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet("/manual/*")
 @Dependent
 public class ManuallyTracingServlet extends HttpServlet {
-    @Inject
+    @Inject @Manual
     Span span;
 
     @Override

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/main/resources/META-INF/microprofile-config.properties
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/main/resources/META-INF/microprofile-config.properties
@@ -39,9 +39,10 @@
 #  holder.
 #
 
-autoconfig=true
+otel.sdk.disabled=false
+#autoconfig=true
 #Place exporter jar into domaindir/lib to enable
 #otel.traces.exporter=logging
 #Not supported in Jaeger, only GRPC
 #otel.exporter.otlp.traces.protocol=http/protobuf
-otel.service.name=manual-otel-app-autoconfig
+#otel.service.name=manual-otel-app-autoconfig

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/AbstractSpanNameTest.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/AbstractSpanNameTest.java
@@ -1,0 +1,133 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.otel.spanname;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.PayaraTestRunnerDelegate;
+import fish.payara.samples.otel.JaxrsApp;
+import fish.payara.samples.otel.async.AsyncResource;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+public class AbstractSpanNameTest {
+    protected final Logger logger = Logger.getLogger(getClass().getName());
+    protected static WebArchive base() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClass(JaxrsApp.class)
+                .addClass(AsyncResource.class)
+                .addClass(Conf.class)
+                .addClass(InMemoryExporter.class)
+                .addClass(InMemoryExporter.Provider.class)
+                .addClass(AbstractSpanNameTest.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemoryExporter.Provider.class)
+                .addAsLibraries(Maven.resolver().loadPomFromFile("pom.xml").resolve("org.assertj:assertj-core").withTransitivity().asFile());
+    }
+
+    protected static WebArchive configSource(WebArchive base, Class<? extends ConfigSource> csclass) {
+        return base.addClass(csclass).addAsServiceProvider(ConfigSource.class, csclass);
+    }
+
+    @ArquillianResource
+    protected URI baseUri;
+
+    @Inject
+    protected InMemoryExporter exporter;
+
+    protected WebTarget target(String wrapType) {
+        var target = ClientBuilder.newClient().target(baseUri).path("jaxrs").path("async").path("compute");
+        if (wrapType != null) {
+            target = target.queryParam("propagation", wrapType);
+        }
+        return target;
+    }
+
+    protected abstract static class Conf implements ConfigSource {
+        protected static final String SPAN_NAMING_KEY = "payara.telemetry.span-convention";
+        private Map<String,String> configProps = Collections.synchronizedMap(new HashMap<>());
+        protected Conf(Map<String, String> additionalProps) {
+            // enable OTEL
+            configProps.put("otel.sdk.disabled", "false");
+            // enable our test exporter
+            configProps.put("otel.traces.exporter", "in-memory");
+            // schedule export every 10 milliseconds
+            configProps.put("otel.bsp.schedule.delay", "10");
+            // anything else (possible overrides)
+            configProps.putAll(additionalProps);
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return configProps;
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return configProps.keySet();
+        }
+
+        @Override
+        public String getValue(String s) {
+            return configProps.get(s);
+        }
+
+        @Override
+        public String getName() {
+            return "test-props";
+        }
+    }
+}

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/InMemoryExporter.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/InMemoryExporter.java
@@ -1,0 +1,136 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.samples.otel.spanname;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.logging.Logger;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class InMemoryExporter implements SpanExporter {
+
+    private volatile boolean stopped;
+    private List<SpanData> exported = new ArrayList<>();
+    private AtomicInteger batches = new AtomicInteger(0);
+
+    private static final Logger LOGGER = Logger.getLogger(InMemoryExporter.class.getName());
+
+    @Inject
+    @ConfigProperty(name = "otel.bsp.schedule.delay")
+    long batchProcessorScheduleMS;
+
+    public void reset() {
+        exported.clear();
+        batches.set(0);
+    }
+
+    public List<SpanData> getSpans() {
+        waitForNextExport();
+        synchronized (exported) {
+            var spanData = new ArrayList<SpanData>(exported);
+            exported.clear();
+            LOGGER.info(() -> "Passing exported list: "+spanData);
+            return spanData;
+        }
+    }
+
+    private void waitForNextExport() {
+        int currentGen;
+        do {
+            currentGen = batches.get();
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(batchProcessorScheduleMS * 2));
+            // no export in two periods means that we're out of fresh spans now.
+        } while (currentGen != batches.get());
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        if (stopped) {
+            return CompletableResultCode.ofFailure();
+        }
+        synchronized (exported) {
+            exported.addAll(spans);
+            batches.incrementAndGet();
+        }
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        stopped = true;
+        flush();
+        return CompletableResultCode.ofSuccess();
+    }
+
+    public static class Provider implements ConfigurableSpanExporterProvider {
+
+        @Override
+        public SpanExporter createExporter(ConfigProperties configProperties) {
+            return CDI.current().select(InMemoryExporter.class).get();
+        }
+
+        @Override
+        public String getName() {
+            return "in-memory";
+        }
+    }
+}

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/MicroprofileSpanNamingIT.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/MicroprofileSpanNamingIT.java
@@ -40,36 +40,38 @@
  *
  */
 
-package fish.payara.samples.otel.manual;
+package fish.payara.samples.otel.spanname;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.context.Scope;
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
-import jakarta.servlet.annotation.WebListener;
+import java.util.Map;
 
-@WebListener
-@Dependent
-public class InitializeOtel implements ServletContextListener {
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-    @Inject
-    ManualTracing tracing;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
-    @Override
-    public void contextInitialized(ServletContextEvent sce) {
-        tracing.initOtel();
-
-        Span span = tracing.getTracer().spanBuilder("otel init").startSpan();
-        try(Scope scope = span.makeCurrent()) {
-            span.addEvent("ApplicationStarted");
-        } finally {
-            span.setStatus(StatusCode.OK);
-            span.end();
+@RunWith(Arquillian.class)
+public class MicroprofileSpanNamingIT extends AbstractSpanNameTest {
+    public static class SpanConfig extends Conf {
+        public SpanConfig() {
+            super(Map.of(SPAN_NAMING_KEY, "microprofile-telemetry"));
         }
     }
+    @Deployment
+    public static WebArchive deployment() {
+        return configSource(base(), SpanConfig.class);
+    }
 
+    @Test
+    public void testSpanName() {
+        var response = target(null).request().get();
+        assertEquals(200, response.getStatus());
+        var spans = exporter.getSpans();
 
+        var expected = baseUri.getPath() + "jaxrs/async/compute";
+        assertThat(spans).describedAs("Expecting span name of "+expected).anySatisfy(span -> assertThat(span.getName()).isEqualTo(expected));
+    }
 }

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTracingClassSpanNamingIT.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTracingClassSpanNamingIT.java
@@ -40,36 +40,39 @@
  *
  */
 
-package fish.payara.samples.otel.manual;
+package fish.payara.samples.otel.spanname;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.context.Scope;
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
-import jakarta.servlet.annotation.WebListener;
+import java.util.Map;
 
-@WebListener
-@Dependent
-public class InitializeOtel implements ServletContextListener {
+import fish.payara.samples.otel.async.AsyncResource;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-    @Inject
-    ManualTracing tracing;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
-    @Override
-    public void contextInitialized(ServletContextEvent sce) {
-        tracing.initOtel();
-
-        Span span = tracing.getTracer().spanBuilder("otel init").startSpan();
-        try(Scope scope = span.makeCurrent()) {
-            span.addEvent("ApplicationStarted");
-        } finally {
-            span.setStatus(StatusCode.OK);
-            span.end();
+@RunWith(Arquillian.class)
+public class OpenTracingClassSpanNamingIT extends AbstractSpanNameTest {
+    public static class SpanConfig extends Conf {
+        public SpanConfig() {
+            super(Map.of(SPAN_NAMING_KEY, "opentracing-class-method"));
         }
     }
+    @Deployment
+    public static WebArchive deployment() {
+        return configSource(base(), SpanConfig.class);
+    }
 
+    @Test
+    public void testSpanName() {
+        var response = target(null).request().get();
+        assertEquals(200, response.getStatus());
+        var spans = exporter.getSpans();
 
+        var expected = "GET:"+AsyncResource.class.getName()+".computation";
+        assertThat(spans).describedAs("Expecting span name of "+expected).anySatisfy(span -> assertThat(span.getName()).isEqualTo(expected));
+    }
 }

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTracingPathSpanNamingIT.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTracingPathSpanNamingIT.java
@@ -40,36 +40,38 @@
  *
  */
 
-package fish.payara.samples.otel.manual;
+package fish.payara.samples.otel.spanname;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.context.Scope;
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
-import jakarta.servlet.annotation.WebListener;
+import java.util.Map;
 
-@WebListener
-@Dependent
-public class InitializeOtel implements ServletContextListener {
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-    @Inject
-    ManualTracing tracing;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
-    @Override
-    public void contextInitialized(ServletContextEvent sce) {
-        tracing.initOtel();
-
-        Span span = tracing.getTracer().spanBuilder("otel init").startSpan();
-        try(Scope scope = span.makeCurrent()) {
-            span.addEvent("ApplicationStarted");
-        } finally {
-            span.setStatus(StatusCode.OK);
-            span.end();
+@RunWith(Arquillian.class)
+public class OpenTracingPathSpanNamingIT extends AbstractSpanNameTest {
+    public static class SpanConfig extends Conf {
+        public SpanConfig() {
+            super(Map.of(SPAN_NAMING_KEY, "opentracing-http-path"));
         }
     }
+    @Deployment
+    public static WebArchive deployment() {
+        return configSource(base(), SpanConfig.class);
+    }
 
+    @Test
+    public void testSpanName() {
+        var response = target(null).request().get();
+        assertEquals(200, response.getStatus());
+        var spans = exporter.getSpans();
 
+        var expected = "GET:/async/compute";
+        assertThat(spans).describedAs("Expecting span name of "+expected).anySatisfy(span -> assertThat(span.getName()).isEqualTo(expected));
+    }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Additional demonstration and tests for OpenTelemetry features

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
Tests for MP config property `payara.telemetry.span-convention` that drives how span gets named and tagged in different configurations (i.e. opentelemetry tck compatible, opentracing tck compatible or opentelemetry semantic conventions).

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
The new tests

## Documentation
<!-- Link documentation if a PR exists -->
Documentation will be written next, will update the PR. But it will be unrelated to this code.
