### PR TITLE
FISH-6863 H2DB 2.2.220

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <microprofile-release.version>6.0</microprofile-release.version>
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
-        <h2db.version>2.1.212</h2db.version>
+        <h2db.version>2.2.220</h2db.version>
         <concurrent.version>3.0.2.payara-p1</concurrent.version>
         <monitoring-console-process.version>2.0.1</monitoring-console-process.version>
         <monitoring-console-webapp.version>2.0.1</monitoring-console-webapp.version>


### PR DESCRIPTION
## Description
Upgrades H2DB to 2.2.220

## Important Info
### Blockers
None - already uploaded H2DB to payara-artifacts

## Testing
### New tests
None

### Testing Performed
Started database using `asadmin start-database`
Payara was able to ping it using `asadmin ping-connection-pool H2Pool`

### Testing Environment
OpenSUSE Leap 15.5 WSL, Zulu 11

## Documentation
N/A

## Notes for Reviewers
None
