### PR TITLE
FISH-6876 FISH-7757 Parsson 1.1.4 & JSON-P API 2.1.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -76,7 +76,7 @@
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
-        <jsonp-api.version>2.1.0</jsonp-api.version>
+        <jsonp-api.version>2.1.2</jsonp-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,7 +67,7 @@
         <jakarta.el-api.version>5.0.0</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>
         <microprofile-config.version>3.0.2</microprofile-config.version>
-        <parsson.version>1.1.4</parsson.version>
+        <parsson.version>1.1.4.payara-p1</parsson.version>
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.0</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,7 +67,7 @@
         <jakarta.el-api.version>5.0.0</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>
         <microprofile-config.version>3.0.2</microprofile-config.version>
-        <parsson.version>1.1.1.payara-p1</parsson.version>
+        <parsson.version>1.1.4</parsson.version>
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.0</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>


### PR DESCRIPTION
## Description
Updates the JSON-P implementation (Parsson) to 1.1.4.
This is a patched version of Parsson, since the published 1.1.4 has a malformed OSGi manifest and doesn't work.

Also updates the JSON-P API to 2.1.2.

## Important Info
### Blockers
https://github.com/payara/patched-src-parsson/pull/1

## Testing
### New tests
None

### Testing Performed
* Created a temp maven repo: `mkdir D:\Downloads\FISH-7757`
* Built patched parsson and let unit tests run: `mvn clean install -Dmaven.repo.local=D:\Downloads\FISH-7757`
* Build Payara server, overriding version of parsson in pom: `mvn clean install -Dmaven.repo.local=D:\Downloads\FISH-7757 -Dparsson.version=1.1.4.payara-p2-SNAPSHOT`
* Started server

### Testing Environment
Windows 11, Zulu JDK 11.0.20

## Documentation
N/A

## Notes for Reviewers
None
