### PR TITLE
FISH-7662 Update Docker images to 11.0.20 & 17.0.8

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2021-2022 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2021-2023 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -57,8 +57,8 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.19</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.7</docker.jdk17.tag>
+        <docker.jdk11.tag>11.0.20</docker.jdk11.tag>
+        <docker.jdk17.tag>17.0.8</docker.jdk17.tag>
 
         <docker.payara.domainName>domain1</docker.payara.domainName>
         <docker.payara.rootDirectoryName>payara6</docker.payara.rootDirectoryName>


### PR DESCRIPTION
## Description
Updates the Docker image JDKs to 11.0.20 and 17.0.8.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built Docker images and let the automated tests run - they passed

### Testing Environment
Windows 11, Zulu JDK 11.0.20

## Documentation
N/A

## Notes for Reviewers
None
