### PR TITLE
FISH-7291 Cherry-pick Missed Commits from Payara 5

### DIFF
--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
@@ -76,11 +76,21 @@ public class ConfigParser {
      */
     protected final ServiceLocator habitat;
 
+    // Whether we should log unrecognised elements while parsing
+    // Added in as a simple flag for the upgrade tool to prevent log vomit
+    private boolean logUnrecognisedElements = true;
 
     public ConfigParser(ServiceLocator habitat) {
         this.habitat = habitat;
     }
 
+    public void logUnrecognisedElements(boolean logUnrecognisedElements) {
+        this.logUnrecognisedElements = logUnrecognisedElements;
+    }
+
+    public boolean loggingUnrecognisedElements() {
+        return logUnrecognisedElements;
+    }
 
     public DomDocument parse(XMLStreamReader in) throws XMLStreamException {
         DomDocument document = new DomDocument(habitat);
@@ -162,8 +172,11 @@ public class ConfigParser {
         ConfigModel model = document.getModelByElementName(in.getLocalName());
         if(model==null) {
             String localName = in.getLocalName();
-            Logger.getLogger(ConfigParser.class.getName()).log(Level.SEVERE, "Ignoring unrecognized element {0} at {1}",
-                    new Object[]{in.getLocalName(), in.getLocation()});
+            if (logUnrecognisedElements) {
+                Logger.getLogger(ConfigParser.class.getName()).log(Level.SEVERE, "Ignoring unrecognized element {0} at {1}",
+                        new Object[]{in.getLocalName(), in.getLocation()});
+            }
+
             // flush the sub element content from the parser
             int depth=1;
             while(depth>0) {

--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2020-2021] Payara Foundation and/or affiliates
+// Portions Copyright 2020-2023 Payara Foundation and/or affiliates
 
 package org.jvnet.hk2.config;
 

--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigParser.java
@@ -44,21 +44,17 @@ package org.jvnet.hk2.config;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.Dom.Child;
 
-import jakarta.validation.constraints.NotNull;
 import javax.xml.stream.XMLInputFactory;
 import static javax.xml.stream.XMLStreamConstants.*;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.events.XMLEvent;
 import javax.xml.transform.stream.StreamSource;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -166,25 +162,26 @@ public class ConfigParser {
         ConfigModel model = document.getModelByElementName(in.getLocalName());
         if(model==null) {
             String localName = in.getLocalName();
-            Logger.getAnonymousLogger().severe("Ignoring unrecognized element "+in.getLocalName() + " at " + in.getLocation());
+            Logger.getLogger(ConfigParser.class.getName()).log(Level.SEVERE, "Ignoring unrecognized element {0} at {1}",
+                    new Object[]{in.getLocalName(), in.getLocation()});
             // flush the sub element content from the parser
             int depth=1;
             while(depth>0) {
                 final int tag = in.next();
                 if (tag==START_ELEMENT && in.getLocalName().equals(localName)) {
-                    if (Logger.getAnonymousLogger().isLoggable(Level.FINE)) {
-                        Logger.getAnonymousLogger().fine("Found child of same type "+localName+" ignoring too");
+                    if (Logger.getLogger(ConfigParser.class.getName()).isLoggable(Level.FINE)) {
+                        Logger.getLogger(ConfigParser.class.getName()).fine("Found child of same type "+localName+" ignoring too");
                     }
                     depth++;
                 }
                 if (tag==END_ELEMENT && in.getLocalName().equals(localName)) {
-                    if (Logger.getAnonymousLogger().isLoggable(Level.FINE)) {
-                        Logger.getAnonymousLogger().fine("closing element type " + localName);
+                    if (Logger.getLogger(ConfigParser.class.getName()).isLoggable(Level.FINE)) {
+                        Logger.getLogger(ConfigParser.class.getName()).fine("closing element type " + localName);
                     }
                     depth--;
                 }
-                if (Logger.getAnonymousLogger().isLoggable(Level.FINE) && tag==START_ELEMENT) {
-                    Logger.getAnonymousLogger().fine("Jumping over " + in.getLocalName());
+                if (Logger.getLogger(ConfigParser.class.getName()).isLoggable(Level.FINE) && tag==START_ELEMENT) {
+                     Logger.getLogger(ConfigParser.class.getName()).fine("Jumping over " + in.getLocalName());
                 }
             }
             return null;


### PR DESCRIPTION
## Description
Cherry-picks across some changes from Payara 5 which never made it to Payara 6, related to preventing the config parser from spamming warnings.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
See Enterprise PR: https://github.com/payara/Payara-Enterprise/pull/828

### Testing Environment
See Enterprise PR: https://github.com/payara/Payara-Enterprise/pull/828

## Documentation
N/A

## Notes for Reviewers
None
