### PR TITLE
[FISH-1419] use separate Hz partition groups for Payara domain instance groups

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/cluster/PayaraCluster.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/cluster/PayaraCluster.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -217,6 +217,7 @@ public class PayaraCluster implements MembershipListener, EventListener {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void event(Event event) {
         if (event.is(HazelcastEvents.HAZELCAST_BOOTSTRAP_COMPLETE)){
             if (hzCore.isEnabled()) {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/eventbus/EventBus.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/eventbus/EventBus.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -108,7 +108,7 @@ public class EventBus implements EventListener, MonitoringDataSource {
      * @param message
      * @return 
      */
-    public boolean publish(String topic, ClusterMessage message) {
+    public boolean publish(String topic, ClusterMessage<?> message) {
         boolean result = false;
         if (hzCore.isEnabled()) {
             hzCore.getInstance().getTopic(topic).publish(message);
@@ -124,7 +124,8 @@ public class EventBus implements EventListener, MonitoringDataSource {
      * @return true if successfully registered, false otherwise (i.e. if Hazelcast
      * is not enabled)
      */
-    public boolean addMessageReceiver(String topic, MessageReceiver mr) {
+    @SuppressWarnings("unchecked")
+    public boolean addMessageReceiver(String topic, MessageReceiver<?> mr) {
         boolean result = false;
         if (hzCore.isEnabled()) {
             TopicListener tl = messageReceivers.get(topic);
@@ -148,7 +149,7 @@ public class EventBus implements EventListener, MonitoringDataSource {
      * @param topic The name of the topic that messages have been received on
      * @param mr The {@link MessageReciever} to stop listening for messages
      */
-    public void removeMessageReceiver(String topic, MessageReceiver mr) {
+    public void removeMessageReceiver(String topic, MessageReceiver<?> mr) {
         TopicListener tl = messageReceivers.get(topic);
         if (tl != null) {
             int remaining = tl.removeMessageReceiver(mr);
@@ -164,6 +165,7 @@ public class EventBus implements EventListener, MonitoringDataSource {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void event(Event event) {
         if (event.is(HazelcastEvents.HAZELCAST_BOOTSTRAP_COMPLETE) && hzCore.isEnabled()) {
             logger.config("Payara Clustered Event Bus Enabled");

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/exec/ClusterExecutionService.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/exec/ClusterExecutionService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -108,7 +108,7 @@ public class ClusterExecutionService implements EventListener {
      * @param callable The Callable object
      * @return Future for the result
      */
-    public <T extends Serializable> Future<T> runCallable(String memberUUID, Callable<T> callable) {
+    public <T extends Serializable> Future<T> runCallable(UUID memberUUID, Callable<T> callable) {
         Future<T> result = null;
         if (hzCore.isEnabled()) {
             Member toSubmitTo = selectMember(memberUUID);
@@ -166,6 +166,7 @@ public class ClusterExecutionService implements EventListener {
      * @param unit The time unit of the delay
      * @return A Future containing the result
      */
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public <V extends Serializable> ScheduledTaskFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
         ScheduledTaskFuture result = null;
         if (hzCore.isEnabled()) {
@@ -185,7 +186,8 @@ public class ClusterExecutionService implements EventListener {
      * @param unit The time unit of the delay
      * @return A Future containing the result
      */
-    public <V extends Serializable> ScheduledTaskFuture<V> schedule(String memberUUID, Callable<V> callable, long delay, TimeUnit unit) {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public <V extends Serializable> ScheduledTaskFuture<V> schedule(UUID memberUUID, Callable<V> callable, long delay, TimeUnit unit) {
         ScheduledTaskFuture result = null;
 
         if (hzCore.isEnabled()) {
@@ -229,6 +231,7 @@ public class ClusterExecutionService implements EventListener {
      * @param unit The time unit of the delay
      * @return A Future containing the result
      */
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public ScheduledTaskFuture<? extends Serializable> scheduleAtFixedRate(Runnable runnable, long delay, long period, TimeUnit unit) {
         ScheduledTaskFuture result = null;
         if (hzCore.isEnabled()) {
@@ -248,7 +251,8 @@ public class ClusterExecutionService implements EventListener {
      * @param unit The time unit of the delay
      * @return A Future containing the result
      */
-    public ScheduledTaskFuture<?> scheduleAtFixedRate(String memberUUID, Runnable runnable, long delay, long period, TimeUnit unit) {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public ScheduledTaskFuture<?> scheduleAtFixedRate(UUID memberUUID, Runnable runnable, long delay, long period, TimeUnit unit) {
         ScheduledTaskFuture result = null;
 
         if (hzCore.isEnabled()) {
@@ -285,6 +289,7 @@ public class ClusterExecutionService implements EventListener {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void event(Event event) {
         if (event.is(HazelcastEvents.HAZELCAST_BOOTSTRAP_COMPLETE)) {
             if (hzCore.isEnabled()) {
@@ -293,7 +298,7 @@ public class ClusterExecutionService implements EventListener {
         }
     }
     
-    private Member selectMember(String memberUUID) {
+    private Member selectMember(UUID memberUUID) {
         Set<Member> members = hzCore.getInstance().getCluster().getMembers();
         Member toSubmitTo = null;
         for (Member member : members) {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MemberAddressPicker.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/MemberAddressPicker.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -115,7 +115,7 @@ public class MemberAddressPicker implements MemberAddressProvider {
     private InetSocketAddress initBindAddress() {
         InetSocketAddress address = new InetSocketAddress(0);
         if (env.isDas() && !env.isMicro() && !config.getDASBindAddress().isEmpty()) {
-            int port = new Integer(config.getDasPort());
+            int port = Integer.valueOf(config.getDasPort());
             address = initAddress(config.getDASBindAddress(), port);
             logger.log(Level.FINE, "Bind address is specified in the configuration so we will use that {0}", address);
         } else if (config.getDiscoveryMode().startsWith("multicast")) {
@@ -132,7 +132,7 @@ public class MemberAddressPicker implements MemberAddressProvider {
         InetSocketAddress address;
         int port = 0;
         if (env.isDas() && !env.isMicro()) {
-            port = new Integer(config.getDasPort());
+            port = Integer.valueOf(config.getDasPort());
             // try setting public address from global Payara config
             address = initAddress(config.getDASPublicAddress(), port);
         } else {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ClearCache.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ClearCache.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -98,6 +98,7 @@ public class ClearCache implements AdminCommand {
     protected String cacheKey;
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void execute(AdminCommandContext context) {
         final ActionReport actionReport = context.getActionReport();
 

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ListCaches.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ListCaches.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -91,6 +91,7 @@ public class ListCaches implements AdminCommand {
     protected String target;
 
     @Override
+    @SuppressWarnings("unchecked")
     public void execute(AdminCommandContext context) {
 
         final ActionReport actionReport = context.getActionReport();

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/store/ClusteredStore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/store/ClusteredStore.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016-2022 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -160,7 +160,7 @@ public class ClusteredStore implements EventListener, MonitoringDataSource {
         boolean result = false;
         if (isEnabled()) {
             try (Context ctx = ctxUtil.empty().pushContext()) {
-                IMap map = hzCore.getInstance().getMap(storeName);
+                var map = hzCore.getInstance().getMap(storeName);
                 if (map != null) {
                     Object value = map.remove(key);
                     result = true;
@@ -181,7 +181,7 @@ public class ClusteredStore implements EventListener, MonitoringDataSource {
          boolean result = false;
         if (isEnabled()) {
             try (Context ctx = ctxUtil.empty().pushContext()) {
-                IMap map = hzCore.getInstance().getMap(storeName);
+                var map = hzCore.getInstance().getMap(storeName);
                 if (map != null) {
                     result = map.containsKey(key);
                 }
@@ -201,7 +201,7 @@ public class ClusteredStore implements EventListener, MonitoringDataSource {
         Serializable result = null;
         if (isEnabled()) {
             try (Context ctx = ctxUtil.empty().pushContext()) {
-                IMap map = hzCore.getInstance().getMap(storeName);
+                var map = hzCore.getInstance().getMap(storeName);
                 if (map != null) {
                     result = (Serializable) map.get(key);
 
@@ -217,6 +217,7 @@ public class ClusteredStore implements EventListener, MonitoringDataSource {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void event(Event event) {
         if (event.is(HazelcastEvents.HAZELCAST_BOOTSTRAP_COMPLETE)){
             if (hzCore.isEnabled()) {
@@ -236,7 +237,7 @@ public class ClusteredStore implements EventListener, MonitoringDataSource {
         HashMap<Serializable,Serializable> result = new HashMap<>();
         if (hzCore.isEnabled()) {
             try (Context ctx = ctxUtil.empty().pushContext()) {
-                IMap map = hzCore.getInstance().getMap(storeName);
+                IMap<Serializable, ?> map = hzCore.getInstance().getMap(storeName);
                 if (map != null) {
                     Set<Serializable> keys = map.keySet();
                     for (Serializable key : keys) {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,0 +1,1 @@
+fish.payara.nucleus.hazelcast.PayaraHazelcastDiscoveryFactory


### PR DESCRIPTION
prevents partitions to be placed on instances where the application is not deployed

Also cleaned up deprecation and lint warnings for Java 11

---
Basically, this resurrects the same PR from a couple of years ago. This was very well tested, and just was waiting for Hazelcast to release version 5, which took way too long, so this PR was closed at the time "due to inactivity"
