### PR TITLE
FISH-7483 : Open telemetry APIs upgraded to 1.26.0

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -546,7 +546,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-opentracing-shim</artifactId>
-                <version>${opentelemetry.alpha.version}</version>
+                <version>${opentelemetry.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,8 +137,8 @@
         <jna.version>5.12.1</jna.version>
         <!-- A pure Java implementation of the SSH-2 protocol -->
         <trilead-ssh2.version>build-217-jenkins-16</trilead-ssh2.version>
-        <opentelemetry.version>1.22.0</opentelemetry.version>
-        <opentelemetry.alpha.version>1.22.0-alpha</opentelemetry.alpha.version>
+        <opentelemetry.version>1.26.0</opentelemetry.version>
+        <opentelemetry.alpha.version>1.26.0-alpha</opentelemetry.alpha.version>
         <testng.version>7.4.0</testng.version>
         <bouncycastle-jdk15on.version>1.64</bouncycastle-jdk15on.version>
         <jsftemplating.version>3.0.0</jsftemplating.version>


### PR DESCRIPTION
## Description
MicroProfile Open Telemetry upgrade necessary for 7.0

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed


### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.6.0
