### PR TITLE
FISH-7377 Hazelcast 5.3.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,7 +100,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <jsp-api.version>3.1.0</jsp-api.version>
         <javax.cache-api.version>1.1.1.payara-p1</javax.cache-api.version>
-        <hazelcast.version>5.2.2</hazelcast.version>
+        <hazelcast.version>5.3.0</hazelcast.version>
         <jakartaee.api.version>10.0.0</jakartaee.api.version>
         <weld-api.version>5.0.SP2</weld-api.version>
         <weld.version>5.0.1.Final</weld.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,7 +100,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <jsp-api.version>3.1.0</jsp-api.version>
         <javax.cache-api.version>1.1.1.payara-p1</javax.cache-api.version>
-        <hazelcast.version>5.3.0</hazelcast.version>
+        <hazelcast.version>5.3.1</hazelcast.version>
         <jakartaee.api.version>10.0.0</jakartaee.api.version>
         <weld-api.version>5.0.SP2</weld-api.version>
         <weld.version>5.0.1.Final</weld.version>

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -111,7 +111,7 @@ eclipselink.bootdelegation=oracle.sql, oracle.sql.*,oracle.jdbc, oracle.jdbc.*
 org.osgi.framework.bootdelegation=${eclipselink.bootdelegation}, \
                                   com.sun.btrace, com.sun.btrace.*, \
                                   org.netbeans.lib.profiler, org.netbeans.lib.profiler.*, \
-                                  jdk.internal.reflect,jdk.internal.reflect.*
+                                  jdk.internal.reflect,jdk.internal.reflect.*,jdk.net
 
 # The OSGi R4.2 spec says boot delegation uses the boot class loader by default. We need
 # to configure it to use the application class loader by default so we have access to


### PR DESCRIPTION
## Description
Upgrades Hazelcast to 5.3.0

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the DAS.
Clustered two Micro instances

### Testing Environment
WSL, Zulu 11

## Documentation
N/A

## Notes for Reviewers
We may want to look into the new warnings on starting the DAS about not supporting the `TCP_KEEPCOUNT`, `TCP_KEEPIDLE`, and `TCP_KEEPINTERVAL` options...
