### PR TITLE
Don't Use Maven Exec for 3rd Party License

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright 2017-2023 Payara Foundation and/or affiliates
+    Portions Copyright 2017-2024 Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -352,6 +352,27 @@
                 </pluginRepository>
             </pluginRepositories>
         </profile>
+
+        <profile>
+            <id>GenerateThirdPartyLicenseFile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>download-and-aggregate-licenses</id>
+                                <goals>
+                                    <goal>aggregate-add-third-party</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -382,22 +403,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>${license-maven-plugin.version}</version>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>download-and-aggregate-licenses</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>aggregate-add-third-party</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
         </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <deploy.skip>true</deploy.skip>
         <javadoc.skip>true</javadoc.skip>
         <source.skip>true</source.skip>
-        <license-maven-plugin.version>2.3.0</license-maven-plugin.version>
+        <license-maven-plugin.version>2.4.0</license-maven-plugin.version>
     </properties>
 
     <profiles>
@@ -385,22 +385,16 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license-maven-plugin.version}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
                         <id>download-and-aggregate-licenses</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>aggregate-add-third-party</goal>
                         </goals>
-                        <configuration>
-                            <executable>mvn</executable>
-                            <arguments>
-                                <argument>license:aggregate-add-third-party</argument>
-                            </arguments>
-                        </configuration>
                     </execution>
                 </executions>
 


### PR DESCRIPTION
## Description
Switches us from using maven exec to spin up a maven command inside our own maven command to more simply binding to a lifecycle phase.

Also updates us to the latest 2.4.0

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Cleared maven repo.
Built server.
Checked that no unstaged changes: `git status`
Checked that a 3rd party license has been bundled in the Payara Server distribution under `payara6/glassfish/legal`
Changed Jackson version to 2.16.1 and rebuilt server.
Checked that a 3rd party license bundled in the Payara Server distribution under `payara6/glassfish/legal` has been updated appropriately.

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
