### PR TITLE
GA Workflow to handle Community PRs Assignment

### DIFF
--- a/.github/workflows/assign-community-prs.yaml
+++ b/.github/workflows/assign-community-prs.yaml
@@ -1,0 +1,29 @@
+name: Agent Assignment
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+  assign-frontline-engineer:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Get Team Members
+        id: team-members
+        env:
+          frontLine: ${{ vars.FRONT_LINE_USERS_LIST }}
+        #TODO - Temporary solution - team member configuration should be dynamic
+        run: |
+          echo "::set-output name=members::$frontLine"
+      - name: Get Next Team Member
+        id: next-member
+        run: |
+          members=($(echo "${{ steps.team-members.outputs.members }}" | tr ',' '\n'))
+          index=$(( (${GITHUB_RUN_NUMBER}-1) % ${#members[@]} ))
+          next_member=${members[$index]}
+          echo "::set-output name=next_member::$next_member"
+      - env:
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+        run: |
+          echo $EVENT_CONTEXT

--- a/.github/workflows/assign-community-prs.yaml
+++ b/.github/workflows/assign-community-prs.yaml
@@ -1,29 +1,49 @@
-name: Agent Assignment
+name: Agent Assignment to Community Contributions
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+      - reopened
 jobs:
-  assign-frontline-engineer:
+  assign-front-line-engineer:
     runs-on: ubuntu-latest
+    #Conditionally runs the job if the author of the PR is not an owner or member of the organisation
+    #See https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    if: github.event.pull_request.author_association != 'OWNER' && github.event.pull_request.author_association != 'MEMBER'
     permissions:
       pull-requests: write
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
-      - name: Get Team Members
-        id: team-members
+      - name: Get Next Assignee
+        id: get-next-assignee
         env:
-          frontLine: ${{ vars.FRONT_LINE_USERS_LIST }}
-        #TODO - Temporary solution - team member configuration should be dynamic
+          FRONT_LINE: ${{ vars.FRONT_LINE_USERS_LIST }}
         run: |
-          echo "::set-output name=members::$frontLine"
-      - name: Get Next Team Member
-        id: next-member
-        run: |
-          members=($(echo "${{ steps.team-members.outputs.members }}" | tr ',' '\n'))
+          if [ -z $FRONT_LINE ]; then
+            echo "::error::'FRONT_LINE_USERS_LIST' environment variable is not set"
+            exit 1
+          fi
+          members=($(echo $FRONT_LINE | tr ',' '\n'))
           index=$(( (${GITHUB_RUN_NUMBER}-1) % ${#members[@]} ))
           next_member=${members[$index]}
-          echo "::set-output name=next_member::$next_member"
-      - env:
-          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+          echo "SELECTED_ASSIGNEE=$next_member" >> "$GITHUB_ENV"
+      - name: Assign selected member
+        id: assign-selected-member
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: success()
         run: |
-          echo $EVENT_CONTEXT
+          echo "::debug::Selected assignee: $SELECTED_ASSIGNEE"
+          gh pr edit $PR_URL --add-assignee $SELECTED_ASSIGNEE
+      - name: Notify MS Teams channel
+        id: notify-ms-teams
+        if: success()
+        uses: simbo/msteams-message-card-action@latest
+        with:
+          webhook: ${{ secrets.COMMUNITY_EVENTS_WEBHOOK_URL }}
+          title: A new Community Contribution has been raised (or re-opened)!
+          message: <code>${{ env.PR_TITLE }}</code> assigned to <strong>${{ env.SELECTED_ASSIGNEE }}</strong>
+          buttons: |
+            View PR on GitHub ${{ env.PR_URL }}


### PR DESCRIPTION
### GitHub Action Workflow to Manage Assignment of Community Contributions

## Description
This pull request introduces a new GA workflow to assign new PRs made by contributors not belonging to Payara so that they are processed by a member of the Service team.

## Testing
### Testing Performed
Testing of the workflow was done on a separate repository: https://github.com/fturizo/GHActionsTester/