### PR TITLE
FISH-6607 Don't Skip Javadoc Generation of payara-api

### DIFF
--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -53,6 +53,10 @@
     <name>Payara-API</name>
     <description>Artefact that exposes public API of Payara Application Server</description>
 
+    <properties>
+        <javadoc.skip>false</javadoc.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  
-  Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
  
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
## Description
The Maven module changes had the unintended side-effect of stopping this generation from happening - this fixes it.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built payara-api - javadoc was generated.

### Testing Environment
WSL, Zulu 11

## Documentation
N/A

## Notes for Reviewers
None
