### PR TITLE
Fish 7356 automate cleanboot test

### DIFF
--- a/appserver/tests/functional/cleanboot/README.md
+++ b/appserver/tests/functional/cleanboot/README.md
@@ -1,0 +1,34 @@
+# Cleanboot File Tests
+
+Test a clean boot with Payara Platform.
+
+Creates an instance, starts it, checks the logs for any trace above INFO, stops the instance(s), deletes the instance(s)
+
+Creates a deployment group, create instances for that group, starts the group, checks the logs for any trce above INFO, stops the instances, delete the instances, delete the group
+
+Logs above INFO are collected in files, to be assessed manually (some warnings are known issues and can be ignored)
+
+
+## Setup
+
+Set PAYARA_HOME to the tested Payara. For example:
+
+    PAYARA_HOME=/path-to-my-payara-src/appserver/distributions/payara/target/stage/payara6
+
+Install the Pytest plugin:
+
+    pip install pytest-playwright
+
+Install the required browsers:
+
+    playwright install
+
+## run the tests:
+
+    pytest testcleanbootcommand.py
+
+use `--headed` to run with headless=False
+
+use `-s` to see the standard output of the tests
+
+to debug the test, set the environment variable PWDEBUG=1

--- a/appserver/tests/functional/cleanboot/README.md
+++ b/appserver/tests/functional/cleanboot/README.md
@@ -13,7 +13,7 @@ Logs above INFO are collected in files, to be assessed manually (some warnings a
 
 Set PAYARA_HOME to the tested Payara. For example:
 
-    PAYARA_HOME=/path-to-my-payara-src/appserver/distributions/payara/target/stage/payara6
+    export PAYARA_HOME=/path-to-my-payara-src/appserver/distributions/payara/target/stage/payara6
 
 Install the Pytest plugin:
 
@@ -22,6 +22,8 @@ Install the Pytest plugin:
 Install the required browsers:
 
     playwright install
+
+Note: you may also need to run the command `playwright install-deps`
 
 ## run the tests:
 

--- a/appserver/tests/functional/cleanboot/admingrouplib.py
+++ b/appserver/tests/functional/cleanboot/admingrouplib.py
@@ -1,0 +1,131 @@
+#!/bin/python3
+from playwright.sync_api import Page, expect
+
+
+def create_group(page: Page, nameGroup, nameInstances):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+	
+	# Click on the option Deployment Groups in the menu
+	instance_button = page.get_by_role("link",name="Deployment Groups", exact=True)
+	instance_button.click()
+	page.wait_for_selector('div[id="propertyForm:dgTable"]')
+
+	# Expect the title to contain Instances
+	expect(page).to_have_title("Deployment Groups")
+
+	# Create new instance
+	page.get_by_role("Button", name="New...").click()
+	page.wait_for_selector('input[id="propertyForm:propertySheet:propertySectionTextField:NameTextProp:NameText"]')
+	page.get_by_role("textbox").fill(nameGroup)
+	page.get_by_role("Button", name="OK").click()
+	page.wait_for_selector('input[value="New..."]')
+
+	# Check for the presence of the new instance in the table
+	group_link = page.get_by_role("link", name=nameGroup, exact=True)
+	expect(group_link).to_be_visible()
+	group_link.click()
+	page.wait_for_selector('table.Tab1TblNew_sun4')
+
+	# Create instances in the group
+	for nameInstance in nameInstances:
+		group_tabs = page.locator('table.Tab1TblNew_sun4')
+		group_instance_tab = group_tabs.get_by_role("link", name="Instances", exact=True)
+		group_instance_tab.click()
+
+		# Create new instance
+		page.get_by_role("Button", name="New...").click()
+		page.wait_for_selector('input[id="propertyForm:propertySheet:propertSectionTextField:NameTextProp:NameText"]')
+		page.get_by_role("textbox").fill(nameInstance)
+		page.get_by_role("Button", name="OK").click()
+		page.wait_for_selector('input[value=" Save "]')
+
+		# Check for the presence of the new instance in the table
+		instance_link = page.get_by_role("link", name=nameInstance, exact=True)
+		expect(instance_link).to_be_visible()
+
+		group_general_tab = group_tabs.get_by_role("link", name="General", exact=True)
+		group_general_tab.click()
+
+
+	# return to homepage
+	page.goto('http://localhost:4848')
+
+def start_groups(page: Page):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+	
+	# Click on the option Deployment Groups in the menu
+	instance_button = page.get_by_role("link",name="Deployment Groups", exact=True)
+	instance_button.click()
+	page.wait_for_selector('div[id="propertyForm:dgTable"]')
+
+	# Expect the title to contain Instances
+	expect(page).to_have_title("Deployment Groups")
+
+	# Confirm the dialog window
+	page.on("dialog", lambda dialog: dialog.accept())
+
+	select_all_button = page.get_by_role("link",name="Select All", exact=True)
+	select_all_button.click()
+	start_button = page.get_by_role("button",name="Start Deployment Group")
+	start_button.click()
+
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=1200000,state="hidden")
+
+	# return to homepage
+	page.goto('http://localhost:4848')
+
+def stop_groups(page: Page):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+
+	# Click on the option Deployment Groups in the menu
+	instance_button = page.get_by_role("link",name="Deployment Groups", exact=True)
+	instance_button.click()
+	page.wait_for_selector('div[id="propertyForm:dgTable"]')
+
+	# Confirm the dialog window
+	page.on("dialog", lambda dialog: dialog.accept())
+
+	# Select all groups and Stop
+	select_all_button = page.get_by_role("link",name="Select All", exact=True)
+	select_all_button.click()
+	stop_button = page.get_by_role("button",name="Stop Deployment Group")
+	stop_button.click()
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=1200000,state="hidden")
+
+def delete_groups(page: Page):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+	
+	# Click on the option Deployment Groups in the menu
+	instance_button = page.get_by_role("link",name="Deployment Groups", exact=True)
+	instance_button.click()
+	page.wait_for_selector('div[id="propertyForm:dgTable"]')
+	
+	# Delete all groups
+	select_all_button = page.get_by_role("link",name="Select All", exact=True)
+	select_all_button.click()
+	delete_button = page.get_by_role("button",name="Delete")
+	delete_button.click()
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	#page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=1200000,state="hidden")
+
+	# return to homepage
+	page.goto('http://localhost:4848')	

