### PR TITLE
FISH-8054 Upgrade the OpenID Security Connector to 3.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,7 +56,7 @@
     <properties>
         <payara.core.version>6.12.0-SNAPSHOT</payara.core.version>
         <!-- BOM dependencies versions -->
-        <payara.security-connectors.version>3.0.alpha8</payara.security-connectors.version>
+        <payara.security-connectors.version>3.1</payara.security-connectors.version>
         <hk2.version>3.0.1.payara-p3</hk2.version>
         <osgi.version>7.0.0</osgi.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
The PR upgrades the Security Connector to expand the functionality of the OIDC Connector by enabling proxy configuration. This addition is crucial for scenarios where the application interacts with an OpenID Connect provider through a reverse proxy, offering more flexibility in handling requests.

## Testing
### Testing Performed
#### **Install NGINX:**
- **Download NGINX for Windows:** Visit the NGINX website ([nginx news](https://nginx.org/) ) and download the Windows version of NGINX.

- **Install NGINX:** Follow the installation instructions provided with the downloaded package to install NGINX on your Windows machine. During the installation, choose the installation directory. For example, C:\nginx.

- **Edit NGINX configuration file:** Locate the NGINX configuration file (`nginx.conf`) in the NGINX installation directory (typically found within a `conf` directory). Edit the file using a text editor like Notepad or any other code editor.

- **Update hostname & port:** Locate the `http {` block within the `nginx.conf` file and proceed to modify the NGINX port specified under `server → listen`. Additionally, within the `location /` block, include the following key-value pairs prefixed with `proxy_`. Specifically, use `proxy_pass` to designate the host and port of the Payara instance.

```
    server {
        listen       8986;
        server_name  localhost;

        location / {
            proxy_pass http://localhost:8080;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            root   html;
            index  index.html index.htm;
        }
.........
}
```

- **Start NGINX:** Now save the NGINX configuration file, and navigate to the root of the NGINX installation directory. Use the command nginx to start the NGINX instance. If there's a need to modify the port or host name in the NGINX configuration file, perform a reload using the command nginx -s reload.

#### **Create OIDC application:**
Here, I am utilizing the following Google authentication definition, which has been registered in Google Cloud. Please note that the client secret is masked for security purposes:

![image](https://github.com/payara/Payara/assets/15934072/b8713271-3be0-414f-9bb5-99848c2392dd)

In this configuration, the Proxy port is set to `8986`, while the Payara Server port remains the default `8080`. Both the `redirectURI` defined in the Google Cloud and within the `GoogleAuthenticationDefinition` annotation are identical.
```
@GoogleAuthenticationDefinition (
        clientId = "870687636777-g4sbfolmrucov57bknst.apps.googleusercontent.com",
        clientSecret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
        jwksReadTimeout = 5000,
        jwksConnectTimeout = 5000,
        redirectURI = "http://localhost:8080/OIDCSample-1.0-SNAPSHOT/Callback",
        tokenAutoRefresh = true,
        extraParameters = {"access_type=offline", "approval_prompt=force"},
        proxyDefinition = @ProxyDefinition(hostName = "localhost", port = "8986")
       
)
```
To utilize this setup, please download the entire application from the following link: [Download Application](https://github.com/payara/Payara/files/14193091/OIDCSampleMain.zip). Make necessary modifications to the configuration by adding your credentials.

#### **Test Scenarios:**
Here are several possible scenarios:

**Existing Scenario:**

- Scenario 1: `redirectURI` employs the `${baseURL}` placeholder, which defaults to `${baseURL}/Callback` when `redirectURI` is not explicitly defined. Proxy definition is also absent.

  Outcome: The generated `redirectURI` should include the request's host and port. The registered Authorized Redirect URI in Google Cloud must contain a URL with the Payara Instance's host and port.

- Scenario 2: `redirectURI` is explicitly defined with the Payara Instance's host and port, while Proxy definition is not present.

  Outcome: The registered Authorized Redirect URI in Google Cloud must contain a URL with the Payara Instance's host and port.

**New Scenarios with Proxy:**

- Scenario 3: `redirectURI` employs the `${baseURL}` placeholder, defaulting to `${baseURL}/Callback` when `redirectURI` is not explicitly defined. Proxy definition is included.

  Outcome: The generated `redirectURI` should include the proxy's host and port. The registered Authorized Redirect URI in Google Cloud must contain a URL with the proxy's host and port.

- Scenario 4: `redirectURI` is explicitly defined with the Payara Instance's host and port, and Proxy definition is also present.

  Outcome: The registered Authorized Redirect URI in Google Cloud must contain a URL with the Payara Instance's host and port.

- Scenario 5: `redirectURI` is explicitly defined with the Proxy's host and port, and Proxy definition is included.

  Outcome: The registered Authorized Redirect URI in Google Cloud must contain a URL with the proxy's host and port."

### Related PRs
https://github.com/payara/ecosystem-security-connectors/pull/278

### Documentation
https://github.com/payara/Payara-Documentation/pull/390