### PR TITLE
FISH-8083 Add Payara-API to Payara-BOM

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -127,7 +127,6 @@
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-api</artifactId>
                 <version>${payara.core.version}</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- APIs -->


### PR DESCRIPTION
## Description
Adds the Payara-API artefact to the Payara-BOM. The reasoning being that it isn't aligned to the Payara version anymore and is client artefact e.g. for creating clustered singleton ejbs.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the Payara-BOM - the API is present in the generated artefact and has the correct version.
Built Server and Embedded and let all unit tests run: `mvn clean install -PBuildEmbedded`

### Testing Environment
Windows 11, Zulu JDK 11.0.21

## Documentation
https://github.com/payara/Payara-Documentation/pull/346

## Notes for Reviewers
None
