### PR TITLE
FISH-7635: increasing size of license field

### DIFF
--- a/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcast.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/hazelcast/hazelcast.jsf
@@ -142,7 +142,7 @@
             <sun:textField id="startPort" columns="$int{40}"  styleClass="integer" maxLength="30" text="#{pageSession.valueMap['startPort']}" />
         </sun:property>
         <sun:property id="licenseKeyProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.licenseKey}"  helpText="$resource{i18nhc.hazelcast.configuration.licenseKeyHelp}">
-            <sun:textField id="licenseKey" columns="$int{40}" maxLength="100" text="#{pageSession.valueMap['licenseKey']}" />
+            <sun:textField id="licenseKey" columns="$int{40}" maxLength="200" text="#{pageSession.valueMap['licenseKey']}" />
         </sun:property> 
         <sun:property id="hostawareProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nhc.hazelcast.configuration.hostaware}"  helpText="$resource{i18nhc.hazelcast.configuration.hostawareHelp}">
             <sun:checkbox id="hostaware" selected="#{pageSession.valueMap['hostAwarePartitioning']}" selectedValue="true" />


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Increasing size of license key field for hazelcast configuration page
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is an improvement to fix an issue when adding big license key to the hazelcast config page, for example::
`Enterprise#3Nodes#wDX5fi8W0y9GbOQJEMglKHdP2N6UB1mjqnuYkSZCTA16010000100090003030302000011000002110179009`
more than 100 characters in size for this kind of key
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, JDK 11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
