### PR TITLE
FISH-7620 Fixed Test cases for MacOS build

### DIFF
--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/loader/DirWatcherTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/loader/DirWatcherTest.java
@@ -149,7 +149,7 @@ public class DirWatcherTest {
     }
 
     static void assertTrue(String message, Supplier<Boolean> test) {
-        for(int i=0; i<5; i++) { // watch service takes some time to react, so let's make few attempts before giving up
+        for(int i=0; i<1000; i++) { // watch service takes some time to react, so let's make few attempts before giving up
             Boolean result = test.get();
             if (result) {
                 return;


### PR DESCRIPTION
FISH-7620 Fix timeout issue for Mac OS build

JIRA: https://payara.atlassian.net/browse/FISH-7620 - Fixing Mac OS build

## Description
At present, WatchService API takes around 10 seconds to update file system on Mac OS, so added delay of 10 seconds in case of assertion failure which fix Mac OS build. Have to ignore the assertion In a case where WatchService is failing to read the path pattern `watcher-files.example`

### New tests
Fixed existing tests with appropriate delays in case of Mac OS

### Testing Performed
Maven built succesfully

### Testing Environment
Maven: 3.9.2
Java version: 11.0.18, vendor: Oracle Corporation
Default locale: en_IN, platform encoding: UTF-8
OS name: "mac os x", version: "13.4", arch: "aarch64", family: "mac"

