### PR TITLE
FISH-7452 FISH-7453 Start/Create Instance When Using JKS Keystores

### DIFF
--- a/nucleus/cluster/admin/src/main/resources/META-INF/config-files
+++ b/nucleus/cluster/admin/src/main/resources/META-INF/config-files
@@ -41,16 +41,20 @@
 #
 # files in the config directory to synchronize to server instances on startup
 #
-# Portions Copyright [2016-2020] [Payara Foundation]
+# Portions Copyright [2016-2023] [Payara Foundation]
 domain.xml
 admin-keyfile
 cacerts.p12
+# for backward compatibility with Payara 5
+cacerts.jks
 client-jnlp-config.properties
 default-web.xml
 domain-passwords
 glassfish-acc.xml
 keyfile
 keystore.p12
+# for backward compatibility with Payara 5
+keystore.jks
 login.conf
 server.policy
 sun-acc.xml

--- a/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/SyncRequest.java
+++ b/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/SyncRequest.java
@@ -37,13 +37,16 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2023 Payara Foundation and/or affiliates
 
 package com.sun.enterprise.util.cluster;
 
-import java.io.*;
-import java.util.*;
 
-import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Request message to synchronize files.
@@ -71,6 +74,15 @@ public final class SyncRequest {
      */
     @XmlElement(name = "file", type = ModTime.class)
     public List<ModTime> files;
+
+    @Override
+    public String toString() {
+        return "SyncRequest{" +
+                "instance='" + instance + "', " +
+                "dir='" + dir + "', " +
+                (files == null ? "null" : files.size()) + " files" +
+                '}';
+    }
 
     /**
      * The file name and mod time.


### PR DESCRIPTION
## Description
We add support to run with jks keystores, not only p12.
When an instance is created, there is a list of files to copy. The jks variants were added to this list (they are ignored if they don't exist).
Instances synchronize files with DAS, therefor it was necessary to add jks there as well. They are required, so a simple list was changed to a list of alternatives -- the first existing file is copied.

## Testing
### Testing Performed
* Check out and build Payara/Payara6
* Replace cacerts.p12 with cacerts.jks, keystore.p12 with keystore.jks (e.g. from Payara 5 build)
* Change settings in config.xml in domain1, replace `.p12` with `.jks` for both keystores
* Start the domain: `payara/bin/asadmin start-domain -v --debug`
* Load the admin console
* **Create a new instance** (FISH-7453) from admin gui - it is now normally created.
* **Start the instance** (FISH-7452) in `payara5/glassfish`: `lib/nadmin  start-local-instance --debug  --node localhost-domain1 --sync normal --timeout 120 i1`
  * Alternatively, start it from admin gui.
  * Instance normally starts.

### Testing Environment
Linux, OpenJDK 11
