### PR TITLE
Create WEB-INF/classes Directory During Deployment

### DIFF
--- a/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
+++ b/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.glassfish.web;
 
@@ -170,7 +170,12 @@ public class WarHandler extends AbstractArchiveHandler {
             r.setDocBase(base.getAbsolutePath());
 
             cloader.setResources(r);
-            cloader.addRepository("WEB-INF/classes/", new File(base, "WEB-INF/classes/"));
+            File classesPath = new File(base, "WEB-INF/classes/");
+            if (!classesPath.exists()) {
+                // make sure the WEB-INF/classes exists, it is searched by class loader
+                classesPath.mkdirs();
+            }
+            cloader.addRepository("WEB-INF/classes/", classesPath);
             if (context.getScratchDir("ejb") != null) {
                 cloader.addRepository(context.getScratchDir("ejb").toURI().toURL().toString().concat("/"));
             }


### PR DESCRIPTION
## Description
Classloader of application without any class, with just static files, contains non-existing directory. This causes problems e.g. in OpenApi search, it uses ../../ - final path exists, but part of it doesn't, failing on Linux.

## Testing
### Testing Performed
This fix helped to pass OpenAPI TCK, but the usecase is common. The affected OS is Linux; Windows evaluate path like `X/../` without looking if `X` exists.

### Testing Environment
OpenJDK, Linux

## Notes for Reviewers
I attached reproducer to Jira ticket FISH-7118, file openapi-3-1-empty-war-1.0-SNAPSHOT.war
Deploy it, open `http://localhost:4848/openapi` and you should see rest spec, e.g. including `title: Simple Inventory API`. This is loaded from `META-INF/openapi.yaml`.
Before this fix, the openapi is empty, not finding the yaml file.