### PR TITLE
FISH-6980 scan ear's lib/*.jar for openapi

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiContext.java
@@ -86,10 +86,17 @@ public interface ApiContext {
 
     /**
      * @param type any class, not null
-     * @return true, if the give type is a filtered class for OpenAPI metadata processing
-     * otherwise false
+     * @return true, if the given type is a filtered class for OpenAPI metadata
+     * processing     * otherwise false
      */
     boolean isAllowedType(Type type);
+
+    /**
+     * @param type any class, not null
+     * @return true, if the given type is a part of the WAR file, otherwise
+     * false (e.g. class in a library)
+     */
+    boolean isAllowedResource(Type type);
 
     /**
      * @param type any class, not null

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/api/visitor/ApiContext.java
@@ -93,13 +93,6 @@ public interface ApiContext {
 
     /**
      * @param type any class, not null
-     * @return true, if the given type is a part of the WAR file, otherwise
-     * false (e.g. class in a library)
-     */
-    boolean isAllowedResource(Type type);
-
-    /**
-     * @param type any class, not null
      * @return type, if the give type is a known type in this context, else null
      */
     Type getType(String type);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
@@ -80,6 +80,11 @@ import fish.payara.microprofile.openapi.impl.processor.ConfigPropertyProcessor;
 import fish.payara.microprofile.openapi.impl.processor.FileProcessor;
 import fish.payara.microprofile.openapi.impl.processor.FilterProcessor;
 import fish.payara.microprofile.openapi.impl.processor.ModelReaderProcessor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 public class OpenAPISupplier implements Supplier<OpenAPI> {
 
@@ -117,14 +122,14 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
         }
 
         try {
-            final Parser parser = Globals.get(ApplicationLifecycle.class).getDeployableParser(
-                    archive,
-                    true,
-                    true,
-                    StructuredDeploymentTracing.create(applicationId),
-                    Logger.getLogger(OpenApiService.class.getName())
-            );
-            final Types types = parser.getContext().getTypes();
+            // collect types from this WAR project, including WEB-INF/lib jars
+            Map<String, Type> types = collectTypesFromArchive(archive, applicationId);
+
+            // if configured to scan libs, scan libs of the parent EAR (if available)
+            if (config != null && config.getScanLib()) {
+                Map<String, Type> earLibTypes = collectEarLibTypes(archive.getParentArchive());
+                types.putAll(earLibTypes);
+            }
 
             OpenAPI doc = new OpenAPIImpl();
             try {
@@ -134,7 +139,8 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
                 doc = new FileProcessor(classLoader).process(doc, config);
                 doc = new ApplicationProcessor(
                         types,
-                        filterTypes(archive, config, types),
+                        filterTypes(archive, types, config != null && config.getScanLib()),
+                        filterTypes(archive, types, false),
                         classLoader
                 ).process(doc, config);
                 if (doc.getPaths() != null && !doc.getPaths().getPathItems().isEmpty()) {
@@ -152,13 +158,52 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
             throw new RuntimeException("An error occurred while creating the OpenAPI document.", ex);
         }
     }
-    
+
+    private Map<String, Type> collectEarLibTypes(ReadableArchive parentArchive) {
+        Map<String, Type> earLibTypes = new HashMap<>();
+        if (parentArchive != null) {
+            Enumeration<String> entries = parentArchive.entries();
+            while (entries.hasMoreElements()) {
+                String entry = entries.nextElement();
+                // scan only lib/*.jar libraries
+                if (entry.startsWith("lib/") && entry.endsWith(".jar")) {
+                    try {
+                        Map<String, Type> libTypes = collectTypesFromArchive(parentArchive.getSubArchive(entry),
+                                applicationId + "-parent-" + entry);
+                        earLibTypes.putAll(libTypes);
+                    } catch (IOException ex) {
+                        Logger.getLogger(OpenAPISupplier.class.getName()).log(Level.SEVERE, "Unable to parse EAR archive '" + entry + "': " + ex.getMessage(), ex);
+                    }
+                }
+            }
+        }
+        return earLibTypes;
+    }
+
+    private Map<String, Type> collectTypesFromArchive(ReadableArchive archive, String entryId) throws IOException {
+        Map<String, Type> types = new HashMap<>();
+        Parser earLibParser;
+        earLibParser = Globals.get(ApplicationLifecycle.class).getDeployableParser(archive,
+                true,
+                true,
+                StructuredDeploymentTracing.create(entryId),
+                Logger.getLogger(OpenApiService.class.getName())
+        );
+        types.putAll(typesToMap(earLibParser.getContext().getTypes()));
+        return types;
+    }
+
+    public static Map<String, Type> typesToMap(Types types) {
+        return types.getAllTypes().stream()
+                .collect(Collectors.toMap((t) -> t.getName(), Function.identity()));
+    }
 
     /**
      * @return a list of all classes in the archive.
      */
-    private Set<Type> filterTypes(ReadableArchive archive, OpenApiConfiguration config, Types hk2Types) {
-        Set<Type> types = new HashSet<>(filterLibTypes(config, hk2Types, archive));
+    private Set<Type> filterTypes(ReadableArchive archive, Map<String, Type> hk2Types, boolean scanLibs) {
+        Set<Type> types = new HashSet<>();
+        types.addAll(filterLibTypes(hk2Types, archive, scanLibs));
         types.addAll(
                 Collections.list(archive.entries()).stream()
                         // Only use the classes
@@ -166,7 +211,7 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
                         // Remove the WEB-INF/classes and return the proper class name format
                         .map(clazz -> clazz.replaceAll("WEB-INF/classes/", "").replace("/", ".").replace(".class", ""))
                         // Fetch class type
-                        .map(clazz -> hk2Types.getBy(clazz))
+                        .map(clazz -> hk2Types.get(clazz))
                         // Don't return null classes
                         .filter(Objects::nonNull)
                         .collect(toSet())
@@ -175,17 +220,29 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
     }
 
     private Set<Type> filterLibTypes(
-            OpenApiConfiguration config,
-            Types hk2Types,
-            ReadableArchive archive) {
+            Map<String, Type> hk2Types,
+            ReadableArchive archive,
+            boolean scanLibs
+    ) {
         Set<Type> types = new HashSet<>();
-        if (config != null && config.getScanLib()) {
-            Enumeration<String> subArchiveItr = archive.entries();
+        if (scanLibs) {
+            // add libraries from WAR's /WEB-INF/lib/*.jar
+            addFoundClasses(archive, hk2Types, "WEB-INF/lib/", types);
+
+            // add here also EAR's /lib/*.jar
+            addFoundClasses(archive.getParentArchive(), hk2Types, "lib/", types);
+        }
+        return types;
+    }
+
+    private void addFoundClasses(ReadableArchive archiveToScan, Map<String, Type> hk2Types, String prefix, Set<Type> types) {
+        if (archiveToScan != null) {
+            Enumeration<String> subArchiveItr = archiveToScan.entries();
             while (subArchiveItr.hasMoreElements()) {
                 String subArchiveName = subArchiveItr.nextElement();
-                if (subArchiveName.startsWith("WEB-INF/lib/") && subArchiveName.endsWith(".jar")) {
+                if (subArchiveName.startsWith(prefix) && subArchiveName.endsWith(".jar")) {
                     try {
-                        ReadableArchive subArchive = archive.getSubArchive(subArchiveName);
+                        ReadableArchive subArchive = archiveToScan.getSubArchive(subArchiveName);
                         types.addAll(
                                 Collections.list(subArchive.entries())
                                         .stream()
@@ -194,7 +251,7 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
                                         // return the proper class name format
                                         .map(clazz -> clazz.replace("/", ".").replace(".class", ""))
                                         // Fetch class type
-                                        .map(clazz -> hk2Types.getBy(clazz))
+                                        .map(clazz -> hk2Types.get(clazz))
                                         // Don't return null classes
                                         .filter(Objects::nonNull)
                                         .collect(toSet())
@@ -205,7 +262,6 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
                 }
             }
         }
-        return types;
     }
 
     private List<URL> getServerURL(String contextRoot) {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/config/OpenApiConfiguration.java
@@ -80,8 +80,8 @@ public class OpenApiConfiguration {
 
     private Class<? extends OASModelReader> modelReader;
     private Class<? extends OASFilter> filter;
-    private boolean scanDisable;
-    private boolean scanLib;
+    private boolean scanDisable = false;
+    private boolean scanLib = false;
     private List<String> scanPackages = new ArrayList<>();
     private List<String> scanClasses = new ArrayList<>();
     private List<String> scanExcludePackages = new ArrayList<>();

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -81,6 +81,7 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response.Status;
+import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.Components;
 import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
@@ -111,7 +112,6 @@ import org.glassfish.hk2.classmodel.reflect.MethodModel;
 import org.glassfish.hk2.classmodel.reflect.ParameterizedInterfaceModel;
 import org.glassfish.hk2.classmodel.reflect.ParameterizedType;
 import org.glassfish.hk2.classmodel.reflect.Type;
-import org.glassfish.hk2.classmodel.reflect.Types;
 
 /**
  * A processor to parse the application for annotations, to add to the OpenAPI
@@ -124,12 +124,13 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     /**
      * A list of all classes in the given application.
      */
-    private final Types allTypes;
+    private final Map<String, Type> allTypes;
 
     /**
      * A list of allowed classes for scanning
      */
     private final Set<Type> allowedTypes;
+    private final Set<Type> allowedResourceTypes;
 
     private final ClassLoader appClassLoader;
 
@@ -141,9 +142,10 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
      * processing
      * @param appClassLoader the class loader for the application.
      */
-    public ApplicationProcessor(Types allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader) {
+    public ApplicationProcessor(Map<String, Type> allTypes, Set<Type> allowedTypes, Set<Type> allowedResourceTypes, ClassLoader appClassLoader) {
         this.allTypes = allTypes;
         this.allowedTypes = allowedTypes;
+        this.allowedResourceTypes = allowedResourceTypes;
         this.appClassLoader = appClassLoader;
     }
 
@@ -154,6 +156,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
                     api,
                     allTypes,
                     config == null ? allowedTypes : config.getValidClasses(allowedTypes),
+                    allowedResourceTypes,
                     appClassLoader
             );
             apiWalker.accept(this);
@@ -164,7 +167,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     // JAX-RS method handlers
     @Override
     public void visitGET(AnnotationModel get, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -186,7 +189,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitPOST(AnnotationModel post, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -208,7 +211,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitPUT(AnnotationModel put, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -230,7 +233,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitDELETE(AnnotationModel delete, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -252,7 +255,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitHEAD(AnnotationModel head, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -274,7 +277,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitOPTIONS(AnnotationModel options, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -296,7 +299,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitPATCH(AnnotationModel patch, MethodModel element, ApiContext context) {
-        if (context.getPath() == null) {
+        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
             return;
         }
 
@@ -1347,7 +1350,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
         // If the schema is an object, insert the reference
         if (schemaType == SchemaType.OBJECT) {
-            if (insertObjectReference(context, schema, type.getType(), typeName)) {
+            if (insertObjectReference(context, schema, context.getType(typeName), typeName)) {
                 schema.setType(null);
                 schema.setItems(null);
             }
@@ -1503,8 +1506,6 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             final AnnotationModel schemaAnnotation = context.getAnnotationInfo(referenceClassType)
                     .getAnnotation(org.eclipse.microprofile.openapi.annotations.media.Schema.class);
             String schemaName = ModelUtils.getSchemaName(context, referenceClass);
-            // Set the reference name
-            referee.setRef(schemaName);
 
             Schema schema = context.getApi().getComponents().getSchemas().get(schemaName);
             if (schema == null) {
@@ -1517,8 +1518,13 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
                     LOGGER.log(FINE, "Unrecognised schema {0} class found.", new Object[]{referenceClassName});
                 }
             }
+            Schema createdReference = context.getApi().getComponents().getSchemas().get(schemaName);
+            // Set the reference name, if the schema was created
+            if (createdReference != null) {
+                referee.setRef(schemaName);
+            }
 
-            return true;
+            return createdReference != null;
         }
 
         return false;

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -156,7 +156,6 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
                     api,
                     allTypes,
                     config == null ? allowedTypes : config.getValidClasses(allowedTypes),
-                    allowedResourceTypes,
                     appClassLoader
             );
             apiWalker.accept(this);
@@ -167,7 +166,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
     // JAX-RS method handlers
     @Override
     public void visitGET(AnnotationModel get, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 
@@ -189,7 +188,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitPOST(AnnotationModel post, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 
@@ -211,7 +210,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitPUT(AnnotationModel put, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 
@@ -233,7 +232,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitDELETE(AnnotationModel delete, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 
@@ -255,7 +254,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitHEAD(AnnotationModel head, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 
@@ -277,7 +276,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitOPTIONS(AnnotationModel options, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 
@@ -299,7 +298,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
 
     @Override
     public void visitPATCH(AnnotationModel patch, MethodModel element, ApiContext context) {
-        if (context.getPath() == null || !context.isAllowedResource(element.getDeclaringType())) {
+        if (context.getPath() == null) {
             return;
         }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiContext.java
@@ -81,7 +81,6 @@ public class OpenApiContext implements ApiContext {
     private final ClassLoader appClassLoader;
     private final OpenAPI api;
     private final Set<Type> allowedTypes;
-    private final Set<Type> allowedResourceTypes;
     private final Map<String, Set<Type>> resourceMapping;
     private String path;
     private Operation operation;
@@ -93,10 +92,9 @@ public class OpenApiContext implements ApiContext {
 
     private Map<String, Set<APIResponse>> mappedExceptionResponses = new ConcurrentHashMap<>();
 
-    public OpenApiContext(Map<String, Type> allTypes, Set<Type> allowedTypes, Set<Type> allowedResourceTypes, ClassLoader appClassLoader, OpenAPI api) {
+    public OpenApiContext(Map<String, Type> allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader, OpenAPI api) {
         this.allTypes = allTypes;
         this.allowedTypes = allowedTypes;
-        this.allowedResourceTypes = allowedResourceTypes;
         this.api = api;
         this.appClassLoader = appClassLoader;
         this.resourceMapping = generateResourceMapping();
@@ -105,7 +103,6 @@ public class OpenApiContext implements ApiContext {
     public OpenApiContext(OpenApiContext parentApiContext, AnnotatedElement annotatedElement) {
         this.allTypes = parentApiContext.allTypes;
         this.allowedTypes = parentApiContext.allowedTypes;
-        this.allowedResourceTypes = parentApiContext.allowedResourceTypes;
         this.api = parentApiContext.api;
         this.appClassLoader = parentApiContext.appClassLoader;
         this.resourceMapping = parentApiContext.resourceMapping;
@@ -161,11 +158,6 @@ public class OpenApiContext implements ApiContext {
     @Override
     public boolean isApplicationType(String type) {
         return allTypes.containsKey(type);
-    }
-
-    @Override
-    public boolean isAllowedResource(Type type) {
-        return allowedResourceTypes.contains(type);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -117,10 +117,10 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
     private Map<Class<? extends Annotation>, VisitorFunction<AnnotationModel, E>> annotationVisitor;
     private Map<Class<? extends Annotation>, List<Class<? extends Annotation>>> annotationAlternatives;
 
-    public OpenApiWalker(OpenAPI api, Map<String, Type> allTypes, Set<Type> allowedTypes, Set<Type> allowedResourceTypes, ClassLoader appClassLoader) {
+    public OpenApiWalker(OpenAPI api, Map<String, Type> allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader) {
         this.allowedTypes = new TreeSet<>(Comparator.comparing(Type::getName, String::compareTo));
         this.allowedTypes.addAll(allowedTypes);
-        this.context = new OpenApiContext(allTypes, this.allowedTypes, allowedResourceTypes, appClassLoader, api);
+        this.context = new OpenApiContext(allTypes, this.allowedTypes, appClassLoader, api);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalker.java
@@ -68,7 +68,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
-import java.util.Collection;
 import static java.util.Collections.singletonList;
 import java.util.List;
 
@@ -105,7 +104,6 @@ import org.glassfish.hk2.classmodel.reflect.ClassModel;
 import org.glassfish.hk2.classmodel.reflect.FieldModel;
 import org.glassfish.hk2.classmodel.reflect.MethodModel;
 import org.glassfish.hk2.classmodel.reflect.Type;
-import org.glassfish.hk2.classmodel.reflect.Types;
 
 /**
  * A walker that visits each filtered class type & it's members, scans for
@@ -119,10 +117,10 @@ public class OpenApiWalker<E extends AnnotatedElement> implements ApiWalker {
     private Map<Class<? extends Annotation>, VisitorFunction<AnnotationModel, E>> annotationVisitor;
     private Map<Class<? extends Annotation>, List<Class<? extends Annotation>>> annotationAlternatives;
 
-    public OpenApiWalker(OpenAPI api, Types allTypes, Set<Type> allowedTypes, ClassLoader appClassLoader) {
+    public OpenApiWalker(OpenAPI api, Map<String, Type> allTypes, Set<Type> allowedTypes, Set<Type> allowedResourceTypes, ClassLoader appClassLoader) {
         this.allowedTypes = new TreeSet<>(Comparator.comparing(Type::getName, String::compareTo));
         this.allowedTypes.addAll(allowedTypes);
-        this.context = new OpenApiContext(allTypes, this.allowedTypes, appClassLoader, api);
+        this.context = new OpenApiContext(allTypes, this.allowedTypes, allowedResourceTypes, appClassLoader, api);
     }
 
     @Override

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
@@ -40,6 +40,7 @@
 package fish.payara.microprofile.openapi.impl.visitor;
 
 
+import fish.payara.microprofile.openapi.impl.OpenAPISupplier;
 import fish.payara.microprofile.openapi.resource.classloader.ApplicationClassLoader;
 import fish.payara.microprofile.openapi.resource.rule.ApplicationProcessedDocument;
 import fish.payara.microprofile.openapi.test.app.OpenApiApplicationTest;
@@ -90,7 +91,8 @@ public class OpenApiWalkerTest extends OpenApiApplicationTest {
         ApplicationClassLoader appClassLoader = new ApplicationClassLoader(testedClasssses);
 
         final OpenApiWalker openApiWalker = new OpenApiWalker(getDocument(),
-                ApplicationProcessedDocument.getTypes(),
+                OpenAPISupplier.typesToMap(ApplicationProcessedDocument.getTypes()),
+                ApplicationProcessedDocument.getApplicationTypes(testedClasssses.toArray(new Class<?>[0])),
                 ApplicationProcessedDocument.getApplicationTypes(testedClasssses.toArray(new Class<?>[0])),
                 appClassLoader);
         final java.lang.reflect.Field sortedClassesField = OpenApiWalker.class.getDeclaredField("allowedTypes");

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
@@ -93,7 +93,6 @@ public class OpenApiWalkerTest extends OpenApiApplicationTest {
         final OpenApiWalker openApiWalker = new OpenApiWalker(getDocument(),
                 OpenAPISupplier.typesToMap(ApplicationProcessedDocument.getTypes()),
                 ApplicationProcessedDocument.getApplicationTypes(testedClasssses.toArray(new Class<?>[0])),
-                ApplicationProcessedDocument.getApplicationTypes(testedClasssses.toArray(new Class<?>[0])),
                 appClassLoader);
         final java.lang.reflect.Field sortedClassesField = OpenApiWalker.class.getDeclaredField("allowedTypes");
         assertEquals(Set.class, sortedClassesField.getType()); // Ensure fast lookup is possible with at least any Set

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/impl/visitor/OpenApiWalkerTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2019-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/resource/rule/ApplicationProcessedDocument.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/test/java/fish/payara/microprofile/openapi/resource/rule/ApplicationProcessedDocument.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.openapi.resource.rule;
 
+import fish.payara.microprofile.openapi.impl.OpenAPISupplier;
 import fish.payara.microprofile.openapi.impl.model.OpenAPIImpl;
 import fish.payara.microprofile.openapi.impl.processor.ApplicationProcessor;
 import fish.payara.microprofile.openapi.impl.processor.BaseProcessor;
@@ -79,7 +80,8 @@ public class ApplicationProcessedDocument {
             new BaseProcessor(asList(new URL("http://localhost:8080/testlocation_123"))).process(document, null);
 
             // Apply application processor
-            new ApplicationProcessor(getTypes(), getApplicationTypes(extraClasses), appClassLoader).process(document, null);
+            new ApplicationProcessor(OpenAPISupplier.typesToMap(getTypes()), getApplicationTypes(extraClasses), getApplicationTypes(extraClasses), appClassLoader)
+                    .process(document, null);
             if (filter != null) {
                 new FilterProcessor(filter.getDeclaredConstructor().newInstance()).process(document, null);
             }


### PR DESCRIPTION
## Description
If mp.openapi.extensions.scan.lib is set to true, include libraries from EAR (lib/*.jar) to schema scanning. Resources are processed only from the WAR file.

Also old error when for `mp.openapi.extensions.scan.lib=false` it wrongly generated reference to a library class (e.g. dangling reference).

## Testing
### Testing Performed
Reproducer app
OpenAPI TCK for `mp.openapi.extensions.scan.lib` both `true` and `false`.

### Testing Environment
OpenJDK 11, Linux

## Documentation
[Doc update](https://github.com/payara/Payara-Documentation/pull/238)

## Notes for Reviewers
Deploy the reproducer app in the Jira ticket.

```
mvn clean install && /path-to-payara/payara6/bin/asadmin deploy --force MultiWarEar-ear/target/MultiWarEar-ear-1.0-SNAPSHOT.ear
```

Set config value (Configurations/server-config/Microprofile/Property) `mp.openapi.extensions.scan.lib` to `true`. Open `localhost:4848/openapi`. The result should look like:

```
openapi: 3.0.0
info:
  title: Deployed Resources
  version: 1.0.0
servers:
- url: http://aubicomp.aubrecht.net:8080/web2
  description: Default Server.
- url: http://aubicomp.aubrecht.net:8080/web1
  description: Default Server.
paths:
  /resources1/earlib-path:
    get:
      operationId: method
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources1/lib-path:
    get:
      operationId: method
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources1/web1/earData:
    get:
      operationId: getEarData
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources1/web1/earlibData:
    get:
      operationId: getEarLibData
      responses:
        default:
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/EarLibTestData'
          description: Default Response.
  /resources1/web1/jarData:
    get:
      operationId: getJarData
      responses:
        default:
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/JarTestData'
          description: Default Response.
  /resources1/web1/warData:
    get:
      operationId: getData
      responses:
        default:
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/WarTestData'
          description: Default Response.
  /resources2/earlib-path:
    get:
      operationId: method
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources2/web2:
    get:
      operationId: ping
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
endpoints:
  /web1:
  - /resources1/earlib-path
  - /resources1/lib-path
  - /resources1/web1/earData
  - /resources1/web1/earlibData
  - /resources1/web1/jarData
  - /resources1/web1/warData
  /web2:
  - /resources2/earlib-path
  - /resources2/web2
components:
  schemas:
    EarLibTestData:
      type: object
      properties:
        testInt:
          type: integer
        testString:
          type: string
    JarTestData:
      type: object
      properties:
        testIntJar:
          type: integer
        testStringJar:
          type: string
    WarTestData:
      type: object
      properties:
        testInt:
          type: integer
        testString:
          type: string
```

Set the value to `false`, redeploy the app and the openapi looks like this:

```
openapi: 3.0.0
info:
  title: Deployed Resources
  version: 1.0.0
servers:
- url: http://aubicomp.aubrecht.net:8080/web2
  description: Default Server.
- url: http://aubicomp.aubrecht.net:8080/web1
  description: Default Server.
paths:
  /resources1/web1/earData:
    get:
      operationId: getEarData
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources1/web1/earlibData:
    get:
      operationId: getEarLibData
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources1/web1/jarData:
    get:
      operationId: getJarData
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
  /resources1/web1/warData:
    get:
      operationId: getData
      responses:
        default:
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/WarTestData'
          description: Default Response.
  /resources2/web2:
    get:
      operationId: ping
      responses:
        default:
          content:
            '*/*':
              schema:
                type: object
          description: Default Response.
endpoints:
  /web1:
  - /resources1/web1/earData
  - /resources1/web1/earlibData
  - /resources1/web1/jarData
  - /resources1/web1/warData
  /web2:
  - /resources2/web2
components:
  schemas:
    WarTestData:
      type: object
      properties:
        testInt:
          type: integer
        testString:
          type: string
```

The difference is in the visibility of `JarTestData` (class in `MultiWarEar-ear-1.0-SNAPSHOT.ear/MultiWarEar-web1-1.0-SNAPSHOT.war/WEB-INF/lib/MultiWarEar-lib-1.0-SNAPSHOT.jar`) and EarLibTestData (class in `MultiWarEar-ear-1.0-SNAPSHOT.ear/lib/fish.payara.reproducers-MultiWarEar-earlib-1.0-SNAPSHOT.jar`).