### PR TITLE
FISH-7820 FISH-7827 FISH-7828 FISH-7829 Update Nimbus-Jose-JWT, Accessors Smart, and JSON Smart

### DIFF
--- a/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
+++ b/appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
@@ -23,7 +23,7 @@ party licensors listed.
 ****************************************
 
 ---------------------------------------------------
-Accessors Smart 2.4.8
+Accessors Smart 2.4.11
 Apache Ant 1.10.9
 Apache BCEL 6.6.1
 Apache Felix OSGI 7.x
@@ -41,10 +41,10 @@ Jackson 2.13.4
 JBoss Class File Writer 1.3.0.Final
 JBoss Logging 3.5.0.Final
 JCIP Annotations 1.0-1
-JSON Smart 2.4.8
+JSON Smart 2.4.11
 JXMPP 0.6.4
 Mini DNS 0.3.4
-Nimbus Jose JWT 9.23
+Nimbus Jose JWT 9.35
 OkHttp3 3.14.9
 OkIO 1.17.2
 Open Telemetry 1.29.0

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -82,9 +82,9 @@
         <!-- Java API for XML Registries Resource Adapter -->
         <jaxr.version>JAXR_RA_20091012</jaxr.version>
 
-        <nimbus-jose-jwt.version>9.25</nimbus-jose-jwt.version>
-        <accessors-smart.version>2.4.8</accessors-smart.version>
-        <json-smart.version>2.4.10</json-smart.version>
+        <nimbus-jose-jwt.version>9.35</nimbus-jose-jwt.version>
+        <accessors-smart.version>2.4.11</accessors-smart.version>
+        <json-smart.version>2.4.11</json-smart.version>
         <reactor-core.version>3.4.4</reactor-core.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jcip-annotations.version>1.0-1</jcip-annotations.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,7 +56,7 @@
     <properties>
         <payara.core.version>6.2023.10-SNAPSHOT</payara.core.version>
         <!-- BOM dependencies versions -->
-        <payara.security-connectors.version>3.0.alpha7</payara.security-connectors.version>
+        <payara.security-connectors.version>3.0.alpha8</payara.security-connectors.version>
         <hk2.version>3.0.1.payara-p3</hk2.version>
         <osgi.version>7.0.0</osgi.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>


### PR DESCRIPTION
## Description
Updates these components to get away from a CVE in JSON Smart.
Also updates the security connector in the same way.

## Important Info
### Blockers
https://github.com/payara/ecosystem-security-connectors/pull/273

## Testing
### New tests
None

### Testing Performed
Built server, ran EE7 samples against it.

### Testing Environment
Windows 11, Zulu 11.0.20

## Documentation
https://github.com/payara/Payara-Documentation/pull/321

## Notes for Reviewers
None
