### PR TITLE
FISH-7835: upgrading okhttp and skipping kotlin dependencies

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -635,6 +635,7 @@
                                 <excludes>
                                     <exclude>io.opentelemetry.extension</exclude>
                                     <exclude>io.opentelemetry.instrumentation</exclude>
+                                    <exclude>fish.payara.shaded</exclude>
                                 </excludes>
                             </parameter>
                         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,7 +118,9 @@
         <stax2-api.version>4.2.1</stax2-api.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jbi.version>1.0</jbi.version>
-
+        <okhttp3-version>4.12.0</okhttp3-version>
+        <kotlin-version>1.8.21</kotlin-version>
+        
         <!-- implementation and build dependencies -->
         <glassfish-management-api.version>3.2.3.payara-p1</glassfish-management-api.version>
         <glassfish-corba.version>4.2.4.payara-p2</glassfish-corba.version>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -60,8 +60,6 @@
 
     <properties>
         <jar.manifest/>
-        <okhttp3-version>4.12.0</okhttp3-version>
-        <kotlin-version>1.8.21</kotlin-version>
     </properties>
 
     <dependencies>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -176,7 +176,7 @@
                             *;groupId=com.squareup.*;inline=true,
                             *;groupId=io.opentelemetry;inline=true,
                             *;groupId=io.opentelemetry.instrumentation;inline=true,
-                            *;groupId=org.jetbrains.*;inline=true
+                            *;groupId=org.jetbrains.kotlin.*;inline=true
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
@@ -208,7 +208,7 @@
                     <artifactSet>
                         <includes>
                             <include>com.squareup.*:*</include>
-                            <inclue>org.jetbrains.*:*</inclue>
+                            <inclue>org.jetbrains.kotlin.*:*</inclue>
                         </includes>
                     </artifactSet>
                     <filters>
@@ -220,7 +220,7 @@
                             </excludes>
                         </filter>
                         <filter>
-                            <artifact>org.jetbrains.*:*</artifact>
+                            <artifact>org.jetbrains.kotlin.*:*</artifact>
                             <excludes>
                                 <exclude>**</exclude>
                             </excludes>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -61,6 +61,7 @@
     <properties>
         <jar.manifest/>
         <okhttp3-version>4.12.0</okhttp3-version>
+        <kotlin-version>1.8.21</kotlin-version>
     </properties>
 
     <dependencies>
@@ -131,6 +132,13 @@
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin-version}</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <!-- next we need to relocate okhttp, and add OSGi manifest -->
@@ -167,7 +175,8 @@
                         <Embed-Dependency>
                             *;groupId=com.squareup.*;inline=true,
                             *;groupId=io.opentelemetry;inline=true,
-                            *;groupId=io.opentelemetry.instrumentation;inline=true
+                            *;groupId=io.opentelemetry.instrumentation;inline=true,
+                            *;groupId=org.jetbrains.*;inline=true
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
@@ -199,12 +208,19 @@
                     <artifactSet>
                         <includes>
                             <include>com.squareup.*:*</include>
+                            <inclue>org.jetbrains.*:*</inclue>
                         </includes>
                     </artifactSet>
                     <filters>
                         <!-- bundle plugin already inlined the classes, so we can skip the contents -->
                         <filter>
                             <artifact>com.squareup.*:*</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.jetbrains.*:*</artifact>
                             <excludes>
                                 <exclude>**</exclude>
                             </excludes>
@@ -218,6 +234,10 @@
                         <relocation>
                             <pattern>okio.</pattern>
                             <shadedPattern>fish.payara.shaded.okio.</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>kotlin.</pattern>
+                            <shadedPattern>fish.payara.shaded.kotlin.</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -60,6 +60,7 @@
 
     <properties>
         <jar.manifest/>
+        <okhttp3-version>4.12.0</okhttp3-version>
     </properties>
 
     <dependencies>
@@ -126,7 +127,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.14.9</version>
+            <version>${okhttp3-version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
@@ -157,6 +158,9 @@
                             !dalvik.*,
                             io.opentelemetry.exporter.prometheus;resolution:=optional,
                             sun.security.ssl;resolution:=optional,
+                            !kotlin.*,
+                            !org.bouncycastle.*,
+                            !org.openjsse.*,
                             *
                         </Import-Package>
                         <!-- Embed the dependencies and then shade them in next step -->


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Upgrading okhttp to fix CVE's CVE-2023-3635 and CVE-2023-0833
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix to resolve both CVE's reported:

- Okio GzipSource unhandled exception Denial of Service: CVE-2023-3635
- Component version with information disclosure flaw: CVE-2023-0833
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Execution of Jenkins pipeline
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
ubuntu 20.04, azul JDK 11, maven 3.8.6
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
