### PR TITLE
FISH-7359 Fix change-master-password for JKS Keystores

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2023] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -115,8 +115,7 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
             if (nmp == null)
                 throw new CommandException(STRINGS.get("no.console"));
 
-            // if password is less than 6 characters then the domain can become corrupt
-            // FIXES GLASSFISH-21017
+            // keytool requires password at least 6 characters
             if (nmp.length() < 6) {
                 throw new CommandException(STRINGS.get("password.too.short"));
             }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -252,23 +252,14 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     protected boolean loadAndVerifyKeystore(File jks, String mpv) {
-        FileInputStream fis = null;
         try {
-            fis = new FileInputStream(jks);
-            KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-            ks.load(fis, mpv.toCharArray());
+            // try to load the keystore with the provided keystore password
+            KeyStore.getInstance(jks, mpv.toCharArray());
             return true;
         } catch (Exception e) {
             if (logger.isLoggable(Level.FINER))
                 logger.finer(e.getMessage());
             return false;
-        } finally {
-            try {
-                if (fis != null)
-                    fis.close();
-            } catch (IOException ioe) {
-                // ignore, I know ...
-            }
         }
     }
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2020] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2023] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.pe;
 
@@ -713,10 +713,25 @@ public class PEFileLayout
         return new File(getConfigRoot(), WSSSERVERCONFIG);
     }
 
+    private File fileAlternative(File root, String fileDefault, String alternative) {
+        File p12 = new File(root, fileDefault);
+        if(p12.exists()) {
+            // if PKCS12 file exists, use it
+            return p12;
+        }
+        File jks = new File(root, alternative);
+        if(jks.exists()) {
+            // if JKS file exists, use it
+            return jks;
+        }
+        // if none exists, use the default one, PKCS12
+        return p12;
+    }
+
     public static final String KEYSTORE = "keystore.p12";
-    public File getKeyStore()
-    {
-        return new File(getConfigRoot(), KEYSTORE);
+    public static final String KEYSTORE_JKS = "keystore.jks";
+    public File getKeyStore() {
+        return fileAlternative(getConfigRoot(), KEYSTORE, KEYSTORE_JKS);
     }
 
     public static final String TRUSTSTORE_TEMPLATE = "cacerts.p12";
@@ -758,9 +773,9 @@ public class PEFileLayout
     }
 
     public static final String TRUSTSTORE = "cacerts.p12";
-    public File getTrustStore()
-    {
-        return new File(getConfigRoot(), TRUSTSTORE);
+    public static final String TRUSTSTORE_JKS = "cacerts.jks";
+    public File getTrustStore() {
+        return fileAlternative(getConfigRoot(), TRUSTSTORE, TRUSTSTORE_JKS);
     }
 
     public File getMasterPasswordFile()

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2021] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2023] Payara Foundation and/or affiliates
  */
 
 package com.sun.enterprise.admin.remote;
@@ -227,10 +227,10 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
      * anything needed prior to the URLConnection#connect invocation.
      * <p>
      * The caller will invoke this method after it has invoked {@link URL#openConnection}
-     * but before it invokes {@link URL#connect}.
+     * but before it invokes {@link URLConnection#connect}.
      * <li>{@link #useConnection} - to read from the
      * input stream, etc.  The caller will invoke this method after it has
-     * successfully invoked {@link URL#connect}.
+     * successfully invoked {@link URLConnection#connect}.
      * </ul>
      * Because the caller might have to work with multiple URLConnection objects
      * (as it follows redirection, for example) this contract allows the caller


### PR DESCRIPTION
## Description
After Payara upgrade from P5 to P6, keystore and cacerts remain in the JKS format.
This PR fixes change-master-password command, so it accepts JKS keystores.

## Testing
### Testing Performed
I tried to use old domain with jks keystores (e.g. no p12 files in domain/config) and copied it to Payara from this PR.

Then try
```
./asadmin change-master-password
```

Verification can be done with second run or with `keytool` in the domain/config directory:
```
keytool -list --keystore cacerts.jks
keytool -list --keystore keystore.jks
```
The new password is required.


### Testing Environment
Linux, OpenJDK 8 and 11

