### PR TITLE
Revert: FISH-7224 Upgrade JAXB-OSGI to 4.0.4

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,7 +75,7 @@
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>
-        <jaxb-impl.version>4.0.4.payara-p1</jaxb-impl.version>
+        <jaxb-impl.version>4.0.1</jaxb-impl.version>
         <jsonp-api.version>2.1.0</jsonp-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>


### PR DESCRIPTION
## Description
This reverts commit 1fb6650acf4c579d7d88a2eea853470d8eb73bdb, reversing changes made to 625a0f89d6d9caab36f7aaae64ddd08ecdc948d3.

This is due to it breaking the Jakarta EE 10 XML-WS TCK

Original PR: https://github.com/payara/Payara/pull/6502

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
None

### Testing Environment
My eyes

## Documentation
N/A

## Notes for Reviewers
None
