### PR TITLE
FISH-7845 Step Towards JDK 21

### DIFF
--- a/appserver/jdbc/jdbc-runtime/pom.xml
+++ b/appserver/jdbc/jdbc-runtime/pom.xml
@@ -73,6 +73,11 @@
                     <classpathDependencyExcludes>
                         <classpathDependencyExcludes>fish.payara.server.internal.core:kernel</classpathDependencyExcludes>
                     </classpathDependencyExcludes>
+                    <!-- required on JDK 21 -->
+                    <argLine>
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/appserver/persistence/cmp/support-ejb/pom.xml
+++ b/appserver/persistence/cmp/support-ejb/pom.xml
@@ -81,7 +81,7 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.omnifaces</groupId>
                 <artifactId>antlr-maven-plugin</artifactId>
                 <configuration>
                     <grammars>EJBQL.g, JDOQLCodeGeneration.g, Semantic.g</grammars>

--- a/appserver/persistence/cmp/support-sqlstore/pom.xml
+++ b/appserver/persistence/cmp/support-sqlstore/pom.xml
@@ -82,7 +82,7 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.omnifaces</groupId>
                 <artifactId>antlr-maven-plugin</artifactId>
                 <configuration>
                     <grammars>JQL.g, Semantic.g, Optimizer.g, CodeGeneration.g</grammars>

--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -301,6 +301,12 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- required on JDK 21 -->
+                    <argLine>
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,7 +158,7 @@
         <!-- build versions -->
         <jdk.version>11</jdk.version>
         <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>
-        <command-security-plugin.version>1.0.13</command-security-plugin.version>
+        <command-security-plugin.version>1.0.17</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -213,6 +213,10 @@
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
+                        <!-- required on JDK 21 -->
+                        <argLine>
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                 </plugin>
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -94,7 +94,7 @@
         <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
         <maven.makepkgs.plugin.version>0.6.2</maven.makepkgs.plugin.version>
         <maven.jaxb2.plugin.version>0.15.1</maven.jaxb2.plugin.version>
-        <maven.antlr.plugin.version>2.2</maven.antlr.plugin.version>
+        <maven.antlr.plugin.version>2.4</maven.antlr.plugin.version>
 
         <maven.jaxws.plugin.version>2.6</maven.jaxws.plugin.version>
         <maven.apt.plugin.version>1.0-alpha-5</maven.apt.plugin.version>
@@ -344,7 +344,7 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.omnifaces</groupId>
                     <artifactId>antlr-maven-plugin</artifactId>
                     <version>${maven.antlr.plugin.version}</version>
                 </plugin>


### PR DESCRIPTION
## Description
Upgrading antlr-maven-plugin to omnifaces, version 2.4
Adding required --add-opens to tests
Includes https://github.com/payara/Payara/pull/6520

## Important Info
### Testing Environment
OpenJDK 11, Linux

## Notes for Reviewers
Current state:
**Compiles on JDK 21(!)**
Backwards compatible, I tried JDK 11, basic tests pass

Tests not running in JDK 21:
```
[ERROR] Tests run: 21, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.485 s <<< FAILURE! - in fish.payara.nucleus.microprofile.config.source.DirConfigSourceTest
[ERROR] fish.payara.nucleus.microprofile.config.source.DirConfigSourceTest.testFindDir_NotExistingPath  Time elapsed: 0.003 s  <<< ERROR!
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:296)
	at java.base/java.nio.file.Path.of(Path.java:148)
	at java.base/java.nio.file.Paths.get(Paths.java:69)
	at fish.payara.nucleus.microprofile.config.source.DirConfigSource.findDir(DirConfigSource.java:292)
	at fish.payara.nucleus.microprofile.config.source.DirConfigSourceTest.testFindDir_NotExistingPath(DirConfigSourceTest.java:126)
```

There is probably some change in JDK, the failing command from `DirConfigSource.findDir()` is this one:
```
candidates.add(Paths.get(System.getProperty("com.sun.aas.instanceRoot"), path).normalize());
```