### PR TITLE
FISH-7077 Fix Blank File Path on Deployment

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-/*Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+/*Portions Copyright 2016-2023 Payara Foundation and/or its affiliates
 /*
  * Common utility
  */
@@ -2049,7 +2049,7 @@ admingui.deploy = {
 
     populateDirAndAppName : function(fileChooserId, dirPathId, appNameId, typeId, dropDownProp, contextRootId, extensionId, appTypeString){
         var fc = document.getElementById(fileChooserId).getSelectionValue();
-        window.opener.getTextElement(dirPathId).value = fc;
+        window.opener.document.getElementById(dirPathId).value = fc;
         //for redeploy, there is no dropdown for app type, there is no need to fill in any field.
         if (dropDownProp != ""){
             admingui.deploy.setFieldValue(appNameId, fc, dropDownProp, typeId, contextRootId, extensionId, window.opener, appTypeString);


### PR DESCRIPTION
## Description
Fixes the bug that when selecting a locally available file for deployment the file path gets left blank, causing an error when you then try to proceed the deployment.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Deploy a locally available file
  * Applications -> Deploy -> Local Packaged File or Directory -> Browse Files -> _select file_ -> Choose File
  * File path should be populated
  * Click deploy
  * Should succeed
* Redeploy a locally available file
  * Applications -> Click on application -> Redeploy -> Local Packaged File or Directory -> Browse Files -> _select file_ -> Choose File
  * File path should be populated
  * Click deploy
  * Should succeed
* Deploy an uploaded file (the "default" way to deploy)
  * Applications -> Deploy -> Upload -> _select file_
  * Click deploy
  * Should succeed

### Testing Environment
Windows 11, Zulu JDK 11

## Documentation
N/A

## Notes for Reviewers
Make sure you use private browsing or clear cache.
