### PR TITLE
FISH-6607 Fix Admin Console OSGi imports and Fragments

### DIFF
--- a/appserver/admingui/common-l10n/osgi.bundle
+++ b/appserver/admingui/common-l10n/osgi.bundle
@@ -40,4 +40,4 @@
 
 # "Portions Copyright [2016-2019] [Payara Foundation]"
 
-Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/admingui/core-l10n/osgi.bundle
+++ b/appserver/admingui/core-l10n/osgi.bundle
@@ -40,4 +40,4 @@
 
 # "Portions Copyright [2016-2019] [Payara Foundation]"
 
-Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -102,7 +102,7 @@
                     <archive>
                         <manifestEntries>
                             <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
-                            <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.core.admingui.console-plugin-service, fish.payara.server.core.deployment.deployment-client,
+                            <HK2-Import-Bundles>fish.payara.server.core.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.core.admingui.console-plugin-service, fish.payara.server.core.deployment.deployment-client,
                                 jakarta.servlet-api,jakarta.servlet.jsp-api,org.glassfish.expressly,fish.payara.server.core.admingui.faces-compat,fish.payara.server.core.admingui.dataprovider,com.sun.pkg.client</HK2-Import-Bundles>
                         </manifestEntries>
                     </archive>

--- a/appserver/admingui/webui-jsf-plugin-l10n/osgi.bundle
+++ b/appserver/admingui/webui-jsf-plugin-l10n/osgi.bundle
@@ -40,4 +40,4 @@
 
 # "Portions Copyright [2016-2019] [Payara Foundation]"
 
-Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/admingui/webui-jsf-suntheme-plugin-l10n/osgi.bundle
+++ b/appserver/admingui/webui-jsf-suntheme-plugin-l10n/osgi.bundle
@@ -40,4 +40,4 @@
 
 # "Portions Copyright [2016-2019] [Payara Foundation]"
 
-Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}


### PR DESCRIPTION
## Description
Fixes loading of the admin console following on from the name changes in https://github.com/payara/Payara/pull/6246
Without this, loading the admin console fails with the following error:
```
com.sun.enterprise.module.ResolveError: Not able to locate a unique module by name fish.payara.server.internal.admingui.console-common
```

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Loaded the admin console

### Testing Environment
Windows, Zulu 11.0.19

## Documentation
N/A

## Notes for Reviewers
I'm unsure ATM if we need to define the bundle version as something other than `${project.osgi.version}` - I guess we'll find out when we attempt to diverge the versions in the future.
