### PR TITLE
FISH-7451 Fixes for Issue 6274

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
@@ -54,6 +54,7 @@ import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionalException;
 
 import com.sun.enterprise.transaction.TransactionManagerHelper;
+import org.glassfish.api.invocation.ComponentInvocation;
 
 /**
  * Transactional annotation Interceptor class for RequiresNew transaction type, ie
@@ -85,13 +86,14 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
 
         setTransactionalTransactionOperationsManger(false);
 
-        boolean hasTransactionInComponentInvocation = false;
+        boolean currentInvocationHasTransaction = false;
         try {
             Transaction suspendedTransaction = null;
             if (getTransactionManager().getTransaction() != null) {
                 _logger.log(FINE, CDI_JTA_MBREQNEW);
 
-                hasTransactionInComponentInvocation = getCurrentInvocation().getTransaction() != null;
+                ComponentInvocation currentInvocation = getCurrentInvocation();
+                currentInvocationHasTransaction = (currentInvocation != null) && currentInvocation.getTransaction() != null;
 
                 suspendedTransaction = getTransactionManager().suspend();
                 // todo catch, wrap in new transactional exception and throw
@@ -142,7 +144,8 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
                     try {
                         getTransactionManager().resume(suspendedTransaction);
 
-                        if (!hasTransactionInComponentInvocation) {
+                        ComponentInvocation currentInvocation = getCurrentInvocation();
+                        if (!currentInvocationHasTransaction && currentInvocation != null) {
                             getCurrentInvocation().setTransaction(null);
                         }
                     } catch (Exception exception) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequiresNew.java
@@ -85,13 +85,17 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
 
         setTransactionalTransactionOperationsManger(false);
 
+        boolean hasTransactionInComponentInvocation = false;
         try {
             Transaction suspendedTransaction = null;
             if (getTransactionManager().getTransaction() != null) {
                 _logger.log(FINE, CDI_JTA_MBREQNEW);
 
+                hasTransactionInComponentInvocation = getCurrentInvocation().getTransaction() != null;
+
                 suspendedTransaction = getTransactionManager().suspend();
                 // todo catch, wrap in new transactional exception and throw
+
             }
             try {
                 getTransactionManager().begin();
@@ -137,6 +141,10 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
                 if (suspendedTransaction != null) {
                     try {
                         getTransactionManager().resume(suspendedTransaction);
+
+                        if (!hasTransactionInComponentInvocation) {
+                            getCurrentInvocation().setTransaction(null);
+                        }
                     } catch (Exception exception) {
                         throw new TransactionalException(
                                 "Managed bean with Transactional annotation and TxType of REQUIRED " +


### PR DESCRIPTION
## Description
This PR fixes issue [6274](https://github.com/payara/Payara/issues/6274).

When using @Transactional(Transactional.TxType.REQUIRES_NEW) the interceptor suspends and resumes the transaction but also the transaction in the current invocation. But when resuming it sets the tx in the invocation also when there was none when the interceptor started. This causes issues when using an observer method with @Observes(during = TransactionPhase.AFTER_SUCCESS) because when this method is executed the tx is already committed and when calling datasource.getConnection() this causes an exception because it is checking the tx status in the current invocation.

## Testing
### New tests
No new tests because the current code do not allow for setting or mocking the invocationmanager/current invocation.

### Testing Performed
Reran the reproducer, no more exception.

### Testing Environment
MacOS Ventura 13.3.1, openjdk 11.0.17 2022-10-18, mvn version 3.8.6

## Documentation
See reproducer: https://github.com/thehpi/payara-after-success

## Notes for Reviewers
This is a quick fix, it might be better to fix it in TransactionalInterceptorBase so other interceptor implementations are also fixed but I cannot oversee this.