### PR TITLE
FISH-7331 [JDK17] Fixes HK2 config for compilation

### DIFF
--- a/appserver/web/web-glue/osgi.bundle
+++ b/appserver/web/web-glue/osgi.bundle
@@ -39,40 +39,40 @@
 #
 
 -exportcontents: \
-                        com.sun.appserv.web.cache;version=${project.osgi.version}, \
-                        com.sun.appserv.web.cache.filter;version=${project.osgi.version}, \
-                        com.sun.appserv.web.cache.mapping;version=${project.osgi.version}, \
-                        com.sun.appserv.web.taglibs.cache;version=${project.osgi.version}, \
-                        com.sun.enterprise.security.web;version=${project.osgi.version}, \
-                        com.sun.enterprise.util.logging;version=${project.osgi.version}, \
-                        com.sun.enterprise.web;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.accesslog;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.connector.coyote;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.connector.extension;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.deploy;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.jsp;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.logger;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.logging.pwc;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.monitor;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.monitor.impl;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.pluggable;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.pwc;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.pwc.connector.coyote;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.reconfig;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.session;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.stats;version=${project.osgi.version}, \
-                        com.sun.enterprise.web.util;version=${project.osgi.version}, \
-                        com.sun.web.server;version=${project.osgi.version}, \
-                        org.glassfish.web;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.archivist;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.descriptor;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.io;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.io.runtime;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.runtime;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.util;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.xml;version=${project.osgi.version}, \
-                        org.glassfish.web.deployment.node.runtime.wls;version=${project.osgi.version} \
-                        
+                        com.sun.appserv.web.cache; \
+                        com.sun.appserv.web.cache.filter; \
+                        com.sun.appserv.web.cache.mapping; \
+                        com.sun.appserv.web.taglibs.cache; \
+                        com.sun.enterprise.security.web; \
+                        com.sun.enterprise.util.logging; \
+                        com.sun.enterprise.web; \
+                        com.sun.enterprise.web.accesslog; \
+                        com.sun.enterprise.web.connector.coyote; \
+                        com.sun.enterprise.web.connector.extension; \
+                        com.sun.enterprise.web.deploy; \
+                        com.sun.enterprise.web.jsp; \
+                        com.sun.enterprise.web.logger; \
+                        com.sun.enterprise.web.logging.pwc; \
+                        com.sun.enterprise.web.monitor; \
+                        com.sun.enterprise.web.monitor.impl; \
+                        com.sun.enterprise.web.pluggable; \
+                        com.sun.enterprise.web.pwc; \
+                        com.sun.enterprise.web.pwc.connector.coyote; \
+                        com.sun.enterprise.web.reconfig; \
+                        com.sun.enterprise.web.session; \
+                        com.sun.enterprise.web.stats; \
+                        com.sun.enterprise.web.util; \
+                        com.sun.web.server; \
+                        org.glassfish.web; \
+                        org.glassfish.web.deployment.archivist; \
+                        org.glassfish.web.deployment.descriptor; \
+                        org.glassfish.web.deployment.io; \
+                        org.glassfish.web.deployment.io.runtime; \
+                        org.glassfish.web.deployment.runtime; \
+                        org.glassfish.web.deployment.util; \
+                        org.glassfish.web.deployment.xml; \
+                        org.glassfish.web.deployment.node.runtime.wls; \
+
                         version=${project.osgi.version}
 
 Import-Package: \

--- a/nucleus/hk2/hk2-config/osgi.bundle
+++ b/nucleus/hk2/hk2-config/osgi.bundle
@@ -38,8 +38,8 @@
 # holder.
 #
 -exportcontents: \
-	org.jvnet.hk2.config; version=${project.osgi.version} \
-	org.jvnet.hk2.config.provider; version=${project.osgi.version} \
-	org.jvnet.hk2.config.provider.annotations; version=${project.osgi.version}
+      org.jvnet.hk2.config; \
+      org.jvnet.hk2.config.provider; \
+      org.jvnet.hk2.config.provider.annotations; version=${project.osgi.version}
 
 DynamicImport-Package: *


### PR DESCRIPTION
While trying to [build](https://docs.payara.fish/community/docs/General%20Info/Build%20Instructions.html) Payara from source, after fixing the bundle plugin (#6262), I hit the following error:

```
[ERROR] Manifest fish.payara.server.core.hk2:hk2-config:glassfish-jar:6.2023.5-SNAPSHOT : package info for org.jvnet.hk2.config attribute [version~='6.2023.5 org.jvnet.hk2.config.provider.annotations'], key must be an EXTENDED (CORE1.3.2 [-.\w]+). From null
[ERROR] Manifest fish.payara.server.core.hk2:hk2-config:glassfish-jar:6.2023.5-SNAPSHOT : package info for org.jvnet.hk2.config attribute [version~~='6.2023.5'], key must be an EXTENDED (CORE1.3.2 [-.\w]+). From null
[ERROR] Error(s) found in manifest configuration
```

Some commas were missing but I tried to align the same declaration as in the other `osgi.bundle` files.
