### PR TITLE
FISH-6607: Remove dependency on core-bom from payara-bom

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -108,15 +108,6 @@
             </dependency>
 
             <dependency>
-                <groupId>fish.payara.server.core</groupId>
-                <artifactId>core-bom</artifactId>
-                <version>${payara.core.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-
-            <dependency>
                 <groupId>fish.payara.server.appclient</groupId>
                 <artifactId>payara-client</artifactId>
                 <version>${project.version}</version>
@@ -921,6 +912,32 @@
                 <artifactId>hazelcast</artifactId>
                 <version>${hazelcast.version}</version>
             </dependency>
+
+            <!-- core dependencies -->
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-bom</artifactId>
+                <version>${hk2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry.alpha.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/core/core-bom/pom.xml
+++ b/core/core-bom/pom.xml
@@ -541,11 +541,6 @@
             </dependency>
             <dependency>
                 <groupId>fish.payara.server.core.admingui</groupId>
-                <artifactId>faces-compat</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.server.core.admingui</groupId>
                 <artifactId>console-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,7 +109,12 @@
         <asm.version>9.5</asm.version>
         <websocket-api.version>2.1.0</websocket-api.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
-
+        <jstl-api.version>3.0.0</jstl-api.version>
+        <concurrent-api.version>3.0.2</concurrent-api.version>
+        <jaxws-api.version>4.0.0</jaxws-api.version>
+        <jms-api.version>3.1.0</jms-api.version>
+        <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>
+        <stax2-api.version>4.2.1</stax2-api.version>
 
         <!-- implementation and build dependencies -->
         <glassfish-management-api.version>3.2.3.payara-p1</glassfish-management-api.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -658,6 +658,13 @@ Parent is ${project.parent}</echo>
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>fish.payara.server.core</groupId>
+                <artifactId>core-bom</artifactId>
+                <version>${payara.core.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-bom</artifactId>
                 <!-- A workaround for case when module redefines its version (rest-monitoring-war) -->

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <stax-api.version>1.0-2</stax-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <jstl-api.version>3.0.0</jstl-api.version>
         <jstl-impl.version>3.0.0</jstl-impl.version>
         <mojarra.version>4.0.0.payara-p2</mojarra.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
@@ -148,18 +147,14 @@
         <yasson.version>3.0.2</yasson.version>
         <eclipselink.version>4.0.1.payara-p1</eclipselink.version>
         <eclipselink.asm.version>9.5.0</eclipselink.asm.version>
-        <jms-api.version>3.1.0</jms-api.version>
         <mq.version>6.3.0.payara-p2</mq.version>
         <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>2.1.1</com.ibm.jbatch.spi.version>
-        <jaxws-api.version>4.0.0</jaxws-api.version>
-        <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>
         <webservices.version>4.0.1</webservices.version>
         <org.apache.santuario.version>3.0.0</org.apache.santuario.version>
         <woodstox.version>6.4.0</woodstox.version>
         <woodstock-jsf.version>5.0.0</woodstock-jsf.version>
         <woodstock-jsf-suntheme.version>5.0.0.payara-p1</woodstock-jsf-suntheme.version>
-        <stax2-api.version>4.2.1</stax2-api.version>
         <angus.activation.version>1.0.0</angus.activation.version>
         <istack-commons-runtime.version>4.0.1</istack-commons-runtime.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
@@ -167,7 +162,6 @@
         <microprofile-release.version>6.0</microprofile-release.version>
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <h2db.version>2.1.212</h2db.version>
-        <concurrent-api.version>3.0.2</concurrent-api.version>
         <concurrent.version>3.0.2.payara-p1</concurrent.version>
         <asm.version>9.5</asm.version>
         <monitoring-console-process.version>2.0.1</monitoring-console-process.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

Payara BOM should not depend on Payara Core BOM, as that one contains lots of internal information. The public dependencies from Core BOM has been copied to Payara BOM (most of them were already there).

Core BOM import moved into nucleus parent, which is next in inheritance hierarchy.

Identified few of the properties that core BOM used, but didn't actually define, they well still in root.
