### PR TITLE
FISH-7132 : config refs list being handled

### DIFF
--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
@@ -89,6 +89,7 @@ class DomainXmlPreParser {
     private List<ClusterData> clusters = new LinkedList<>();
     private List<DeploymentGroupData> deploymentGroups = new LinkedList<>();
     private List<String> configNames = new LinkedList<>();
+    private Map<String, String> mapServerConfig = new HashMap<>();
     private ClusterData cluster;
     private DeploymentGroupData deploymentGroup;
     private String instanceName;
@@ -148,6 +149,10 @@ class DomainXmlPreParser {
             return Collections.EMPTY_LIST;
         }
         return deploymentGroup.dgServerRefs;
+    }
+
+    public Map<String, String> getMapServerConfig() {
+        return this.mapServerConfig;
     }
 
     final String getConfigName() {
@@ -275,9 +280,11 @@ class DomainXmlPreParser {
         String configRef = getConfigRef();
 
         printf("SERVER: " + name + ", ref= " + configRef);
+        mapServerConfig.put(name, configRef);
 
-        if (instanceName.equals(name))
+        if (instanceName.equals(name)) {
             serverConfigRef = configRef;
+        }
     }
 
     private void handleDeploymentGroups() throws XMLStreamException {

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/InstanceReaderFilter.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/InstanceReaderFilter.java
@@ -43,6 +43,8 @@ package org.glassfish.config.support;
 
 import com.sun.enterprise.util.StringUtils;
 import java.net.*;
+import java.util.List;
+import java.util.Map;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -133,7 +135,16 @@ class InstanceReaderFilter extends ServerReaderFilter {
     private boolean handleConfig(XMLStreamReader reader) {
         String name = reader.getAttributeValue(null, NAME);
 
-        return !dxpp.getConfigName().equals(name);
+        Map<String, String> mapServerConfig = dxpp.getMapServerConfig();
+        boolean isConfigFromServerInDG = false;
+        List<String> dgServerNames = dxpp.getDGServerNames();
+        for (String server : mapServerConfig.keySet()) {
+            if (dgServerNames.contains(server) && mapServerConfig.get(server).equals(name)) {
+                isConfigFromServerInDG = true;
+            }
+        }
+
+        return !(dxpp.getConfigName().equals(name) || isConfigFromServerInDG);
     }
 
     /**


### PR DESCRIPTION
## Description
In general, JMS Service availability doesn’t work when setting up a JMS cluster in LOCAL mode when using deployment groups unlike traditional clusters (generally known as Shoal clusters).

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps:

1. build Payara 6 Community
2. run it
3. Run the following commands using asadmin:
```
copy-config default-config mqc-config
set configs.config.mqc-config.availability-service.jms-availability.availability-enabled=true
set configs.config.mqc-config.jms-service.type=LOCAL

create-node-ssh --sshport=22 --nodehost=localhost --installdir=${com.sun.aas.productRoot} --sshuser=${user.name} remote-node-1
create-node-ssh --sshport=22 --nodehost=localhost --installdir=${com.sun.aas.productRoot} --sshuser=${user.name} remote-node-2

create-deployment-group dg1
create-instance --deploymentgroup=dg1 --node=remote-node-1 --config=mqc-config i1
create-instance --deploymentgroup=dg1 --node=remote-node-2 --config=mqc-config i2
start-deployment-group dg1

```
5. open server.log files for the 2 instances: i1 and i2
6. verify that it is exposing JMS Service in the 2 hosts like done in traditional clusters:
  ```
ADDRESSLIST in setJmsServiceProvider : mq://localhost:27677/,mq://localhost:27677/]]
  JMS Service Connection URL is : mq://localhost:27677/,mq://localhost:27677/]] 

```
### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.8.4