### PR TITLE
FISH-7462 : new PFL patched version for JDK 11 Support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,7 +137,7 @@
         <ha-api.version>3.1.13</ha-api.version>
         <apache.bcel.version>6.7.0</apache.bcel.version>
         <!-- Primitive Function Library (PFL); a library of simple utilities used by Glassfish -->
-        <pfl.version>4.1.2</pfl.version>
+        <pfl.version>4.1.2.payara-p1</pfl.version>
         <opendmk.version>1.0-b01-ea</opendmk.version>
         <jna.version>5.12.1</jna.version>
         <!-- A pure Java implementation of the SSH-2 protocol -->


### PR DESCRIPTION
## Description
Using new new PFL patched version

<!-- Provide some context here -->
Remote EJB calls/communication done from a remote Java client application are not working properly on Payara Enterprise 5 and 6 when run in JDK 11 (on both ends).

## Important Info

## Testing

### Testing Performed

### Test suites executed
- Quicklook
- Payara Samples
- Java EE7 Samples
- Java EE8 Samples
- Payara Microprofile TCKs Runner
- Jakarta TCKs
- Mojarra
- Cargo Tracker

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.6.0
