### PR TITLE
FISH-7168 Repackage SNMP4j For OSGi

### DIFF
--- a/appserver/packager/external/snmp4j-repackaged/pom.xml
+++ b/appserver/packager/external/snmp4j-repackaged/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.server.internal.packager</groupId>
+        <artifactId>external</artifactId>
+        <version>6.2023.3-SNAPSHOT</version>
+    </parent>
+
+    <groupId>fish.payara.server.core.packager</groupId>
+    <artifactId>snmp4j-repackaged</artifactId>
+    <name>snmp4j repackaged as a module</name>
+    <description>snmp4j repackaged as a module</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <snmp4j.version>3.7.5</snmp4j.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>
+                            *;scope=compile;inline=true
+                        </Embed-Dependency>
+                        <!-- Export everything from snmp4j in the final bundle -->
+                        <Export-Package>*;version=${snmp4j.version}</Export-Package>
+                        <!-- Exclude unnecessary imports -->
+                        <Private-Package>!*</Private-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.snmp4j</groupId>
+            <artifactId>snmp4j</artifactId>
+            <version>${snmp4j.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
## Description
Repackages SNMP4j with requires OSGi headers.

## Important Info
### Related
The Community Notifiers PR: https://github.com/payara/Notifiers/pull/37

## Testing

### Testing Performed
Tested the server starts, the snmp admin console page looks correct and values save correctly. Tested the `get-snmp-notifier-configuration` and `set-snmp-notifier-configuration` commands work.

### Testing Environment
Maven 3.8.4, Windows 10, Zulu JDK 11

## Documentation
Coming later.

## Notes for Reviewers
This module intentionally is not part of the default build. Notifiers aren't bundled in Payara Community by default and therefore SNMP4j isn't required. To test this module needs building and the resulting jar putting in the `payara6/glassfish/notifiers` directory along with the notifier core and console-plugin