--- a/appserver/tests/functional/cleanboot/admingrouplib.py
+++ b/appserver/tests/functional/cleanboot/admingrouplib.py
@@ -2,7 +2,7 @@
 from playwright.sync_api import Page, expect
 
 
-def create_group(page: Page, nameGroup, nameInstances):
+def create_group(page: Page, name_group, name_instances):
 	# Open the admin page 
 	page.goto('http://localhost:4848')
 	page.wait_for_selector('div[id="treeForm:tree_children"]')
@@ -18,18 +18,18 @@ def create_group(page: Page, nameGroup, nameInstances):
 	# Create new instance
 	page.get_by_role("Button", name="New...").click()
 	page.wait_for_selector('input[id="propertyForm:propertySheet:propertySectionTextField:NameTextProp:NameText"]')
-	page.get_by_role("textbox").fill(nameGroup)
+	page.get_by_role("textbox").fill(name_group)
 	page.get_by_role("Button", name="OK").click()
 	page.wait_for_selector('input[value="New..."]')
 
 	# Check for the presence of the new instance in the table
-	group_link = page.get_by_role("link", name=nameGroup, exact=True)
+	group_link = page.get_by_role("link", name=name_group, exact=True)
 	expect(group_link).to_be_visible()
 	group_link.click()
 	page.wait_for_selector('table.Tab1TblNew_sun4')
 
 	# Create instances in the group
-	for nameInstance in nameInstances:
+	for name_instance in name_instances:
 		group_tabs = page.locator('table.Tab1TblNew_sun4')
 		group_instance_tab = group_tabs.get_by_role("link", name="Instances", exact=True)
 		group_instance_tab.click()
@@ -37,12 +37,12 @@ def create_group(page: Page, nameGroup, nameInstances):
 		# Create new instance
 		page.get_by_role("Button", name="New...").click()
 		page.wait_for_selector('input[id="propertyForm:propertySheet:propertSectionTextField:NameTextProp:NameText"]')
-		page.get_by_role("textbox").fill(nameInstance)
+		page.get_by_role("textbox").fill(name_instance)
 		page.get_by_role("Button", name="OK").click()
 		page.wait_for_selector('input[value=" Save "]')
 
 		# Check for the presence of the new instance in the table
-		instance_link = page.get_by_role("link", name=nameInstance, exact=True)
+		instance_link = page.get_by_role("link", name=name_instance, exact=True)
 		expect(instance_link).to_be_visible()
 
 		group_general_tab = group_tabs.get_by_role("link", name="General", exact=True)
