### PR TITLE
Fish 7426 fix payara config cache timing comm

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigProviderResolverImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -203,7 +203,7 @@ public class ConfigProviderResolverImpl extends ConfigProviderResolver implement
 
     long getCacheDurationSeconds() {
         if (serverLevelConfig != null) {
-            return serverLevelConfig.getCacheDurationSeconds();
+            return serverLevelConfig.getCacheDurationMilliSeconds() / 1_000;
         }
         return Integer.parseInt(getMPConfig().getCacheDurationSeconds());
     }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfig.java
@@ -80,6 +80,8 @@ public class PayaraConfig implements Config {
     private static final String MP_CONFIG_EXPANSION_ENABLED_STRING = "mp.config.property.expressions.enabled";
     private static final String MP_CONFIG_PROFILE_NAME_STRING = "mp.config.profile";
 
+    private static final Logger log = Logger.getLogger(PayaraConfig.class.getName());
+
     private static final class CacheEntry {
         final ConfigValueImpl value;
         final long expires;
@@ -136,7 +138,8 @@ public class PayaraConfig implements Config {
                         configuredCacheDurationSeconds = defaultCacheDurationMilliSeconds;
                     }
                     configuredCacheDurationSecondsExpires = currentTimeMillis + configuredCacheDurationSeconds;
-                    Logger.getLogger(PayaraConfig.class.getName()).log(Level.SEVERE, "getCacheDurationSeconds took about {0} ms", currentTimeMillis() - currentTimeMillis);
+                    long endTimeMillis = currentTimeMillis();
+                    log.log(Level.FINER, () -> "getCacheDurationSeconds took about " + (endTimeMillis - currentTimeMillis) + " ms");
                     return configuredCacheDurationSeconds;
                 }
             }

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/spi/PayaraConfigTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -272,7 +272,7 @@ public class PayaraConfigTest {
     @Test
     public void ttlParameterIsRespected() {
         final long ttl = 60 * 1000L;
-        assertEquals(ttl, new PayaraConfig(emptyList(), emptyMap(), ttl).getCacheDurationSeconds());
+        assertEquals(ttl, new PayaraConfig(emptyList(), emptyMap(), ttl).getCacheDurationMilliSeconds());
     }
 
     private <T> void assertCachedValue(ConfigSource source, String key, Class<T> propertyType, T expectedValue1,


### PR DESCRIPTION
## Description
Renaming variables according to their content and fix code accordingly. Also do synchronization only when setting data, otherwise use the fast path.

The problem was, that the config didn't cache at all and always did search for the DurationSeconds.

## Testing
### Testing Performed
I use the reproducer from Jira ticket, using only the simple request (basically simple REST):

```
wrk -c 400 -t 400 -d 120 http://localhost:8080/jee-mongo/api/hello-world/
```

Comparison:
* Glassfish: `Requests/sec:   3543.07`
* Current Payara 6: `Requests/sec:   1400.88`
* This version: `Requests/sec:  35984.01`

Feel free to correct this result as it seems really to fast.

### Testing Environment
Linux, OpenJDK 11 (compile) 17 (run)
