### PR TITLE
FISH-8217 : duplicated semicolon removed

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/GFFileHandler.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.server.logging;
 
@@ -51,7 +51,7 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.logging.AgentFormatterDelegate;
 import fish.payara.enterprise.server.logging.JSONLogFormatter;
-import fish.payara.enterprise.server.logging.PayaraNotificationLogRotationTimer;;
+import fish.payara.enterprise.server.logging.PayaraNotificationLogRotationTimer;
 import java.io.*;
 import java.security.PrivilegedAction;
 import java.text.FieldPosition;


### PR DESCRIPTION
## Description
Removing of duplicated semicolon in import to build on JDK 21

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Samples, quicklook, etc

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.6

## Documentation
None

## Notes for Reviewers
None
