### PR TITLE
FISH-7846 Fix Missing Manpages

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -361,6 +361,27 @@
                 </configuration>
             </plugin>
 
+            <!-- Add manpages for asadmin commands -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/manpages</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -359,11 +359,6 @@
                     <version>${maven.apt.plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>${maven.build.helper.plugin.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco.plugin.version}</version>
@@ -431,27 +426,6 @@
                                 <message>You need Maven greater than 3.0.3 (3.2.2 not supported)</message>
                                 </requireMavenVersion>
                             </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-resource</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>add-resource</goal>
-                        </goals>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>src/main/manpages</directory>
-                                </resource>
-                            </resources>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Description
Some asadmin commands were missing their manpages for the --help option. This adds them back in.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built server, ran `asadmin create-domain --help` and got man page.

### Testing Environment
Windows 11, Zulu 11.0.20.1

## Documentation
N/A

## Notes for Reviewers
None
