### PR TITLE
Update Enforcer to Allow Running Tests on JDK 21

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -246,7 +246,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[${jdk.version},21)</version>
+                                    <version>[${jdk.version},)</version>
                                     <message>You need at least JDK11</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -155,7 +155,7 @@
 
         <!-- build versions -->
         <jdk.version>11</jdk.version>
-        <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
+        <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>
         <command-security-plugin.version>1.0.13</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -406,32 +406,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven.enforcer.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[${jdk.version},18.9)</version>
-                                    <message>You need at least JDK11</message>
-                                </requireJavaVersion>
-                                <requireMavenVersion>
-                                    <version>[3.0.3,3.2.1],[3.2.3,)</version>
-                                <message>You need Maven greater than 3.0.3 (3.2.2 not supported)</message>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
                 <extensions>true</extensions>


### PR DESCRIPTION
## Description
Updates the enforcer settings to allow compiling and running tests on JDK 21.
Also removes redundant enforcer settings.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Tried to compile on JDK 21 - enforcer didn't trip.

### Testing Environment
Windows 11, Zulu 21.0.0

## Documentation
N/A

## Notes for Reviewers
None
