### PR TITLE
FISH-6607 Don't skip javadoc on EJB HTTP Client

### DIFF
--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -60,6 +60,7 @@
     </description>
 
     <properties>
+        <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>
     </properties>
 


### PR DESCRIPTION
## Description
With the changes from https://github.com/payara/Payara/pull/6246 we're skipping javadoc generation on EJB HTTP Client, breaking the release scripts. This fixes that.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Build the server using `mvn clean install` and checked up `appserver/ejb/ejb-http-remoting/client` and the javadoc was present

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
