### PR TITLE
FISH-7641 Add Version to opentracing-api in Payara BOM

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -303,6 +303,7 @@
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
+                <version>${opentracing.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Description
Adds the `opentracing.version` property to the Payara BOM, as the flatten doesn't appear to be expanding out the version from the inherited `core-parent` pom. 

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built `payara-bom` - `opentracing-api` now has a version.

### Testing Environment
Windows 11, Zulu 11.0.19

## Documentation
N/A

## Notes for Reviewers
None
