### PR TITLE
FISH-7865 Update to ASM 9.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,7 +107,7 @@
         <weld.version>5.0.1.Final</weld.version>
         <tyrus.version>2.1.3.payara-p1</tyrus.version>
         <jsp-impl.version>3.2.0</jsp-impl.version>
-        <asm.version>9.5</asm.version>
+        <asm.version>9.6</asm.version>
         <websocket-api.version>2.1.0</websocket-api.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
         <jstl-api.version>3.0.0</jstl-api.version>


### PR DESCRIPTION
Hi,

I'm trying to deploy my application in payara-embedded-all 6.2023.9 with the JDK21 and hit a ClassReader issue.
It seems that simply updating the ASM version to 9.6 solves the problem.