### PR TITLE
FISH-7354 : replacing old jsp class on the fly

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/Constants.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/Constants.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2022-2023] [Payara Foundation and/or its affiliates]
 
 package org.apache.catalina.core;
 
@@ -68,6 +68,9 @@ public class Constants {
 
     public static final String JSP_SERVLET_CLASS
             = "org.glassfish.wasp.servlet.JspServlet";
+
+    public static final String OLD_JSP_SERVLET_CLASS
+            = "org.apache.jasper.servlet.JspServlet";
 
     public static final String JSP_SERVLET_NAME = "jsp";
 


### PR DESCRIPTION
## Description
ClassNotFoundException on `org.apache.jasper.servlet.JspServlet` after Payara 5 to Payara 6 Upgrade

<!-- Provide some context here -->
After an upgrade from Payara 5 to 6 the admin console was failing to load with a CNFE on Apache Jasper JspServlet, and this was later confirmed.

## Important Info

## Testing

### Testing Performed
1. mvn clean install -T 14 -DskipTests
2. Copy default-web.xml from Payara5 attached in https://payara.atlassian.net/browse/FISH-7354
3. .\appserver\distributions\payara\target\stage\payara6\bin\asadmin start-domain -v
4. Poke localhost:4848
5. Payara Server Console should load without CNE errors

### Test suites executed
- Quicklook
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples
- Payara Microprofile TCKs Runner
- Jakarta TCKs
- Mojarra
- Cargo Tracker

### Testing Environment
Zulu JDK 11.0.17 on Windows 11 with Maven 3.8.6
