### PR TITLE
FISH-7665: fixing issue creating osgi bundle for libpam4j

### DIFF
--- a/appserver/packager/external/libpam4j/pom.xml
+++ b/appserver/packager/external/libpam4j/pom.xml
@@ -77,6 +77,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.9</version>
                 <configuration>
                     <instructions>
                         <Embed-Dependency>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fixing issue to start server caused by the libpam4j-repackaged.jar dependency

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

This is fix for a bug when creating the jar bundle for the libpam4j, older version of the maven-bundle-plugin 
is generating a jar file with error in zip headers. To fix, it is needed to use last version of
the plugin 5.1.9

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Manual testing with most recent versions of JDK 11 and 17. Now the server can start with both JDK's

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
windows 11, Azul JDK 11.0.20 and Azul JDK  17.0.8
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
