### PR TITLE
ITOPS-2602 Make Grizzly HTTP Test More Predictable

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -190,6 +190,8 @@
 
         <payara.deployment.transformer.version>1.3</payara.deployment.transformer.version>
         <payara.transformer.version>0.2.12</payara.transformer.version>
+
+        <awaitility.version>4.2.0</awaitility.version>
     </properties>
 
     <issueManagement>

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -144,5 +144,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
@@ -38,15 +38,18 @@
  * holder.
  */
 
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright [2016-2023] [Payara Foundation]
+
 package org.glassfish.grizzly.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.glassfish.grizzly.Transport;
 import org.glassfish.grizzly.config.dom.NetworkAddressValidator;
@@ -64,6 +67,8 @@ import org.glassfish.grizzly.strategies.WorkerThreadIOStrategy;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.awaitility.Awaitility.await;
+import static org.glassfish.grizzly.config.GrizzlyTestUtils.portsAreAvailable;
 import static org.junit.Assert.*;
 
 /**
@@ -77,7 +82,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void processConfig() throws IOException, InstantiationException {
         GrizzlyConfig grizzlyConfig = null;
-        
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083, 38084));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config.xml");
             grizzlyConfig.setupNetwork();
@@ -101,6 +106,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void references() throws IOException {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083, 38084));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config.xml");
             final List<NetworkListener> list = grizzlyConfig.getConfig().getNetworkListeners().getNetworkListener();
@@ -130,6 +136,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void defaults() throws IOException {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083, 38084));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config.xml");
             final ThreadPool threadPool = grizzlyConfig.getConfig().getNetworkListeners().getThreadPool().get(0);
@@ -144,6 +151,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void testDefaultBufferConfiguration() throws Exception {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083, 38084));
         try {
             configure();
             grizzlyConfig = new GrizzlyConfig("grizzly-config.xml");
@@ -165,6 +173,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void testSelectionKeyHandlerConfiguration() throws Exception {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38084));
         try {
             configure();
             grizzlyConfig = new GrizzlyConfig("grizzly-config-skh.xml");
@@ -185,6 +194,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void testDirectBufferConfiguration() throws Exception {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38084));
         try {
             configure();
             grizzlyConfig = new GrizzlyConfig("grizzly-direct-buffer.xml");
@@ -207,6 +217,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void testSocketBufferConfiguration() throws Exception {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38084, 38085, 38086, 38087));
         try {
             configure();
             grizzlyConfig = new GrizzlyConfig("grizzly-config-socket.xml");
@@ -246,6 +257,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void ssl() throws URISyntaxException, IOException {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083, 38084, 38085));
         try {
             configure();
             grizzlyConfig = new GrizzlyConfig("grizzly-config-ssl.xml");
@@ -321,6 +333,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void ioStrategySet() throws IOException, InstantiationException {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config-io-strategies.xml");
             grizzlyConfig.setupNetwork();
@@ -344,6 +357,7 @@ public class GrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void backendConfig() throws IOException, InstantiationException {
         GrizzlyConfig grizzlyConfig = null;
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082, 38083, 38084, 38085));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-backend-config.xml");
 

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyTestUtils.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyTestUtils.java
@@ -1,0 +1,69 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2023] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.grizzly.config;
+
+import java.net.ServerSocket;
+
+/**
+ * A collection of utilities used in the Grizzly Tests
+ *
+ * @author James Hillyard
+ */
+public class GrizzlyTestUtils {
+
+    /**
+     * Used to verify if all the varargs of ports are available. This is useful with awaitility to ensure tests don't
+     * run while the ports are still open, likely due to a previous test not closing it yet.
+     *
+     * @param ports A varargs of ports to verify all are available
+     * @return true if all ports are available
+     */
+    protected static boolean portsAreAvailable(int... ports) {
+        for (int port : ports) {
+            try (ServerSocket ignored = new ServerSocket(port)) {
+                // No exception means the port was available
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/HttpRedirectTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/HttpRedirectTest.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2023] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.grizzly.config;
 
 import java.io.BufferedReader;
@@ -47,10 +49,14 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.glassfish.grizzly.config.GrizzlyTestUtils.portsAreAvailable;
 
 public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
@@ -59,6 +65,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void legacyHttpToHttpsRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(SocketFactory.getDefault(),
                "legacy-http-https-redirect.xml",
                 "/",
@@ -69,6 +76,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void legacyHttpsToHttpRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(getSSLSocketFactory(),
                "legacy-https-http-redirect.xml",
                 "/",
@@ -79,6 +87,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void httpToHttpsSamePortRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(SocketFactory.getDefault(),
                "http-https-redirect-same-port.xml",
                 "/",
@@ -89,6 +98,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void httpsToHttpSamePortRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(getSSLSocketFactory(),
                "https-http-redirect-same-port.xml",
                 "/",
@@ -99,6 +109,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void httpToHttpsDifferentPortRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(getSSLSocketFactory(),
                "http-https-redirect-different-port.xml",
                 "/",
@@ -109,6 +120,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void httpToHttpsWithAttributesRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(getSSLSocketFactory(),
                 "http-https-redirect-different-port.xml",
                 "/index.html?DEFAULT=D:%5Cprojects%5Ceclipse%5CSimpleWAR.war&name=SimpleWAR&contextroot=SimpleWAR&force=true&keepstate=true",
@@ -119,6 +131,7 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
 
     @Test
     public void httpsToHttpDifferentPortRedirect() throws IOException {
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(48480));
         doTest(SocketFactory.getDefault(),
                "https-http-redirect-different-port.xml",
                 "/",

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/PUGrizzlyConfigTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/PUGrizzlyConfigTest.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2023] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.grizzly.config;
 
 import java.io.ByteArrayOutputStream;
@@ -47,10 +49,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HttpsURLConnection;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.glassfish.grizzly.config.GrizzlyTestUtils.portsAreAvailable;
 
 /**
  * Created Jan 5, 2009
@@ -63,7 +69,7 @@ public class PUGrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void puConfig() throws IOException, InstantiationException {
         GrizzlyConfig grizzlyConfig = null;
-        
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config-pu.xml");
             grizzlyConfig.setupNetwork();
@@ -88,7 +94,7 @@ public class PUGrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void puHttpHttpsSamePortConfig() throws IOException, InstantiationException {
         GrizzlyConfig grizzlyConfig = null;
-
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config-pu-http-https-same-port.xml");
             grizzlyConfig.setupNetwork();
@@ -114,9 +120,9 @@ public class PUGrizzlyConfigTest extends BaseTestGrizzlyConfig {
     @Test
     public void wrongPuConfigLoop() throws IOException, InstantiationException {
         GrizzlyConfig grizzlyConfig = null;
-
         boolean isIllegalState = false;
-        
+
+        await().atMost(1, TimeUnit.MINUTES).until(() -> portsAreAvailable(38082));
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config-pu-loop.xml");
             grizzlyConfig.setupNetwork();

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -158,8 +158,6 @@
         <findbugs.glassfish.logging.validLoggerPrefixes>jakarta.enterprise</findbugs.glassfish.logging.validLoggerPrefixes>
         <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
 
-        <awaitility.version>4.2.0</awaitility.version>
-
     </properties>
 
     <modules>


### PR DESCRIPTION
## Description
In new Jenkins, the Grizzly tests failed ~ 20% of the time due to `Address already in use` errors. It's fairly well documented that after closing a socket, the port will enter a TIME WAIT state to prevent delayed packets arriving to a different listener. The OS will make the port available again after a period of time that is not deterministic.

This PR introduces a wait period of up to 1 minute to ensure the port is available before beginning the test.

## Important Info
### Blockers
None

## Testing

### Testing Performed
Ran the tests locally where it was always observed to pass and they continue to pass 100% of the time with no added delay in running the test suite. 
Ran 15 Jenkins builds and none failed where it's expected ~ 3-5 would fail. Verified some tests took 20+ seconds showing the await functionality was activated to make this test pass.

### Testing Environment
New Engineering Jenkins:
- Maven 3.6.3
- Zulu 11.0.19
- Ubuntu 22.04 LTS

## Documentation
N/A

## Notes for Reviewers
This does **not** force all tests to wait for 1 minute before starting. Awaitility will continue to check the condition and start the test immediately after the condition returns true. In most cases there is no observed time gain. I have observed in some cases the tests take ~ 30-50 seconds to execute up from ~ 2 seconds. This is infrequent and significantly better than the build failing.
