### PR TITLE
FISH-7268 Add Semantic Versioning Check in Core Module

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -599,4 +599,64 @@
             </plugins>
         </pluginManagement>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>force-semver</id>
+            <!-- Force semantic versioning. The differences are in target/japicmp in text, html and xml -->
+            <build>
+                <plugins>
+                    <!-- plugin to parse version number without "-SNAPSHOT" -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>released-version</id>
+                                <goals>
+                                    <goal>released-version</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.siom79.japicmp</groupId>
+                        <artifactId>japicmp-maven-plugin</artifactId>
+                        <version>0.17.2</version>
+                        <configuration>
+                            <!-- Use the latest published version. It's necessary to use specific version because subprojects using glassfish-jar cannot be found. -->
+                            <oldVersion> 
+                                <dependency>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${releasedVersion.majorVersion}.${releasedVersion.minorVersion}.${releasedVersion.incrementalVersion}</version>
+                                    <type>jar</type>
+                                </dependency>
+                            </oldVersion>
+                            <!-- Use the current version. It's necessary to use <file> because subprojects using glassfish-jar cannot be found.-->
+                            <newVersion>
+                                <file>
+                                    <path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+                                </file>
+                            </newVersion>
+                            <parameter>
+                                <!-- see documentation https://siom79.github.io/japicmp/MavenPlugin.html -->
+                                <ignoreMissingClasses>true</ignoreMissingClasses>
+                                <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                            </parameter>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>cmp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
## Description
In the path to split core modules, we add semantic versioning check for core modules. This PR adds the check to the parent, e.g. all core modules must pass this check: no incompatible changes in patch releases.

The check is currently added as a profile `force-semver`. If it will cause no problems for some longer time, let's activate it by default.

## Testing
### Testing Performed
Build works normally:
```
mvn clean install -T 16 -PQuickBuild,force-semver -DskipTests
```

Let's to some incompatible change, e.g. delete file `nucleus/common/glassfish-api/src/main/java/org/glassfish/api/Startup.java`, which doesn't cause build error otherwise. The same build fails with this message:
```
[ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.17.2:cmp (default) on
project glassfish-api: Versions of archives indicate a patch change but binary incompatible changes found.
```

The errors in build show reason (among others):
```
Aug 25, 2023 10:19:40 AM japicmp.output.incompatible.IncompatibleErrorOutput warn
WARNING: Incompatibility detected: Requires semantic version level MAJOR: JApiClass [fullyQualifiedName=org.glassfish.api.Startup, changeStatus=REMOVED, compatibilityChanges=[CLASS_REMOVED]]
```

The detailed report of changes is generated to `nucleus/common/glassfish-api/target/japicmp/japicmp.*` in form of text diff, xml, html.

Withtout the profile, the project builds normally even with incompatible changes:
```
mvn clean install -T 16 -Pforce-semver -DskipTests
```

### Testing Environment
Linux, OpenJDK 11
