### PR TITLE
FISH-7132 : handling deployment groups  in the same way done by clusters

### DIFF
--- a/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/JMSDestination.java
+++ b/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/JMSDestination.java
@@ -37,38 +37,43 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-//Portions Copyright [2017-2021] Payara Foundation and/or affiliates
+//Portions Copyright [2017-2023] Payara Foundation and/or affiliates
 
 package org.glassfish.jms.admin.cli;
 
+import com.sun.appserv.connectors.internal.api.ConnectorConstants;
+import com.sun.appserv.connectors.internal.api.ConnectorRuntime;
+import com.sun.appserv.connectors.internal.api.ConnectorRuntimeException;
+import com.sun.appserv.connectors.internal.api.ConnectorsUtil;
+import com.sun.enterprise.config.serverbeans.Cluster;
+import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.config.serverbeans.Server;
+import com.sun.enterprise.connectors.ConnectorRegistry;
 import com.sun.enterprise.connectors.jms.config.JmsHost;
 import com.sun.enterprise.connectors.jms.config.JmsService;
 import com.sun.enterprise.connectors.jms.system.ActiveJmsResourceAdapter;
 import com.sun.enterprise.connectors.jms.system.MQAddressList;
 import com.sun.enterprise.connectors.jms.util.JmsRaUtil;
-import com.sun.enterprise.connectors.ConnectorRegistry;
 import com.sun.enterprise.util.LocalStringManagerImpl;
