### PR TITLE
FISH-7404 Upgrade Docker Image JDKs

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,8 +57,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.18</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.6</docker.jdk17.tag>
+        <docker.jdk11.tag>11.0.19</docker.jdk11.tag>
+        <docker.jdk17.tag>17.0.7</docker.jdk17.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara6</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
Upgrades the Docker image JDKs to 11.0.19 and 17.0.7

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built and started Docker images

### Testing Environment
Windows

## Documentation
N/A

## Notes for Reviewers
None
