### PR TITLE
FISH-6858 JBoss Class File Writer 1.3.0

### DIFF
--- a/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
+++ b/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
@@ -38,7 +38,7 @@ Hazelcast 5.1.1
 Hibernate Validator 8.0.0.Final
 IBM Batch 2.1.1
 Jackson 2.13.4
-JBoss Class File Writer 1.2.5.Final
+JBoss Class File Writer 1.3.0.Final
 JBoss Logging 3.5.0.Final
 JCIP Annotations 1.0-1
 JSON Smart 2.4.8

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -60,7 +60,7 @@
 
     <properties>
         <jakarta.faces-spec.version>4.0.0</jakarta.faces-spec.version>
-        <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
+        <jboss.classfilewriter.version>1.3.0.Final.payara-p1</jboss.classfilewriter.version>
         <!-- Java EE Security API -->
         <jakarta.security.enterprise-spec.version>1.0</jakarta.security.enterprise-spec.version>
 


### PR DESCRIPTION
## Description
Updates the JBoss Class File Writer to 1.3.0.Final with amendments.

The vanilla 1.3.0.Final release has malformed OSGi, with the osgi.ee filter being set to UNKNOWN. This is fixed by using a more recent version of the Maven Bundle plugin.

This however also starts importing java.* packages by default (the ones from the JDK), which we don't currently support, so there's also an additional change to make it so that these packages are excluded.

## Important Info
### Blockers
https://github.com/payara/patched-src-jboss-classfilewriter/pull/1

## Testing
### New tests
None

### Testing Performed
* Make a temporary maven repo to ensure no "cheating" going on via cache: `mkdir D:\Downloads\FISH-6858`
* Build patched JBoss ClassFileWriter: `mvn clean install "-Dmaven.repo.local=D:\Downloads\FISH-6858"`
* Build Payara, overriding jboss classfilewriter version to the SNAPSHOT version present on my PR: `mvn clean install "-Dmaven.repo.local=D:\Downloads\FISH-6858" -Djboss.classfilewriter.version=1.3.0.Final.payara-p2-SNAPSHOT`
* Start the server and load the admin console - no OSGi errors
* Ran _Payara6_ branch of EE7 samples: 
  * `asadmin start-database`
  * `mvn clean verify "-Dmaven.repo.local=D:\Downloads\FISH-6858" "-Dpayara.version=6.2023.10-SNAPSHOT" -Dpayara_domain=domain1 "-Ppayara-server-remote,stable"`

### Testing Environment
Windows 11, Zulu 11

## Documentation
Third party license file updated in PR.

## Notes for Reviewers
None