@@ -102,7 +102,6 @@ def stop_groups(page: Page):
 	stop_button.click()
 	# wait for modal to appear and disappear
 	page.wait_for_selector('input[value="Processing..."]')
-	page.wait_for_selector('div#ajaxPanelBody')
 	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
 	page.wait_for_selector('div#ajaxPanelBody', timeout=1200000,state="hidden")
 

--- a/appserver/tests/functional/cleanboot/admininstancelib.py
+++ b/appserver/tests/functional/cleanboot/admininstancelib.py
@@ -1,7 +1,7 @@
 #!/bin/python3
 from playwright.sync_api import Page, expect
 
-def create_instance(page: Page, nameInstance):
+def create_instance(page: Page, name_instance):
 	# Open the admin page 
 	page.goto('http://localhost:4848')
 	page.wait_for_selector('div[id="treeForm:tree_children"]')
@@ -17,18 +17,18 @@ def create_instance(page: Page, nameInstance):
 	# Create new instance
 	page.get_by_role("Button", name="New...").click()
 	page.wait_for_selector('input[id="propertyForm:propertySheet:propertSectionTextField:NameTextProp:NameText"]')
-	page.get_by_role("textbox").fill(nameInstance)
+	page.get_by_role("textbox").fill(name_instance)
 	page.get_by_role("Button", name="OK").click()
 	page.wait_for_selector('input[value=" Save "]')
 
 	# Check for the presence of the new instance in the table
-	instance_link = page.get_by_role("link", name=nameInstance, exact=True)
+	instance_link = page.get_by_role("link", name=name_instance, exact=True)
 	expect(instance_link).to_be_visible()
 
 	# return to homepage
 	page.goto('http://localhost:4848')
 
-def start_instance(page: Page, nameInstance):
+def start_instance(page: Page, name_instance):
 	# Open the admin page 
 	page.goto('http://localhost:4848')
 	page.wait_for_selector('div[id="treeForm:tree_children"]')
@@ -39,7 +39,7 @@ def start_instance(page: Page, nameInstance):
 	page.wait_for_selector('input[value=" Save "]')
 	
 	# Open the page of the instance to start it
-	instance_link = page.get_by_role("link", name=nameInstance, exact=True)
+	instance_link = page.get_by_role("link", name=name_instance, exact=True)
 	instance_link.click()
 	page.wait_for_selector('div[id="propertyForm:propertyContentPage"]')
 

