### PR TITLE
FISH-7339: Update span attributes for MP OpenTelemetry Tracing 1.1

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/OpenTracingHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/OpenTracingHelper.java
@@ -149,6 +149,10 @@ public class OpenTracingHelper {
         determineSpanStrategy().augmentSpan(spanBuilder);
     }
 
+    public String getHttpRoute(ContainerRequest request, ResourceInfo resourceInfo) {
+        return SpanStrategy.OTEL_MP_TCK.determineSpanName(request, resourceInfo);
+    }
+
     /**
      * Strategy for naming spans.
      */

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/JerseyOpenTelemetryAutoDiscoverable.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/JerseyOpenTelemetryAutoDiscoverable.java
@@ -39,7 +39,7 @@
  */
 package fish.payara.microprofile.telemetry.tracing.jaxrs;
 
-import fish.payara.microprofile.telemetry.tracing.jaxrs.client.PayaraTracingServices;
+import fish.payara.microprofile.telemetry.tracing.PayaraTracingServices;
 import jakarta.ws.rs.core.FeatureContext;
 import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable;

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTelemetryApplicationEventListener.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTelemetryApplicationEventListener.java
@@ -39,14 +39,12 @@
  */
 package fish.payara.microprofile.telemetry.tracing.jaxrs;
 
-import fish.payara.nucleus.requesttracing.RequestTracingService;
 import fish.payara.opentracing.OpenTelemetryService;
-import fish.payara.microprofile.telemetry.tracing.jaxrs.client.PayaraTracingServices;
+import fish.payara.microprofile.telemetry.tracing.PayaraTracingServices;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ResourceInfo;
-import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.Context;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
@@ -60,14 +58,12 @@ public class OpenTelemetryApplicationEventListener implements ApplicationEventLi
 
     private static final Logger LOG = Logger.getLogger(OpenTelemetryApplicationEventListener.class.getName());
 
-    private RequestTracingService requestTracing;
     private OpenTelemetryService openTelemetryService;
 
     @Context
     private ResourceInfo resourceInfo;
 
-    @Context
-    private Configuration configuration;
+    private OpenTracingHelper openTracingHelper;
 
     /**
      * Initialization of internal services.
@@ -76,8 +72,8 @@ public class OpenTelemetryApplicationEventListener implements ApplicationEventLi
     public void postConstruct() {
         LOG.finest("postConstruct()");
         final PayaraTracingServices payaraTracingServices = new PayaraTracingServices();
-        this.requestTracing = payaraTracingServices.getRequestTracingService();
         this.openTelemetryService = payaraTracingServices.getOpenTelemetryService();
+        this.openTracingHelper = new OpenTracingHelper();
     }
 
 
@@ -94,7 +90,7 @@ public class OpenTelemetryApplicationEventListener implements ApplicationEventLi
             LOG.finest("isRequestTracingInProgress() returned false, nothing to do.");
             return null;
         }
-        return new OpenTelemetryRequestEventListener(this.resourceInfo, this.openTelemetryService);
+        return new OpenTelemetryRequestEventListener(this.resourceInfo, this.openTelemetryService, this.openTracingHelper);
     }
 
 

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTelemetryRequestEventListener.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTelemetryRequestEventListener.java
@@ -193,7 +193,14 @@ public class OpenTelemetryRequestEventListener implements RequestEventListener {
                 .setAttribute(SemanticAttributes.HTTP_URL, requestContext.getRequestUri().toString())
                 .setAttribute(SemanticAttributes.HTTP_TARGET,
                         requestContext.getUriInfo().getRequestUri().getPath() + queryParam)
+                .setAttribute(SemanticAttributes.HTTP_SCHEME, requestContext.getRequestUri().getScheme())
+                .setAttribute(SemanticAttributes.NET_HOST_NAME, requestContext.getRequestUri().getHost())
+                .setAttribute(SemanticAttributes.HTTP_ROUTE, openTracingHelper.getHttpRoute(requestContext, resourceInfo))
                 .setAttribute("component", "jaxrs");
+
+        if (requestContext.getRequestUri().getPort() != -1) {
+            spanBuilder.setAttribute(SemanticAttributes.NET_HOST_PORT, (long)requestContext.getRequestUri().getPort());
+        }
 
         openTracingHelper.augmentSpan(spanBuilder);
 

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTracingCdiUtils.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTracingCdiUtils.java
@@ -1,43 +1,45 @@
 /*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2023] Payara Foundation and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *     The contents of this file are subject to the terms of either the GNU
- *     General Public License Version 2 only ("GPL") or the Common Development
- *     and Distribution License("CDDL") (collectively, the "License").  You
- *     may not use this file except in compliance with the License.  You can
- *     obtain a copy of the License at
- *     https://github.com/payara/Payara/blob/master/LICENSE.txt
- *     See the License for the specific
- *     language governing permissions and limitations under the License.
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
- *     When distributing the software, include this License Header Notice in each
- *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
  *
- *     GPL Classpath Exception:
- *     The Payara Foundation designates this particular file as subject to the "Classpath"
- *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
- *     file that accompanied this code.
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
  *
- *     Modifications:
- *     If applicable, add the following below the License Header, with the fields
- *     enclosed by brackets [] replaced by your own identifying information:
- *     "Portions Copyright [year] [name of copyright owner]"
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
  *
- *     Contributor(s):
- *     If you wish your version of this file to be governed by only the CDDL or
- *     only the GPL Version 2, indicate your decision by adding "[Contributor]
- *     elects to include this software in this distribution under the [CDDL or GPL
- *     Version 2] license."  If you don't indicate a single choice of license, a
- *     recipient has the option to distribute your version of this file under
- *     either the CDDL, the GPL Version 2 or to extend the choice of license to
- *     its licensees as provided above.  However, if you add GPL Version 2 code
- *     and therefore, elected the GPL Version 2 license, then the option applies
- *     only if the new code is made subject to such option by the copyright
- *     holder.
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
  */
