### PR TITLE
FISH-7597 : adding health checks for the qualifiers

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/cdi/extension/HealthCDIExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/cdi/extension/HealthCDIExtension.java
@@ -85,35 +85,18 @@ public class HealthCDIExtension implements Extension {
     }
 
     void processBean(@Observes ProcessBean<?> event) {
-        final Annotated annotated = event.getAnnotated();
-        if (annotated.isAnnotationPresent(Readiness.class)
-                || annotated.isAnnotationPresent(Liveness.class)
-                || annotated.isAnnotationPresent(Startup.class)) {
-            this.healthCheckBeans.add(event.getBean());
-        } else {
-            final Bean bean = event.getBean();
-            if (bean != null) {
-                Set<Annotation> annotations = bean.getQualifiers();
-                for (Annotation annotation : annotations) {
-                    Class<? extends Annotation> annotationType = annotation.annotationType();
-                    if (inheritsFromHealthTypes(annotationType)) {
-                        this.healthCheckBeans.add(event.getBean());
-                    }
+        Bean<?> bean = event.getBean();
+        if (bean != null) {
+            Set<Annotation> annotations = bean.getQualifiers();
+            for (Annotation annotation : annotations) {
+                Class<? extends Annotation> annotationType = annotation.annotationType();
+                if (Readiness.class.equals(annotationType)
+                        || Liveness.class.equals(annotationType)
+                        || Startup.class.equals(annotationType)) {
+                    this.healthCheckBeans.add(event.getBean());
                 }
             }
         }
-    }
-
-    private boolean inheritsFromHealthTypes(Class<? extends Annotation> annotationType) {
-        Class<?> currentClass = annotationType;
-        while (currentClass != null) {
-            if (currentClass.equals(Readiness.class) || currentClass.equals(Liveness.class)
-                    || currentClass.equals(Startup.class)) {
-                return true;
-            }
-            currentClass = currentClass.getSuperclass();
-        }
-        return false;
     }
 
     void applicationInitialized(@Observes @Initialized(ApplicationScoped.class) Object init, BeanManager beanManager) {

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/cdi/extension/HealthCDIExtension.java
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/src/main/java/fish/payara/microprofile/healthcheck/cdi/extension/HealthCDIExtension.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) 2020-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2020-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
## Description
The user reported an issue in which, at runtime, the synthetic HealthCheck bean can be injected but is not included in the health check APIs. 

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. build Payara Server
2. git clone https://github.com/ghunteranderson/payara-issue-5594.git
3. edit the pom.xml file to change payara version: **<payara.version>6.2023.9-SNAPSHOT</payara.version>**
4. http://localhost:8080/health
5. In Payara 6, the API GET /health now includes health checks defined as synthetic beans

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.6
