### PR TITLE
FISH-8262 FISH-8263 FISH-8264 Upgrade Docker JDK Versions

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,7 +57,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.21</docker.jdk11.tag>
+        <docker.jdk11.tag>11.0.22</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.9</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.1</docker.jdk21.tag>
 

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,7 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.22</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.9</docker.jdk17.tag>
+        <docker.jdk17.tag>17.0.10</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.1</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -59,7 +59,7 @@
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.22</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.10</docker.jdk17.tag>
-        <docker.jdk21.tag>21.0.1</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.2</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.


### PR DESCRIPTION
## Description
Updates the Docker JDK versions to 11.0.22, 17.0.10, and 21.0.2.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
_Waiting for Azul to publish the Docker images..._
Built Payara server using 11.0.22.
Built Docker images and let unit tests run.

### Testing Environment
Windows 11, Zulu 11.0.22

## Documentation
N/A

## Notes for Reviewers
None
