### PR TITLE
Fix Some Maven Build Warnings

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -238,7 +238,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven.enforcer.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -499,6 +499,11 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${maven.enforcer.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${maven.build.helper.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -494,6 +494,11 @@
                         </supportedProjectTypes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven.enforcer.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
## Description
Fixes a couple of warnings about missing plugin versions.

## Important Info
### Blockers
N/A

## Testing
### New tests
None

### Testing Performed
Built the server - no warnings about missing plugin versions for enforcer and build-helper.

### Testing Environment
Windows 11.

## Documentation
N/A

## Notes for Reviewers
None
