### PR TITLE
FISH-6875 FISH-6872 FISH-6877 FISH-7224 : Upgrades

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,7 +64,7 @@
         <cdi-api.version>4.0.1</cdi-api.version>
         <grizzly.version>4.0.0.payara-p1</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <jakarta.el-api.version>5.0.0</jakarta.el-api.version>
+        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
         <parsson.version>1.1.1.payara-p1</parsson.version>
@@ -72,10 +72,10 @@
         <jaxb-api.version>4.0.0</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>
         <jersey.version>3.1.3.payara-p1</jersey.version>
-        <jakarta.validation.version>3.0.1</jakarta.validation.version>
+        <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>
-        <jaxb-impl.version>4.0.1</jaxb-impl.version>
+        <jaxb-impl.version>4.0.4</jaxb-impl.version>
         <jsonp-api.version>2.1.0</jsonp-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <jstl-impl.version>3.0.0</jstl-impl.version>
+        <jstl-impl.version>3.0.1</jstl-impl.version>
         <mojarra.version>4.0.0.payara-p2</mojarra.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
 


### PR DESCRIPTION
## Description
FISH-6875 : Upgrade Jakarta Validation to 3.0.2
FISH-6872 : Upgrade Jakarta EL API to 5.0.1
FISH-6877 : Upgrade JSTL Impl to 3.0.1
FISH-7224 : Upgrade JAXB-OSGi to 4.0.4

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Payara Samples, Quicklook

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.8.4

## Documentation
None

## Notes for Reviewers
None