### PR TITLE
FISH-6504 Load cacerts.jks if p12 is not Found

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -37,8 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-
-// Portions Copyright [2016-2022] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2023] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -563,7 +562,7 @@ public abstract class LocalServerCommand extends CLICommand {
 
         File configDir = serverDirs.getConfigDir();
         File mp = Stream.of(new File(configDir, DomainConstants.TRUSTSTORE_FILE),
-                        new File(configDir, DomainConstants.TRUSTSTORE_JSK_FILE))
+                        new File(configDir, DomainConstants.TRUSTSTORE_JKS_FILE))
                 .filter(f -> f.canRead())
                 .findFirst()
                 .orElse(null);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainConstants.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainConstants.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2023 Payara Foundation and/or its affiliates 
 
 package com.sun.enterprise.admin.servermgmt.domain;
 
@@ -78,7 +79,7 @@ public class DomainConstants {
     /**
      * Fallback TRUSTSTORE_FILE if the P12 format is not found, use JKS format
      */
-    public static final String TRUSTSTORE_JSK_FILE = "cacerts.jks";
+    public static final String TRUSTSTORE_JKS_FILE = "cacerts.jks";
 
     /**
      * Filename contains most of the domain configuration.

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainConstants.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainConstants.java
@@ -60,15 +60,28 @@ public class DomainConstants {
     /** Name of directory stores the domain information. */
     public static final String INFO_DIRECTORY = "init-info";
 
-    /** Filename contains the server certificates, including its private key. */
+    /**
+     * Filename contains the server certificates, including its private key.
+     */
     public static final String KEYSTORE_FILE = "keystore.p12";
 
-    /** Master password file name stores the password for secure key store.  */
+    /**
+     * Master password file name stores the password for secure key store.
+     */
     public static final String MASTERPASSWORD_FILE = "master-password";
 
-    /** Filename contains the trusted certificates, including public keys. */
+    /**
+     * Filename contains the trusted certificates, including public keys.
+     */
     public static final String TRUSTSTORE_FILE = "cacerts.p12";
 
-    /** Filename contains most of the domain configuration. */
+    /**
+     * Fallback TRUSTSTORE_FILE if the P12 format is not found, use JKS format
+     */
+    public static final String TRUSTSTORE_JSK_FILE = "cacerts.jks";
+
+    /**
+     * Filename contains most of the domain configuration.
+     */
     public static final String DOMAIN_XML_FILE = "domain.xml";
 }

--- a/nucleus/admin/server-mgmt/src/main/java/fish/payara/admin/servermgmt/cli/AddKeypairCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/fish/payara/admin/servermgmt/cli/AddKeypairCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2018-2023 Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/admin/server-mgmt/src/main/java/fish/payara/admin/servermgmt/cli/AddKeypairCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/fish/payara/admin/servermgmt/cli/AddKeypairCommand.java
@@ -39,10 +39,14 @@
  */
 package fish.payara.admin.servermgmt.cli;
 
-import com.sun.enterprise.admin.servermgmt.DomainException;
 import com.sun.enterprise.admin.servermgmt.KeystoreManager;
 import com.sun.enterprise.admin.servermgmt.cli.LocalDomainCommand;
-import com.sun.enterprise.admin.servermgmt.domain.DomainConstants;
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.CommandException;
+import org.glassfish.api.admin.CommandValidationException;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -56,11 +60,6 @@ import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.glassfish.hk2.api.PerLookup;
-import org.jvnet.hk2.annotations.Service;
-import org.glassfish.api.Param;
-import org.glassfish.api.admin.CommandException;
-import org.glassfish.api.admin.CommandValidationException;
 
 /**
  * Adds a new PKCS#8 encoded plain (unencrypted) RSA keypair to the domain's keystore
@@ -86,20 +85,6 @@ public class AddKeypairCommand extends LocalDomainCommand {
 	//@Inject
 	KeystoreManager keyManager = new KeystoreManager();
 
-	private File getKeyStoreFile() throws DomainException, IOException {
-
-		if (getServerDirs() == null) {
-			return null;
-		}
-
-		File mp = new File(getServerDirs().getConfigDir(), DomainConstants.KEYSTORE_FILE);
-		Logger.getLogger(AddKeypairCommand.class.getName()).log(Level.SEVERE, mp.getAbsolutePath());
-		if (!mp.canRead()) {
-			return null;
-		}
-		return mp;
-	}
-
 	@Override
 	protected void validate()
 			throws CommandException, CommandValidationException {
@@ -120,12 +105,12 @@ public class AddKeypairCommand extends LocalDomainCommand {
 				keyManager.addKeyPair(destKeyStore, "JKS",
 						mp.toCharArray(), privKey, certChain.toArray(new Certificate[1]), destAlias);
 				logger.fine(() -> MessageFormat.format("Private key with alias [{0}] added to keystore {1}.",
-						new Object[] {destAlias, destKeyStore.getAbsolutePath()}));
+						new Object[]{destAlias, destKeyStore.getAbsolutePath()}));
 			} catch (IOException | NoSuchAlgorithmException | KeyStoreException ex) {
 				Logger.getLogger(AddKeypairCommand.class.getName()).log(Level.SEVERE, null, ex);
 				throw new CommandException(ex.getLocalizedMessage());
 			}
-		} catch (DomainException | IOException | InvalidKeySpecException ex) {
+		} catch (InvalidKeySpecException ex) {
 			throw new CommandException(ex.getLocalizedMessage());
 		}
 


### PR DESCRIPTION
During verification of master password, load `cacerts.jks` if `cacerts.p12` is not found

## Description
After the transition to key/truststores to P12 format, server doesn't start if the stores are in JKS.
This change allows to start the server and serve HTTPS.

## Testing
### Testing Performed

After building this PR, replace both *.p12 files in `appserver/distributions/payara/target/stage/payara6/glassfish/domains/domain1/config` (`cacerts` and `keystore`) with their jks version (e.g. from Payara 5 build).
Also change the names in `domain.xml`:
```
<jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
```
Start the server normally and try all ports: 8080, 8181, 4848


### Testing Environment
OpenJDK 11, Linux

