### PR TITLE
FISH-7760 Enable Semantic Versioning of Core by Default

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -609,6 +609,13 @@
         <profile>
             <id>force-semver</id>
             <!-- Force semantic versioning. The differences are in target/japicmp in text, html and xml -->
+            <activation>
+                <property>
+                    <!-- Active unless explicitly set to false -->
+                    <name>core.force.semver</name>
+                    <value>!false</value>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <!-- plugin to parse version number without "-SNAPSHOT" -->


### PR DESCRIPTION
## Description
Follow on to https://github.com/payara/Payara/pull/6379

Enables semantic versioning in Core by default.
To disable, you must define the `core.force.semver` property to _false_.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Attempted to build core with no property - it fails on semver (because opentelemetry introduced breaking API changes): `mvn clean install -f core`
* Attempt to build core with property set to _true_ - it fails on semver: `mvn clean install -f .\core\ "-Dcore.force.semver=true"`
* Attempt to build core with property set to _false_ - build succeeds: `mvn clean install -f .\core\ "-Dcore.force.semver=false"`

### Testing Environment
Windows 11, Zulu JDK 11.0.20

## Documentation
Pending...

## Notes for Reviewers
Name of property obviously up for discussion.
