### PR TITLE
FISH-7821 Multiplatform Docker Images for Micro

### DIFF
--- a/appserver/extras/docker-images/micro/pom.xml
+++ b/appserver/extras/docker-images/micro/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -70,7 +70,7 @@
             <id>generate-multiplatform-docker-images</id>
             <properties>
                 <!-- List of platform architectures which we wish to build Docker images for - shouldn't have anything not provided as an option by ${docker.java.repository} -->
-                <docker.platforms>linux/amd64,linux/arm64/v8</docker.platforms>
+                <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
             </properties>
         </profile>
     </profiles>

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2021-2023 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2021-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
## Description
Allows creation of multiplatform Docker images for the payara/micro image.

Azul provide AMD64 and ARM64 versions of their azul/zulu-openjdk and azul/zulu-openjdk-alpine images, which we can leverage to create [multiplatform images](https://docs.docker.com/build/building/multi-platform/).

Generating multiplatform images is currently locked behind a new profile: _generate-multiplatform-docker-images_
This is due to an issue with buildx and the server images (see below).

Server images will hopefully follow shortly, but there is currently some rejigging that needs to be done due to an issue with buildx where it requires images to be published to utilise them. Since the payara/basic image utilised by all Server images is versioned in the same manner as them currently (as in, the `payara/server:6.2024.1-SNAPSHOT` image expects to pull from a `payara/basic:6.2024.1-SNAPSHOT` image), this breaks the build unless we _always_ publish (no local builds allowed). I'm currently investigating versioning the basic separately so it only gets built when required to help alleviate this, but for the meantime only micro gets built for multiplatform.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
#### On my local machine
* Built Server and Micro so that they're present in maven cache: `mvn clean install -DskipTests -T 1C`
* Built all Docker images for single architecture: `mvn clean install -pl .\appserver\extras\docker-images -amd -PBuildDockerImages`
  * Images built successfully
* Built all Docker images with new _generate-multiplatform-docker-images_ profile active: `mvn clean install -pl .\appserver\extras\docker-images -amd "-PBuildDockerImages,generate-multiplatform-docker-images`
  * Images built successfully
  * Checking the build logs, you should see that the basic and server images built as normal, but the micro image was built using buildx: `[INFO] DOCKER> docker --config ... **-------> buildx <-------** build --progress=plain --builder maven --platform linux/amd64 --tag payara/micro:latest ...`
* Build all Docker images utilising an older version of Payara with new _generate-multiplatform-docker-images_ profile active: `mvn clean install -pl .\appserver\extras\docker-images -amd -PBuildDockerImages,generate-multiplatform-docker-images "-Dpayara.version=6.2023.12"`
  * Images built successfully
  * Should see in the logs that it's downloading and tagging for the older payara version

#### On an ARM machine I set up in AWS
* Built Server and Micro so that they're present in maven cache: `mvn clean install -DskipTests -T 1C`
* Built Micro Docker image for single architecture: `mvn clean install -pl ./appserver/extras/docker-images -pl ./appserver/extras/docker-images/micro -pl ./appserver/extras/docker-images/tests "-Dtest=PayaraMicroTest.java" -PBuildDockerImages`
  * Images built and test ran successfully
* Built all Docker images with new _generate-multiplatform-docker-images_ profile active: `mvn clean install -pl ./appserver/extras/docker-images -pl ./appserver/extras/docker-images/micro -pl ./appserver/extras/docker-images/tests "-Dtest=PayaraMicroTest.java" -PBuildDockerImages,generate-multiplatform-docker-images`
  * Images built and test ran successfully successfully
  * Checking the build logs, saw that the micro image was built using buildx

### Testing Environment
Windows 11.
Amazon Linux (ARM).

## Documentation
https://github.com/payara/Payara-Documentation/pull/357

## Notes for Reviewers
None
