### PR TITLE
FISH-7847 Fix InaccessibleObjectException for `javax.management` and `javax.management.openmbean` on JDK 17 & 21

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/domain.xml
@@ -212,6 +212,8 @@
                 <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
                 <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
                 <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
@@ -449,6 +451,8 @@
                 <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
                 <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
                 <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
                 <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>

--- a/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/domain.xml
@@ -207,6 +207,8 @@
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
@@ -440,6 +442,8 @@
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>

--- a/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template/src/main/resources/config/domain.xml
@@ -188,6 +188,8 @@
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
@@ -403,6 +405,8 @@
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>

--- a/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
+++ b/appserver/admin/production_domain_template_web/src/main/resources/config/domain.xml
@@ -211,6 +211,8 @@
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
@@ -420,6 +422,8 @@
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
         <jvm-options>[17|]--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>

--- a/appserver/extras/payara-micro/payara-micro-distribution/build.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/build.xml
@@ -221,7 +221,7 @@
                 <attribute name="Start-Class" value="fish.payara.micro.impl.PayaraMicroImpl"/>
                 <attribute name="Add-Exports" value="java.base/jdk.internal.ref jdk.naming.dns/com.sun.jndi.dns java.naming/com.sun.jndi.ldap"/>
                 <attribute name="Add-Opens"
-                           value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.base/java.io java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging"/>
+                           value="java.base/jdk.internal.loader java.base/java.lang java.base/java.net java.base/java.nio java.base/java.util java.base/sun.nio.ch java.management/sun.management jdk.management/com.sun.management.internal java.base/sun.net.www.protocol.jrt java.base/sun.net.www.protocol.jar java.base/java.io java.naming/javax.naming.spi java.rmi/sun.rmi.transport java.logging/java.util.logging java.management/javax.management java.management/javax.management.openmbean"/>
             </manifest>
         </jar>
     </target>

--- a/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
@@ -2,7 +2,7 @@
 <!--
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2016-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2016-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
@@ -147,7 +147,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${maven.failsafe.plugin.version}</version>
                         <configuration>
-                            <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                            <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.management/javax.management.openmbean=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.logging/java.util.logging=ALL-UNNAMED --add-opens=java.base/sun.net.www=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Description
Title.

Also adds extra required JVM options for Remote EJB Tracing test

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran Remote EJB Tracing test on JDK 17 AND 21 - no errors.

### Testing Environment
Windows 11, Zulu 17.0.8.1 & 21.0.0

## Documentation
N/A

## Notes for Reviewers
None
