### PR TITLE
FISH-7965 OpenAPI endpoint crashes on duplicate types

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/OpenAPISupplier.java
@@ -193,9 +193,13 @@ public class OpenAPISupplier implements Supplier<OpenAPI> {
         return types;
     }
 
+    /**
+     * @return a map of the provided types indexed by name with duplicates removed
+     */
     public static Map<String, Type> typesToMap(Types types) {
-        return types.getAllTypes().stream()
-                .collect(Collectors.toMap((t) -> t.getName(), Function.identity()));
+        return types.getAllTypes().stream().collect(
+                Collectors.toMap((t) -> t.getName(),   // Types are indexed by name
+                Function.identity(), (t1, t2) -> t1)); // Ignoring repeated types with the same name
     }
 
     /**


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This PR addresses GitHub issue #6369 (FISH-7965).

When the MicroProfile OpenAPI implementation is scanning for types, the same type may be discovered multiple times; I assume its class file is found in multiple jars. Payara attempts to store this list of types in a map indexed by type name. However, since the same type name appears more than once in the list, an exception is thrown and no OpenAPI spec is built.

I believe the bug was introduced in #6256 (FISH-6980) when the MicroProfile OpenAPI scanner was modified to scan libraries in the web archive.

I've implemented the solution suggested by issue author [marcinpaton](https://github.com/marcinpaton). That is, when duplicate types are found, one is discarded. It is not specified which type will be selected; only that exactly one will be used. I don't know if its possible to determine which type _should_ be used. However, with the current behavior (HTTP 500), this feels like a step in the right direction.

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
No new automated tests were added.

Author of issue #6369 [provided a reproducer.](https://github.com/payara/Payara/issues/6369#issuecomment-1770498059)

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
1. Build master branch of Payara with command `mvn clean package`
2. Deploy application using Payara Micro.
3. Request `GET /openapi`. Observe error.
4. Build branch with bug fix with command `mvn clean package`
5. Deploy same application using Payara Micro.
6. Request `GET /openapi`. Observe correct OpenAPI spec.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
* Zulu JDK 11.0.21
* Maven 3.9.5
* Ubuntu 20.04.6 virtualized with WSL2
