### PR TITLE
FISH-8317 - Microprofile Config NPE for profiled setting

### DIFF
--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigExpressionResolver.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/main/java/fish/payara/nucleus/microprofile/config/spi/ConfigExpressionResolver.java
@@ -109,8 +109,12 @@ final class ConfigExpressionResolver {
         
         if(profile != null && result != null) {
             ConfigValueImpl resultWithoutProfile = getValue(resolveExpression(propertyName));
-            result = resultWithoutProfile.getSourceOrdinal() == result.getSourceOrdinal() ? result :
-                    (resultWithoutProfile.getSourceOrdinal() > result.getSourceOrdinal()) ? resultWithoutProfile : result;
+            // Note: In case there is a non-profiled value from a source with the same ordinal value, it will be ignored.
+            //       All spec versions including v3.1 do not include a definition for this edge case -
+            //       all sources are supposed to have a unique ordinal value.
+            if (resultWithoutProfile != null && resultWithoutProfile.getSourceOrdinal() > result.getSourceOrdinal()) {
+                result = resultWithoutProfile;
+            }
         } 
         
 


### PR DESCRIPTION
## Description
- Fixes #6549 

## Important Info
### Blockers
None

## Testing
### New tests
Included in PR

### Testing Performed
I ran `ConfigExpressionResolverTest`, which has been extended in this PR, too.

### Testing Environment
Fedora 39 with Maven 3.9.6 and Java 17.0.9

## Documentation
-

## Notes for Reviewers
If you want to see the failing test, simply checkout the PR branch and reset HEAD to one commit before. I compiled Payara using `mvn package -Dmaven.javadoc.skip -DskipTests -pl nucleus/payara-modules/nucleus-microprofile/config-service -am` and ran the tests from my IDE.