### PR TITLE
Fix build of Docker images - JDKs 11 and 17 were being skipped

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -169,48 +169,48 @@
                                     <goal>build</goal>
                                 </goals>
                                 <phase>package</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                            </build>
+                                        </image>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}-jdk17</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk17</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk11</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}-jdk17</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk17</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -231,7 +231,7 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>filter-dockerfiles</id>
+                                <id>filter-dockerfiles-jdk21</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>run</goal>
@@ -254,35 +254,35 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>build-docker-image</id>
+                                <id>build-docker-image-jdk21</id>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
                                 <phase>package</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}-jdk21</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk21</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${docker.payara.repository}</name>
-                                    <build>
-                                        <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
-                                        <filter>@</filter>
-                                        <tags>
-                                            <tag>${docker.payara.tag}-jdk21</tag>
-                                        </tags>
-                                        <cleanup>none</cleanup>
-                                        <noCache>${docker.noCache}</noCache>
-                                        <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk21</dockerFile>
-                                        <assembly>
-                                            <mode>tar</mode>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <tarLongFileMode>gnu</tarLongFileMode>
-                                        </assembly>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Description
Title.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built Docker images and _very carefully_ checked the logs to ensure 11, 17, and 21 images were being created.

### Testing Environment
Windows

## Documentation
N/A

## Notes for Reviewers
None
