### PR TITLE
FISH-6479 Metro and xmlsec Repackaging

### DIFF
--- a/appserver/packager/external/metro-xmlsec/pom.xml
+++ b/appserver/packager/external/metro-xmlsec/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  ~
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.server.internal.packager</groupId>
+        <artifactId>external</artifactId>
+        <version>6.2023.3-SNAPSHOT</version>
+    </parent>
+
+    <groupId>fish.payara.server.core.packager</groupId>
+    <artifactId>metro-xmlsec-repackaged</artifactId>
+    <name>metro-xmlsec-repackaged</name>
+    <description>Metro xmlsec repackaged as a module</description>
+
+    <properties>
+      <metro.version>${webservices.version}</metro.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>
+                            *;scope=compile;inline=true
+                        </Embed-Dependency>                        
+                        <!-- Export everything from the embedded jar
+                             in the final bundle
+                        -->
+                        <!-- Exclude unnecessary imports -->
+                        <Export-Package>
+                            !org.slf4j.*,
+                            *
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.xml.dtm;resolution:=optional;version="[2.7,3)",
+                            org.apache.commons.codec.binary;version="[1.6,2)",
+                            org.apache.xml.utils;resolution:=optional;version="[2.7,3)",
+                            org.apache.xpath;resolution:=optional;version="[2.7,3)",
+                            org.apache.xpath.compiler;resolution:=optional;version="[2.7,3)",
+                            org.apache.xpath.functions;resolution:=optional;version="[2.7,3)",
+                            org.apache.xpath.objects;resolution:=optional;version="[2.7,3)",
+                            *
+                        </Import-Package>
+                        <Private-Package>!*</Private-Package>
+                        <HK2-Bundle-Name>${project.groupId}:${project.artifactId}</HK2-Bundle-Name>
+                        <excludeDependencies>tools-jar</excludeDependencies>
+                    </instructions>
+                    <!-- Maven uses the output directory (target/classes)
+                    rather than the final bundle, when compiling against
+                    projects in the same reactor (ie. the same build).
+                    Since this jar comprises of classes that come from
+                    some other jar and other modules depend on this
+                    artifact, we need to unpack.
+                    -->
+                    <unpackBundle>true</unpackBundle>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.santuario</groupId>
+            <artifactId>xmlsec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.metro</groupId>
+            <artifactId>webservices-extra-xmlsec</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/packager/external/pom.xml
+++ b/appserver/packager/external/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates] -->
 
 <!--
   External repackaging modules.
@@ -73,6 +73,7 @@
         <module>jcip</module>
         <module>libpam4j</module>
         <module>jersey-container-grizzly2-http-transition</module>
+        <module>metro-xmlsec</module>
         <module>jakarta-ee9-shim</module>
     </modules>
     <build>

--- a/appserver/packager/metro/pom.xml
+++ b/appserver/packager/metro/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2019-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2019-2023] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -154,6 +154,10 @@
            <groupId>jakarta.xml.bind</groupId>
            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
+        
+        <!-- Replace santuario xmlsec and metro webservices-extra-xmlsec with
+        repackaged version, needed to remove export of SLF4 -->
+        <!--
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
@@ -162,6 +166,14 @@
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-extra-xmlsec</artifactId>
         </dependency>
+        -->
+        <dependency>
+            <groupId>fish.payara.server.core.packager</groupId>
+            <artifactId>metro-xmlsec-repackaged</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        
         <dependency>
            <groupId>com.fasterxml.woodstox</groupId>
            <artifactId>woodstox-core</artifactId>


### PR DESCRIPTION
## Description
Metro and xmlsec use and also exported SLF4J. Payara therefor exported them as well, but deployed applications didn't run successfully anyway.
The fix is to stop exporting SLF4J. Both libraries are repackaged now, forbidding SLF4J export.

## Testing

### Testing Performed
Deployed both reproducers, one is JEE 8, other JEE 9, one uses SLF4J v 2, the other version 1. Both now work correctly.
Reproducers are attached to the Jira ticket, use the *-fixed versions. The fix was in packaging slf4j with the apps, Payara now doesn't provide slf4j.

### Testing Environment
Linux, OpenJDK 11
