### PR TITLE
FISH-6866 Upgrade Santuario to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>2.1.1</com.ibm.jbatch.spi.version>
         <webservices.version>4.0.1</webservices.version>
-        <org.apache.santuario.version>3.0.0</org.apache.santuario.version>
+        <org.apache.santuario.version>3.0.2</org.apache.santuario.version>
         <woodstox.version>6.4.0</woodstox.version>
         <woodstock-jsf.version>5.0.0</woodstock-jsf.version>
         <woodstock-jsf-suntheme.version>5.0.0.payara-p1</woodstock-jsf-suntheme.version>


### PR DESCRIPTION
## Description
Upgrade Santuario to the latest version 3.0.2

## Testing
### Testing Environment
OpenJDK 11, Linux