### PR TITLE
FISH-6874 : jakarta security upgraded to 3.0.3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,7 +60,7 @@
         <hk2.version>3.0.1.payara-p3</hk2.version>
         <osgi.version>7.0.0</osgi.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>
-        <jakarta.security.enterprise.version>3.0.1.payara-p1</jakarta.security.enterprise.version>
+        <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
         <cdi-api.version>4.0.1</cdi-api.version>
         <grizzly.version>4.0.0.payara-p1</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>


### PR DESCRIPTION
## Description
jakarta security upgraded to 3.0.3

## Important Info
### Blockers
Depends on:

- https://github.com/payara/patched-src-security-soteria/pull/8
- Deploy of version 3.0.3.payara-p1 on maven central

## Testing
### New tests
None

### Testing Performed
Samples, Quicklook

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.8.4

## Documentation
None

## Notes for Reviewers
None