### PR TITLE
FISH-7716 openjava.base/java.io on jdk 17

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -218,7 +218,7 @@
                 <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-                <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+                <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
                 <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
                 <jvm-options>-Xmx512m</jvm-options>
                 <jvm-options>-XX:NewRatio=2</jvm-options>
@@ -455,7 +455,7 @@
                 <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-                <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+                <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
                 <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
                 <jvm-options>-Xmx512m</jvm-options>
                 <jvm-options>-XX:NewRatio=2</jvm-options>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -213,7 +213,7 @@
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-        <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-XX:NewRatio=2</jvm-options>
@@ -445,7 +445,7 @@
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-        <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-XX:NewRatio=2</jvm-options>

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -194,7 +194,7 @@
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-        <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>
@@ -408,7 +408,7 @@
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-        <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -217,7 +217,7 @@
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
-        <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>
@@ -425,7 +425,7 @@
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
-        <jvm-options>[21|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+        <jvm-options>[17|]--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>[21|]--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
         <jvm-options>-Xmx2g</jvm-options>
         <jvm-options>-Xms2g</jvm-options>


### PR DESCRIPTION
## Description
Cargotracker didn't run on JDK 17. The required --add-opens is used from JDK 21. This PR lowers the required JDK to 17.

## Testing
### Testing Performed
* Compile Payara
* checkout Cargotracker: `git clone git@github.com:eclipse-ee4j/cargotracker.git`
* change version of Payara to use in `pom.xml`: `<payara.version>6.2023.9-SNAPSHOT</payara.version>`
* run cargotracker in JDK 17: `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn clean package -DskipTests cargo:run`

### Testing Environment
Linux, OpenJDK 11 (to compile Payara), OpenJDK 17 to run
