### PR TITLE
FISH-7740 Disable Extra Zip Validation in Docker Images

### DIFF
--- a/appserver/extras/docker-images/basic/pom.xml
+++ b/appserver/extras/docker-images/basic/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/extras/docker-images/basic/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/basic/src/main/docker/Dockerfile
@@ -1,3 +1,42 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+
 FROM @docker.java.image@
 
 ENV HOME_DIR=/opt/payara

--- a/appserver/extras/docker-images/micro/pom.xml
+++ b/appserver/extras/docker-images/micro/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV HOME_DIR=${PAYARA_HOME}
 ENV PAYARA_DIR=${HOME_DIR} \
     SCRIPT_DIR=${HOME_DIR} \
     DEPLOY_DIR=/opt/payara/deployments \
-    JVM_ARGS="" \
+    JVM_ARGS="-Djdk.util.zip.disableZip64ExtraFieldValidation=true" \
     MEM_MAX_RAM_PERCENTAGE="70.0" \
     MEM_XSS="512k"
 

--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -1,3 +1,42 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+
 FROM @docker.java.image@
 
 # Default payara ports to expose

--- a/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
@@ -1,4 +1,42 @@
 #!/bin/sh
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+
 set -e
 
 exec java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar "$@"

--- a/appserver/extras/docker-images/server-full/pom.xml
+++ b/appserver/extras/docker-images/server-full/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -1,3 +1,42 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+
 FROM payara/basic:@docker.payara.tag@
 
 # Default payara ports to expose

--- a/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-full/src/main/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/password-change-file.txt \
     && echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> ${PASSWORD_FILE} \
     && ${PAYARA_DIR}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/tmp/password-change-file.txt change-admin-password --domain_name=${DOMAIN_NAME} \
+    && sed -i 's/<\/java-config>/  <jvm-options>-Djdk\.util\.zip\.disableZip64ExtraFieldValidation=true<\/jvm-options>\n      <\/java-config>/g'  ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/domain.xml \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin \
     && for MEMORY_JVM_OPTION in \

--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/entrypoint.sh
@@ -1,4 +1,43 @@
 #!/bin/bash
+################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+################################################################################
 
 for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do
       case "$f" in

--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/init_1_generate_deploy_commands.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/init_1_generate_deploy_commands.sh
@@ -1,5 +1,45 @@
 #!/bin/bash
 ################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+################################################################################
+
+################################################################################
 #
 # A script to append deploy commands to the post boot command file at
 # $PAYARA_HOME/scripts/post-boot-commands.asadmin file. All applications in the

--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/startInForeground.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/startInForeground.sh
@@ -1,5 +1,45 @@
 #!/bin/bash
 ##########################################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+##########################################################################################################
+
+##########################################################################################################
 #
 # This script is to execute Payara Server in foreground, mainly in a docker environment.
 # It allows to avoid running 2 instances of JVM, which happens with the start-domain --verbose command.

--- a/appserver/extras/docker-images/server-node/pom.xml
+++ b/appserver/extras/docker-images/server-node/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-node/src/main/docker/Dockerfile
@@ -1,3 +1,42 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+
 FROM payara/basic:@docker.payara.tag@
 
 ENV PAYARA_DAS_HOST="localhost" \

--- a/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-node/src/main/docker/bin/entrypoint.sh
@@ -1,4 +1,44 @@
 #!/usr/bin/env bash
+################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+################################################################################
+
 set -e
 
 DOCKER_CONTAINER_ID="$(cat /proc/self/cgroup | grep :/docker/  | sed s/\\//\\n/g | tail -1)"

--- a/appserver/extras/docker-images/server-web/pom.xml
+++ b/appserver/extras/docker-images/server-web/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
@@ -1,3 +1,42 @@
+#
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+
 FROM payara/basic:@docker.payara.tag@
 
 # Default payara ports to expose

--- a/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/server-web/src/main/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/password-change-file.txt \
     && echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> ${PASSWORD_FILE} \
     && ${PAYARA_DIR}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/tmp/password-change-file.txt change-admin-password --domain_name=${DOMAIN_NAME} \
+    && sed -i 's/<\/java-config>/  <jvm-options>-Djdk\.util\.zip\.disableZip64ExtraFieldValidation=true<\/jvm-options>\n      <\/java-config>/g'  ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/domain.xml \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin \
     && for MEMORY_JVM_OPTION in \

