### PR TITLE
FISH-7153 FISH-7155 Docker JDK 11.0.18 & 17.0.6

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,8 +57,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.17</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.5</docker.jdk17.tag>
+        <docker.jdk11.tag>11.0.18</docker.jdk11.tag>
+        <docker.jdk17.tag>17.0.6</docker.jdk17.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara6</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
Updates the JDK image used for the Payara Docker images to the latest.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the unit tests against 6.2023.2

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
