### PR TITLE
FISH-8172 Jersey 3.1.5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.1.payara-p1</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>
-        <jersey.version>3.1.3.payara-p1</jersey.version>
+        <jersey.version>3.1.5.payara-p1</jersey.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>


### PR DESCRIPTION
## Description
Updates Jersey to 3.1.5 with our patches reapplied.

Set to SNAPSHOT for now to let this run through all tests via Jenkins.

## Important Info
### Blockers
https://github.com/payara/patched-src-jersey/pull/208

## Testing
### New tests
None

### Testing Performed
Built locally and ran MicroProfile REST Client TCK

### Testing Environment
Windows 11, Zulu JDK 11.0.21

## Documentation
N/A

## Notes for Reviewers
None