--- a/appserver/extras/docker-images/server-web/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-web/src/main/docker/bin/entrypoint.sh
@@ -1,4 +1,43 @@
 #!/bin/bash
+################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+################################################################################
 
 for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do
       case "$f" in

--- a/appserver/extras/docker-images/server-web/src/main/docker/bin/init_1_generate_deploy_commands.sh
+++ b/appserver/extras/docker-images/server-web/src/main/docker/bin/init_1_generate_deploy_commands.sh
@@ -1,5 +1,45 @@
 #!/bin/bash
 ################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+################################################################################
+
+################################################################################
 #
 # A script to append deploy commands to the post boot command file at
 # $PAYARA_HOME/scripts/post-boot-commands.asadmin file. All applications in the

--- a/appserver/extras/docker-images/server-web/src/main/docker/bin/startInForeground.sh
+++ b/appserver/extras/docker-images/server-web/src/main/docker/bin/startInForeground.sh
@@ -1,5 +1,45 @@
 #!/bin/bash
 ##########################################################################################################
+#    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#    The contents of this file are subject to the terms of either the GNU
+#    General Public License Version 2 only ("GPL") or the Common Development
+#    and Distribution License("CDDL") (collectively, the "License").  You
+#    may not use this file except in compliance with the License.  You can
+#    obtain a copy of the License at
+#    https://github.com/payara/Payara/blob/master/LICENSE.txt
+#    See the License for the specific
+#    language governing permissions and limitations under the License.
+#
+#    When distributing the software, include this License Header Notice in each
+#    file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#    GPL Classpath Exception:
+#    The Payara Foundation designates this particular file as subject to the "Classpath"
+#    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#    file that accompanied this code.
+#
+#    Modifications:
+#    If applicable, add the following below the License Header, with the fields
+#    enclosed by brackets [] replaced by your own identifying information:
+#    "Portions Copyright [year] [name of copyright owner]"
+#
+#    Contributor(s):
+#    If you wish your version of this file to be governed by only the CDDL or
+#    only the GPL Version 2, indicate your decision by adding "[Contributor]
+#    elects to include this software in this distribution under the [CDDL or GPL
+#    Version 2] license."  If you don't indicate a single choice of license, a
+#    recipient has the option to distribute your version of this file under
+#    either the CDDL, the GPL Version 2 or to extend the choice of license to
+#    its licensees as provided above.  However, if you add GPL Version 2 code
+#    and therefore, elected the GPL Version 2 license, then the option applies
+#    only if the new code is made subject to such option by the copyright
+#    holder.
+##########################################################################################################
+
+##########################################################################################################
 #
 # This script is to execute Payara Server in foreground, mainly in a docker environment.
 # It allows to avoid running 2 instances of JVM, which happens with the start-domain --verbose command.

--- a/appserver/extras/docker-images/tests/pom.xml
+++ b/appserver/extras/docker-images/tests/pom.xml
@@ -1,4 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>


### PR DESCRIPTION
## Description
Disables the extra zip validation added in JDK 11.0.20 & 17.0.8 which breaks the libpam4j package we bundle in Payara Server & Micro. While no longer an issue on the **most recent** releases due to fix introduced in https://github.com/payara/Payara-Enterprise/pull/899, if we ever decide to rebuild an older Community image utlising the newest JDKs we either need to add this option or backport the fix to all previous releases!

Since the `create-jvm-options` command requires the domain be running (and it cannot start due to the missing JVM option!) I've had to resort to inserting the option via sed (because I can't think of a better way). I have attempted to preserve the indentation because it pleases me.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built latest Payara Server & Micro and their respective Docker images and let the unit tests run - all worked: `mvn clean install -PBuildDockerImages`
Started Payara Micro image and deployed clusterjsp - worked.

Rebuilt Docker images utilising an older version of Payara without the fix: `mvn clean verify -Dpayara.version=6.2023.4 -PBuildDockerImages -pl :docker-images -amd`

### Testing Environment
Windows 11

## Documentation
https://github.com/payara/Payara-Documentation/pull/307

## Notes for Reviewers
Also adds missing copyright blocks so you may wish to filter the diff on only the first two commits.

The Payara Micro way of adding it as a default JVM_ARG is slightly fragile in that it can be overridden, but I feel that it's slightly better than hardcoding it into the entrypoint.sh file like -Xss is since this should only be required for older versions of Payara.
