### PR TITLE
FISH-7262 : monitoring console using jQuery 3.6.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,7 +130,7 @@
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
         <mimepull.version>1.10.0</mimepull.version>
         <gmbal.version>4.0.3</gmbal.version>
-        <monitoring-console-api.version>2.0.1</monitoring-console-api.version>
+        <monitoring-console-api.version>2.0.2</monitoring-console-api.version>
         <metainf-services.version>1.9</metainf-services.version>
         <ldapbp.version>1.0</ldapbp.version>
         <!-- Javassist (JAVA programming ASSISTant) makes Java bytecode manipulation simple. It is a class library for editing bytecodes in Java. -->

--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,8 @@
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <h2db.version>2.2.220</h2db.version>
         <concurrent.version>3.0.2.payara-p1</concurrent.version>
-        <monitoring-console-process.version>2.0.1</monitoring-console-process.version>
-        <monitoring-console-webapp.version>2.0.1</monitoring-console-webapp.version>
+        <monitoring-console-process.version>2.0.2</monitoring-console-process.version>
+        <monitoring-console-webapp.version>2.0.2</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
 
         <deploy.skip>true</deploy.skip>


### PR DESCRIPTION
## Description
Vulnerability on JQuery 1.2 < 3.5.0

## Important Info
### Blockers
Depends On: 

- https://github.com/payara/monitoring-console/pull/39 being merged
- monitoring-console 2.0.2 deploy on Nexus 

## Testing
### New tests
None

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.4