### PR TITLE
FISH-7809 Remove 'deploy-internals' Profile and Fix Deployment of Core

### DIFF
--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -189,15 +189,6 @@
     </build>
 
     <profiles>
-
-        <!-- Don't deploy any distributions if only the internals are being deployed -->
-        <profile>
-            <id>deploy-internals</id>
-            <properties>
-                <deploy.skip>true</deploy.skip>
-            </properties>
-        </profile>
-
         <!-- Default build profile -->
         <profile>
             <id>DefaultBuild</id>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -481,11 +481,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>deploy-internals</id>
-            <properties>
-                <deploy.skip>true</deploy.skip>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/appserver/extras/embedded/pom.xml
+++ b/appserver/extras/embedded/pom.xml
@@ -60,12 +60,4 @@
         <module>tests</module>
     </modules>
 
-    <profiles>
-        <profile>
-            <id>deploy-internals</id>
-            <properties>
-                <deploy.skip>true</deploy.skip>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -419,11 +419,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>deploy-internals</id>
-            <properties>
-                <deploy.skip>true</deploy.skip>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -528,11 +528,5 @@
                 <product.name>Payara Micro Enterprise</product.name>
             </properties>
         </profile>
-        <profile>
-            <id>deploy-internals</id>
-            <properties>
-                <deploy.skip>true</deploy.skip>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -54,20 +54,7 @@
 
     <name>Payara Core Parent</name>
 
-    <distributionManagement>
-        <repository>
-            <id>payara-nexus-artifacts</id>
-            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
-        </repository>
-        <snapshotRepository>
-            <id>payara-nexus-snapshots</id>
-            <url>https://nexus.payara.fish/repository/payara-snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <properties>
-        <!-- core artifacts end up in payara-artifacts repo -->
-        <deploy.skip>false</deploy.skip>
         <jar.manifest>${project.build.outputDirectory}/META-INF/MANIFEST.MF</jar.manifest>
     </properties>
 
@@ -401,15 +388,6 @@
                         <testExcludes>
                             <testExclude>**/.ade_path/**</testExclude>
                         </testExcludes>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven.deploy.plugin.version}</version>
-                    <configuration>
-                        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                        <skip>${deploy.skip}</skip>
                     </configuration>
                 </plugin>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -185,7 +185,7 @@
         <!-- build settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <deploy.skip>true</deploy.skip>
+        <deploy.skip>false</deploy.skip>
         <javadoc.skip>true</javadoc.skip>
 
         <payara.deployment.transformer.version>1.3</payara.deployment.transformer.version>
@@ -214,6 +214,17 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
+
+    <distributionManagement>
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
+        </repository>
+        <snapshotRepository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.payara.fish/repository/payara-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <repositories>
         <!-- Try Maven central first, not last, which happens when omitted here -->
@@ -447,6 +458,15 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven.deploy.plugin.version}</version>
+                    <configuration>
+                        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+                        <skip>${deploy.skip}</skip>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <distributionManagement>
+        <repository>
+            <id>payara-nexus-distributions</id>
+            <url>https://nexus.payara.fish/repository/payara-community/</url>
+        </repository>
+    </distributionManagement>
+
     <properties>
         <dynamic.build.properties.version>0.0.1.a2</dynamic.build.properties.version>
 
@@ -150,6 +157,8 @@
         <monitoring-console-process.version>2.0.1</monitoring-console-process.version>
         <monitoring-console-webapp.version>2.0.1</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
+
+        <deploy.skip>true</deploy.skip>
     </properties>
 
     <profiles>
@@ -279,25 +288,6 @@
         </profile>
 
         <profile>
-            <!-- only internal modules deployed, so tests can run without Server build built -->
-            <id>deploy-internals</id>
-            <properties>
-                <deploy.skip>false</deploy.skip>
-            </properties>
-
-            <distributionManagement>
-                <repository>
-                    <id>payara-nexus-artifacts</id>
-                    <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>payara-nexus-snapshots</id>
-                    <url>https://nexus.payara.fish/repository/payara-snapshots/</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-
-        <profile>
             <id>BuildCore</id>
             <activation>
                 <property>
@@ -388,15 +378,6 @@
                         <testExcludes>
                             <testExclude>**/.ade_path/**</testExclude>
                         </testExcludes>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven.deploy.plugin.version}</version>
-                    <configuration>
-                        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                        <skip>${deploy.skip}</skip>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
## Description
With the introduction of Core, the `deploy-internals` profile becomes redundant.

This also moves the deployment information from the `core-parent` module to the `core-aggregator` module, since otherwise deployment of Core would fail due to the `core-aggregator` and `core-bom` not knowing where to deploy to.

The structure is now:
* `core-aggregator` - contains deployment and distribution management information. Also sets the `deploy.skip` property to false so that Core modules are deployed.
* `core-parent` - all deployment information removed. Should™ inherit from `core-aggregator`
* `core-bom` - Should™ inherit deployment information from `core-aggregator`
* `payara-aggregator` - Should™ inherit deployment information from `core-aggregator`. Also sets the `deploy.skip` property to _true_ so that the non-Core _Server_ artefacts aren't deployed, and sets the deployment repository to [payara-community](https://nexus.payara.fish/#browse/browse:payara-community).
* Payara Server distributions (`payara-bom`, `payara`, `payara-web`, `payara-ml`, `payara-web-ml`, `payara-micro`, `payara-embedded-all`, `payara-embedded-web`) - sets the `deploy.skip` property to false

The intent is that Core modules get deployed to [payara-artifacts](https://nexus.payara.fish/#browse/browse:payara-artifacts), Server modules are not deployed at all, and Server distributions are deployed to [payara-community](https://nexus.payara.fish/#browse/browse:payara-community). Snapshots for both Core and Server should end up in [payara-snapshots](https://nexus.payara.fish/#browse/browse:payara-snapshots).

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Make a temporary maven repo to ensure no "cheating" going on via cache: `mkdir D:\Downloads\FISH-7809`
* Deployed Core SNAPSHOTs standalone: 
  * `mvn clean deploy -f core/pom.xml "-Dmaven.repo.local=D:\Downloads\FISH-7809"`
  * Verify in payara-snapshots that only Core modules have been deployed
* Deployed Server distributable artefact SNAPSHOTs without rebuilding Core:
  * `mvn clean deploy "-P!BuildCore,BuildEmbedded" "-Dmaven.repo.local=D:\Downloads\FISH-7809"`
  * Verify in payara-snapshots that only Server distributions have been deployed
    * `fish.payara.distributions:payara:6.2023.10-SNAPSHOT` - present 👍
    * `fish.payara.extras:payara-embedded-all:6.2023.10-SNAPSHOT` - present 👍
    * `fish.payara.server.internal.extras:payara-micro-boot:6.2023.10-SNAPSHOT` - **not present** 👍
    * `fish.payara.api:payara-api:6.2023.10-SNAPSHOT` - only **one** snapshot present (implying it didn't get rebuilt and redeployed) 👍

_Currently investigating why some modules under appserver/packager are being deployed and whether they should be..._

### Testing Environment
Windows 11, Zulu JDK 11.0.20, Maven 3.9.4

## Documentation
N/A

## Notes for Reviewers
None