--- a/appserver/tests/functional/cleanboot/admininstancelib.py
+++ b/appserver/tests/functional/cleanboot/admininstancelib.py
@@ -1,0 +1,183 @@
+#!/bin/python3
+from playwright.sync_api import Page, expect
+
+def create_instance(page: Page, nameInstance):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+	
+	# Click on the option Instances in the menu
+	instance_button = page.get_by_role("link",name="Instances", exact=True)
+	instance_button.click()
+	page.wait_for_selector('input[value=" Save "]')
+
+	# Expect the title to contain Instances
+	expect(page).to_have_title("Payara Server Instances")
+
+	# Create new instance
+	page.get_by_role("Button", name="New...").click()
+	page.wait_for_selector('input[id="propertyForm:propertySheet:propertSectionTextField:NameTextProp:NameText"]')
+	page.get_by_role("textbox").fill(nameInstance)
+	page.get_by_role("Button", name="OK").click()
+	page.wait_for_selector('input[value=" Save "]')
+
+	# Check for the presence of the new instance in the table
+	instance_link = page.get_by_role("link", name=nameInstance, exact=True)
+	expect(instance_link).to_be_visible()
+
+	# return to homepage
+	page.goto('http://localhost:4848')
+
+def start_instance(page: Page, nameInstance):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+
+	# Click on the option Instances in the menu
+	instance_button = page.get_by_role("link",name="Instances", exact=True)
+	instance_button.click()
+	page.wait_for_selector('input[value=" Save "]')
+	
+	# Open the page of the instance to start it
+	instance_link = page.get_by_role("link", name=nameInstance, exact=True)
+	instance_link.click()
+	page.wait_for_selector('div[id="propertyForm:propertyContentPage"]')
+
+	# Confirm the dialog window
+	page.on("dialog", lambda dialog: dialog.accept())
+
+	start_button = page.locator('input[value="Start"]')
+	start_button.click()
+
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=600000,state="hidden")
+
+	# return to homepage
+	page.goto('http://localhost:4848')
+	
+def start_instances(page: Page):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+
+	# Click on the option Instances in the menu
+	instance_button = page.get_by_role("link",name="Instances", exact=True)
+	instance_button.click()
+	page.wait_for_selector('input[value=" Save "]')
+	
+	# Select all instances and start
+	select_all_button = page.get_by_role("link",name="Select All", exact=True)
+	select_all_button.click()
+
+	# Confirm the dialog window
+	page.on("dialog", lambda dialog: dialog.accept())
+
+	start_button = page.locator('input[value="Start"]')
+	start_button.click()
+
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=600000,state="hidden")
+
+	# return to homepage
+	page.goto('http://localhost:4848')
+
+def stop_instances(page: Page):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+
+	# Click on the option Instances in the menu
+	instance_button = page.get_by_role("link",name="Instances", exact=True)
+	instance_button.click()
+	page.wait_for_selector('input[value=" Save "]')
+
+	# Confirm the dialog window
+	page.on("dialog", lambda dialog: dialog.accept())
+
+	# Select all instances and Stop
+	select_all_button = page.get_by_role("link",name="Select All", exact=True)
+	select_all_button.click()
+	stop_button = page.get_by_role("button",name=" Stop ")
+	stop_button.click()
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=600000,state="hidden")
+
+def delete_instances(page: Page):
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+	
+	# Click on the option Instances in the menu
+	instance_button = page.get_by_role("link",name="Instances", exact=True)
+	instance_button.click()
+	page.wait_for_selector('input[value=" Save "]')
+	
+	# Delete all instances
+	select_all_button = page.get_by_role("link",name="Select All", exact=True)
+	select_all_button.click()
+	delete_button = page.get_by_role("button",name="Delete")
+	delete_button.click()
+	# wait for modal to appear and disappear
+	page.wait_for_selector('input[value="Processing..."]')
+	#page.wait_for_selector('div#ajaxPanelBody')
+	page.wait_for_selector('input[value="Processing..."]', timeout=1200000,state="hidden")
+	page.wait_for_selector('div#ajaxPanelBody', timeout=1200000,state="hidden")
+
+	# return to homepage
+	page.goto('http://localhost:4848')
+
+def collect_logs(page: Page, name_instance, log_levels):
+	logs = [name_instance + " : "]
+	# Open the admin page 
+	page.goto('http://localhost:4848')
+	page.wait_for_selector('div[id="treeForm:tree_children"]')
+	
+	# Click on the option Instances in the menu
+	instance_button = page.get_by_role("link",name="Instances", exact=True)
+	instance_button.click()
+	page.wait_for_selector('input[value=" Save "]')
+	
+	# Open the page of the instance and open the logs
+	instance_link = page.get_by_role("link", name=name_instance, exact=True)
+	instance_link.click()
+	page.wait_for_selector('div[id="propertyForm:propertyContentPage"]')
+	view_log_button = page.locator('input[value="View Log Files"]')
+	
+	with page.context.expect_page() as new_page_event:
+		view_log_button.click()
+
+	new_page = new_page_event.value
+
+	new_page.wait_for_load_state()
+	new_page.wait_for_selector('div[id="propertyForm:basicTable"]')
+
+	log_level_combobox = new_page.locator('select[id="propertyForm:propertyContentPage:propertySheet:propertSectionTextField:logLevelProp:logLevel"]')
+	log_level_combobox.click();
+	for log_level in log_levels:
+		# Change the log level to the desired value and filter logs on that level
+		new_page.get_by_label("Log Level:").select_option(value=log_level, force=True)
+		search_button = new_page.locator('input[id="propertyForm:propertyContentPage:bottomButtons:searchButtonBottom"]')
+		search_button.click()
+
+		# create list of every rows displayed
+		log_entries = new_page.get_by_role("row").all()
+		for log_entry in log_entries:
+			cells = log_entry.get_by_role("rowheader").all()
+			if cells: 
+				log_entry_level = cells[1].text_content()
+				log_entry_message = cells[2].text_content()
+				logs.append(log_entry_level + " - " + log_entry_message + " \n")
+
+	new_page.close()
+	logs.append(" \n")
+	logs = ' '.join(logs)
+	return logs

