### PR TITLE
FISH-7016: adding fix when ports are used from another instance

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.launcher;
 
@@ -232,6 +232,10 @@ public abstract class GFLauncher {
         needsAutoUpgrade = !parser.hasNetworkConfig();
         needsManualUpgrade = !parser.hasDefaultConfig();
         setupCalledByClients = true;
+    }
+    
+    public Map<String, String> getSysPropsFromXml() {
+        return sysPropsFromXml;
     }
 
     /**

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -306,7 +306,6 @@ public class StartServerHelper {
         err = validateAdditionalPortsForConnection();
 
         if (err != null) {
-            //incrementing level of severity when ports are used
             logger.severe(err);
             return false;
         }
@@ -358,7 +357,7 @@ public class StartServerHelper {
                                 && e.getKey().contains(PROPS_PORT_NAME)).collect(Collectors.toSet());
                 for (Map.Entry<String, String> e: setOfPorts) {
                     if(!NetUtils.isPortFree(host, Integer.parseInt(e.getValue()))) {
-                        return STRINGS.get("Port in use for an instance", Integer.parseInt(e.getValue()));
+                        return String.format("Port %d is in use", Integer.parseInt(e.getValue()));
                     }
                 }
             }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -98,6 +98,8 @@ public class StartServerHelper {
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(StartServerHelper.class);
     
     private static final String PROPS_PORT_NAME = "_PORT";
+    
+    private static final String PROPS_HZ_PORT_NAME = "HZ_LISTENER_PORT";
 
     public StartServerHelper(Logger logger0, boolean terse0,
             ServerDirs serverDirs0, GFLauncher launcher0,
@@ -352,7 +354,8 @@ public class StartServerHelper {
                 host = addr.getHost();
                 Map<String, String> propsFromXMl = this.launcher.getSysPropsFromXml();
                 Set<Map.Entry<String, String>> setOfPorts = propsFromXMl.entrySet().stream()
-                        .filter(e -> e.getKey().contains(PROPS_PORT_NAME)).collect(Collectors.toSet());
+                        .filter(e -> !e.getKey().contains(PROPS_HZ_PORT_NAME) 
+                                && e.getKey().contains(PROPS_PORT_NAME)).collect(Collectors.toSet());
                 for (Map.Entry<String, String> e: setOfPorts) {
                     if(!NetUtils.isPortFree(host, Integer.parseInt(e.getValue()))) {
                         return STRINGS.get("Port in use for an instance", Integer.parseInt(e.getValue()));

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -301,7 +301,7 @@ public class StartServerHelper {
 
     private boolean checkPorts() {
         String err = adminPortInUse();
-        err = validateAdditionPortsForConnection();
+        err = validateAdditionalPortsForConnection();
 
         if (err != null) {
             //incrementing level of severity when ports are used
@@ -344,7 +344,7 @@ public class StartServerHelper {
      * This method will validate configuration ports for each host on this StartServer configuration
      * @return String error message if some port is used by another instance
      */
-    private String validateAdditionPortsForConnection() {
+    private String validateAdditionalPortsForConnection() {
         List<HostAndPort> list = info.getAdminAddresses();
         String host = null;
         if(list.size() > 0) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fix for zombie instance when ports are used from another instance
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for a bug reported when trying to start an instance from a deployment group trying to use ports used for another available running instance like payara micro

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing, now the error is showed on the logs when trying to start the instance:


https://user-images.githubusercontent.com/279375/223603704-657331b5-e86e-4c8c-a0db-033184b336be.mp4


















On logs now we can see the following message:

`
Command start-local-instance failed.

Port 28080 is in use

To complete this operation run the following command locally on host localhost from the Payara Server install location C:\java\projects\Payara\appserver\distributions\payara\target\stage\payara6:

 lib/nadmin  start-local-instance --node localhost-domain1 --sync normal --timeout 600 instance1

The command start-instance failed for: instance1
Command start-deployment-group failed.
`

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, azul jdk 11, maven 3.8.3
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
