### PR TITLE
FISH-7341 FISH-7381 upgrade asm and eclipselink.asm to 9.5

### DIFF
--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
@@ -114,4 +114,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/RemoteEjbClientIT.java
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/src/test/java/fish/payara/samples/rolesallowed/unprotected/methods/RemoteEjbClientIT.java
@@ -90,6 +90,8 @@ public class RemoteEjbClientIT {
             System.out.println(ejb.sayHello());
             Assert.assertTrue(ejb.sayHello().equalsIgnoreCase("Hello Anonymous!"));
         } catch (NamingException ne) {
+            // Print the exception, so we know, where it failed
+            ne.printStackTrace();
             Assert.fail("Failed performing lookup:\n" + ne.getCause());
         }
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -106,7 +106,7 @@
         <weld.version>5.0.1.Final</weld.version>
         <tyrus.version>2.1.0.payara-p1</tyrus.version>
         <jsp-impl.version>3.1.0</jsp-impl.version>
-        <asm.version>9.4</asm.version>
+        <asm.version>9.5</asm.version>
         <websocket-api.version>2.1.0</websocket-api.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 
         <yasson.version>3.0.2</yasson.version>
         <eclipselink.version>4.0.1.payara-p1</eclipselink.version>
-        <eclipselink.asm.version>9.4.0</eclipselink.asm.version>
+        <eclipselink.asm.version>9.5.0</eclipselink.asm.version>
         <jms-api.version>3.1.0</jms-api.version>
         <mq.version>6.3.0.payara-p2</mq.version>
         <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>
@@ -169,7 +169,7 @@
         <h2db.version>2.1.212</h2db.version>
         <concurrent-api.version>3.0.2</concurrent-api.version>
         <concurrent.version>3.0.2.payara-p1</concurrent.version>
-        <asm.version>9.4</asm.version>
+        <asm.version>9.5</asm.version>
         <monitoring-console-process.version>2.0.1</monitoring-console-process.version>
         <monitoring-console-webapp.version>2.0.1</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>


### PR DESCRIPTION
## Description
Upgrade libs, fix RemoteEjbClientIT test by passing module-related arguments to tests, enhance the test by printing stacktrace in case of failure.

## Testing
### Testing Performed
I compiled the server by Java 11.
I started the server by Java 21.
I ran Concurrency TCK - there is one failure due to changes in JDK (reported https://github.com/jakartaee/concurrency/issues/282), otherwise it runs well.
I ran Payara Samples:
* in `nucleus/pom.xml` and `core/core-parent/pom.xml` in tag `maven-enforcer-plugin` remove the upper JDK limit:
```
<version>[${jdk.version},)</version>
```
In directory `appserver/tests/payara-samples` run tests:
```
JAVA_HOME=/usr/lib/jvm/java21-openjdk-amd64 mvn clean install -Ppayara-server-remote
```
All tests pass well.

### Testing Environment
Linux, OpenJDK 11 and 21
