### PR TITLE
FISH-7115 : jdk 11 min version upgraded

### DIFF
--- a/appserver/packager/appserver-base/src/main/docs/README.txt
+++ b/appserver/packager/appserver-base/src/main/docs/README.txt
@@ -8,14 +8,14 @@ Here are a few short steps to get you started...
 
 Payara Server currently supports the following Java Virtual Machines:
 
-* Azul Zulu JDK: 11 (11.0.5u10+), 17 (17.34/17.0.3+)
-* Oracle JDK: 11 (11.0.5+), 17 (17.0.3+)
-* Amazon Corretto: 11 (11.0.5+), 17 (17.0.3+)
-* Adopt Open JDK: 11 (11.0.5+), 17 (17.0.3+)
-* Adopt Open JDK with Eclipse Open J9: 11 (11.0.5+), 17 (17.0.3+)
-* Any other JVM based on OpenJDK 11.0.5+ or 17.0.3+
+* Azul Zulu JDK: 11 (11.0.12+), 17 (17.34/17.0.3+)
+* Oracle JDK: 11 (11.0.12+), 17 (17.0.3+)
+* Amazon Corretto: 11 (11.0.12+), 17 (17.0.3+)
+* Adopt Open JDK: 11 (11.0.12+), 17 (17.0.3+)
+* Adopt Open JDK with Eclipse Open J9: 11 (11.0.12+), 17 (17.0.3+)
+* Any other JVM based on OpenJDK 11.0.12+ or 17.0.3+
 
-The Payara Platform runs on the x64 and arm64 variants of the above JVMs.
+The Payara Platform runs on the x64 and arm64 variants of the above JVMs.thi
 
 1. Installing Payara Server
 ===========================

--- a/appserver/packager/appserver-base/src/main/docs/README.txt
+++ b/appserver/packager/appserver-base/src/main/docs/README.txt
@@ -15,7 +15,7 @@ Payara Server currently supports the following Java Virtual Machines:
 * Adopt Open JDK with Eclipse Open J9: 11 (11.0.12+), 17 (17.0.3+)
 * Any other JVM based on OpenJDK 11.0.12+ or 17.0.3+
 
-The Payara Platform runs on the x64 and arm64 variants of the above JVMs.thi
+The Payara Platform runs on the x64 and arm64 variants of the above JVMs.
 
 1. Installing Payara Server
 ===========================


### PR DESCRIPTION
## Description
With the merging of [FISH-1366: Upgrade cacerts.jks and keystore.jks to pkcs12IN COMMUNITY REVIEW](https://payara.atlassian.net/browse/FISH-1366) the minimum requirement within the bundled README and in the docs should be changed to JDK 11.0.12+
