### PR TITLE
FISH-7129 Jersey 3.1.3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.0</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>
-        <jersey.version>3.1.3.payara-p1-SNAPSHOT</jersey.version>
+        <jersey.version>3.1.3.payara-p1</jersey.version>
         <jakarta.validation.version>3.0.1</jakarta.validation.version>
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.0</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>
-        <jersey.version>3.1.0.payara-p1</jersey.version>
+        <jersey.version>3.1.3.payara-p1-SNAPSHOT</jersey.version>
         <jakarta.validation.version>3.0.1</jakarta.validation.version>
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>


### PR DESCRIPTION
## Description
Jersey 3.1.3 with our fix for and with JDK packages excluded from OSGi imports

## Important Info
### Blockers
https://github.com/payara/patched-src-jersey/pull/206

## Testing
### New tests
None

### Testing Performed
Built server and started admin console - no OSGi errors and console loads successfully.

### Testing Environment
Windows 11, Zulu JDK 11.0.21

## Documentation
N/A

## Notes for Reviewers
Jenkins run against SNAPSHOT: https://engineeringjenkins.payara.fish/blue/organizations/jenkins/Payara%20Community%20PR%20Testing/detail/PR-6491/3/pipeline