-import com.sun.enterprise.config.serverbeans.*;
-import com.sun.appserv.connectors.internal.api.ConnectorRuntimeException;
-import com.sun.appserv.connectors.internal.api.ConnectorConstants;
-import com.sun.appserv.connectors.internal.api.ConnectorsUtil;
-import com.sun.appserv.connectors.internal.api.ConnectorRuntime;
-
-import jakarta.resource.spi.ResourceAdapter;
-import javax.management.AttributeList;
-import javax.management.Attribute;
-import java.util.logging.Logger;
-import java.util.logging.Level;
-import java.util.*;
-import java.lang.reflect.Method;
-import java.io.StringWriter;
-import java.io.PrintWriter;
-
-import com.sun.enterprise.config.serverbeans.Cluster;
-import org.glassfish.internal.api.ServerContext;
-import org.glassfish.internal.api.Globals;
-import org.glassfish.config.support.TargetType;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import org.glassfish.config.support.CommandTarget;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.api.ServerContext;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import jakarta.resource.spi.ResourceAdapter;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public abstract class JMSDestination {
 
@@ -76,608 +81,577 @@ public abstract class JMSDestination {
     final private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(CreateJMSDestination.class);
 
     // JMS destination types
-           public static final String JMS_DEST_TYPE_TOPIC		= "topic";
-           public static final String JMS_DEST_TYPE_QUEUE		= "queue";
-           public static final String DEFAULT_MAX_ACTIVE_CONSUMERS = "-1";
-           public static final String MAX_ACTIVE_CONSUMERS_ATTRIBUTE = "MaxNumActiveConsumers";
-           public static final String MAX_ACTIVE_CONSUMERS_PROPERTY = "maxNumActiveConsumers";
-           public static final String JMXSERVICEURLLIST = "JMXServiceURLList";
-           public static final String JMXCONNECTORENV = "JMXConnectorEnv";
-           // flag to enable the use of JMX for JMS destination commands
-           // if false uses the old behavior
-           // The value for DONT_USE_MQ_JMX can be set thru sysproperty
-           private static final boolean USE_JMX =  true;//!(Boolean.getBoolean("DONT_USE_MQ_JMX"));
-           //Following properties are from com.sun.messaging.jms.management.server.MQObjectName
-            /*   Domain name for MQ MBeans   */
-           protected static final String MBEAN_DOMAIN_NAME = "com.sun.messaging.jms.server";
-            /* String representation of the ObjectName for the DestinationManager Config MBean. */
-           protected static final String DESTINATION_MANAGER_CONFIG_MBEAN_NAME
-    			= MBEAN_DOMAIN_NAME
-				+ ":type=" + "DestinationManager"
-				+ ",subtype=Config";
-           
-	   protected static final String CLUSTER_CONFIG_MBEAN_NAME
-    			= MBEAN_DOMAIN_NAME
-				+ ":type=" + "Cluster"
-				+ ",subtype=Config";
-            // Queue destination type
-            protected static final String DESTINATION_TYPE_QUEUE= "q";
-            //Topic destination type
-            protected static final String DESTINATION_TYPE_TOPIC = "t";
-
+    public static final String JMS_DEST_TYPE_TOPIC		= "topic";
+    public static final String JMS_DEST_TYPE_QUEUE		= "queue";
+    public static final String DEFAULT_MAX_ACTIVE_CONSUMERS = "-1";
+    public static final String MAX_ACTIVE_CONSUMERS_ATTRIBUTE = "MaxNumActiveConsumers";
+    public static final String MAX_ACTIVE_CONSUMERS_PROPERTY = "maxNumActiveConsumers";
+    public static final String JMXSERVICEURLLIST = "JMXServiceURLList";
+    public static final String JMXCONNECTORENV = "JMXConnectorEnv";
+    // flag to enable the use of JMX for JMS destination commands
+    // if false uses the old behavior
+    // The value for DONT_USE_MQ_JMX can be set thru sysproperty
+    private static final boolean USE_JMX =  true;//!(Boolean.getBoolean("DONT_USE_MQ_JMX"));
+    //Following properties are from com.sun.messaging.jms.management.server.MQObjectName
+    /*   Domain name for MQ MBeans   */
+    protected static final String MBEAN_DOMAIN_NAME = "com.sun.messaging.jms.server";
+    /* String representation of the ObjectName for the DestinationManager Config MBean. */
+    protected static final String DESTINATION_MANAGER_CONFIG_MBEAN_NAME
+            = MBEAN_DOMAIN_NAME
+            + ":type=" + "DestinationManager"
+            + ",subtype=Config";
+    protected static final String CLUSTER_CONFIG_MBEAN_NAME
+            = MBEAN_DOMAIN_NAME
+            + ":type=" + "Cluster"
+            + ",subtype=Config";
+    // Queue destination type
+    protected static final String DESTINATION_TYPE_QUEUE= "q";
+    //Topic destination type
+    protected static final String DESTINATION_TYPE_TOPIC = "t";
 
     protected void validateJMSDestName(String destName) {
-                if(destName==null || destName.length() <= 0 || destName.contains("/")){
-                    throw new IllegalArgumentException(localStrings.getLocalString("admin.mbeans.rmb.invalid_jms_destname",destName));
-                }                
-         }
+        if (destName == null || destName.length() <= 0 || destName.contains("/")) {
+            throw new IllegalArgumentException(localStrings.getLocalString("admin.mbeans.rmb.invalid_jms_destname", destName));
+        }
+    }
 
-        protected void validateJMSDestType(String destType) {
-            if(destType==null || destType.length() <= 0)
-                throw new IllegalArgumentException(localStrings.getLocalString("admin.mbeans.rmb.invalid_jms_desttype",destType));
-            if(!destType.equals(JMS_DEST_TYPE_QUEUE) &&
-                 !destType.equals(JMS_DEST_TYPE_TOPIC))
-                throw new IllegalArgumentException(localStrings.getLocalString("admin.mbeans.rmb.invalid_jms_desttype",destType));
-         }
-        
+    protected void validateJMSDestType(String destType) {
+        if (destType == null || destType.length() <= 0)
+            throw new IllegalArgumentException(localStrings.getLocalString("admin.mbeans.rmb.invalid_jms_desttype", destType));
+        if (!destType.equals(JMS_DEST_TYPE_QUEUE) &&
+                !destType.equals(JMS_DEST_TYPE_TOPIC))
+            throw new IllegalArgumentException(localStrings.getLocalString("admin.mbeans.rmb.invalid_jms_desttype", destType));
+    }
+
     protected MQJMXConnectorInfo getMQJMXConnectorInfo(String target, Config config, ServerContext serverContext, Domain domain, ConnectorRuntime connectorRuntime)
-                                                        throws Exception {
-                    logger.log(Level.FINE, "getMQJMXConnectorInfo for " + target);
-                    MQJMXConnectorInfo mcInfo = null;
+            throws Exception {
+        logger.log(Level.FINE, "getMQJMXConnectorInfo for " + target);
+        MQJMXConnectorInfo mcInfo = null;
 
-                    try {
-                            MQJMXConnectorInfo [] cInfo =
-                                    getMQJMXConnectorInfos(target, config, serverContext, domain, connectorRuntime);
-                            if (cInfo.length < 1) {
-                                    throw new Exception(
-                            localStrings.getLocalString("admin.mbeans.rmb.error_obtaining_jms", "Error obtaining JMS Info"));
-                            }
-                            mcInfo = cInfo[0];
-
-                    } catch (Exception e) {
-                        handleException(e);
-                    }
-                    return mcInfo;
+        try {
+            MQJMXConnectorInfo[] cInfo =
+                    getMQJMXConnectorInfos(target, config, serverContext, domain, connectorRuntime);
+            if (cInfo.length < 1) {
+                throw new Exception(
+                        localStrings.getLocalString("admin.mbeans.rmb.error_obtaining_jms", "Error obtaining JMS Info"));
             }
+            mcInfo = cInfo[0];
 
-        protected MQJMXConnectorInfo[] getMQJMXConnectorInfos(final String target, final Config config, final ServerContext serverContext, final Domain domain, ConnectorRuntime connectorRuntime)
-                                       throws ConnectorRuntimeException {
-               try {
-                   final JmsService jmsService = config.getExtensionByType(JmsService.class);
+        } catch (Exception e) {
+            handleException(e);
+        }
+        return mcInfo;
+    }
 
-                   ActiveJmsResourceAdapter air = getMQAdapter(connectorRuntime);
-                   final Class mqRAClassName = air.getResourceAdapter().getClass();
-                   final CommandTarget ctarget = this.getTypeForTarget(target);
-                   MQJMXConnectorInfo mqjmxForServer = (MQJMXConnectorInfo)
-                   java.security.AccessController.doPrivileged
-                       (new java.security.PrivilegedExceptionAction() {
-                        public java.lang.Object run() throws Exception {
-                            if(ctarget == CommandTarget.CLUSTER || ctarget == CommandTarget.CLUSTERED_INSTANCE) {
-                                if (logger.isLoggable(Level.FINE)) {
-                                    logger.log(Level.FINE, "Getting JMX connector for"  +
-                                                               " cluster target " + target);
+    protected MQJMXConnectorInfo[] getMQJMXConnectorInfos(final String target, final Config config, final ServerContext serverContext, final Domain domain, ConnectorRuntime connectorRuntime)
+            throws ConnectorRuntimeException {
+        try {
+            final JmsService jmsService = config.getExtensionByType(JmsService.class);
+
+            ActiveJmsResourceAdapter air = getMQAdapter(connectorRuntime);
+            final Class mqRAClassName = air.getResourceAdapter().getClass();
+            final CommandTarget ctarget = this.getTypeForTarget(target);
+            MQJMXConnectorInfo mqjmxForServer = (MQJMXConnectorInfo)
+                    java.security.AccessController.doPrivileged
+                            (new java.security.PrivilegedExceptionAction() {
+                                public java.lang.Object run() throws Exception {
+                                    if (ctarget == CommandTarget.CLUSTER || ctarget == CommandTarget.CLUSTERED_INSTANCE) {
+                                        if (logger.isLoggable(Level.FINE)) {
+                                            logger.log(Level.FINE, "Getting JMX connector for cluster target " + target);
+                                        }
+                                        return _getMQJMXConnectorInfoForCluster(target,
+                                                jmsService, mqRAClassName, serverContext);
+                                    } else if (ctarget == CommandTarget.DEPLOYMENT_GROUP) {
+                                        if (logger.isLoggable(Level.FINE)) {
+                                            logger.log(Level.FINE, "Getting JMX connector for" +
+                                                    " cluster target " + target);
+                                        }
+                                        return _getMQJMXConnectorInfoForDeploymentGroup(target,
+                                                jmsService, mqRAClassName, serverContext);
+                                    } else {
+                                        if (logger.isLoggable(Level.FINE)) {
+                                            logger.log(Level.FINE, "Getting JMX connector for" +
+                                                    " standalone target " + target);
+                                        }
+                                        return _getMQJMXConnectorInfo(target,
+                                                jmsService, mqRAClassName, serverContext, config, domain);
+                                    }
                                 }
-                                return _getMQJMXConnectorInfoForCluster(target,
-                                                             jmsService, mqRAClassName, serverContext);
-                            } else {
-                                if (logger.isLoggable(Level.FINE)) {
-                                    logger.log(Level.FINE, "Getting JMX connector for" +
-                                                          " standalone target " + target);
-                                }
-                                return _getMQJMXConnectorInfo(target,
-                                                             jmsService, mqRAClassName, serverContext, config, domain);                    }
-                        }
-                   });
+                            });
 
-                   return new MQJMXConnectorInfo[]{mqjmxForServer};
-               } catch (Exception e) {
-                   //e.printStackTrace();
-                   ConnectorRuntimeException cre = new ConnectorRuntimeException(e.getMessage());
-                   cre.initCause(e);
-                   throw cre;
-               }
-           }
+            return new MQJMXConnectorInfo[]{mqjmxForServer};
+        } catch (Exception e) {
+            throw new ConnectorRuntimeException(e.getMessage(), e);
+        }
+    }
 
+    protected MQJMXConnectorInfo _getMQJMXConnectorInfo(
+            String targetName, JmsService jmsService, Class mqRAClassName, ServerContext serverContext, Config config, Domain domain)
+            throws ConnectorRuntimeException {
+        try {
+            String connectionURL = null;
+            MQAddressList mqadList = new MQAddressList();
 
-        protected MQJMXConnectorInfo _getMQJMXConnectorInfo(
-                           String targetName, JmsService jmsService, Class mqRAClassName, ServerContext serverContext, Config config, Domain domain)
-                                               throws ConnectorRuntimeException {
-               try {
-                   //If DAS, use the default address list, else obtain
-
-                   String connectionURL = null;
-                   MQAddressList mqadList = new MQAddressList();
-                   //boolean isDAS = mqadList.isDAS(targetName);
-
-                   if (getTypeForTarget(targetName) == CommandTarget.DAS) {
-                       connectionURL = getDefaultAddressList(jmsService).toString();
-                   } else {
-                       //Standalone server instance
-                       if (logger.isLoggable(Level.FINE)) {
-                           logger.log(Level.FINE,"not in DAS");
-                           logger.log(Level.FINE," _getMQJMXConnectorInfo - NOT in DAS");
-                       }
-                       JmsService serverJmsService= getJmsServiceOfStandaloneServerInstance(targetName, config, domain);
-                       //MQAddressList mqadList = new MQAddressList(serverJmsService, targetName);
-                       mqadList.setJmsService(serverJmsService);
-                       mqadList.setTargetName(targetName);
-                       mqadList.setup(false);
-                       connectionURL = mqadList.toString();
-                   }
-                   if (logger.isLoggable(Level.FINE)) {
-                       logger.log(Level.FINE, " _getMQJMXConnectorInfo - connection URL " + connectionURL);
-                   }
-                   String adminUserName = null;
-                String adminPassword = null;
-                JmsHost jmsHost = mqadList.getDefaultJmsHost(jmsService);
-                if (jmsHost != null) {//&& jmsHost.isEnabled()) {
-                    adminUserName = jmsHost.getAdminUserName();
-                    adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
-                } else {
-                    if (logger.isLoggable(Level.FINE)) {
-                        logger.log(Level.FINE, " _getMQJMXConnectorInfo, using default jms admin user and password ");
-                    }
-                }
-                ResourceAdapter raInstance = getConfiguredRA(mqRAClassName,
-                            connectionURL, adminUserName, adminPassword);
-                   String jmxServiceURL = null, jmxServiceURLList = null;
-                   Map<String, ?> jmxConnectorEnv = null;
-                   Method[] methds = raInstance.getClass().getMethods();
-                   for (int i = 0; i < methds.length; i++) {
-                       Method m = methds[i];
-               if (m.getName().equalsIgnoreCase("get" + JMXSERVICEURLLIST)){
-                           jmxServiceURLList = (String)m.invoke(raInstance, new Object[]{});
-                       } else if (m.getName().equalsIgnoreCase("get" + JMXCONNECTORENV)){
-                           jmxConnectorEnv = (Map<String,?>)m.invoke(raInstance, new Object[]{});
-                       }
-                   }
-                   if (logger.isLoggable(Level.FINE)) {
-                       logger.log(Level.FINE, " _getMQJMXConnectorInfo - jmxServiceURLList " +  jmxServiceURLList);
-                       logger.log(Level.FINE, " _getMQJMXConnectorInfo - jmxConnectorEnv " + jmxConnectorEnv);
-                   }
-                   jmxServiceURL = getFirstJMXServiceURL(jmxServiceURLList);
-
-                   MQJMXConnectorInfo mqInfo = new MQJMXConnectorInfo(targetName,
-                                   ActiveJmsResourceAdapter.getBrokerInstanceName(jmsService) ,
-                                   jmsService.getType(), jmxServiceURL, jmxConnectorEnv);
-                   return mqInfo;
-               } catch (Exception e) {
-                   e.printStackTrace();
-                   ConnectorRuntimeException cre = new ConnectorRuntimeException(e.getMessage());
-                   cre.initCause(e);
-                   throw cre;
-               }
-           }
-
-        /**
-          *  Gets the <code>MQJMXConnector</code> object for a cluster. Since this code is
-          *  executed in DAS, an admin API is used to resolve hostnames and ports of
-          *  cluster instances for LOCAL type brokers while creating the connectionURL.
-          */
-         protected  MQJMXConnectorInfo _getMQJMXConnectorInfoForCluster(
-                         String target, JmsService jmsService, Class mqRAClassName, ServerContext serverContext)
-                         throws ConnectorRuntimeException {
-            // Create a new RA instance.
-             ResourceAdapter raInstance = null;
-             // Set the ConnectionURL
-            MQAddressList list = null;
-             try {
-                 if (jmsService.getType().equalsIgnoreCase(ActiveJmsResourceAdapter.REMOTE)) {
-                     list = getDefaultAddressList(jmsService);
-                 } else {
-                     list = new MQAddressList();
-                     CommandTarget ctarget = this.getTypeForTarget(target);
-                     if (ctarget == CommandTarget.CLUSTER)
-                     {
-                         Server[] servers = list.getServersInCluster(target);
-                         if (servers != null && servers.length > 0)
-                            list.setInstanceName(servers[0].getName());
-                     } else if (ctarget == CommandTarget.CLUSTERED_INSTANCE ){
-                         list.setInstanceName(target);
-                     }
-                     java.util.Map<String,JmsHost> hostMap =  list.getResolvedLocalJmsHostsInMyCluster(true);
-
-                     if ( hostMap.size() == 0 ) {
-                         String msg = localStrings.getLocalString("mqjmx.no_jms_hosts", "No JMS Hosts Configured");
-                         throw new ConnectorRuntimeException(msg);
-
-                     }
-
-
-                     for (JmsHost host : hostMap.values()) {
-                         list.addMQUrl(host);
-                     }
-                 }
-
-              String connectionUrl = list.toString();
-              String adminUserName = null;
-              String adminPassword = null;
-              JmsHost jmsHost = list.getDefaultJmsHost(jmsService);
-              if (jmsHost != null){// && jmsHost.isEnabled()) {
-                  adminUserName = jmsHost.getAdminUserName();
-                  adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
-              } else {
-                  if (logger.isLoggable(Level.FINE)) {
-                      logger.log(Level.FINE, " _getMQJMXConnectorInfo, using default jms admin user and password ");
-                  }
-              }
-               raInstance = getConfiguredRA(mqRAClassName, connectionUrl,
-                                           adminUserName, adminPassword);
-             } catch (Exception e) {
-                 e.printStackTrace();
-                 ConnectorRuntimeException cre = new ConnectorRuntimeException(e.getMessage());
-                 cre.initCause(e);
-                 throw cre;
-             }
-
-             try {
-                 String jmxServiceURL = null, jmxServiceURLList = null;
-                 Map<String, ?> jmxConnectorEnv = null;
-                 Method[] methds = raInstance.getClass().getMethods();
-                 for (int i = 0; i < methds.length; i++) {
-                     Method m = methds[i];
-                     if (m.getName().equalsIgnoreCase("get" + JMXSERVICEURLLIST)){
-                         jmxServiceURLList = (String)m.invoke(raInstance, new Object[]{});
-                         if (jmxServiceURLList != null && !jmxServiceURLList.trim().equals("")){
-                             jmxServiceURL = getFirstJMXServiceURL(jmxServiceURLList);
-                         }
-                     } else if (m.getName().equalsIgnoreCase("get" + JMXCONNECTORENV)){
-                         jmxConnectorEnv = (Map<String,?>)m.invoke(raInstance, new Object[]{});
-                     }
-                 }
-                 MQJMXConnectorInfo mqInfo = new MQJMXConnectorInfo(target,
-                                 ActiveJmsResourceAdapter.getBrokerInstanceName(jmsService) ,
-                                 jmsService.getType(), jmxServiceURL, jmxConnectorEnv);
-                 return mqInfo;
-             } catch (Exception e) {
-                 e.printStackTrace();
-                 ConnectorRuntimeException cre = new ConnectorRuntimeException(e.getMessage());
-                 cre.initCause(e);
-                 throw cre;
-             }
-         }
-
-      /*  protected boolean isAConfig(String targetName) throws Exception {
-                Domain domain = Globals.get(Domain.class);
-                Configs configs = domain.getConfigs();
-                List configsList = configs.getConfig();
-                for (int i =0; i < configsList.size(); i++){
-                    Config config = (Config)configsList.get(i);
-                    if (targetName.equals(config.getName()))
-                        return true;
-                }
-                return false;
-                //ConfigContext con = com.sun.enterprise.admin.server.core.AdminService.getAdminService().getAdminContext().getAdminConfigContext();
-                //return ServerHelper.isAConfig(con, targetName);
-            } */
-
-     /*   protected JmsHost getDefaultJmsHost(JmsService jmsService){
-            String defaultJmsHost = jmsService.getDefaultJmsHost();
-            JmsHost jmsHost = null;
-           if (defaultJmsHost == null || defaultJmsHost.equals("")) {
-                 try {
-                         jmsHost = jmsService.getJmsHost().get(0);
-                 }catch (Exception e) {
-                     ;
-                 }
+            if (getTypeForTarget(targetName) == CommandTarget.DAS) {
+                connectionURL = getDefaultAddressList(jmsService).toString();
             } else {
-                    for (JmsHost defaultHost: jmsService.getJmsHost())
-                        if(defaultJmsHost.equals(defaultHost.getName()))
-                            jmsHost = defaultHost;
-            }
-            return jmsHost;
-        } */
-
-        /* protected Map<String, JmsHost> getResolvedLocalJmsHostsInCluster(String clusterName, MQAddressList list) {
-             Map<String, JmsHost> map = new HashMap<String, JmsHost> ();
-
-             Domain domain = Globals.get(Domain.class);
-             Clusters clusters = domain.getClusters();
-             List clusterList = clusters.getCluster();
-             Cluster cluster = null;
-             for (int i =0; i < clusterList.size(); i++){
-                if (clusterName.equals(((Cluster)clusterList.get(i)).getName()))
-                    cluster =    (Cluster)clusterList.get(i);
-             }
-
-        //final String myCluster      = ClusterHelper.getClusterByName(domainCC, clusterName).getName();
-	    final Server[] buddies      = this.getServersInCluster(cluster);//ServerHelper.getServersInCluster(domainCC, myCluster);
-        final Config cfg =  getConfigForServer(buddies[0]);
-
-             final String myCluster      = ClusterHelper.getClusterByName(domainCC, clusterName).getName();
-             final Server[] buddies      = ServerHelper.getServersInCluster(domainCC, myCluster);
-             for (final Server as : buddies) {
-             try {
-                 final JmsHost copy   = getResolvedJmsHost(as);
-                 map.put(as.getName(), copy);
-                } catch (Exception e) {
-                    // we dont add the host if we cannot get it
-                    ;
+                //Standalone server instance
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, "not in DAS");
+                    logger.log(Level.FINE, " _getMQJMXConnectorInfo - NOT in DAS");
                 }
-             }
-             return map;
-        } */
-
-            /*
-         *  Configures an instance of MQ-RA with the connection URL passed in.
-         *  This configured RA is then used to obtain the JMXServiceURL/JMXServiceURLList
-         */
-        protected ResourceAdapter getConfiguredRA(Class mqRAclassname,
-                                                  String connectionURL, String adminuser,
-                                                  String adminpasswd) throws Exception {
-            ResourceAdapter raInstance = (ResourceAdapter) mqRAclassname.newInstance();
-            Method setConnectionURL = mqRAclassname.getMethod(
-                           "set" + ActiveJmsResourceAdapter.CONNECTION_URL,
-                            new Class[] { String.class});
-            setConnectionURL.invoke(raInstance, new Object[] {connectionURL});
+                JmsService serverJmsService = getJmsServiceOfStandaloneServerInstance(targetName, config, domain);
+                mqadList.setJmsService(serverJmsService);
+                mqadList.setTargetName(targetName);
+                logger.log(Level.FINE, "JMSDestination L204 NOT CLUSTERED");
+                mqadList.setup(false);
+                connectionURL = mqadList.toString();
+            }
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, " getConfiguredRA - set connectionURL as " + connectionURL);
+                logger.log(Level.FINE, " _getMQJMXConnectorInfo - connection URL " + connectionURL);
             }
-            if (adminuser != null) {
-                 Method setAdminUser = mqRAclassname.getMethod(
-                       "set" + ActiveJmsResourceAdapter.ADMINUSERNAME,
-                        new Class[] { String.class});
-             setAdminUser.invoke(raInstance, new Object[] {adminuser});
-             if (logger.isLoggable(Level.FINE)) {
-                 logger.log(Level.FINE, " getConfiguredRA - set admin user as " + adminuser);
-             }
-          }
-          if (adminpasswd != null) {
-              Method setAdminPasswd = mqRAclassname.getMethod(
-                           "set" + ActiveJmsResourceAdapter.ADMINPASSWORD,
-                                 new Class[] { String.class});
-              setAdminPasswd.invoke(raInstance, new Object[] {adminpasswd});
-              if (logger.isLoggable(Level.FINE)) {
-                  logger.log(Level.FINE, " getConfiguredRA - set admin passwd as *****  ");
-              }
-          }
-             return raInstance;
-        }
-
-            private JmsService getJmsServiceOfStandaloneServerInstance(String target, Config cfg, Domain domain) throws Exception {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.log(Level.FINE, "getJMSServiceOfSI LL " + target);
-                    //ConfigContext con = com.sun.enterprise.admin.server.core.AdminService.getAdminService().getAdminContext().getAdminConfigContext();
-                    logger.log(Level.FINE, "cfg " + cfg);
-                }
-                JmsService jmsService = cfg.getExtensionByType(JmsService.class);
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.log(Level.FINE, "jmsservice " + jmsService);
-                }
-                return jmsService;
-            }
-
-
-         protected String getFirstJMXServiceURL(String jmxServiceURLList) {
-            //If type is REMOTE, MQ RA returns a null jmxServiceURL and a non-null
-            //jmxServiceURLList for PE also.
-            if ((jmxServiceURLList == null) || ("".equals(jmxServiceURLList))) {
-                return jmxServiceURLList;
+            String adminUserName = null;
+            String adminPassword = null;
+            JmsHost jmsHost = mqadList.getDefaultJmsHost(jmsService);
+            if (jmsHost != null) {
+                adminUserName = jmsHost.getAdminUserName();
+                adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
             } else {
-                StringTokenizer tokenizer = new StringTokenizer(jmxServiceURLList, " ");
-                return  tokenizer.nextToken();
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, " _getMQJMXConnectorInfo, using default jms admin user and password ");
+                }
             }
