### PR TITLE
FISH-7362 : Ignore ReplicatedMapCantBeCreatedOnLiteMemberException dispatched from Hazelcast

### DIFF
--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or affiliates
 
 package org.glassfish.kernel.event;
 
@@ -47,6 +48,8 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import jakarta.inject.Inject;
 import org.glassfish.api.event.EventListener;
 import org.glassfish.api.event.EventListener.Event;
@@ -121,6 +124,7 @@ public class EventsImpl implements Events {
                     public void run() {
                         try {
                             listener.event(event);
+                        } catch(ReplicatedMapCantBeCreatedOnLiteMemberException e) { // Ignore
                         } catch(Throwable e) {
                             logger.log(Level.WARNING, KernelLoggerInfo.exceptionDispatchEvent, e);
                         }

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
@@ -137,6 +137,7 @@ public class EventsImpl implements Events {
                     // when synchronous listener throws DeploymentException
                     // we re-throw the exception to abort the deployment
                     throw de;
+                } catch(ReplicatedMapCantBeCreatedOnLiteMemberException e) { // Ignore
                 } catch (Throwable e) {
                     logger.log(Level.WARNING, KernelLoggerInfo.exceptionDispatchEvent, e);
                 }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/config/ClusteredConfig.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/config/ClusteredConfig.java
@@ -153,9 +153,10 @@ public class ClusteredConfig extends MembershipAdapter {
     public void clearSharedConfiguration(String name) {
         HazelcastInstance hzInstance = hzCore.getInstance();
         if (hzInstance != null) { // can be null during shutdown
-            String instance = instanceName(hzInstance.getCluster().getLocalMember());
+            Member localMember = hzInstance.getCluster().getLocalMember();
+            String instance = instanceName(localMember);
             String mapName = CONFIGURATION_PREFIX + name;
-            if (instance != null) {
+            if (instance != null && !localMember.isLiteMember()) {
                 hzInstance.getReplicatedMap(mapName).remove(instance);
             }
         }

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/config/ClusteredConfig.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/config/ClusteredConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
## Description
Cleanup unnecessary warning log

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Build Payara: 6.2024.3-SNAPSHOT
2. Donwload zipped application reproducer: **PayaraMicroHelloWorld.zip** from https://payara.atlassian.net/browse/FISH-7367
3. Change payara versions in pom.xml: `<version.payara.micro>6.2024.3-SNAPSHOT</version.payara.micro><version.payara>6.2024.3-SNAPSHOT</version.payara>`
4. Build the reproducer: `mvn clean package`
5. Download Hazelcast 5.3.6
6. run bin/hz-start.bat
7. run the reproducer via: `mvn clean package payara-micro:start`
8. Check that the exception is not logged any more

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.6

## Documentation
None