### PR TITLE
FISH-7993 : ignoring JMS PORT

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -103,6 +103,8 @@ public class StartServerHelper {
     
     private static final String PROPS_HZ_PORT_NAME = "HZ_LISTENER_PORT";
 
+    private static final String PROPS_JMS_PROVIDER_PORT = "JMS_PROVIDER_PORT";
+
     public StartServerHelper(Logger logger0, boolean terse0,
             ServerDirs serverDirs0, GFLauncher launcher0,
             String masterPassword0) {
@@ -358,7 +360,9 @@ public class StartServerHelper {
                 host = addr.getHost();
                 Map<String, String> propsFromXMl = this.launcher.getSysPropsFromXml();
                 Set<Map.Entry<String, String>> setOfPorts = propsFromXMl.entrySet().stream()
-                        .filter(e -> !e.getKey().contains(PROPS_HZ_PORT_NAME) 
+                        .filter(e -> !e.getKey().contains(PROPS_HZ_PORT_NAME)
+                                // Ignore JMS as it might be set to REMOTE
+                                && !e.getKey().contains(PROPS_JMS_PROVIDER_PORT)
                                 && e.getKey().contains(PROPS_PORT_NAME)).collect(Collectors.toSet());
                 for (Map.Entry<String, String> e: setOfPorts) {
                     if(!NetUtils.isPortFree(host, Integer.parseInt(e.getValue()))) {


### PR DESCRIPTION
## Description
Remote JMS Broker Fails to Start

## Important Info
### Blockers
None

## Testing
### Steps

1. payara6/glassfish/bin/asadmin start-domain
2. payara6/glassfish/bin/asadmin set configs.config.server-config.jms-service.type=REMOTE
3. payara6/glassfish/bin/asadmin stop-domain
4. payara6/mq/bin imqbrokerd
5. payara6/glassfish/bin/asadmin start-domain
It should start beautifully

### Testing Performed
Samples, quicklook etc

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.8.4

## Documentation
None

## Notes for Reviewers
None
