### PR TITLE
FISH-7238 FISH-7721 FISH-7723 Changes to Accommodate Releasing Core Separately

### DIFF
--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -99,5 +99,17 @@
                 <module>docker-images</module>
             </modules>
         </profile>
+        <!-- Profile to build Certificate Management modules-->
+        <profile>
+            <id>BuildCertificateManagement</id>
+            <activation>
+                <property>
+                    <name>BuildCertificateManagement</name>
+                </property>
+            </activation>
+            <modules>
+                <module>certificate-management</module>
+            </modules>
+        </profile>
     </profiles>
 </project>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -57,7 +57,6 @@
     <name>GlassFish Extras modules</name>  
     
     <modules>
-        <!--module>embedded-shell</module-->
         <module>javaee</module>
         <module>appserv-rt</module>
         <module>payara-micro</module>
@@ -76,31 +75,16 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>embedded</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <modules>
-                <module>embedded</module>
-            </modules>
-        </profile>
-        
         <!-- Profile to build Embedded distributions-->
         <profile>
-            <id>BuildExtras</id>
+            <id>BuildEmbedded</id>
             <activation>
                 <property>
-                    <name>BuildExtras</name>
+                    <name>BuildEmbedded</name>
                 </property>
             </activation>
             <modules>
                 <module>embedded</module>
-                <module>certificate-management</module>
             </modules>
         </profile>
         <!-- Profile to build Docker Images-->

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -111,5 +111,19 @@
                 <module>certificate-management</module>
             </modules>
         </profile>
+        <!-- Profile to build all optional modules under extras -->
+        <profile>
+            <id>BuildExtras</id>
+            <activation>
+                <property>
+                    <name>BuildExtras</name>
+                </property>
+            </activation>
+            <modules>
+                <module>embedded</module>
+                <module>docker-images</module>
+                <module>certificate-management</module>
+            </modules>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
     <name>Payara Project</name>
 
     <modules>
-        <module>core</module>
         <module>nucleus</module>
         <module>appserver</module>
         <module>api</module>
@@ -296,6 +295,19 @@
                     <url>https://nexus.payara.fish/repository/payara-snapshots/</url>
                 </snapshotRepository>
             </distributionManagement>
+        </profile>
+
+        <profile>
+            <id>BuildCore</id>
+            <activation>
+                <property>
+                    <name>build.core.skip</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>core</module>
+            </modules>
         </profile>
 
     </profiles>


### PR DESCRIPTION
## Description
Some changes to accomodate releasing Core separately.
This renames the old "embedded" profile to be better aligned with the other "BuildX" profiles we use.
This also moves Certificate Management into its own profile to separate it out in prep for it being moved into its own repo like other extensions.
BuildExtras still builds both Embedded and Certificate Management, but now also builds the Docker images - the rational is that BuildExtras is now a "build all optional modules", and that there are separate "BuildX" profiles for the individual optional modules.

This also introduces a profile to skip building Core: `BuildCore`.
This is a profile that is active by default (so Core continues to be built by default). It doesn't use the maligned `activeByDefault` option, and is instead active as long as you either aren't explicitly disabled it (`-P!BuildCore`) or set the `build.core.skip` property to true.

## Important Info
### Blockers
We need to align this with updates to any Jenkins jobs that use BuildExtras (if we care about them building Docker or not)

## Testing
### New tests
None

### Testing Performed
Built server without specifying any profiles - certificate management not included, Core included.
Built server using BuildExtras - Docker Images, Certificate Management, Embedded, Core all built.
Built using BuildExtras,!BuildCore (requires that you've installed Core somewhere previously) - Docker Images, Certificate Management, Embedded all built, Core not built.
Built using BuildEmbedded - Server, Core, and Embedded built, Certificate Management and Docker Images skipped.

### Testing Environment
Windows 1, Zulu 11.0.20

## Documentation
Confluence doc updated - it's not listed anywhere else.

## Notes for Reviewers
None
