### PR TITLE
FISH-7409: adding property to load com.sun.jndi.ldap classes for jdk 17

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -217,6 +217,7 @@
                 <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+                <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
                 <jvm-options>-Xmx512m</jvm-options>
                 <jvm-options>-XX:NewRatio=2</jvm-options>
                 <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
@@ -451,6 +452,7 @@
                 <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+                <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
                 <jvm-options>-Xmx512m</jvm-options>
                 <jvm-options>-XX:NewRatio=2</jvm-options>
                 <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>

--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -42,7 +42,7 @@
 
 -->
 
-<!-- Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates] -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
     <hazelcast-runtime-configuration start-port="%%%HAZELCAST_START_PORT%%%" das-port="%%%HAZELCAST_DAS_PORT%%%" auto-increment-port="%%%HAZELCAST_AUTO_INCREMENT%%%"></hazelcast-runtime-configuration>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -212,6 +212,7 @@
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-XX:NewRatio=2</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -3,7 +3,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2017-2023 Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -442,6 +442,7 @@
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-XX:NewRatio=2</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -193,6 +193,7 @@
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>
         <jvm-options>-XX:+UseG1GC</jvm-options>

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
- * Copyright (c) 2016-2022 Payara Foundation. All rights reserved.
+ * Copyright (c) 2016-2023 Payara Foundation. All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (collectively, the "License").  You
@@ -405,6 +405,7 @@
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>
         <jvm-options>-XX:+UseG1GC</jvm-options>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -216,6 +216,7 @@
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>
         <jvm-options>-XX:+UseG1GC</jvm-options>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -3,7 +3,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2017-2023] Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -420,6 +420,7 @@
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -219,7 +219,7 @@
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="fish.payara.micro.PayaraMicro"/>
                 <attribute name="Start-Class" value="fish.payara.micro.impl.PayaraMicroImpl"/>
-                <attribute name="Add-Exports" value="java.base/jdk.internal.ref jdk.naming.dns/com.sun.jndi.dns"/>
+                <attribute name="Add-Exports" value="java.base/jdk.internal.ref jdk.naming.dns/com.sun.jndi.dns java.naming/com.sun.jndi.ldap"/>
                 <attribute name="Add-Opens"
                            value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging"/>
             </manifest>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Adding fix to include com.sun.jndi.ldap classes when using jdk 17
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix of a reported bug when trying to use jndi.ldap classes
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing:
Now the call of the endpoint is responding with 200 from micro, server a web:

![image](https://github.com/payara/Payara/assets/279375/b9446d8a-efd6-498f-8624-1a2ea01154e6)

No issues from logs using JDK 17

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, maven 3.8.6, azul jdk 17
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