-package fish.payara.microprofile.telemetry.tracing;
+package fish.payara.microprofile.telemetry.tracing.jaxrs;
 
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.interceptor.InvocationContext;
@@ -68,7 +70,7 @@ import static java.util.logging.Level.FINEST;
  * @author Andrew Pielage <andrew.pielage@payara.fish>
  * @author Arjan Tijms <arjan.tijms@payara.fish>
  */
-public class OpenTracingCdiUtils {
+final class OpenTracingCdiUtils {
 
     private static final Logger LOG = Logger.getLogger(OpenTracingCdiUtils.class.getName());
 

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTracingHelper.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/OpenTracingHelper.java
@@ -1,44 +1,47 @@
 /*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2023] Payara Foundation and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *     The contents of this file are subject to the terms of either the GNU
- *     General Public License Version 2 only ("GPL") or the Common Development
- *     and Distribution License("CDDL") (collectively, the "License").  You
- *     may not use this file except in compliance with the License.  You can
- *     obtain a copy of the License at
- *     https://github.com/payara/Payara/blob/master/LICENSE.txt
- *     See the License for the specific
- *     language governing permissions and limitations under the License.
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
- *     When distributing the software, include this License Header Notice in each
- *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
  *
- *     GPL Classpath Exception:
- *     The Payara Foundation designates this particular file as subject to the "Classpath"
- *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
- *     file that accompanied this code.
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
  *
- *     Modifications:
- *     If applicable, add the following below the License Header, with the fields
- *     enclosed by brackets [] replaced by your own identifying information:
- *     "Portions Copyright [year] [name of copyright owner]"
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
  *
- *     Contributor(s):
- *     If you wish your version of this file to be governed by only the CDDL or
- *     only the GPL Version 2, indicate your decision by adding "[Contributor]
- *     elects to include this software in this distribution under the [CDDL or GPL
- *     Version 2] license."  If you don't indicate a single choice of license, a
- *     recipient has the option to distribute your version of this file under
- *     either the CDDL, the GPL Version 2 or to extend the choice of license to
- *     its licensees as provided above.  However, if you add GPL Version 2 code
- *     and therefore, elected the GPL Version 2 license, then the option applies
- *     only if the new code is made subject to such option by the copyright
- *     holder.
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
  */
-package fish.payara.microprofile.telemetry.tracing;
+package fish.payara.microprofile.telemetry.tracing.jaxrs;
 
+import fish.payara.microprofile.telemetry.tracing.PayaraTracingServices;
 import io.opentelemetry.api.trace.SpanBuilder;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
@@ -46,17 +49,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.UriInfo;
+import java.lang.annotation.Annotation;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.ConfigValue;
-import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.config.spi.Converter;
 import org.eclipse.microprofile.opentracing.Traced;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ExtendedUriInfo;
 
-import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,27 +62,54 @@ import java.util.logging.Logger;
 /**
  * A helper class for OpenTracing instrumentation in JAX-RS resources.
  */
-public class OpenTracingHelper {
+final class OpenTracingHelper {
 
     private static final Logger LOG = Logger.getLogger(OpenTracingHelper.class.getName());
     public static final String SPAN_CONVENTION_MP_KEY = "payara.telemetry.span-convention";
 
-    private final ResourceInfo resourceInfo;
-    private final Config mpConfig;
+    // Cache cannot store null
+    private static final Traced NULL_TRACED = new Traced() {
+        @Override
+        public boolean value() {
+            return false;
+        }
 
-    public OpenTracingHelper(final ResourceInfo resourceInfo) {
-        this.resourceInfo = resourceInfo;
-        this.mpConfig = getConfig();
+        @Override
+        public String operationName() {
+            return null;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Traced.class;
+        }
+    };
+
+
+    private final Config mpConfig;
+    private SpanStrategy spanStrategy;
+
+    private ResourceCache<String> routeCache = new ResourceCache<>();
+    private ResourceCache<String> operationNameCache = new ResourceCache<>();
+
+    private ResourceCache<Traced> tracedCache = new ResourceCache<>();
+
+    public OpenTracingHelper() {
+        this.mpConfig = PayaraTracingServices.getConfig();
     }
 
     /**
      * Determines the operation name of the span based on the given ContainerRequestContext and Traced annotation.
      *
      * @param request          the ContainerRequestContext object for this request
-     * @param tracedAnnotation the Traced annotation object for this request
      * @return the name to use as the span's operation name
      */
-    public String determineOperationName(final ContainerRequestContext request, final Traced tracedAnnotation) {
+    public String determineOperationName(final ResourceInfo resourceInfo, final ContainerRequestContext request) {
+        return operationNameCache.get(resourceInfo, () -> computeOperationName(resourceInfo, request));
+    }
+
+    public String computeOperationName(final ResourceInfo resourceInfo, final ContainerRequestContext request) {
+        Traced tracedAnnotation = getTracedAnnotation(resourceInfo);
         if (tracedAnnotation != null) {
             String operationName = OpenTracingCdiUtils.getConfigOverrideValue(
                             Traced.class, "operationName", resourceInfo, String.class)
@@ -98,7 +123,6 @@ public class OpenTracingHelper {
             }
             return operationName;
         }
-        // TODO: OpenTelemetry @WithSpan
 
         SpanStrategy naming = determineSpanStrategy();
 
@@ -106,6 +130,13 @@ public class OpenTracingHelper {
     }
 
     private SpanStrategy determineSpanStrategy() {
+        if (spanStrategy == null) {
+            spanStrategy = computeSpanStrategy();
+        }
+        return spanStrategy;
+    }
+    private SpanStrategy computeSpanStrategy() {
+
         // Determine if an operation name provider has been given
         final Optional<String> operationNameProviderOptional = mpConfig.getOptionalValue("mp.opentracing.server.operation-name-provider", String.class);
 
@@ -127,21 +158,13 @@ public class OpenTracingHelper {
                 case "opentelemetry":
                     return SpanStrategy.OTEL_SEM_CONV;
                 case "microprofile-telemetry":
+                case "opentelemetry-1.13":
                     return SpanStrategy.OTEL_MP_TCK;
                 default:
                     LOG.fine(() -> "Unsupported value of " + SPAN_CONVENTION_MP_KEY + ": " + vendorCompatibilitySetting.get());
             }
         }
 
-        // TODO: Remove after TCK runners are updated with span convention setting
-        if (resourceInfo.getResourceClass().getPackageName().startsWith("org.eclipse.microprofile.opentracing.tck")) {
-            return SpanStrategy.OPENTRACING_CLASS_METHOD;
-        }
-
-        // similar dirty hack for opentelemetry TCK
-        if (resourceInfo.getResourceClass().getPackageName().startsWith("org.eclipse.microprofile.telemetry.tracing.tck")) {
-            return SpanStrategy.OTEL_MP_TCK;
-        }
         return SpanStrategy.OTEL_SEM_CONV;
     }
 
@@ -150,7 +173,7 @@ public class OpenTracingHelper {
     }
 
     public String getHttpRoute(ContainerRequest request, ResourceInfo resourceInfo) {
-        return SpanStrategy.OTEL_MP_TCK.determineSpanName(request, resourceInfo);
+        return routeCache.get(resourceInfo, () -> SpanStrategy.OTEL_MP_TCK.determineSpanName(request, resourceInfo));
     }
 
     /**
@@ -291,27 +314,37 @@ public class OpenTracingHelper {
      *
      * @return the Traced annotation object for this request, or null if CDI has not been initialized
      */
-    public Traced getTracedAnnotation() {
+    private Traced getTracedAnnotation(ResourceInfo resourceInfo) {
         final BeanManager beanManager = getBeanManager();
         if (beanManager == null) {
             return null;
         }
-        return OpenTracingCdiUtils.getAnnotation(beanManager, Traced.class, resourceInfo);
+        Traced cached = tracedCache.get(resourceInfo, () -> computeTracedAnnotation(resourceInfo, beanManager));
+        return cached == NULL_TRACED ? null : cached;
     }
 
+    private Traced computeTracedAnnotation(ResourceInfo resourceInfo, BeanManager beanManager) {
+        Traced result = OpenTracingCdiUtils.getAnnotation(beanManager, Traced.class, resourceInfo);
+        return result == null ? NULL_TRACED : result;
+    }
+
+    private static ResourceCache<Boolean> canTraceCache = new ResourceCache<>();
     /**
      * Helper method that checks if any specified skip patterns match this method name
      *
      * @param request the request to check if we should skip
      * @return
      */
-    public boolean canTrace(final ContainerRequest request, final Traced tracedAnnotation) {
+    public boolean canTrace(ResourceInfo resourceInfo, final ContainerRequest request) {
         // we cannot trace if we don't have enough information.
         // this can occur on early request processing stages
         if (request == null || resourceInfo.getResourceClass() == null || resourceInfo.getResourceMethod() == null) {
             return false;
         }
+        return canTraceCache.get(resourceInfo, () -> computeCanTrace(resourceInfo, request, getTracedAnnotation(resourceInfo)));
+    }
 
+    private boolean computeCanTrace(ResourceInfo resourceInfo, final ContainerRequest request, final Traced tracedAnnotation) {
         // Prepend a slash for safety (so that a pattern of "/blah" or just "blah" will both match)
         final String uriPath = "/" + request.getUriInfo().getPath();
         // Because the openapi resource path is always empty we need to use the base path
@@ -341,7 +374,7 @@ public class OpenTracingHelper {
             }
         }
 
-        return tracedAnnotation == null || getTracingFromConfig().orElse(tracedAnnotation.value());
+        return tracedAnnotation == null || getTracingFromConfig(resourceInfo).orElse(tracedAnnotation.value());
     }
 
     private BeanManager getBeanManager() {
@@ -360,57 +393,8 @@ public class OpenTracingHelper {
      *
      * @return an Optional<Boolean> indicating whether or not tracing is enabled for this request
      */
-    private Optional<Boolean> getTracingFromConfig() {
+    private Optional<Boolean> getTracingFromConfig(ResourceInfo resourceInfo) {
         return OpenTracingCdiUtils.getConfigOverrideValue(Traced.class, "value", resourceInfo, Boolean.class);
     }
 
-    /**
-     * Gets the Config object for current application.
-     *
-     * @return the Config object for this request, or null if no config could be found
-     */
-    public static Config getConfig() {
-        try {
-            return ConfigProvider.getConfig();
-        } catch (final IllegalArgumentException ex) {
-            return EMPTY_CONFIG;
-        }
-    }
-
-    static final Config EMPTY_CONFIG = new Config() {
-        @Override
-        public <T> T getValue(String s, Class<T> aClass) {
-            throw new NoSuchElementException("Empty config");
-        }
-
-        @Override
-        public ConfigValue getConfigValue(String s) {
-            throw new NoSuchElementException("Empty Config");
-        }
-
-        @Override
-        public <T> Optional<T> getOptionalValue(String s, Class<T> aClass) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Iterable<String> getPropertyNames() {
-            return List.of();
-        }
-
-        @Override
-        public Iterable<ConfigSource> getConfigSources() {
-            return List.of();
-        }
-
-        @Override
-        public <T> Optional<Converter<T>> getConverter(Class<T> aClass) {
-            return Optional.empty();
-        }
-
-        @Override
-        public <T> T unwrap(Class<T> aClass) {
-            return null;
-        }
-    };
 }

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/ResourceCache.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/ResourceCache.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.microprofile.telemetry.tracing.jaxrs;
+
+import jakarta.ws.rs.container.ResourceInfo;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.eclipse.microprofile.opentracing.Traced;
+
+class ResourceCache<T> {
+
+    private static class ResourceKey {
+        Class<?> resourceClass;
+        Method resourceMethod;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ResourceKey that = (ResourceKey) o;
+            return resourceClass.equals(that.resourceClass) && resourceMethod.equals(that.resourceMethod);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(resourceClass, resourceMethod);
+        }
+
+        ResourceKey(ResourceInfo info) {
+            this.resourceClass = info.getResourceClass();
+            this.resourceMethod = info.getResourceMethod();
+        }
+    }
+
+    private final ConcurrentHashMap<ResourceKey, T> tracedCache = new ConcurrentHashMap<>();
+
+    T get(ResourceInfo info, Supplier<T> supplier) {
+        return tracedCache.computeIfAbsent(new ResourceKey(info), k -> supplier.get());
+    }
+}

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/JaxrsClientRequestTelemetryFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/JaxrsClientRequestTelemetryFilter.java
@@ -116,9 +116,14 @@ public class JaxrsClientRequestTelemetryFilter implements ClientRequestFilter, C
             SpanBuilder spanBuilder = tracer.spanBuilder(requestContext.getMethod())
                     .setAttribute(SemanticAttributes.HTTP_URL, requestContext.getUri().toString())
                     .setAttribute(SemanticAttributes.HTTP_METHOD, requestContext.getMethod())
+                    .setAttribute(SemanticAttributes.NET_PEER_NAME, requestContext.getUri().getHost())
                     .setAttribute("component", "jaxrs")
                     .setAttribute("span.kind", "client")
                     .setSpanKind(SpanKind.CLIENT);
+
+            if (requestContext.getUri().getPort() != -1) {
+                spanBuilder.setAttribute(SemanticAttributes.NET_PEER_PORT, (long)requestContext.getUri().getPort());
+            }
 
             // Get the propagated span context from the request if present
             // This is required to account for asynchronous client requests

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/JaxrsClientRequestTelemetryFilter.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/JaxrsClientRequestTelemetryFilter.java
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.telemetry.tracing.jaxrs.client;
 
+import fish.payara.microprofile.telemetry.tracing.PayaraTracingServices;
 import fish.payara.notification.requesttracing.RequestTraceSpan;
 import fish.payara.nucleus.requesttracing.RequestTracingService;
 import fish.payara.nucleus.requesttracing.domain.PropagationHeaders;

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/RestClientTelemetryListener.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/jaxrs/client/RestClientTelemetryListener.java
@@ -39,7 +39,7 @@
  */
 package fish.payara.microprofile.telemetry.tracing.jaxrs.client;
 
-import fish.payara.microprofile.telemetry.tracing.OpenTracingHelper;
+import fish.payara.microprofile.telemetry.tracing.PayaraTracingServices;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
@@ -49,13 +49,11 @@ public class RestClientTelemetryListener implements RestClientListener {
 
     static final String REST_CLIENT_INVOKED_METHOD = "org.eclipse.microprofile.rest.client.invokedMethod";
 
-    private static final Logger logger = Logger.getLogger(RestClientTelemetryListener.class.getName());
-
     @Override
     public void onNewClient(Class<?> aClass, RestClientBuilder restClientBuilder) {
         restClientBuilder.register(new AsyncContextPropagator.Factory());
         // OpenTracing mandates respecting setting of @Traced annotation on the class
         restClientBuilder.property(JaxrsClientRequestTelemetryFilter.REQUEST_CONTEXT_TRACING_PREDICATE,
-                new TracedMethodFilter(OpenTracingHelper.getConfig(), aClass));
+                new TracedMethodFilter(PayaraTracingServices.getConfig(), aClass));
     }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

This PR adds new span attributes that will be required by Microprofile OpenTelemetry Tracing TCK 1.1 (a388a3f).

Then it tries to minimize number of MP Config lookups and reflection done on every request by introducing REST application-scoped `ResourceCache`, where information is cached for every invoked resource (Jakarta Rest method).

And finally rearranges helper classes, makes them package private where possible  and removes dead code from them.

Also adds new alias for span strategy of Microprofile Telemetry 1.0 -- `opentelemetry-1.13`, as that is more fair designation of where that strategy comes from.

## Important Info
### Blockers
Depends on payara/MicroProfile-TCK-Runners#226, as in-server workaround for OpenTracing TCK has been removed.

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
OpenTracing TCK (with patch above), MP Telemetry Tracing 1.1-SNAPSHOT

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
```
Apache Maven 3.8.7 (b89d5959fcde851dcb1c8946a785a163f14e1e29)
Java version: 11.0.18, vendor: Azul Systems, Inc.
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-69-generic", arch: "amd64", family: "unix"
```
