### PR TITLE
FISH-8152 Micro - Devmode - Store session state

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/DeployCommandParameters.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/deployment/DeployCommandParameters.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.api.deployment;
 
@@ -303,6 +303,7 @@ public class DeployCommandParameters extends OpsParams {
         public static final String DEPLOYMENT_ORDER = "deploymentorder";
         public static final String ALT_DD = "altdd";
         public static final String RUNTIME_ALT_DD = "runtimealtdd";
+        public static final String KEEP_STATE = "keepState";
         public static final String HOT_DEPLOY = "hotdeploy";
         public static final String SOURCES_CHANGED = "sourceschanged";
         public static final String METADATA_CHANGED = "metadatachanged";

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/DynamicReloader.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.v3.server;
 
@@ -262,6 +262,10 @@ public class DynamicReloader implements Runnable {
             if (sourcesChanged != null && !sourcesChanged.isEmpty()) {
                 deployParam.set(DeployCommandParameters.ParameterNames.SOURCES_CHANGED, sourcesChanged);
             }
+        }
+        boolean keepState = Boolean.parseBoolean(reloadFile.getProperty(DeployCommandParameters.ParameterNames.KEEP_STATE));
+        if(keepState) {
+            deployParam.set(DeployCommandParameters.ParameterNames.KEEP_STATE, "true");
         }
         commandRunner.getCommandInvocation("deploy", new XMLActionReporter(), kernelSubject).parameters(deployParam).execute();
 


### PR DESCRIPTION
This pull request introduces passing the deployment argument, keepState, to the Payara Micro runtime. The keepState argument allows developers to control the persistence of the session state across multiple redeployments during the development process. By default, the keepState argument is set to false.

### Usage Example
To make use of this new feature, IDEs or tools can set the `keepState` property to `true` in the `.reload` file in the root directory of the deployed binary when redeploying Payara Micro.

### Testing Process
For detailed instructions on testing and more information about this enhancement, please refer to the following link: [Testing Process - Pull Request #284](https://github.com/payara/ecosystem-maven/pull/284)
