### PR TITLE
Fish-7158: adding warmup option to start domain

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherInfo.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherInfo.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation]
+// Portions Copyright [2016-2023] [Payara Foundation]
 
 package com.sun.enterprise.admin.launcher;
 
@@ -149,6 +149,12 @@ public class GFLauncherInfo {
         upgrade = b;
     }
 
+    /**
+     * Starts the server and after bootstrapping immediately stop
+     * @param b
+     */
+    public void setWarmup(boolean b) { warmup = b; }
+
     public void setDomainRootDir(File f) {
         domainRootDir = f;
     }
@@ -204,6 +210,12 @@ public class GFLauncherInfo {
     public boolean isUpgrade() {
         return upgrade;
     }
+
+    /**
+     * 
+     * @return true if the warmup is on.
+     */
+    public boolean isWarmup() { return warmup; }
 
     /**
      * 
@@ -337,6 +349,7 @@ public class GFLauncherInfo {
         map.put("-debug", Boolean.toString(debug));
         map.put("-instancename", instanceName);
         map.put("-upgrade", Boolean.toString(upgrade));
+        map.put("-warmup", Boolean.toString(warmup));
         map.put("-read-stdin", "true"); //always make the server read the stdin for master password, at least.
         
         if(respawnInfo != null) {
@@ -458,6 +471,12 @@ public class GFLauncherInfo {
             upgrade = true;
         else if(tsb.isFalse())
             upgrade = false;
+        
+        tsb = getBoolean("warmup");
+        if(tsb.isTrue())
+            warmup = true;
+        else if(tsb.isFalse())
+            warmup = false;
     }
 
     private void finalSetup() throws GFLauncherException {
@@ -607,6 +626,7 @@ public class GFLauncherInfo {
     private boolean watchdog = false;
     private boolean debug = false;
     private boolean upgrade = false;
+    private boolean warmup = false;
     File installDir;
     private File domainParentDir;
     private File domainRootDir;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -194,6 +194,7 @@ ServerStart.SuccessMessage=Successfully started the {0}: {1}\n{0} Location: {2}\
 ServerStart.DebuggerMessage=Debugging is enabled.  The debugging port is: {0}
 ServerStart.DebuggerSuspendedMessage=Debugging is enabled and the server is suspended.  \
 Please attach to the debugging port at: {0}
+ServerStart.SuccessWithWarmupEnabled=The server stops because warmup option was set to true. \nYou can reuse configuration because Server finishes after bootstrapping.
 DomainLocation=Started domain: {0}\nDomain location: {1}\nLog file: {2}
 DomainAdminPort=Admin port for the domain: {0}
 DomainDebugPort=Debug port for the domain: {0}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
@@ -101,6 +101,9 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
     @Param(defaultValue = "600", optional = true)
     protected int timeout;
     
+    @Param(optional = true, defaultValue = "false")
+    private boolean warmup;
+    
     @Inject
     ServerEnvironment senv;
     
@@ -181,6 +184,10 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
 
             doAdminPasswordCheck();
 
+            if(warmup) {
+                info.setWarmup(true);
+            }
+
             // launch returns very quickly if verbose is not set
             // if verbose is set then it returns after the domain dies
             launcher.launch();
@@ -247,6 +254,7 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
         info.setDebug(debug);
         info.setUpgrade(upgrade);
         info.setWatchdog(watchdog);
+        info.setWarmup(warmup);
         info.setDropInterruptedCommands(drop_interrupted_commands);
         info.setPrebootCommandsFile(preBootCommand);
         info.setpostbootCommandsFile(postBootCommand);
@@ -270,6 +278,7 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
         args.add("--verbose=" + verbose);
         args.add("--watchdog=" + watchdog);
         args.add("--debug=" + debug);
+        args.add("--warmup=" + warmup);
         args.add("--domaindir");
         args.add(getDomainsDir().toString());
         if (ok(getDomainName()))

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
@@ -185,7 +185,8 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
             doAdminPasswordCheck();
 
             if(warmup) {
-                info.setWarmup(true);
+                info.setWarmup(warmup);
+                helper.setWarmup(warmup);
             }
 
             // launch returns very quickly if verbose is not set

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -94,6 +94,8 @@ public class StartServerHelper {
     private final int debugPort;
     private final boolean isDebugSuspend;
     // only set when actively trouble-shooting or investigating...
+    
+    private boolean isWarmup = false;
     private static final  boolean DEBUG_MESSAGES_ON = false;
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(StartServerHelper.class);
     
@@ -273,6 +275,9 @@ public class StartServerHelper {
         if (debugPort >= 0) {
             logger.info(STRINGS.get("ServerStart.DebuggerMessage", "" + debugPort));
         }
+        if (isWarmup) {
+            logger.info(STRINGS.get("ServerStart.SuccessWithWarmupEnabled"));
+        }
     }
 
     /**
@@ -423,6 +428,14 @@ public class StartServerHelper {
             Environment env = new Environment();
             CLIUtil.writeCommandToDebugLog("restart-debug", env, new String[]{"DEBUG MESSAGE FROM RESTART JVM", s}, 99999);
         }
+    }
+    
+    public void setWarmup(boolean warmup) {
+        this.isWarmup = warmup;
+    }
+    
+    public boolean getWarmup() {
+        return isWarmup;
     }
 
     /**

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/LogFacade.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/LogFacade.java
@@ -265,6 +265,11 @@ public class LogFacade {
             message = "Got an unexpected exception.",
             level = "WARNING")
     public static final String CAUGHT_EXCEPTION = "NCLS-BOOTSTRAP-00039";
+    
+    @LogMessageInfo(
+            message = "The option warmup was set to true, stopping the server.",
+            level = "WARNING")
+    public static final String WARMUP_OPTION_AS_TRUE = "NCLS-BOOTSTRAP-00040";
 
 }
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishImpl.java
@@ -74,6 +74,11 @@ public class EmbeddedOSGiGlassFishImpl extends GlassFishDecorator {
     public void start() throws GlassFishException {
         super.start();
         registerService();
+        if(bundleContext.getProperty("-warmup") != null && bundleContext.getProperty("-warmup").equals("true")){
+            logger.log(Level.WARNING, LogFacade.WARMUP_OPTION_AS_TRUE);
+            stop();
+            System.exit(0);
+        }
     }
 
     @Override

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -50,6 +50,9 @@ import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.bootstrap.ModuleStartup;
 import com.sun.enterprise.module.bootstrap.StartupContext;
 import com.sun.enterprise.util.Result;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -61,12 +64,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jakarta.inject.Inject;
-import jakarta.inject.Provider;
-import jakarta.inject.Singleton;
 import org.glassfish.api.FutureProvider;
 import org.glassfish.api.StartupRunLevel;
-import org.glassfish.api.admin.CommandRunner;
 import org.glassfish.api.admin.ProcessEnvironment;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.event.EventListener.Event;
@@ -376,13 +375,6 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             long postStartupFinishTime = System.currentTimeMillis();
             logger.log(level, "PostStartup level done in " +
                 (postStartupFinishTime - startupFinishTime) + " ms");
-        }
-        if(context.getArguments().containsKey("-warmup") && 
-                context.getArguments().getProperty("-warmup").equals("true")){
-            logger.info(String.format("Doing warmup stop of server, " +
-                    "please check configurations to be reused on another server instances"));
-            stop();
-            return false;
         }
         return true;
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -377,6 +377,13 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             logger.log(level, "PostStartup level done in " +
                 (postStartupFinishTime - startupFinishTime) + " ms");
         }
+        if(context.getArguments().containsKey("-warmup") && 
+                context.getArguments().getProperty("-warmup").equals("true")){
+            logger.info(String.format("Doing warmup stop of server, " +
+                    "please check configurations to be reused on another server instances"));
+            stop();
+            return false;
+        }
         return true;
     }
     


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Adding warmup option to stop server after bootstrapping
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a feature to replicate same functionality from payara micro to payara server with the start-domain command
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing, the server stops after bootstrapping
message from logs:

`
payara6/bin$ ./asadmin start-domain --warmup
Waiting for domain1 to start .......
Successfully started the domain : domain1
domain  Location: /home/alfv83/projects/Payara/appserver/distributions/payara/target/stage/payara6/glassfish/domains/domain1
Log File: /home/alfv83/projects/Payara/appserver/distributions/payara/target/stage/payara6/glassfish/domains/domain1/logs/server.log
Admin Port: 4848
The server stops because warmup option was set to true.
You can reuse configuration because Server finishes after bootstrapping.
Command start-domain executed successfully.
`

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11 with azul JDK 11, maven 3.8.3 and Ubuntu 20.04 with azul JDK 11, maven 3.8.6 
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
