### PR TITLE
FISH-7341 Upgrade ASM from 9.4 to 9.5 to allow running on Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <websocket-api.version>1.1.2</websocket-api.version>
         <concurrent-api.version>1.1.2</concurrent-api.version>
         <concurrent.version>1.1.payara-p1</concurrent.version>
-        <asm.version>9.4</asm.version>
+        <asm.version>9.5</asm.version>
         <monitoring-console-api.version>1.2</monitoring-console-api.version>
         <monitoring-console-process.version>1.8.1</monitoring-console-process.version>
         <monitoring-console-webapp.version>1.8.1</monitoring-console-webapp.version>


### PR DESCRIPTION
## Description
Upgrading to the latest version of ASM allows Payara 5 to run on the latest Java 21.

## Testing
### Testing Performed
Tested by replacing `asm-*` jars with their respective 9.5 versions downloaded from Maven Central. Ran Payara 5 with an internal build of Java 21 and verified that the server starts and can deploy applications.

### Testing Environment
macOS 12.6.3

## Notes for Reviewers
I noticed the statement that no further community releases will be made from Payara 5, but considered this useful anyway in case someone wants to build from source. Also, this could be applied to any Enterprise offerings.