### PR TITLE
FISH-7278 Remove Redundant Dependency

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -254,12 +254,6 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-api-logs</artifactId>
-                <version>${opentelemetry.alpha26.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
                 <version>${opentelemetry.version}</version>
                 <scope>provided</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,7 +147,6 @@
         <trilead-ssh2.version>build-217-jenkins-16</trilead-ssh2.version>
         <opentelemetry.version>1.29.0</opentelemetry.version>
         <opentelemetry.alpha.version>1.29.0-alpha</opentelemetry.alpha.version>
-        <opentelemetry.alpha26.version>1.26.0-alpha</opentelemetry.alpha26.version>
         <testng.version>7.4.0</testng.version>
         <bouncycastle-jdk15on.version>1.64</bouncycastle-jdk15on.version>
         <jsftemplating.version>3.0.0</jsftemplating.version>


### PR DESCRIPTION
## Description
Removes a redundant dependency.
This dependency was rolled into the main api artefact.
https://github.com/open-telemetry/opentelemetry-java/blob/main/CHANGELOG.md?plain=1#L208

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built server, started server, ran against OpenTelemetry-Tracing TCK

### Testing Environment
Windows 11, Zulu 11.0.20.1

## Documentation
N/A

## Notes for Reviewers
None
