### PR TITLE
FISH-7953 Fix Cannot Load Custom Realm Class Error on Windows

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/Realm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/Realm.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2020] Payara Foundation and/or affiliates
+// Portions Copyright 2018-2023 Payara Foundation and/or affiliates
 
 package com.sun.enterprise.security.auth.realm;
 
@@ -51,6 +51,7 @@ import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.INFO;
 import static org.glassfish.external.probe.provider.PluginPoint.SERVER;
 
+import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -368,7 +369,7 @@ public abstract class Realm extends AbstractStatefulRealm implements Comparable<
                             serviceLocator.getService(ClassLoaderHierarchy.class).getCommonClassLoader();
                     String realmJarPath = props.getProperty("realmJarPath");
                     if (realmJarPath != null) {
-                        commonClassLoader.addURL(new URL("file://" + realmJarPath));
+                        commonClassLoader.addURL(Paths.get(realmJarPath).toUri().toURL());
                     }
                     // TODO: workaround here. Once fixed in V3 we should be able to use
                     // Context ClassLoader instead.


### PR DESCRIPTION
## Description
Fixes the Custom LoginModule/Realm feature for Windows. 
When running the `create-auth-realm` command to utilise a custom realm it fails because the `realmJarPath` property resolves to an incorrect URL on Windows.

The path `C:\asd\dsa\example.jar` ends up being registered to the class loader as `file://C:/asd/dsa/example.jar` which is an incorrect URL: it should either be `file:/C:/asd/dsa/example.jar` or `file:///C:/asd/dsa/example.jar`

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the custom-loginmodule-realm sample on Windows and WSL.

### Testing Environment
Windows 11, Zulu JDK 11.0.20.1.
WSL OpenSUSE Leap 15.5

## Documentation
N/A

## Notes for Reviewers
None
