### PR TITLE
FISH-7292 FISH-7374 JSON Smart 2.4.10

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -87,7 +87,7 @@
 
         <nimbus-jose-jwt.version>9.25</nimbus-jose-jwt.version>
         <accessors-smart.version>2.4.8</accessors-smart.version>
-        <json-smart.version>2.4.8</json-smart.version>
+        <json-smart.version>2.4.10</json-smart.version>
         <reactor-core.version>3.4.4</reactor-core.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jcip-annotations.version>1.0-1</jcip-annotations.version>


### PR DESCRIPTION
## Description
Upgrades JSON Smart to 2.4.10 to fix CVE-2023-1370

## Important Info

### Dependant PRs 
None

### Blockers 
None

## Testing

### New tests
None

### Testing Performed
Jenkins test please

### Testing Environment
N/A

## Documentation
https://github.com/payara/Payara-Documentation/pull/260

## Notes for Reviewers
None
