### PR TITLE
FISH-8248 Use Core 6.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>fish.payara.server.core</groupId>
         <artifactId>core-aggregator</artifactId>
-        <version>6.11.0</version>
+        <version>6.11.1</version>
         <relativePath>core</relativePath>
     </parent>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Description
Sets the parent version of the release to 6.11.1, which reverts JAXB to 4.0.1 to fix the XML-WS TCK.

## Important Info
### Blockers
~Review, testing, and release of https://github.com/payara/Payara/tree/Payara-Core-6.11.1-Release~
Tag published: https://github.com/payara/Payara/tree/payara-core-6.11.1

## Testing
### New tests
None

### Testing Performed
Jenkins test please
https://engineeringjenkins.payara.fish/blue/organizations/jenkins/JakartaEE-10-TCK/detail/JakartaEE-10-TCK/52/pipeline/

### Testing Environment
Jenkins

## Documentation
Pending... 
Release notes will need adjusting...

## Notes for Reviewers
Pending...
