### PR TITLE
Fish 7127 unable to create jvm option

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
@@ -386,7 +386,7 @@ public abstract class CollectionLeafResource extends AbstractResource {
         return part.replace("\\", "\\\\")
                 .replace(":", "\\:")
                 .replace("'", "\\'")
-                .replace("\"", "\\");
+                .replace("\"", "\\\"");
     }
 
     // TODO: JvmOptions needs to have its own class, but the generator doesn't seem to support

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/CollectionLeafResource.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.admin.rest.resources;
 
@@ -73,8 +73,7 @@ import org.glassfish.api.ActionReport;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Optional;
-import java.util.function.Function;
+
 import org.glassfish.admin.rest.utils.ResourceUtil;
 import org.glassfish.admin.rest.utils.Util;
 import org.jvnet.hk2.config.Dom;
@@ -198,7 +197,6 @@ public abstract class CollectionLeafResource extends AbstractResource {
         } else {
             payload = data;
         }
-
 
         return runCommand(postCommand, payload, "rest.resource.create.message",
             "\"{0}\" created successfully.", "rest.resource.post.forbidden","POST on \"{0}\" is forbidden.");
@@ -386,7 +384,9 @@ public abstract class CollectionLeafResource extends AbstractResource {
      */
     protected String escapeOptionPart(String part) {
         return part.replace("\\", "\\\\")
-                .replace(":", "\\:");
+                .replace(":", "\\:")
+                .replace("'", "\\'")
+                .replace("\"", "\\");
     }
 
     // TODO: JvmOptions needs to have its own class, but the generator doesn't seem to support


### PR DESCRIPTION
Unable to create JVM option using Web UI

## Description
Getting Exception “JVM option${ } already exists in the configuration” upon creating JVM option using WEB UI.

## Important Info

### Steps
1. mvn clean install -T 14 -DskipTests
2. .\appserver\distributions\payara\target\stage\payara6\bin\asadmin start-domain -v
3. Navigate to Payara -> Server config-> JVM Settings -> Jvm Options Tab
4. Click on "Add Jvm Option" button
5. Type: -Dhttps.nonProxyHosts="localhost|127.0.0.1|10.*.*.*|*.fmp-fbz.fgov.be|*.fedris.be|*.faofat.fgov.be"
6. Click on Save button
7. Click on "Add Jvm Option" button
8. Type: -Dhttp.nonProxyHosts="localhost|127.0.0.1|10.*.*.*|*.fmp-fbz.fgov.be|*.fedris.be|*.faofat.fgov.be"
9. Click on Save button

### Testing Performed
- Quicklook
- Samples

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.4

