### PR TITLE
FISH-7817 add-opens java.base/java.io for payara micro

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -221,7 +221,7 @@
                 <attribute name="Start-Class" value="fish.payara.micro.impl.PayaraMicroImpl"/>
                 <attribute name="Add-Exports" value="java.base/jdk.internal.ref jdk.naming.dns/com.sun.jndi.dns java.naming/com.sun.jndi.ldap"/>
                 <attribute name="Add-Opens"
-                           value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging"/>
+                           value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.base/java.io java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging"/>
             </manifest>
         </jar>
     </target>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright 2016-2022 Payara Foundation and/or its affiliates -->
+<!-- Portions Copyright 2016-2023 Payara Foundation and/or its affiliates -->
 
 <project name="payara-micro" default="new.create" basedir=".">
     <property name="rootdir" value="target"/>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Added add-opens `java.base/java.io` to the MANIFEST.MF for Payara Micro

Fixes #6406 

## Testing
### Testing Performed
Ran Cargotracker tests using Payara Micro 6.2023.10-SNAPSHOT on JDK17
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 22.04.2 LTS, Zulu JDK 17, Maven 3.8.6
