### PR TITLE
FISH-7203 Add Null Check for OpenTelemetry

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/JaxrsClientRequestTelemetryFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/JaxrsClientRequestTelemetryFilter.java
@@ -108,7 +108,7 @@ public class JaxrsClientRequestTelemetryFilter implements ClientRequestFilter, C
 
         // ***** OpenTracing Instrumentation *****
         // Check if we should trace this client call
-        if (payaraTracingServices.getOpenTelemetryService().isEnabled() && shouldTrace(requestContext)) {
+        if (openTelemetryService != null && openTelemetryService.isEnabled() && shouldTrace(requestContext)) {
             // Get or create the tracer instance for this application
             final Tracer tracer = payaraTracingServices.getActiveTracer();
 


### PR DESCRIPTION
## Description
Adds a null check for the OpenTelemtry service to avoid a NPE when running the embedded tests.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built and ran all unit tests: `mvn clean install -PBuildExtras`
Ran payara-samples.
Ran OpenTracing and OpenTelemetry TCKs.

### Testing Environment
Windows 11, Zulu 11.

## Documentation
N/A

## Notes for Reviewers
None