+            ResourceAdapter raInstance = getConfiguredRA(mqRAClassName,
+                    connectionURL, adminUserName, adminPassword);
+            String jmxServiceURL = null, jmxServiceURLList = null;
+            Map<String, ?> jmxConnectorEnv = null;
+            Method[] methds = raInstance.getClass().getMethods();
+            for (int i = 0; i < methds.length; i++) {
+                Method m = methds[i];
+                if (m.getName().equalsIgnoreCase("get" + JMXSERVICEURLLIST)) {
+                    jmxServiceURLList = (String) m.invoke(raInstance, new Object[]{});
+                } else if (m.getName().equalsIgnoreCase("get" + JMXCONNECTORENV)) {
+                    jmxConnectorEnv = (Map<String, ?>) m.invoke(raInstance, new Object[]{});
+                }
+            }
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, " _getMQJMXConnectorInfo - jmxServiceURLList " + jmxServiceURLList);
+                logger.log(Level.FINE, " _getMQJMXConnectorInfo - jmxConnectorEnv " + jmxConnectorEnv);
+            }
+            jmxServiceURL = getFirstJMXServiceURL(jmxServiceURLList);
+
+            return new MQJMXConnectorInfo(targetName,
+                    ActiveJmsResourceAdapter.getBrokerInstanceName(jmsService),
+                    jmsService.getType(), jmxServiceURL, jmxConnectorEnv);
+        } catch (Exception e) {
+            throw new ConnectorRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Gets the <code>MQJMXConnector</code> object for a deployment group. Since this code is
+     * executed in DAS, an admin API is used to resolve hostnames and ports of
+     * cluster instances for LOCAL type brokers while creating the connectionURL.
+     */
+    protected MQJMXConnectorInfo _getMQJMXConnectorInfoForDeploymentGroup(String target, JmsService jmsService, Class mqRAClassName, ServerContext serverContext)
+            throws ConnectorRuntimeException {
+        ResourceAdapter raInstance = null;
+        MQAddressList list = null;
+        try {
+            if (jmsService.getType().equalsIgnoreCase(ActiveJmsResourceAdapter.REMOTE)) {
+                list = getDefaultAddressList(jmsService);
+            } else {
+                list = new MQAddressList();
+                List<Server> servers = list.getServersInDeploymentGroup(target);
+                if (servers != null && servers.size() > 0) {
+                    list.setInstanceName(servers.get(0).getName());
+                }
+                Map<String, JmsHost> hostMap = list.getResolvedLocalJmsHostsInDeploymentGroup(true);
+                if (hostMap.size() == 0) {
+                    String msg = localStrings.getLocalString("mqjmx.no_jms_hosts", "No JMS Hosts Configured");
+                    throw new ConnectorRuntimeException(msg);
+                }
+                for (JmsHost host : hostMap.values()) {
+                    list.addMQUrl(host);
+                }
+            }
+            String connectionUrl = list.toString();
+            String adminUserName = null;
+            String adminPassword = null;
+            JmsHost jmsHost = list.getDefaultJmsHost(jmsService);
+            if (jmsHost != null) {
+                adminUserName = jmsHost.getAdminUserName();
+                adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
+            } else {
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, " _getMQJMXConnectorInfo, using default jms admin user and password ");
+                }
+            }
+            raInstance = getConfiguredRA(mqRAClassName, connectionUrl,
+                    adminUserName, adminPassword);
+        } catch (Exception e) {
+            throw new ConnectorRuntimeException(e.getMessage(), e);
         }
 
