### PR TITLE
FISH-7430 : send-error_X property being skipped

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -1553,7 +1553,8 @@ public class WebModule extends PwcWebModule implements Context {
         } else if(name.startsWith("alternatedocroot_")) {
             parseAlternateDocBase(name, value);
         } else if(name.startsWith("valve_") ||
-                name.startsWith("listener_")) {
+            name.startsWith("listener_") ||
+            name.startsWith("send-error_")) {
             // do nothing; these properties are dealt with
             // in configureCatalinaProperties()
         } else {


### PR DESCRIPTION
## Description
Warning Falsely Logged with Custom Error Pages

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Replace tag `<virtual-server>` into domain.xml in Payara Server to:
```
<virtual-server network-listeners="http-listener-1,http-listener-2" id="server">
        <property name="send-error_1" value="code=404 path=${com.sun.aas.instanceRoot}/docroot/404.html reason=NOT_FOUND"></property>
</virtual-server>
```
2. Create a 404.html file in domain1/docroot/
3. Start server ./asadmin start-domain -v
4. Warning should **NOT** be logged during deployment

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.8.6

## Documentation
None