### PR TITLE
FISH-7776: fixing naming for span to pass tck issues

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/WithSpanMethodInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/WithSpanMethodInterceptor.java
@@ -274,8 +274,8 @@ public class WithSpanMethodInterceptor {
     private String getWithSpanValue(final InvocationContext invocationContext, final WithSpan withSpan) {
         final String withSpanValue = withSpan.value();
         if (withSpanValue.isEmpty()) {
-            if(invocationContext.getMethod().getDeclaringClass().getName().contains("$")) {
-                return invocationContext.getMethod().getDeclaringClass().getSimpleName() 
+            if (invocationContext.getMethod().getDeclaringClass().getName().contains("$")) {
+                return invocationContext.getMethod().getDeclaringClass().getSimpleName()
                         + "." + invocationContext.getMethod().getName();
             } else {
                 return invocationContext.getMethod().getDeclaringClass().getCanonicalName()

--- a/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/WithSpanMethodInterceptor.java
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/src/main/java/fish/payara/microprofile/telemetry/tracing/WithSpanMethodInterceptor.java
@@ -274,8 +274,13 @@ public class WithSpanMethodInterceptor {
     private String getWithSpanValue(final InvocationContext invocationContext, final WithSpan withSpan) {
         final String withSpanValue = withSpan.value();
         if (withSpanValue.isEmpty()) {
-            return invocationContext.getMethod().getDeclaringClass().getCanonicalName()
-                    + "." + invocationContext.getMethod().getName();
+            if(invocationContext.getMethod().getDeclaringClass().getName().contains("$")) {
+                return invocationContext.getMethod().getDeclaringClass().getSimpleName() 
+                        + "." + invocationContext.getMethod().getName();
+            } else {
+                return invocationContext.getMethod().getDeclaringClass().getCanonicalName()
+                        + "." + invocationContext.getMethod().getName();
+            }
         }
         return withSpanValue;
     }

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTelemetryWithSpanIT.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTelemetryWithSpanIT.java
@@ -139,7 +139,7 @@ public class OpenTelemetryWithSpanIT extends AbstractSpanNameTest {
         var spans = exporter.getSpans();
         assertEquals(2, spans.size());
         assertEquals("SpanChildBean.spanChild", spans.get(0).getName());
-        assertEquals("SpanBean.spanChild", spans.get(1).getName());
+        assertEquals("fish.payara.samples.otel.annotation.SpanBean.spanChild", spans.get(1).getName());
         assertEquals(spans.get(0).getParentSpanId(), spans.get(1).getSpanId());
     }
 

--- a/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTelemetryWithSpanIT.java
+++ b/appserver/tests/payara-samples/samples/opentelemetry/src/test/java/fish/payara/samples/otel/spanname/OpenTelemetryWithSpanIT.java
@@ -138,8 +138,8 @@ public class OpenTelemetryWithSpanIT extends AbstractSpanNameTest {
         spanBean.spanChild();
         var spans = exporter.getSpans();
         assertEquals(2, spans.size());
-        assertEquals("fish.payara.samples.otel.annotation.SpanBean.SpanChildBean.spanChild", spans.get(0).getName());
-        assertEquals("fish.payara.samples.otel.annotation.SpanBean.spanChild", spans.get(1).getName());
+        assertEquals("SpanChildBean.spanChild", spans.get(0).getName());
+        assertEquals("SpanBean.spanChild", spans.get(1).getName());
         assertEquals(spans.get(0).getParentSpanId(), spans.get(1).getSpanId());
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fixing naming of span to fix TCK issues
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for the TCK issues reported from the last version of opentelemetry
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
now the TCK tests are passing:
`

[INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 220.243 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M5:verify (verify) @ MicroProfile-OpenTelemetry-Tracing ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

`
and full TCK

`

[INFO] Reactor Summary for MicroProfile TCK Suite Parent 1.1-SNAPSHOT:
[INFO]
[INFO] MicroProfile TCK Suite Parent ...................... SUCCESS [  0.375 s]
[INFO] MicroProfile Fault Tolerance TCK Runner ............ SUCCESS [04:41 min]
[INFO] MicroProfile JWT-Auth TCK Runner Parent ............ SUCCESS [  0.098 s]
[INFO] MicroProfile JWT Auth TCK Arquillian Extension ..... SUCCESS [  0.157 s]
[INFO] MicroProfile JWT-Auth TCK Runner ................... SUCCESS [ 48.569 s]
[INFO] MicroProfile Metrics TCK Runner .................... SUCCESS [01:00 min]
[INFO] MicroProfile Rest Client TCK Runner - Parent ....... SUCCESS [  0.008 s]
[INFO] MicroProfile Rest Client Apache HTTP Client Connector SUCCESS [  1.765 s]
[INFO] MicroProfile Rest Client TCK Runner - Arquillian Extension SUCCESS [  0.074 s]
[INFO] smallrye-config repackaged as a module ............. SUCCESS [  1.322 s]
[INFO] MicroProfile Rest Client TCK Runners - Parent ...... SUCCESS [  0.528 s]
[INFO] MicroProfile Rest Client TCK Runner - Default ...... SUCCESS [04:20 min]
[INFO] MicroProfile Rest Client TCK Runner - Apache HTTP Client SUCCESS [ 26.042 s]
[INFO] MicroProfile Health TCK Runner Parent .............. SUCCESS [  0.019 s]
[INFO] MicroProfile Health TCK Runner Arquillian Extension  SUCCESS [  0.093 s]
[INFO] MicroProfile Health TCK Runner ..................... SUCCESS [ 26.466 s]
[INFO] MicroProfile Config TCK Runner ..................... SUCCESS [01:01 min]
[INFO] MicroProfile OpenAPI TCK Runner .................... SUCCESS [ 45.925 s]
[INFO] MicroProfile-OpenTelemetry-Tracing ................. SUCCESS [03:42 min]
[INFO] MicroProfile OpenTracing TCK Runner ................ SUCCESS [ 55.589 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

`

payara samples are now passing:

`

[INFO] Reactor Summary for Payara Samples - root 6.2023.9-SNAPSHOT:
[INFO]
[INFO] Payara Samples - root .............................. SUCCESS [  0.532 s]
[INFO] Payara Samples - test-utils ........................ SUCCESS [  2.784 s]
[INFO] Payara Samples - Test Domain Setup ................. SUCCESS [ 34.428 s]
[INFO] Payara Samples - Payara - AsAdmin .................. SUCCESS [ 15.904 s]
[INFO] Payara Samples - Payara - ejb-invoker Secure Endpoint SUCCESS [ 22.668 s]
[INFO] Payara Samples - Parallel Tests Root ............... SUCCESS [  0.012 s]
[INFO] Payara Samples - Payara Expression MicroProfile Config Properties SUCCESS [  5.264 s]
[INFO] Payara Samples - Clustered Singleton Parent ........ SUCCESS [  0.010 s]
[INFO] Payara Samples - Clustered Singleton EJB ........... SUCCESS [  2.558 s]
[INFO] Payara Tests - Clustered Singleton Sample and Test . SUCCESS [  6.833 s]
[INFO] Payara Samples - Payara - Custom LoginModule/Realm . SUCCESS [  0.009 s]
[INFO] Payara Samples - Payara - Custom LoginModule/Realm - Implementation SUCCESS [  0.126 s]
[INFO] Payara Samples - Payara - Custom LoginModule/Realm - Test SUCCESS [  5.088 s]
[INFO] Payara Samples - Datagrid Encryption: Stateful Session Bean Passivation SUCCESS [  3.471 s]
[INFO] Payara Samples - Payara - Dynamic Roles ............ SUCCESS [  4.490 s]
[INFO] Payara Samples - Payara - FORM Auth ................ SUCCESS [  3.808 s]
[INFO] Payara Samples - Payara - Jacc Providers per Application SUCCESS [  4.099 s]
[INFO] Payara Samples - Payara - JAX-RS using RolesAllowed and EE Security SUCCESS [  2.379 s]
[INFO] Payara Samples - Payara - JAX-RS using RolesAllowed and Servlet Security SUCCESS [  2.926 s]
[INFO] Payara Samples - JAX-WS - Security ................. SUCCESS [  0.651 s]
[INFO] Payara Samples - Legacy mode of empty beans.xml .... SUCCESS [  2.602 s]
[INFO] Payara Samples - Payara - Microprofile Config ...... SUCCESS [  2.381 s]
[INFO] Payara Samples - Payara - Microprofile endpoints ... SUCCESS [  0.008 s]
[INFO] Payara Samples - Payara - Microprofile Secure endpoints SUCCESS [  3.348 s]
[INFO] Payara Samples - Payara - Microprofile insecure endpoints SUCCESS [  2.461 s]
[INFO] Payara Samples - MicroProfile Healthcheck Example .. SUCCESS [  2.931 s]
[INFO] Payara Samples - Payara - OAuth2 ................... SUCCESS [  3.097 s]
[INFO] Payara Samples - Payara - OpenId Connect ........... SUCCESS [ 19.999 s]
[INFO] Payara Samples - Payara - REST Management .......... SUCCESS [  8.088 s]
[INFO] Payara Samples - Payara - Roles Permitted .......... SUCCESS [  3.776 s]
[INFO] Payara Samples - Payara - Realm Identity Stores .... SUCCESS [  9.041 s]
[INFO] Payara Samples - Payara - Jakarta EE Namespace transformer SUCCESS [  2.572 s]
[INFO] Payara Samples - Logging ........................... SUCCESS [  8.086 s]
[INFO] Payara Samples - EJB http remoting ................. SUCCESS [ 11.319 s]
[INFO] Payara Samples - Remote EJB Tracing ................ SUCCESS [ 15.301 s]
[INFO] Payara Samples - RolesAllowed Unprotected Methods .. SUCCESS [  6.738 s]
[INFO] Payara Samples - Payara - Microprofile Rest Client Fault Tolerance SUCCESS [  2.814 s]
[INFO] Payara Samples - Payara - Multiple Keystores ....... SUCCESS [  2.405 s]
[INFO] Payara Samples - Payara - Concurrency .............. SUCCESS [ 25.827 s]
[INFO] Payara Samples - Reproducers ....................... SUCCESS [  7.247 s]
[INFO] Payara Samples - OpenTelemetry ..................... SUCCESS [ 12.974 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

`

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
