### PR TITLE
Minor fix to monitor issues in voting workflow GitHub action

### DIFF
--- a/.github/workflows/monitor-issues-in-voting.yaml
+++ b/.github/workflows/monitor-issues-in-voting.yaml
@@ -20,18 +20,14 @@ jobs:
             return await script({github, context, core})
       - name: Notify MS Teams channel
         id: notify-ms-teams
-        if: ${{ success() && steps.select-top-voted-issue.outputs.result }}
+        if: ${{ success() && !steps.select-top-voted-issue.outputs.result == '' }}
         uses: simbo/msteams-message-card-action@latest
-        env:
-          issueTitle: ${{ fromJSON(steps.select-top-voted-issue.outputs.result).title }}
-          issueURL: ${{ fromJSON(steps.select-top-voted-issue.outputs.result).url }}
-          assignee: ${{ fromJSON(steps.select-top-voted-issue.outputs.result).assignee }}
         with:
           webhook: ${{ secrets.COMMUNITY_EVENTS_WEBHOOK_URL }}
           title: An Enhancement Proposal Issue has been selected the top-voted issue!
-          message: <code>${{ env.issueTitle }}</code> assigned to <strong>${{ env.assignee }}</strong>
+          message: <code>${{ fromJSON(steps.select-top-voted-issue.outputs.result).title }}</code> assigned to <strong>${{ fromJSON(steps.select-top-voted-issue.outputs.result).assignee }}</strong>
           buttons: |
-            View Issue on GitHub ${{ env.issueURL }}
+            View Issue on GitHub ${{ fromJSON(steps.select-top-voted-issue.outputs.result).url }}
   close-forgotten-voting-issues:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This PR fixes the https://github.com/payara/Payara/actions/workflows/monitor-issues-in-voting.yaml[Monitor Issues in Voting] GitHub action so it doesn't report an error when attempting to notify the MS Teams channels if no issues were selected.