### PR TITLE
FISH-7499 Fix Missing and Incorrect URLs Tags

### DIFF
--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -53,6 +53,9 @@
     <name>Payara-API</name>
     <description>Artefact that exposes public API of Payara Application Server</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <properties>
         <javadoc.skip>false</javadoc.skip>
     </properties>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -52,6 +52,9 @@
     <packaging>pom</packaging>
     <description>List of dependencies provided by and compatible with specific Payara Release</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <dependencyManagement>
         <dependencies>
             <!-- Public artifacts -->
@@ -946,7 +949,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.3.0</version>
+                <version>${maven.flatten.plugin.version}</version>
                 <configuration>
                     <flattenMode>bom</flattenMode>
                     <flattenDependencyMode>all</flattenDependencyMode>

--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -53,6 +53,9 @@
     <packaging>glassfish-distribution</packaging>
     <description>This pom describes how to assemble the Payara Multi-Language Distribution</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <build>
         <plugins>
             <plugin>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -53,6 +53,9 @@
     <packaging>glassfish-distribution</packaging>
     <description>This pom describes how to assemble the Payara Web Multi-Language Distribution</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <build>
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <testOutputDirectory>target/test-classes/WEB-INF/classes</testOutputDirectory>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -54,6 +54,9 @@
     <packaging>glassfish-distribution</packaging>
     <description>This pom describes how to assemble the Payara Web Distribution</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <build>
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <testOutputDirectory>target/test-classes/WEB-INF/classes</testOutputDirectory>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -56,6 +56,9 @@
 
     <description>This pom describes how to assemble the Payara Distribution</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <build>
         <plugins>
             <plugin>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -59,6 +59,9 @@
         which will be sent via HTTP to Payara.
     </description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <properties>
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -55,6 +55,9 @@
     <artifactId>payara-embedded-all</artifactId>
     <name>Embedded Payara All-In-One</name>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <properties>
         <deploy.skip>false</deploy.skip>
     </properties>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -55,6 +55,9 @@
     <artifactId>payara-embedded-web</artifactId>
     <name>Embedded Payara Web</name>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <properties>
         <deploy.skip>false</deploy.skip>
     </properties>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -51,6 +51,9 @@
     <artifactId>payara-micro</artifactId>
     <name>Payara Micro Distribution</name>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <properties>
         <product.name>Payara Micro</product.name>
         <deploy.skip>false</deploy.skip>

--- a/core/core-bom/pom.xml
+++ b/core/core-bom/pom.xml
@@ -52,6 +52,9 @@
     <packaging>pom</packaging>
     <description>List of dependencies of Payara core projects</description>
 
+    <!-- Override to stop flatten plugin resolving it to an incorrect URL using parent artifact IDs -->
+    <url>https://github.com/payara/Payara/</url>
+
     <properties>
         <payara.core.version>${project.version}</payara.core.version>
     </properties>

--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -433,31 +433,6 @@
                         </supportedProjectTypes>
                     </configuration>
                 </plugin>
-                <!-- Flatten plugin for use in public artifacts. -->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.1.0</version>
-                    <configuration>
-                        <flattenMode>ossrh</flattenMode>
-                        <pomElements>
-                            <developers>resolve</developers>
-                            <build>remove</build>
-                        </pomElements>
-                        <flattenedPomFilename>target/flattened-pom.xml</flattenedPomFilename>
-                    </configuration>
-                    <executions>
-                        <!-- enable flattening -->
-                        <execution>
-                            <id>flatten</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>flatten</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,7 @@
 
     <packaging>pom</packaging>
     <name>Payara Core Aggregator</name>
+    <url>https://github.com/payara/Payara</url>
 
     <description>All of Payara Core modules</description>
 
@@ -175,6 +176,7 @@
         <maven.assembly.plugin.version>3.4.2</maven.assembly.plugin.version>
         <hk2.plugin.version>3.0.2</hk2.plugin.version>
         <maven.build.helper.plugin.version>3.3.0</maven.build.helper.plugin.version>
+        <maven.flatten.plugin.version>1.5.0</maven.flatten.plugin.version>
 
 
         <!-- build settings -->
@@ -399,7 +401,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.1.0</version>
+                    <version>${maven.flatten.plugin.version}</version>
                     <configuration>
                         <flattenMode>ossrh</flattenMode>
                         <pomElements>

--- a/pom.xml
+++ b/pom.xml
@@ -427,30 +427,6 @@
                         </supportedProjectTypes>
                     </configuration>
                 </plugin>
-                <!-- Flatten plugin for use in public artifacts. -->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.1.0</version>
-                    <configuration>
-                        <flattenMode>ossrh</flattenMode>
-                        <pomElements>
-                            <developers>resolve</developers>
-                            <build>remove</build>
-                        </pomElements>
-                        <flattenedPomFilename>target/flattened-pom.xml</flattenedPomFilename>
-                    </configuration>
-                    <executions>
-                        <!-- enable flattening -->
-                        <execution>
-                            <id>flatten</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>flatten</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>


### PR DESCRIPTION
## Description
Some flattened poms were missing the URL tag (e.g. payara-api) which meant they could not be used to upload to Maven Central. This fixes that, and also corrects the incorrect tags that the flatten plugin was creating. The flatten plugin was appending the artifact IDs to the "base" URL and leading to entries such as `https://github.com/payara/Payara/payara-nucleus-parent/payara-parent/ejb/ejb-http-remoting/ejb-http-client` which don't resolve.

Also updates the flatten plugin to 1.5.0 because I hoped they might have fixed the URL issue themselves (but haven't). When doing so I noticed a number of duplications of the flatten plugin configuration which I've removed.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built with BuildExtras - checked all POMs had correct URL tag in flattened POM.

### Testing Environment
Windows 11, Zulu 11

## Documentation
N/A

## Notes for Reviewers
None