--- a/appserver/tests/functional/cleanboot/asadminlib.py
+++ b/appserver/tests/functional/cleanboot/asadminlib.py
@@ -1,0 +1,35 @@
+#!/bin/python3
+import os
+import subprocess
+from pathlib import Path
+import platform
+
+global PAYARA_PATH_BIN
+
+
+
+def start_domain():	
+	current_path = os.getcwd()
+	print("Current path: "+current_path)
+	print("Changing path to Payara: "+PAYARA_PATH_BIN)
+	print("Going to Payara dir: '"+os.path.join(PAYARA_PATH_BIN, "bin")+"'")
+	if not os.path.isdir(PAYARA_PATH_BIN):
+		raise Exception("Unable to find Payara, used: '" + PAYARA_PATH_BIN + "', try to set PAYARA_HOME env. variable") 
+	os.chdir(os.path.join(PAYARA_PATH_BIN, "bin"))
+	asadmin_cmd = os.path.join('.', 'asadmin')
+	if platform.system() == "Windows":
+		asadmin_cmd = asadmin_cmd + ".bat"
+	subprocess.run([asadmin_cmd , 'start-domain'])
+	os.chdir(current_path)
+
+def stop_domain():
+	current_path = os.getcwd()
+	if not os.path.isdir(PAYARA_PATH_BIN):
+		raise Exception("Unable to find Payara, used: '" + PAYARA_PATH_BIN + "', try to set PAYARA_HOME env. variable") 
+	os.chdir(os.path.join(PAYARA_PATH_BIN, "bin"))
+	asadmin_cmd = os.path.join('.', 'asadmin')
+	if platform.system() == "Windows":
+		asadmin_cmd = asadmin_cmd + ".bat"
+	print("Shutdown Payara")
+	subprocess.run([asadmin_cmd, 'stop-domain'])
+	os.chdir(current_path)

--- a/appserver/tests/functional/cleanboot/testcleanbootcommand.py
+++ b/appserver/tests/functional/cleanboot/testcleanbootcommand.py
@@ -1,0 +1,44 @@
+#!/bin/python3
+import os
+import admingrouplib
+import admininstancelib
+import asadminlib
+from playwright.sync_api import Page
+from datetime import datetime
+
+
+# Setup
+asadminlib.PAYARA_PATH_BIN = os.path.abspath(os.environ["PAYARA_HOME"] if "PAYARA_HOME" in os.environ else "../../../../appserver/distributions/payara/target/stage/payara6")
+
+
+def test_start_payara():
+	asadminlib.start_domain()
+
+def test_instance(page: Page):
+	logs = str(datetime.now()) + " \n"
+	admininstancelib.create_instance(page, "testInstance1")
+	admininstancelib.start_instance(page, "testInstance1")
+	logs += admininstancelib.collect_logs(page, "testInstance1", ["WARNING", "SEVERE", "ALERT", "EMERGENCY"])
+	admininstancelib.stop_instances(page)
+	admininstancelib.delete_instances(page)
+	logs += str(datetime.now()) + " \n"
+	file = open("resultsInstance.txt", "w")
+	file.write(logs)
+	file.close()
+        
+def test_deployment_group(page: Page):
+	logs = str(datetime.now()) + " \n"
+	admingrouplib.create_group(page, "group1", ["groupInstance1", "groupInstance2"])
+	admingrouplib.start_groups(page)
+	logs += admininstancelib.collect_logs(page, "groupInstance1", ["WARNING", "SEVERE", "ALERT", "EMERGENCY"])
+	logs += admininstancelib.collect_logs(page, "groupInstance2", ["WARNING", "SEVERE", "ALERT", "EMERGENCY"])
+	admingrouplib.stop_groups(page)
+	admingrouplib.delete_groups(page)
+	admininstancelib.delete_instances(page)
+	logs += str(datetime.now()) + " \n"
+	file = open("resultsGroup.txt", "w")
+	file.write(logs)
+	file.close()
+
+def test_stop_payara():
+	asadminlib.stop_domain()


### PR DESCRIPTION
Automated test using Python 3 and Playwright.
The goal is to automate the Clean Boot test performed with each release candidate:
- start the domain
- create an instance, start the instance, check the logs for any warning/error, stop the instance, delete the instance
- create a deployment group with 2 instances, start the group, check the logs for any warning/error, stop the group, delete the group and the instance
- stop the domain

Instructions to run it are in the README.md

Tested with Payara 5 and 6