-        protected CommandTarget getTypeForTarget(String target){
-            Domain domain = Globals.get(Domain.class);
-            Config config = domain.getConfigNamed(target);
-            if (config != null)
-                return CommandTarget.CONFIG;
-            Server targetServer = domain.getServerNamed(target);
-            if (targetServer!=null) {
-               // Clusters clusters = domain.getClusters();
-               // List clustersList = clusters.getCluster();
-                //if (JmsRaUtil.isServerClustered(clustersList, target))
-                  //  return CommandTarget.CLUSTERED_INSTANCE;
-               if (targetServer.isDas())
-                    return CommandTarget.DAS;
-                else return CommandTarget.STANDALONE_INSTANCE;
-            }//end if (targetServer!=null)
-            Cluster cluster =domain.getClusterNamed(target);
-            if (cluster!=null) {
-                return CommandTarget.CLUSTER;
+        try {
+            String jmxServiceURL = null, jmxServiceURLList = null;
+            Map<String, ?> jmxConnectorEnv = null;
+            Method[] methds = raInstance.getClass().getMethods();
+            for (Method m : methds) {
+                if (m.getName().equalsIgnoreCase("get" + JMXSERVICEURLLIST)) {
+                    jmxServiceURLList = (String) m.invoke(raInstance, new Object[]{});
+                    if (jmxServiceURLList != null && !jmxServiceURLList.trim().equals("")) {
+                        jmxServiceURL = getFirstJMXServiceURL(jmxServiceURLList);
+                    }
+                } else if (m.getName().equalsIgnoreCase("get" + JMXCONNECTORENV)) {
+                    jmxConnectorEnv = (Map<String, ?>) m.invoke(raInstance, new Object[]{});
+                }
             }
-            return CommandTarget.DAS;
-
+            MQJMXConnectorInfo mqInfo = new MQJMXConnectorInfo(target,
+                    ActiveJmsResourceAdapter.getBrokerInstanceName(jmsService),
+                    jmsService.getType(), jmxServiceURL, jmxConnectorEnv);
+            return mqInfo;
+        } catch (Exception e) {
+            throw new ConnectorRuntimeException(e.getMessage(), e);
         }
-           /*
-         *  Starts the MQ RA in the DAS, as all MQ related operations are
-         *  performed in DAS.
-         */
-        protected ActiveJmsResourceAdapter getMQAdapter(final ConnectorRuntime connectorRuntime) throws Exception {
-            //Start ActiveJMSResourceAdapter.
+    }
 
-            ActiveJmsResourceAdapter air = (ActiveJmsResourceAdapter)
-            java.security.AccessController.doPrivileged
-                (new java.security.PrivilegedExceptionAction() {
-                     public java.lang.Object run() throws Exception {
-                          String module = ConnectorConstants.DEFAULT_JMS_ADAPTER;
-                          String loc = ConnectorsUtil.getSystemModuleLocation(module);
-                          connectorRuntime.createActiveResourceAdapter(loc, module, null);
-                         return (ActiveJmsResourceAdapter) ConnectorRegistry.getInstance().
-                               getActiveResourceAdapter(module);
-                 }
-            });
-            return air;
-        }
-
-      /*   private boolean isDAS(String targetName) {
-             //return true;
-            if (isAConfig(targetName)) {
-            return false;
+    /**
+     * Gets the <code>MQJMXConnector</code> object for a cluster. Since this code is
+     * executed in DAS, an admin API is used to resolve hostnames and ports of
+     * cluster instances for LOCAL type brokers while creating the connectionURL.
+     */
+    protected MQJMXConnectorInfo _getMQJMXConnectorInfoForCluster(
+            String target, JmsService jmsService, Class mqRAClassName, ServerContext serverContext)
+            throws ConnectorRuntimeException {
+        ResourceAdapter raInstance = null;
+        MQAddressList list = null;
+        try {
+            if (jmsService.getType().equalsIgnoreCase(ActiveJmsResourceAdapter.REMOTE)) {
+                list = getDefaultAddressList(jmsService);
+            } else {
+                list = new MQAddressList();
+                CommandTarget ctarget = this.getTypeForTarget(target);
+                if (ctarget == CommandTarget.CLUSTER) {
+                    Server[] servers = list.getServersInCluster(target);
+                    if (servers != null && servers.length > 0)
+                        list.setInstanceName(servers[0].getName());
+                } else if (ctarget == CommandTarget.CLUSTERED_INSTANCE) {
+                    list.setInstanceName(target);
+                }
+                Map<String, JmsHost> hostMap = list.getResolvedLocalJmsHostsInMyCluster(true);
+                if (hostMap.size() == 0) {
+                    String msg = localStrings.getLocalString("mqjmx.no_jms_hosts", "No JMS Hosts Configured");
+                    throw new ConnectorRuntimeException(msg);
+                }
+                for (JmsHost host : hostMap.values()) {
+                    list.addMQUrl(host);
+                }
             }
-
-            return getServerByName(targetName).isDas();
-
-        }*/
-       /* private Server getServerByName(String serverName){
-            Domain domain = Globals.get(Domain.class);
-            Servers servers = domain.getServers();
-            List serverList = servers.getServer();
-
-            for (int i=0; i < serverList.size(); i++){
-                Server server = (Server) serverList.get(i);
-                if(serverName.equals(server.getName()))
-                    return server;
+            String connectionUrl = list.toString();
+            String adminUserName = null;
+            String adminPassword = null;
+            JmsHost jmsHost = list.getDefaultJmsHost(jmsService);
+            if (jmsHost != null) {
+                adminUserName = jmsHost.getAdminUserName();
+                adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
+            } else {
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, " _getMQJMXConnectorInfo, using default jms admin user and password ");
+                }
             }
-            return null;
-        }*/
-        protected MQAddressList getDefaultAddressList(JmsService jmsService)
-                                                           throws Exception {
-            MQAddressList list = new MQAddressList(jmsService);
-            list.setup(false);
-            return list;
+            raInstance = getConfiguredRA(mqRAClassName, connectionUrl,
+                    adminUserName, adminPassword);
+        } catch (Exception e) {
+            throw new ConnectorRuntimeException(e.getMessage(), e);
         }
 
-        protected void logAndHandleException(Exception e, String errorMsg)
-                                            throws JMSAdminException {
-            //log JMX Exception trace as WARNING
-            StringWriter s = new StringWriter();
-            e.getCause().printStackTrace(new PrintWriter(s));
-            logger.log(Level.WARNING, s.toString());
-            JMSAdminException je = new JMSAdminException(localStrings.getLocalString(errorMsg, ""));
+        try {
+            String jmxServiceURL = null, jmxServiceURLList = null;
+            Map<String, ?> jmxConnectorEnv = null;
+            Method[] methds = raInstance.getClass().getMethods();
+            for (int i = 0; i < methds.length; i++) {
+                Method m = methds[i];
+                if (m.getName().equalsIgnoreCase("get" + JMXSERVICEURLLIST)) {
+                    jmxServiceURLList = (String) m.invoke(raInstance, new Object[]{});
+                    if (jmxServiceURLList != null && !jmxServiceURLList.trim().equals("")) {
+                        jmxServiceURL = getFirstJMXServiceURL(jmxServiceURLList);
+                    }
+                } else if (m.getName().equalsIgnoreCase("get" + JMXCONNECTORENV)) {
+                    jmxConnectorEnv = (Map<String, ?>) m.invoke(raInstance, new Object[]{});
+                }
+            }
+            MQJMXConnectorInfo mqInfo = new MQJMXConnectorInfo(target,
+                    ActiveJmsResourceAdapter.getBrokerInstanceName(jmsService),
+                    jmsService.getType(), jmxServiceURL, jmxConnectorEnv);
+            return mqInfo;
+        } catch (Exception e) {
+            throw new ConnectorRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /*
+     *  Configures an instance of MQ-RA with the connection URL passed in.
+     *  This configured RA is then used to obtain the JMXServiceURL/JMXServiceURLList
+     */
+    protected ResourceAdapter getConfiguredRA(Class mqRAclassname,
+                                              String connectionURL, String adminuser,
+                                              String adminpasswd) throws Exception {
+        ResourceAdapter raInstance = (ResourceAdapter) mqRAclassname.newInstance();
+        Method setConnectionURL = mqRAclassname.getMethod(
+                "set" + ActiveJmsResourceAdapter.CONNECTION_URL,
+                new Class[]{String.class});
+        setConnectionURL.invoke(raInstance, new Object[]{connectionURL});
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, " getConfiguredRA - set connectionURL as " + connectionURL);
+        }
+        if (adminuser != null) {
+            Method setAdminUser = mqRAclassname.getMethod(
+                    "set" + ActiveJmsResourceAdapter.ADMINUSERNAME,
+                    new Class[]{String.class});
+            setAdminUser.invoke(raInstance, new Object[]{adminuser});
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, " getConfiguredRA - set admin user as " + adminuser);
+            }
+        }
+        if (adminpasswd != null) {
+            Method setAdminPasswd = mqRAclassname.getMethod(
+                    "set" + ActiveJmsResourceAdapter.ADMINPASSWORD,
+                    new Class[]{String.class});
+            setAdminPasswd.invoke(raInstance, new Object[]{adminpasswd});
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, " getConfiguredRA - set admin passwd as *****  ");
+            }
+        }
+        return raInstance;
+    }
+
+    private JmsService getJmsServiceOfStandaloneServerInstance(String target, Config cfg, Domain domain) throws Exception {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "getJMSServiceOfSI LL " + target);
+            //ConfigContext con = com.sun.enterprise.admin.server.core.AdminService.getAdminService().getAdminContext().getAdminConfigContext();
+            logger.log(Level.FINE, "cfg " + cfg);
+        }
+        JmsService jmsService = cfg.getExtensionByType(JmsService.class);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "jmsservice " + jmsService);
+        }
+        return jmsService;
+    }
+
+
+    protected String getFirstJMXServiceURL(String jmxServiceURLList) {
+        //If type is REMOTE, MQ RA returns a null jmxServiceURL and a non-null
+        //jmxServiceURLList for PE also.
+        if ((jmxServiceURLList == null) || ("".equals(jmxServiceURLList))) {
+            logger.log(Level.FINE, "jmxServiceURLList: " + jmxServiceURLList);
+            return jmxServiceURLList;
+        } else {
+            StringTokenizer tokenizer = new StringTokenizer(jmxServiceURLList, " ");
+            return tokenizer.nextToken();
+        }
+    }
+
+    protected CommandTarget getTypeForTarget(String target) {
+        Domain domain = Globals.get(Domain.class);
+        Config config = domain.getConfigNamed(target);
+        if (config != null)
+            return CommandTarget.CONFIG;
+        Server targetServer = domain.getServerNamed(target);
+        if (targetServer != null) {
+            if (targetServer.isDas()) {
+                return CommandTarget.DAS;
+            } else {
+                return CommandTarget.STANDALONE_INSTANCE;
+            }
+        }
+        Cluster cluster = domain.getClusterNamed(target);
+        if (cluster != null) {
+            return CommandTarget.CLUSTER;
+        }
+        DeploymentGroup deploymentGroup = domain.getDeploymentGroupNamed(target);
+        if (deploymentGroup != null) {
+            return CommandTarget.DEPLOYMENT_GROUP;
+        }
+        return CommandTarget.DAS;
+    }
+
+    /*
+     *  Starts the MQ RA in the DAS, as all MQ related operations are
+     *  performed in DAS.
+     */
+    protected ActiveJmsResourceAdapter getMQAdapter(final ConnectorRuntime connectorRuntime) throws Exception {
+        //Start ActiveJMSResourceAdapter.
+
+        ActiveJmsResourceAdapter air = (ActiveJmsResourceAdapter)
+                java.security.AccessController.doPrivileged
+                        (new java.security.PrivilegedExceptionAction() {
+                            public java.lang.Object run() throws Exception {
+                                String module = ConnectorConstants.DEFAULT_JMS_ADAPTER;
+                                String loc = ConnectorsUtil.getSystemModuleLocation(module);
+                                connectorRuntime.createActiveResourceAdapter(loc, module, null);
+                                return (ActiveJmsResourceAdapter) ConnectorRegistry.getInstance().
+                                        getActiveResourceAdapter(module);
+                            }
+                        });
+        return air;
+    }
+
+    protected MQAddressList getDefaultAddressList(JmsService jmsService)
+            throws Exception {
+        MQAddressList list = new MQAddressList(jmsService);
+        logger.log(Level.FINE, "JMSDestination L529: NOT CLUSTERED");
+        list.setup(false);
+        return list;
+    }
+
+    protected void logAndHandleException(Exception e, String errorMsg)
+            throws JMSAdminException {
+        //log JMX Exception trace as WARNING
+        StringWriter s = new StringWriter();
+        e.getCause().printStackTrace(new PrintWriter(s));
+        logger.log(Level.WARNING, s.toString());
+        JMSAdminException je = new JMSAdminException(localStrings.getLocalString(errorMsg, ""));
         /* Cause will be InvocationTargetException, cause of that
-           * wil be  MBeanException and cause of that will be the
-          * real exception we need
-          */
+         * wil be  MBeanException and cause of that will be the
+         * real exception we need
+         */
         if ((e.getCause() != null) &&
-            (e.getCause().getCause() != null)) {
-              je.initCause(e.getCause().getCause().getCause());
+                (e.getCause().getCause() != null)) {
+            je.initCause(e.getCause().getCause().getCause());
         }
-            handleException(je);
+        handleException(je);
+    }
+
+    protected void handleException(Exception e)
+            throws JMSAdminException {
+
+        if (e instanceof JMSAdminException) {
+            throw ((JMSAdminException) e);
         }
 
+        String msg = e.getMessage();
 
-        protected void handleException(Exception e)
-                                    throws JMSAdminException {
+        JMSAdminException jae;
+        if (msg == null) {
+            jae = new JMSAdminException();
+        } else {
+            jae = new JMSAdminException(msg);
+        }
 
-            if (e instanceof JMSAdminException)  {
-                throw ((JMSAdminException)e);
+        /*
+         * Don't do this for now because the CLI does not include jms.jar
+         * (at least not yet) in the classpath. Sending over a JMSException
+         * will cause a class not found exception to be thrown.
+         */
+        //jae.setLinkedException(e);
+
+        throw jae;
+    }
+
+    //XXX: To refactor into a Generic attribute type mapper, so that it is extensible later.
+    protected AttributeList convertProp2Attrs(Properties destProps) {
+
+        AttributeList destAttrs = new AttributeList();
+
+        String propName = null;
+        String propValue = null;
+
+        for (Enumeration e = destProps.propertyNames(); e.hasMoreElements(); ) {
+            propName = (String) e.nextElement();
+            if (propName.equals("AutoCreateQueueMaxNumActiveConsumers")) {
+                destAttrs.add(new Attribute("AutoCreateQueueMaxNumActiveConsumers",
+                        Integer.valueOf(destProps.getProperty("AutoCreateQueueMaxNumActiveConsumers"))));
+            } else if (propName.equals("maxNumActiveConsumers")) {
+                destAttrs.add(new Attribute("MaxNumActiveConsumers",
+                        Integer.valueOf(destProps.getProperty("maxNumActiveConsumers"))));
+            } else if (propName.equals("MaxNumActiveConsumers")) {
+                destAttrs.add(new Attribute("MaxNumActiveConsumers",
+                        Integer.valueOf(destProps.getProperty("MaxNumActiveConsumers"))));
+            } else if (propName.equals("AutoCreateQueueMaxNumBackupConsumers")) {
+                destAttrs.add(new Attribute("AutoCreateQueueMaxNumBackupConsumers",
+                        Integer.valueOf(destProps.getProperty("AutoCreateQueueMaxNumBackupConsumers"))));
+            } else if (propName.equals("AutoCreateQueues")) {
+                boolean b = false;
+
+                propValue = destProps.getProperty("AutoCreateQueues");
+                if (propValue.equalsIgnoreCase("true")) {
+                    b = true;
+                }
+                destAttrs.add(new Attribute("AutoCreateQueues",
+                        Boolean.valueOf(b)));
+            } else if (propName.equals("AutoCreateTopics")) {
+                boolean b = false;
+
+                propValue = destProps.getProperty("AutoCreateTopics");
+                if (propValue.equalsIgnoreCase("true")) {
+                    b = true;
+                }
+                destAttrs.add(new Attribute("AutoCreateTopics",
+                        Boolean.valueOf(b)));
+            } else if (propName.equals("DMQTruncateBody")) {
+                boolean b = false;
+
+                propValue = destProps.getProperty("DMQTruncateBody");
+                if (propValue.equalsIgnoreCase("true")) {
+                    b = true;
+                }
+                destAttrs.add(new Attribute("DMQTruncateBody",
+                        Boolean.valueOf(b)));
+            } else if (propName.equals("LogDeadMsgs")) {
+                boolean b = false;
+
+                propValue = destProps.getProperty("LogDeadMsgs");
+                if (propValue.equalsIgnoreCase("true")) {
+                    b = true;
+                }
+                destAttrs.add(new Attribute("LogDeadMsgs",
+                        Boolean.valueOf(b)));
+            } else if (propName.equals("MaxBytesPerMsg")) {
+                destAttrs.add(new Attribute("MaxBytesPerMsg",
+                        Long.valueOf(destProps.getProperty("MaxBytesPerMsg"))));
+            } else if (propName.equals("MaxNumMsgs")) {
+                destAttrs.add(new Attribute("MaxNumMsgs",
+                        Long.valueOf(destProps.getProperty("MaxNumMsgs"))));
+            } else if (propName.equals("MaxTotalMsgBytes")) {
+                destAttrs.add(new Attribute("MaxTotalMsgBytes",
+                        Long.valueOf(destProps.getProperty("MaxTotalMsgBytes"))));
+            } else if (propName.equals("NumDestinations")) {
+                destAttrs.add(new Attribute("NumDestinations",
+                        Integer.valueOf(destProps.getProperty("NumDestinations"))));
+            } else if (propName.equals("ConsumerFlowLimit")) {
+                destAttrs.add(new Attribute("ConsumerFlowLimit",
+                        Long.valueOf(destProps.getProperty("ConsumerFlowLimit"))));
+            } else if (propName.equals("LocalDeliveryPreferred")) {
+                destAttrs.add(new Attribute("LocalDeliveryPreferred",
+                        getBooleanValue(destProps.getProperty("LocalDeliveryPreferred"))));
+            } else if (propName.equals("ValidateXMLSchemaEnabled")) {
+                destAttrs.add(new Attribute("ValidateXMLSchemaEnabled",
+                        getBooleanValue(destProps.getProperty("ValidateXMLSchemaEnabled"))));
+            } else if (propName.equals("UseDMQ")) {
+                destAttrs.add(new Attribute("UseDMQ",
+                        getBooleanValue(destProps.getProperty("UseDMQ"))));
+            } else if (propName.equals("LocalOnly")) {
+                destAttrs.add(new Attribute("LocalOnly",
+                        getBooleanValue(destProps.getProperty("LocalOnly"))));
+            } else if (propName.equals("ReloadXMLSchemaOnFailure")) {
+                destAttrs.add(new Attribute("ReloadXMLSchemaOnFailure",
+                        getBooleanValue(destProps.getProperty("ReloadXMLSchemaOnFailure"))));
+            } else if (propName.equals("MaxNumProducers")) {
+                destAttrs.add(new Attribute("MaxNumProducers",
+                        Integer.valueOf(destProps.getProperty("MaxNumProducers"))));
+            } else if (propName.equals("MaxNumBackupConsumers")) {
+                destAttrs.add(new Attribute("MaxNumBackupConsumers",
+                        Integer.valueOf(destProps.getProperty("MaxNumBackupConsumers"))));
+            } else if (propName.equals("LimitBehavior")) {
+                destAttrs.add(new Attribute("LimitBehavior",
+                        destProps.getProperty("LimitBehavior")));
             }
-
-            String msg = e.getMessage();
-
-            JMSAdminException jae;
-            if (msg == null)  {
-                jae = new JMSAdminException();
-            } else  {
-                jae = new JMSAdminException(msg);
-            }
-
-            /*
-             * Don't do this for now because the CLI does not include jms.jar
-             * (at least not yet) in the classpath. Sending over a JMSException
-             * will cause a class not found exception to be thrown.
-             */
-            //jae.setLinkedException(e);
-
-            throw jae;
         }
-        //XXX: To refactor into a Generic attribute type mapper, so that it is extensible later.
-        protected AttributeList convertProp2Attrs(Properties destProps) {
+        return destAttrs;
+    }
 
-            AttributeList destAttrs = new AttributeList();
-
-            String propName = null;
-            String propValue = null;
-
-            for (Enumeration e = destProps.propertyNames(); e.hasMoreElements();) {
-                         propName = (String) e.nextElement();
-                         if (propName.equals("AutoCreateQueueMaxNumActiveConsumers")) {
-                             destAttrs.add(new Attribute("AutoCreateQueueMaxNumActiveConsumers",
-                                                         Integer.valueOf(destProps.getProperty("AutoCreateQueueMaxNumActiveConsumers"))));
-                         } else if (propName.equals("maxNumActiveConsumers")) {
-                             destAttrs.add(new Attribute("MaxNumActiveConsumers",
-                                                         Integer.valueOf(destProps.getProperty("maxNumActiveConsumers"))));
-                         } else if (propName.equals("MaxNumActiveConsumers")) {
-                             destAttrs.add(new Attribute("MaxNumActiveConsumers",
-                                                         Integer.valueOf(destProps.getProperty("MaxNumActiveConsumers"))));
-                         } else if (propName.equals("AutoCreateQueueMaxNumBackupConsumers")) {
-                             destAttrs.add(new Attribute("AutoCreateQueueMaxNumBackupConsumers",
-                                                         Integer.valueOf(destProps.getProperty("AutoCreateQueueMaxNumBackupConsumers"))));
-                         } else if (propName.equals("AutoCreateQueues")) {
-                             boolean b = false;
-
-                             propValue = destProps.getProperty("AutoCreateQueues");
-                             if (propValue.equalsIgnoreCase("true")) {
-                                 b = true;
-                             }
-                             destAttrs.add(new Attribute("AutoCreateQueues",
-                                                         Boolean.valueOf(b)));
-                         } else if (propName.equals("AutoCreateTopics")) {
-                             boolean b = false;
-
-                             propValue = destProps.getProperty("AutoCreateTopics");
-                             if (propValue.equalsIgnoreCase("true")) {
-                                 b = true;
-                             }
-                             destAttrs.add(new Attribute("AutoCreateTopics",
-                                                         Boolean.valueOf(b)));
-                         } else if (propName.equals("DMQTruncateBody")) {
-                             boolean b = false;
-
-                             propValue = destProps.getProperty("DMQTruncateBody");
-                             if (propValue.equalsIgnoreCase("true")) {
-                                 b = true;
-                             }
-                             destAttrs.add(new Attribute("DMQTruncateBody",
-                                                         Boolean.valueOf(b)));
-                         } else if (propName.equals("LogDeadMsgs")) {
-                             boolean b = false;
-
-                             propValue = destProps.getProperty("LogDeadMsgs");
-                             if (propValue.equalsIgnoreCase("true")) {
-                                 b = true;
-                             }
-                             destAttrs.add(new Attribute("LogDeadMsgs",
-                                                         Boolean.valueOf(b)));
-                         } else if (propName.equals("MaxBytesPerMsg")) {
-                             destAttrs.add(new Attribute("MaxBytesPerMsg",
-                                                         Long.valueOf(destProps.getProperty("MaxBytesPerMsg"))));
-                         } else if (propName.equals("MaxNumMsgs")) {
-                             destAttrs.add(new Attribute("MaxNumMsgs",
-                                                         Long.valueOf(destProps.getProperty("MaxNumMsgs"))));
-                         } else if (propName.equals("MaxTotalMsgBytes")) {
-                             destAttrs.add(new Attribute("MaxTotalMsgBytes",
-                                                         Long.valueOf(destProps.getProperty("MaxTotalMsgBytes"))));
-                         } else if (propName.equals("NumDestinations")) {
-                             destAttrs.add(new Attribute("NumDestinations",
-                                                         Integer.valueOf(destProps.getProperty("NumDestinations"))));
-                         } else if (propName.equals("ConsumerFlowLimit")) {
-                             destAttrs.add(new Attribute("ConsumerFlowLimit",
-                                                         Long.valueOf(destProps.getProperty("ConsumerFlowLimit"))));
-                         } else if (propName.equals("LocalDeliveryPreferred")) {
-                             destAttrs.add(new Attribute("LocalDeliveryPreferred",
-                                                         getBooleanValue(destProps.getProperty("LocalDeliveryPreferred"))));
-                         } else if (propName.equals("ValidateXMLSchemaEnabled")) {
-                             destAttrs.add(new Attribute("ValidateXMLSchemaEnabled",
-                                                         getBooleanValue(destProps.getProperty("ValidateXMLSchemaEnabled"))));
-                         } else if (propName.equals("UseDMQ")) {
-                             destAttrs.add(new Attribute("UseDMQ",
-                                                         getBooleanValue(destProps.getProperty("UseDMQ"))));
-                         } else if (propName.equals("LocalOnly")) {
-                             destAttrs.add(new Attribute("LocalOnly",
-                                                         getBooleanValue(destProps.getProperty("LocalOnly"))));
-                         } else if (propName.equals("ReloadXMLSchemaOnFailure")) {
-                             destAttrs.add(new Attribute("ReloadXMLSchemaOnFailure",
-                                                         getBooleanValue(destProps.getProperty("ReloadXMLSchemaOnFailure"))));
-                         } else if (propName.equals("MaxNumProducers")) {
-                             destAttrs.add(new Attribute("MaxNumProducers",
-                                                         Integer.valueOf(destProps.getProperty("MaxNumProducers"))));
-                         } else if (propName.equals("MaxNumBackupConsumers")) {
-                             destAttrs.add(new Attribute("MaxNumBackupConsumers",
-                                                         Integer.valueOf(destProps.getProperty("MaxNumBackupConsumers"))));
-                         } else if (propName.equals("LimitBehavior")) {
-                             destAttrs.add(new Attribute("LimitBehavior",
-                                                         destProps.getProperty("LimitBehavior")));
-                         }
-                     }
-            return destAttrs;
-        }
-
-        private Boolean getBooleanValue(String propValue) {
-            return propValue.equalsIgnoreCase("true") ? Boolean.TRUE : Boolean.FALSE;
-//            UseDMQ
-        }
+    private Boolean getBooleanValue(String propValue) {
+        return propValue.equalsIgnoreCase("true") ? Boolean.TRUE : Boolean.FALSE;
+    }
 }

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/util/JmsRaUtil.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/util/JmsRaUtil.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2023 [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.connectors.jms.util;
 
@@ -60,7 +61,7 @@ import com.sun.enterprise.deployment.ConnectorConfigProperty;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.zip.ZipFile;
 import com.sun.enterprise.util.zip.ZipFileException;
-import com.sun.logging.LogDomains;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 
 import org.glassfish.ejb.config.MdbContainer;
 import org.glassfish.internal.api.Globals;
@@ -154,23 +155,44 @@ public class JmsRaUtil {
               return (enableClustering() && isServerClustered(clusters,
                 instanceName));
      }
-      /**
+
+    /**
      * Return true if the given server instance is part of a cluster.
      */
-    public static boolean isServerClustered(List clusters, String instanceName)
-    {
+    public static boolean isServerClustered(List clusters, String instanceName) {
         return (getClusterForServer(clusters, instanceName) != null);
     }
-    public static Cluster getClusterForServer(List clusters, String instanceName){
+
+    public static Cluster getClusterForServer(List<Cluster> clusters, String instanceName){
         //Return the server only if it is part of a cluster (i.e. only if a cluster
         //has a reference to it).
-        for (int i = 0; i < clusters.size(); i++) {
-            final List servers = ((Cluster)clusters.get(i)).getInstances();
-            for (int j = 0; j < servers.size(); j++) {
-                if (((Server)servers.get(j)).getName().equals(instanceName)) {
+        for (Cluster cluster : clusters) {
+            final List<Server> servers = cluster.getInstances();
+            for (Server server : servers) {
+                if (server.getName().equals(instanceName)) {
                     // check to see if the server exists as a sanity check.
                     // NOTE: we are not checking for duplicate server instances here.
-                    return (Cluster) clusters.get(i);
+                    return cluster;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return true if the given server instance is part of a deployment group.
+     */
+    public static boolean isServerInDeploymentGroup(List<DeploymentGroup> deploymentGroupList, String instanceName)
+    {
+        return (getDeploymentGroupForServer(deploymentGroupList, instanceName) != null);
+    }
+
+    public static DeploymentGroup getDeploymentGroupForServer(List<DeploymentGroup> deploymentGroupList, String instanceName){
+        for (DeploymentGroup deploymentGroup : deploymentGroupList) {
+            final List<Server> servers = deploymentGroup.getInstances();
+            for (Server server : servers) {
+                if (server.getName().equals(instanceName)) {
+                    return deploymentGroup;
                 }
             }
         }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Domain.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Domain.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -771,7 +771,7 @@ public interface Domain extends ConfigBeanProxy, PropertyBag, SystemPropertyBag,
 
         public static List<Server> getServersInTarget(
             Domain me, String target) {
-            List<Server> servers = new ArrayList<Server>();
+            List<Server> servers = new ArrayList<>();
             Server server = me.getServerNamed(target);
             if (server != null) {
                 servers.add(server);
@@ -795,7 +795,7 @@ public interface Domain extends ConfigBeanProxy, PropertyBag, SystemPropertyBag,
         }
 
         public static List<String> getTargets(final Domain me, final String tgt) {
-            List<String> targets = new ArrayList<String>();
+            List<String> targets = new ArrayList<>();
             if (!tgt.equals("domain")) {
                 targets.add(tgt);
             } else {
@@ -920,13 +920,12 @@ public interface Domain extends ConfigBeanProxy, PropertyBag, SystemPropertyBag,
                     targets.add(server.getName());
                 }
             }
-                for (Cluster cluster : d.getClusters().getCluster()) {
-                    targets.add(cluster.getName());
-                }
-            
-                for (DeploymentGroup dg : d.getDeploymentGroups().getDeploymentGroup()) {
-                    targets.add(dg.getName());
-                }
+            for (Cluster cluster : d.getClusters().getCluster()) {
+                targets.add(cluster.getName());
+            }
+            for (DeploymentGroup dg : d.getDeploymentGroups().getDeploymentGroup()) {
+                targets.add(dg.getName());
+            }
             return targets;
         }
 
@@ -1005,25 +1004,27 @@ public interface Domain extends ConfigBeanProxy, PropertyBag, SystemPropertyBag,
              }
          }
 
-         public static String getEnabledForApplication(Domain d,
-             String target, String appName) {
-             ApplicationRef appRef = d.getApplicationRefInTarget(
-                 appName, target);
-             if (appRef != null) {
+        public static String getEnabledForApplication(Domain d,
+                                                      String target, String appName) {
+            ApplicationRef appRef = d.getApplicationRefInTarget(
+                    appName, target);
+            if (appRef != null) {
                 return appRef.getEnabled();
-             } else {
+            } else {
                 return null;
+            }
+        }
+
+         public static ReferenceContainer getReferenceContainerNamed(Domain domain, String name) {
+             Cluster cluster = getClusterNamed(domain, name);
+             if (cluster != null) {
+                 return cluster;
              }
-         }
-
-         public static ReferenceContainer getReferenceContainerNamed(Domain d, String name) {
-            // Clusters and Servers are ReferenceContainers
-            Cluster c = getClusterNamed(d, name);
-
-            if(c != null)
-                return c;
-            
-            return getServerNamed(d, name);
+             DeploymentGroup deploymentGroup = getDeploymentGroupNamed(domain, name);
+             if (deploymentGroup != null) {
+                 return deploymentGroup;
+             }
+             return getServerNamed(domain, name);
         }
 
         public static List<ReferenceContainer> getReferenceContainersOf(Domain d, Config config) {
@@ -1052,6 +1053,7 @@ public interface Domain extends ConfigBeanProxy, PropertyBag, SystemPropertyBag,
             List<ReferenceContainer> referenceContainers = new LinkedList<ReferenceContainer>();
             referenceContainers.addAll(d.getServers().getServer());
             referenceContainers.addAll(d.getClusters().getCluster());
+            referenceContainers.addAll(d.getDeploymentGroups().getDeploymentGroup());
             return referenceContainers;
         }
 

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Server.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Server.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2023] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -796,7 +796,7 @@ public interface Server extends ConfigBeanProxy, PropertyBag, Named, SystemPrope
         }
 
         private void setupSupplemental(AdminCommandContext context, final Server instance) {
-            if (clusterName != null) {
+            if (clusterName != null || deploymentGroup != null) {
                 InstanceRegisterInstanceCommandParameters cp = new InstanceRegisterInstanceCommandParameters();
                 context.getActionReport().
                         setResultType(InstanceRegisterInstanceCommandParameters.class, cp);

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/Constants.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/Constants.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2023 [Payara Foundation and/or its affiliates]
 
 package org.glassfish.config.support;
 
@@ -50,8 +51,11 @@ public class Constants {
     static final String SERVER = "server";
     static final String CLUSTERS = "clusters";
     static final String CLUSTER = "cluster";
+    static final String DEPLOYMENT_GROUPS = "deployment-groups";
+    static final String DEPLOYMENT_GROUP = "deployment-group";
     static final String REF = "ref";
     static final String SERVER_REF = "server-ref";
+    static final String DG_SERVER_REF = "dg-server-ref";
     static final String CONFIG = "config";
     static final String CONFIGS = "configs";
     static final String CONFIG_REF = "config-ref";

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2023] Payara Foundation and/or affiliates
 
 package org.glassfish.config.support;
 
@@ -86,12 +86,15 @@ class DomainXmlPreParser {
     }
     
     private XMLStreamReader reader;
-    private List<ClusterData> clusters = new LinkedList<ClusterData>();
-    private List<String> configNames = new LinkedList<String>();
+    private List<ClusterData> clusters = new LinkedList<>();
+    private List<DeploymentGroupData> deploymentGroups = new LinkedList<>();
+    private List<String> configNames = new LinkedList<>();
     private ClusterData cluster;
+    private DeploymentGroupData deploymentGroup;
     private String instanceName;
     private String serverConfigRef;
     private boolean valid = false;
+    private boolean validDG = false;
     
     private static final boolean DEBUG = Boolean.parseBoolean(Utility.getEnvOrProp("AS_DEBUG"));
     private static final Logger LOGGER = Logger.getLogger("org.glassfish.config.support");
@@ -125,11 +128,26 @@ class DomainXmlPreParser {
         return cluster.name;
     }
 
+
+    final String getDeploymentGroupName() {
+        if(!validDG) {
+            return null;
+        }
+        return deploymentGroup.name;
+    }
+
     final List<String> getServerNames() {
         if(!valid) {
             return null;
         }
         return cluster.serverRefs;
+    }
+
+    final List<String> getDGServerNames() {
+        if(!validDG) {
+            return Collections.EMPTY_LIST;
+        }
+        return deploymentGroup.dgServerRefs;
     }
 
     final String getConfigName() {
@@ -181,6 +199,20 @@ class DomainXmlPreParser {
         cluster = new ClusterData();
         cluster.configRef = serverConfigRef;
         cluster.serverRefs.add(instanceName);
+
+        // our instance is in either zero or one dg. Find it and set it.
+        for (DeploymentGroupData dgData : deploymentGroups) {
+            for (String serverName : dgData.dgServerRefs) {
+                if (instanceName.equals(serverName)) {
+                    deploymentGroup = dgData;
+                    return;
+                }
+            }
+        }
+        // if we get here that means the instance either
+        // does not exist or it is stand-alone
+        deploymentGroup = new DeploymentGroupData();
+        deploymentGroup.dgServerRefs.add(instanceName);
     }
 
     private void validate() throws DomainXmlPreParserException {
@@ -198,8 +230,11 @@ class DomainXmlPreParser {
             throw new DomainXmlPreParserException(Strings.get("dxpp.confignotfound", instanceName, serverConfigRef));
         }
 
-
         valid = true;
+
+        if (deploymentGroup != null) {
+            validDG = true;
+        }
     }
 
     private void handleElement() throws XMLStreamException {
@@ -214,6 +249,9 @@ class DomainXmlPreParser {
                 break;
             case CLUSTERS:
                 handleClusters();
+                break;
+            case DEPLOYMENT_GROUPS:
+                handleDeploymentGroups();
                 break;
             case CONFIGS:
                 handleConfigs();
@@ -242,6 +280,15 @@ class DomainXmlPreParser {
             serverConfigRef = configRef;
     }
 
+    private void handleDeploymentGroups() throws XMLStreamException {
+        // we are pointed at the servers element
+        printf("FOUND DEPLOYMENT GROUPS");
+
+        while (skipToStartButNotPast(DEPLOYMENT_GROUP, DEPLOYMENT_GROUPS)) {
+            handleDeploymentGroup();
+        }
+    }
+
     private void handleClusters() throws XMLStreamException {
         // we are pointed at the servers element
         printf("FOUND CLUSTERS");
@@ -260,10 +307,24 @@ class DomainXmlPreParser {
         printf(cd.toString());
     }
 
+    private void handleDeploymentGroup() throws XMLStreamException {
+        DeploymentGroupData deploymentGroupData = new DeploymentGroupData();
+        deploymentGroupData.name = getName();
+        handleDGServerRefs(deploymentGroupData);
+        deploymentGroups.add(deploymentGroupData);
+        printf(deploymentGroupData.toString());
+    }
+
     private void handleServerRefs(ClusterData cd) throws XMLStreamException {
 
         while (skipToStartButNotPast(SERVER_REF, CLUSTER)) {
             cd.serverRefs.add(reader.getAttributeValue(null, REF));
+        }
+    }
+
+    private void handleDGServerRefs(DeploymentGroupData dgData) throws XMLStreamException {
+        while (skipToStartButNotPast(DG_SERVER_REF, DEPLOYMENT_GROUP)) {
+            dgData.dgServerRefs.add(reader.getAttributeValue(null, REF));
         }
     }
 
@@ -313,14 +374,23 @@ class DomainXmlPreParser {
     }
 
     private static class ClusterData {
-
         String name;
         String configRef;
-        List<String> serverRefs = new ArrayList<String>();
+        List<String> serverRefs = new ArrayList<>();
 
         @Override
         public String toString() {
             return "Cluster:name=" + name + ", config-ref=" + configRef + ", server-refs = " + serverRefs;
+        }
+    }
+
+    private static class DeploymentGroupData {
+        String name;
+        List<String> dgServerRefs = new ArrayList<>();
+
+        @Override
+        public String toString() {
+            return "DeploymentGroup:name=" + name + ", dg-server-refs = " + dgServerRefs;
         }
     }
 }

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/InstanceReaderFilter.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/InstanceReaderFilter.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2023] Payara Foundation and/or affiliates
 
 package org.glassfish.config.support;
 
@@ -67,7 +67,7 @@ class InstanceReaderFilter extends ServerReaderFilter {
 
     /**
      * This method is called for every element.  We are very interested
-     * in server, config and cluster.
+     * in server, config, cluster and deployment group.
      * We will only filter out config and server and cluster elements never other elements
      * We use this as a handy hook to get info about other elements -- which really
      * is a side-effect.
@@ -96,6 +96,10 @@ class InstanceReaderFilter extends ServerReaderFilter {
             if (elementName.equals(CLUSTER)){
                 return handleCluster(reader);
             }
+
+            if (elementName.equals(DEPLOYMENT_GROUP)){
+                return handleDeploymentGroup(reader);
+            }
             
             // keep everything else
             return false;
@@ -119,7 +123,8 @@ class InstanceReaderFilter extends ServerReaderFilter {
     private boolean handleServer(XMLStreamReader r) {
         String name = r.getAttributeValue(null, NAME);
 
-        return !(StringUtils.ok(name) && dxpp.getServerNames().contains(name));
+        return !(StringUtils.ok(name) &&
+                (dxpp.getServerNames().contains(name) || dxpp.getDGServerNames().contains(name)));
     }
 
     /**
@@ -142,6 +147,19 @@ class InstanceReaderFilter extends ServerReaderFilter {
         String myCluster = dxpp.getClusterName();
 
         return !(StringUtils.ok(myCluster) && myCluster.equals(name));
+    }
+
+    /**
+     * Note that dxpp.getClusterName() will definitely return null
+     * for stand-alone instances.  This is normal.
+     *
+     * @return true if we want to filter out this DEPLOYMENT GROUP element
+     */
+    private boolean handleDeploymentGroup(XMLStreamReader reader) {
+        String name = reader.getAttributeValue(null, NAME);
+        String myDG = dxpp.getDeploymentGroupName();
+
+        return !(StringUtils.ok(myDG) && myDG.equals(name));
     }
 
     private final DomainXmlPreParser dxpp;

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ListInstancesCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ListInstancesCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2023] [Payara Foundation and/or its affiliates]
 package com.sun.enterprise.v3.admin.cluster;
 
 import com.sun.enterprise.admin.util.InstanceStateService;
@@ -349,6 +349,10 @@ public class ListInstancesCommand implements AdminCommand {
         else if (rc.isCluster()) { 
             Cluster cluster = (Cluster) rc;
             return cluster.getInstances();
+        }
+        else if (rc.isDeploymentGroup()) {
+            DeploymentGroup deploymentGroup = (DeploymentGroup) rc;
+            return deploymentGroup.getInstances();
         }
         else {
             return null;

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/PostRegisterInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/PostRegisterInstanceCommand.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2023 [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.admin.cluster;
 
@@ -86,16 +87,16 @@ public class PostRegisterInstanceCommand extends RegisterInstanceCommandParamete
         ActionReport report = context.getActionReport();
         final Logger logger = context.getLogger();
 
-        final  InstanceRegisterInstanceCommandParameters suppInfo =
+        final InstanceRegisterInstanceCommandParameters suppInfo =
                 context.getActionReport().getResultType(InstanceRegisterInstanceCommandParameters.class);
 
-        if (suppInfo != null && clusterName != null) {
+        if (suppInfo != null && (clusterName != null || deploymentGroup != null)) {
             try {
                 ParameterMapExtractor pme = new ParameterMapExtractor(suppInfo, this);
                 final ParameterMap paramMap = pme.extract();
 
                 List<String> targets = new ArrayList<String>();
-                List<Server> instances = target.getInstances(this.clusterName);
+                List<Server> instances = target.getInstances(this.clusterName != null ? clusterName : deploymentGroup);
                 for (Server s : instances) {
                     targets.add(s.getName());
                 }


### PR DESCRIPTION
## Description
In general, JMS Service availability doesn’t work when setting up a JMS cluster in LOCAL mode when using deployment groups unlike traditional clusters (generally known as Shoal clusters).

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps:

1. build Payara Community
2. run it
3. Run the next commands using asadmin:
```
copy-config default-config mqc-config
set configs.config.mqc-config.availability-service.jms-availability.availability-enabled=true
set configs.config.mqc-config.jms-service.type=LOCAL

create-node-ssh --sshport=22 --nodehost=localhost --installdir=${com.sun.aas.productRoot} --sshuser=${user.name} remote-node-1
create-node-ssh --sshport=22 --nodehost=localhost --installdir=${com.sun.aas.productRoot} --sshuser=${user.name} remote-node-2

create-deployment-group dg1
create-instance --deploymentgroup=dg1 --node=remote-node-1 --config=mqc-config i1
create-instance --deploymentgroup=dg1 --node=remote-node-2 --config=mqc-config i2
start-deployment-group dg1

```
5. open server.log files for the 2 instances: i1 and i2
6. verify that it is exposing JMS Service in the 2 hosts like done in traditional clusters:
  ```
ADDRESSLIST in setJmsServiceProvider : mq://localhost:27677/,mq://localhost:27677/]]
  JMS Service Connection URL is : mq://localhost:27677/,mq://localhost:27677/]] 

```
### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.8.4