### PR TITLE
FISH-8072 - cleanboot test with arquillian

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
         stage('Run Payara Samples Tests') {
             steps {
                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Running test  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-                sh """mvn -V -B -ff clean install --strict-checksums -Ppayara-server-remote \
+                sh """mvn -V -B -ff clean install --strict-checksums -Ppayara-server-remote,playwright \
                 -Dpayara.version=${pom.version} \
                 -Djavax.net.ssl.trustStore=${env.JAVA_HOME}/lib/security/cacerts \
                 -Djavax.xml.accessExternalSchema=all \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,21 +74,6 @@ pipeline {
         }
         stage('Setup for Payara Samples Tests') {
             steps {
-                echo '*#*#*#*#*#*#*#*#*#*#*#*#  Install Playwright Dependencies  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-                sh """sudo apt-get update"""
-                sh """sudo apt-get -y install libatk1.0-0\
-                libatk-bridge2.0-0\
-                libcups2\
-                libxkbcommon0\
-                libatspi2.0-0\
-                libxcomposite1\
-                libxdamage1\
-                libxfixes3\
-                libxrandr2\
-                libgbm1\
-                libpango-1.0-0\
-                libcairo2"""
-                echo '*#*#*#*#*#*#*#*#*#*#*#*#  Playwright Dependencies installed  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                 setupDomain()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,21 @@ pipeline {
         }
         stage('Setup for Payara Samples Tests') {
             steps {
+                echo '*#*#*#*#*#*#*#*#*#*#*#*#  Install Playwright Dependencies  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+                sh """sudo apt-get update"""
+                sh """sudo apt-get -y install libatk1.0-0\
+                libatk-bridge2.0-0\
+                libcups2\
+                libxkbcommon0\
+                libatspi2.0-0\
+                libxcomposite1\
+                libxdamage1\
+                libxfixes3\
+                libxrandr2\
+                libgbm1\
+                libpango-1.0-0\
+                libcairo2"""
+                echo '*#*#*#*#*#*#*#*#*#*#*#*#  Playwright Dependencies installed  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                 setupDomain()
             }
         }

--- a/appserver/tests/payara-samples/samples/cleanboot/README.md
+++ b/appserver/tests/payara-samples/samples/cleanboot/README.md
@@ -22,3 +22,24 @@ This will run the test against the current version of Payara Server, with Arquil
 Alternatively, you can start the domain indepedently and run the test in remote mode:
 
     mvn clean verify -Ppayara-server-remote
+
+## Playwright dependencies
+
+By default, this test will check and install Playwright dependencies before running the test. 
+The user needs to have the permimssions to install such dependencies. 
+Alternatively, dependencies can be installed manually. 
+Playwright needs the following libraries to run:
+    libatk1.0-0
+    libatk-bridge2.0-0
+    libcups2
+    libxkbcommon0
+    libatspi2.0-0
+    libxcomposite1
+    libxdamage1
+    libxfixes3
+    libxrandr2
+    libgbm1
+    libpango-1.0-0
+    libcairo2
+and to run the test without installing the dependencies with maven and Playwright CLI command:
+    mvn clean verify -P!install-deps

--- a/appserver/tests/payara-samples/samples/cleanboot/README.md
+++ b/appserver/tests/payara-samples/samples/cleanboot/README.md
@@ -1,0 +1,24 @@
+# Cleanboot File Tests
+
+Boots the domain and test the admin console in a browser.
+
+Creates an instance, starts it, checks the logs for any trace above INFO, stops the instance(s), deletes the instance(s)
+
+Creates a deployment group, create instances for that group, starts the group, checks the logs for any trce above INFO, stops the instances, delete the instances, delete the group
+
+Logs above INFO are printed in the output, to be assessed manually (some warnings are known issues and can be ignored). 
+
+Any log above WARNING will fail the test.
+
+
+## run the tests:
+
+By default, it is run in managed mode, with the command
+
+    mvn clean verify
+
+This will run the test against the current version of Payara Server, with Arquillian.
+
+Alternatively, you can start the domain indepedently and run the test in remote mode:
+
+    mvn clean verify -Ppayara-server-remote

--- a/appserver/tests/payara-samples/samples/cleanboot/pom.xml
+++ b/appserver/tests/payara-samples/samples/cleanboot/pom.xml
@@ -57,6 +57,36 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                  <execution>
+                    <id>install-playwright-dependencies</id>
+                    <phase>pre-integration-test</phase>
+                    <goals>
+                      <goal>exec</goal>
+                    </goals>
+                  </execution>
+                </executions>
+                <configuration>
+                    <executable>java</executable>
+                    <mainClass>com.microsoft.playwright.CLI</mainClass>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath />
+                        <argument>com.microsoft.playwright.CLI</argument>
+                        <argument>install-deps</argument>
+                    </arguments>
+                    <async>false</async>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     
     <profiles>
         <profile>

--- a/appserver/tests/payara-samples/samples/cleanboot/pom.xml
+++ b/appserver/tests/payara-samples/samples/cleanboot/pom.xml
@@ -29,17 +29,16 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    
+    <artifactId>cleanboot</artifactId>
+    <version>6.2024.1-SNAPSHOT</version>
+    <name>Payara Samples - Payara - Clean boot test</name>
 
     <parent>
         <groupId>fish.payara.samples</groupId>
         <artifactId>payara-samples-profiled-tests</artifactId>
         <version>6.2024.1-SNAPSHOT</version>
     </parent>
-    
-    <groupId>fish.payara.samples</groupId>
-    <artifactId>clean-boot-test</artifactId>
-    <version>6.2024.1-SNAPSHOT</version>
-    <name>Payara Samples - Payara - Clean boot test</name>
 
     <properties>
       <playwright.version>1.40.0</playwright.version>

--- a/appserver/tests/payara-samples/samples/cleanboot/pom.xml
+++ b/appserver/tests/payara-samples/samples/cleanboot/pom.xml
@@ -57,35 +57,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                  <execution>
-                    <id>install-playwright-dependencies</id>
-                    <phase>pre-integration-test</phase>
-                    <goals>
-                      <goal>exec</goal>
-                    </goals>
-                  </execution>
-                </executions>
-                <configuration>
-                    <executable>java</executable>
-                    <mainClass>com.microsoft.playwright.CLI</mainClass>
-                    <arguments>
-                        <argument>-classpath</argument>
-                        <classpath />
-                        <argument>com.microsoft.playwright.CLI</argument>
-                        <argument>install-deps</argument>
-                    </arguments>
-                    <async>false</async>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+
 
     
     <profiles>
@@ -98,5 +70,39 @@
                 <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
             </properties>
         </profile>
+        <profile>
+            <id>install-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>  
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                          <execution>
+                            <id>install-playwright-dependencies</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                              <goal>exec</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                        <configuration>
+                            <executable>java</executable>
+                            <mainClass>com.microsoft.playwright.CLI</mainClass>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>com.microsoft.playwright.CLI</argument>
+                                <argument>install-deps</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>         
+        </profile> 
     </profiles>
 </project>

--- a/appserver/tests/payara-samples/samples/cleanboot/pom.xml
+++ b/appserver/tests/payara-samples/samples/cleanboot/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER. Copyright (c)
+    [2023] Payara Foundation and/or its affiliates. All rights reserved. The
+    contents of this file are subject to the terms of either the GNU General
+    Public License Version 2 only ("GPL") or the Common Development and Distribution
+    License("CDDL") (collectively, the "License"). You may not use this file
+    except in compliance with the License. You can obtain a copy of the License
+    at https://github.com/payara/Payara/blob/master/LICENSE.txt See the License
+    for the specific language governing permissions and limitations under the
+    License. When distributing the software, include this License Header Notice
+    in each file and include the License file at glassfish/legal/LICENSE.txt.
+    GPL Classpath Exception: The Payara Foundation designates this particular
+    file as subject to the "Classpath" exception as provided by the Payara Foundation
+    in the GPL Version 2 section of the License file that accompanied this code.
+    Modifications: If applicable, add the following below the License Header,
+    with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions Copyright [year] [name of copyright owner]" Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor] elects
+    to include this software in this distribution under the [CDDL or GPL Version
+    2] license." If you don't indicate a single choice of license, a recipient
+    has the option to distribute your version of this file under either the CDDL,
+    the GPL Version 2 or to extend the choice of license to its licensees as
+    provided above. However, if you add GPL Version 2 code and therefore, elected
+    the GPL Version 2 license, then the option applies only if the new code is
+    made subject to such option by the copyright holder. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>6.2024.1-SNAPSHOT</version>
+    </parent>
+    
+    <groupId>fish.payara.samples</groupId>
+    <artifactId>clean-boot-test</artifactId>
+    <version>6.2024.1-SNAPSHOT</version>
+    <name>Payara Samples - Payara - Clean boot test</name>
+
+    <properties>
+      <playwright.version>1.40.0</playwright.version>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>playwright</artifactId>
+          <version>${playwright.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>payara-server-managed</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminGroup.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminGroup.java
@@ -1,0 +1,134 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package fish.payara.functional.cleanboot;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.WaitForSelectorState;
+
+public class AdminGroup {
+
+    static public void goToDeploymentGroupPage(Page page) {
+        // Click on the option Instances in the menu
+        Locator groupButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Deployment Groups").setExact(true));
+        groupButton.click();
+        page.waitForSelector("div[id='propertyForm:dgTable']");
+
+        // Expect the title to contain Instances
+        assertThat(page).hasTitle("Deployment Groups");
+    }
+
+    static public void waitForProcess(Page page) {
+        // wait for modal to appear and disappear
+        page.waitForSelector("input[value='Processing...']");
+        //page.waitForSelector("div#ajaxPanelBody");
+        page.waitForSelector("input[value='Processing...']",
+                new Page.WaitForSelectorOptions().setTimeout(120000).setState(WaitForSelectorState.HIDDEN));
+        page.waitForSelector("div#ajaxPanelBody",
+                new Page.WaitForSelectorOptions().setTimeout(120000).setState(WaitForSelectorState.HIDDEN));
+
+    }
+
+    static public void acceptDialog(Page page) {
+        //Confirm the next dialog window
+        page.onceDialog(dialog -> {
+            dialog.accept();
+        });
+    }
+
+    static public void dismissDialog(Page page) {
+        //Confirm the next dialog window
+        page.onceDialog(dialog -> {
+            dialog.dismiss();
+        });
+    }
+
+    static public void createGroup(Page page, String nameGroup, String[] nameInstances) {
+
+        AdminPage.gotoHomepage(page);
+        goToDeploymentGroupPage(page);
+
+        // Create new instance
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("New...")).click();
+        page.waitForSelector("input[id='propertyForm:propertySheet:propertySectionTextField:NameTextProp:NameText']");
+        page.getByRole(AriaRole.TEXTBOX).fill(nameGroup);
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("OK")).click();
+        page.waitForSelector("input[value='New...']");
+
+        //Check for the presence of the new instance in the table
+        Locator groupLink = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(nameGroup).setExact(true));
+        assertThat(groupLink).isVisible();
+        groupLink.click();
+        page.waitForSelector("table.Tab1TblNew_sun4");
+
+        //Create instances in the group
+        for (String nameInstance : nameInstances) {
+            Locator groupTabs = page.locator("table.Tab1TblNew_sun4");
+            Locator groupInstanceTab = groupTabs.getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("Instances").setExact(true));
+            groupInstanceTab.click();
+
+            //Create new instance
+            page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("New...")).click();
+            page.waitForSelector("input[id='propertyForm:propertySheet:propertSectionTextField:NameTextProp:NameText']");
+            page.getByRole(AriaRole.TEXTBOX).fill(nameInstance);
+            page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("OK")).click();
+            page.waitForSelector("input[value=' Save ']");
+
+            // Check for the presence of the new instance in the table
+            Locator instanceLink = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(nameInstance).setExact(true));
+            assertThat(instanceLink).isVisible();
+
+            Locator groupGeneralTab = groupTabs.getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("General").setExact(true));
+            groupGeneralTab.click();
+        }
+
+    }
+
+    static public void startGroups(Page page) {
+        AdminPage.gotoHomepage(page);
+        goToDeploymentGroupPage(page);
+
+        acceptDialog(page);
+
+	Locator selectAllButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Select All").setExact(true));
+        selectAllButton.click();
+        Locator startButton = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Start Deployment Group"));
+        startButton.click();
+
+        waitForProcess(page);
+    }
+
+    static public void stopGroups(Page page) {
+        AdminPage.gotoHomepage(page);
+        goToDeploymentGroupPage(page);
+
+        acceptDialog(page);
+
+        //Select all groups and Stop
+        Locator selectAllButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Select All").setExact(true));
+        selectAllButton.click();
+        Locator stopButton = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Stop Deployment Group"));
+        stopButton.click();
+
+        waitForProcess(page);
+    }
+
+    static public void deleteGroups(Page page) {
+        AdminPage.gotoHomepage(page);
+        goToDeploymentGroupPage(page);
+
+        acceptDialog(page);
+
+        //Delete all groups
+        Locator selectAllButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Select All").setExact(true));
+        selectAllButton.click();
+        Locator deleteButton = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Delete"));
+        deleteButton.click();
+
+        waitForProcess(page);
+    }
+}

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminGroup.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminGroup.java
@@ -49,6 +49,8 @@ public class AdminGroup {
 
     static public void createGroup(Page page, String nameGroup, String[] nameInstances) {
 
+        System.out.println("Create the deployment group " + nameGroup);
+
         AdminPage.gotoHomepage(page);
         goToDeploymentGroupPage(page);
 
@@ -89,6 +91,9 @@ public class AdminGroup {
     }
 
     static public void startGroups(Page page) {
+
+        System.out.println("Start the deployment groups");
+
         AdminPage.gotoHomepage(page);
         goToDeploymentGroupPage(page);
 

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminInstance.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminInstance.java
@@ -1,0 +1,184 @@
+package fish.payara.functional.cleanboot;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import java.util.List;
+
+public class AdminInstance {
+
+    static public void goToInstancePage(Page page) {
+        //Click on the option Instances in the menu
+        Locator instanceButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Instances").setExact(true));
+        instanceButton.click();
+        page.waitForSelector("input[value=' Save ']");
+
+        //Expect the title to contain Instances
+        assertThat(page).hasTitle("Payara Server Instances");
+    }
+
+    static public void waitForProcess(Page page) {
+        //Wait for modal to appear and disappear
+        page.waitForSelector("input[value='Processing...']");
+        //page.waitForSelector("div#ajaxPanelBody");
+        page.waitForSelector("input[value='Processing...']",
+                new Page.WaitForSelectorOptions().setTimeout(120000).setState(WaitForSelectorState.HIDDEN));
+        page.waitForSelector("div#ajaxPanelBody",
+                new Page.WaitForSelectorOptions().setTimeout(120000).setState(WaitForSelectorState.HIDDEN));
+
+    }
+
+    static public void acceptDialog(Page page) {
+        //Confirm the next dialog window
+        page.onceDialog(dialog -> {
+            dialog.accept();
+        });
+    }
+
+    static public void dismissDialog(Page page) {
+        //Confirm the next dialog window
+        page.onceDialog(dialog -> {
+            dialog.dismiss();
+        });
+    }
+
+    static public void createInstance(Page page, String nameInstance) {
+
+        AdminPage.gotoHomepage(page);
+        goToInstancePage(page);
+
+        //Create new instance
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("New...")).click();
+        page.waitForSelector("input[id='propertyForm:propertySheet:propertSectionTextField:NameTextProp:NameText']");
+	page.getByRole(AriaRole.TEXTBOX).fill(nameInstance);
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("OK")).click();
+        page.waitForSelector("input[value=' Save ']");
+
+        //Check for the presence of the new instance in the table
+	Locator instanceLink = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(nameInstance).setExact(true));
+        assertThat(instanceLink).isVisible();
+    }
+
+    static public void startInstance(Page page, String nameInstance) {
+
+        AdminPage.gotoHomepage(page);
+        goToInstancePage(page);
+
+        //Open the page of the instance to start it
+	Locator instanceLink = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(nameInstance).setExact(true));
+        instanceLink.click();
+        page.waitForSelector("div[id='propertyForm:propertyContentPage']");
+
+        //Confirm the dialog window
+	acceptDialog(page);
+
+        Locator startButton = page.locator("input[value='Start']");
+        startButton.click();
+
+        waitForProcess(page);
+    }
+
+    static public void startInstances(Page page, String nameInstance) {
+
+        AdminPage.gotoHomepage(page);
+        goToInstancePage(page);
+
+        //Select all instances and start
+        Locator selectAllButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Select All").setExact(true));
+        selectAllButton.click();
+
+        //Confirm the dialog window
+        acceptDialog(page);
+
+        Locator startButton = page.locator("input[value='Start']");
+        startButton.click();
+
+        waitForProcess(page);
+    }
+
+    static public void stopInstances(Page page) {
+
+        AdminPage.gotoHomepage(page);
+        goToInstancePage(page);
+
+        //Confirm the dialog window
+        acceptDialog(page);
+
+        //Select all instances and start
+        Locator selectAllButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Select All").setExact(true));
+        selectAllButton.click();
+        Locator stopButton = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Stop"));
+        stopButton.click();
+
+        waitForProcess(page);
+    }
+
+    static public void deleteInstances(Page page) {
+
+        AdminPage.gotoHomepage(page);
+        goToInstancePage(page);
+
+        //Confirm the dialog window
+        acceptDialog(page);
+
+        //Delete all instances
+        Locator selectAllButton = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Select All").setExact(true));
+        selectAllButton.click();
+        Locator deleteButton = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Delete"));
+        deleteButton.click();
+
+        waitForProcess(page);
+}
+
+    static public String collectLogs(Page page, String nameInstance, String[] logLevels) {
+        String logs = nameInstance + " : \n";
+
+        AdminPage.gotoHomepage(page);
+        goToInstancePage(page);
+
+        //Open the page of the instance and open the logs
+        Locator instanceLink = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(nameInstance).setExact(true));
+        instanceLink.click();
+        page.waitForSelector("div[id='propertyForm:propertyContentPage']");
+        Locator viewLogButton = page.locator("input[value='View Log Files']");
+
+        try (
+                Page logPage = page.waitForPopup(() -> {
+                    viewLogButton.click();
+                })) {
+            logPage.waitForLoadState();
+
+            logPage.waitForSelector("div[id='propertyForm:basicTable']");
+
+            Locator logLevelCombobox = logPage.locator("select[id='propertyForm:propertyContentPage:propertySheet:propertSectionTextField:logLevelProp:logLevel']");
+            logLevelCombobox.click();
+            for (String logLevel : logLevels) {
+                //Change the log level to the desired value and filter logs on that level
+                Locator logLevelSelector = logPage.getByLabel("Log Level:");
+                logLevelSelector.selectOption(logLevel, new Locator.SelectOptionOptions().setForce(true));
+                Locator searchButton = logPage.locator("input[id='propertyForm:propertyContentPage:bottomButtons:searchButtonBottom']");
+                searchButton.click();
+                logPage.waitForLoadState();
+                //Create list of every details buttons displayed
+                List<Locator> detailsButtons = logPage.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("(details)")).all();
+                for (Locator detailsButton : detailsButtons) {
+                    try (Page detailPageEvent = logPage.waitForPopup(() -> {
+                        detailsButton.click();
+                    })) {
+                        detailPageEvent.waitForLoadState();
+                        String logEntryLevel = detailPageEvent.locator("span[id*='logLevel']").textContent();
+                        List<Locator> logEntryMessages = detailPageEvent.locator("span[id*='completeMessage']").all();
+                        if (!logEntryMessages.isEmpty()) {
+                            String logEntryMessage = detailPageEvent.locator("span[id*='completeMessage']").textContent();
+                            logs = logs.concat(logEntryLevel + " - " + logEntryMessage + " \n");
+                        }
+                    }
+                }
+            }
+        }
+        logs = logs.concat(" \n");
+        return logs;
+    }
+}

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminInstance.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminInstance.java
@@ -46,6 +46,8 @@ public class AdminInstance {
 
     static public void createInstance(Page page, String nameInstance) {
 
+        System.out.println("Create the instance " + nameInstance);
+
         AdminPage.gotoHomepage(page);
         goToInstancePage(page);
 
@@ -62,6 +64,8 @@ public class AdminInstance {
     }
 
     static public void startInstance(Page page, String nameInstance) {
+
+        System.out.println("Start the instance " + nameInstance);
 
         AdminPage.gotoHomepage(page);
         goToInstancePage(page);
@@ -80,7 +84,9 @@ public class AdminInstance {
         waitForProcess(page);
     }
 
-    static public void startInstances(Page page, String nameInstance) {
+    static public void startInstances(Page page) {
+
+        System.out.println("Start the instances");
 
         AdminPage.gotoHomepage(page);
         goToInstancePage(page);
@@ -100,6 +106,8 @@ public class AdminInstance {
 
     static public void stopInstances(Page page) {
 
+        System.out.println("Stop the instances");
+
         AdminPage.gotoHomepage(page);
         goToInstancePage(page);
 
@@ -117,6 +125,8 @@ public class AdminInstance {
 
     static public void deleteInstances(Page page) {
 
+        System.out.println("Delete the instances");
+
         AdminPage.gotoHomepage(page);
         goToInstancePage(page);
 
@@ -133,6 +143,9 @@ public class AdminInstance {
 }
 
     static public String collectLogs(Page page, String nameInstance, String[] logLevels) {
+
+        System.out.println("Collect the logs from " + nameInstance);
+
         String logs = nameInstance + " : \n";
 
         AdminPage.gotoHomepage(page);

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminPage.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/AdminPage.java
@@ -1,0 +1,21 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package fish.payara.functional.cleanboot;
+
+import com.microsoft.playwright.Page;
+
+/**
+ *
+ * @author SimonLaden
+ */
+public class AdminPage {
+
+    static public void gotoHomepage(Page page) {
+        // Open the admin page
+        page.navigate("http://localhost:4848");
+        page.waitForSelector("div[id='treeForm:tree_children']");
+    }
+
+}

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/CleanBootIT.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/CleanBootIT.java
@@ -1,0 +1,99 @@
+package fish.payara.functional.cleanboot;
+
+import com.microsoft.playwright.*;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.PayaraTestShrinkWrap;
+import fish.payara.samples.NotMicroCompatible;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import java.sql.Timestamp;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PayaraArquillianTestRunner.class)
+@NotMicroCompatible
+public class CleanBootIT {
+
+    static private Page page;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = PayaraTestShrinkWrap.getWebArchive();
+        return archive;
+    }
+
+    @BeforeClass
+    static public void openPage() {
+        //Load the Admin Console
+        Playwright playwright = Playwright.create();
+        Browser browser = playwright.chromium().launch();
+        page = browser.newPage();
+        page.navigate("http://localhost:4848/");
+        page.waitForSelector("table[role='presentation']", new Page.WaitForSelectorOptions().setTimeout(120000));
+    }
+
+    @AfterClass
+    static public void closePage() {
+        page.close();
+    }
+
+    @Test
+    @RunAsClient
+    public void openAdminConsole() {
+        AdminPage.gotoHomepage(page);
+        assertThat(page).hasTitle("Payara Server Console - Common Tasks");
+    }
+
+    @Test
+    @RunAsClient
+    public void createInstanceTest() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        String logs = timestamp.toString() + " \n";
+
+        AdminInstance.createInstance(page, "testInstance1");
+        AdminInstance.startInstance(page, "testInstance1");
+
+        String[] logLevels = {"WARNING", "SEVERE", "ALERT", "EMERGENCY"};
+        logs = logs.concat(AdminInstance.collectLogs(page, "testInstance1", logLevels));
+
+        AdminInstance.stopInstances(page);
+        AdminInstance.deleteInstances(page);
+
+        timestamp = new Timestamp(System.currentTimeMillis());
+        logs = logs.concat(timestamp.toString()) + " \n";
+        Assert.assertTrue(!(logs.contains("SEVERE") && !(logs.contains("ALERT"))) && !(logs.contains("EMERGENCY")));
+        System.out.println(logs);
+    }
+
+    @Test
+    @RunAsClient
+    public void createDeploymentGroupTest() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        String logs = timestamp.toString() + " \n";
+        String[] instances = {"groupInstance1", "groupInstance2"};
+
+        AdminGroup.createGroup(page, "group1", instances);
+        AdminGroup.startGroups(page);
+
+        String[] logLevels = {"WARNING", "SEVERE", "ALERT", "EMERGENCY"};
+        logs = logs.concat(AdminInstance.collectLogs(page, "groupInstance1", logLevels));
+        logs = logs.concat(AdminInstance.collectLogs(page, "groupInstance2", logLevels));
+
+        AdminGroup.stopGroups(page);
+        AdminGroup.deleteGroups(page);
+        AdminInstance.deleteInstances(page);
+
+        timestamp = new Timestamp(System.currentTimeMillis());
+        logs = logs.concat(timestamp.toString()) + " \n";
+        Assert.assertTrue(!(logs.contains("SEVERE") && !(logs.contains("ALERT"))) && !(logs.contains("EMERGENCY")));
+        System.out.println(logs);
+    }
+}

--- a/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/CleanBootIT.java
+++ b/appserver/tests/payara-samples/samples/cleanboot/src/test/java/fish/payara/functional/cleanboot/CleanBootIT.java
@@ -69,8 +69,11 @@ public class CleanBootIT {
 
         timestamp = new Timestamp(System.currentTimeMillis());
         logs = logs.concat(timestamp.toString()) + " \n";
-        Assert.assertTrue(!(logs.contains("SEVERE") && !(logs.contains("ALERT"))) && !(logs.contains("EMERGENCY")));
         System.out.println(logs);
+        boolean containsError = logs.contains("SEVERE") || logs.contains("ALERT") || logs.contains("EMERGENCY");
+        if (containsError) {
+            Assert.fail("Logs contain SEVERE or ALERT or EMERGENCY");
+        }
     }
 
     @Test
@@ -93,7 +96,10 @@ public class CleanBootIT {
 
         timestamp = new Timestamp(System.currentTimeMillis());
         logs = logs.concat(timestamp.toString()) + " \n";
-        Assert.assertTrue(!(logs.contains("SEVERE") && !(logs.contains("ALERT"))) && !(logs.contains("EMERGENCY")));
         System.out.println(logs);
+        boolean containsError = logs.contains("SEVERE") || logs.contains("ALERT") || logs.contains("EMERGENCY");
+        if (containsError) {
+            Assert.fail("Logs contain SEVERE or ALERT or EMERGENCY");
+        }
     }
 }

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -90,6 +90,7 @@
         <module>reproducers</module>
         <module>opentelemetry</module>
         <module>use-bundled-jsf-primefaces</module>
+        <module>cleanboot</module>
     </modules>
 
     <dependencyManagement>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -90,7 +90,6 @@
         <module>reproducers</module>
         <module>opentelemetry</module>
         <module>use-bundled-jsf-primefaces</module>
-        <module>cleanboot</module>
     </modules>
 
     <dependencyManagement>
@@ -109,4 +108,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    
+    <profiles>
+        <profile>
+            <id>playwright</id>
+            <modules>
+                <module>cleanboot</module>
+            </modules>        
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Cleanboot test converted in Java. 
It uses Arquillian to start/stop the server.
Playwright opens a browser (in headless mode by default), loads the admin console, then runs 2 tests
- create an instance, start the instance, check the logs, stop the instance and delete the instance. It fails if the logs contain errors.
- create a deployment group with 2 instances, start the group, check the logs for both instances, stop the group, delete the group and the instances. It fails if the logs contain errors.
Any warning in the logs is printed in the output, for manual verifications when necessary.