### PR TITLE
FISH-8328 Expand Deployment Transformer OSGi Version Range

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -256,6 +256,16 @@
             </snapshots>
         </repository>
 
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -280,6 +290,17 @@
             </releases>
             <snapshots>
                 <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+
+        <pluginRepository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -191,8 +191,8 @@
         <javadoc.skip>true</javadoc.skip>
         <source.skip>true</source.skip>
 
-        <payara.deployment.transformer.version>1.3</payara.deployment.transformer.version>
-        <payara.transformer.version>0.2.12</payara.transformer.version>
+        <payara.deployment.transformer.version>1.4-SNAPSHOT</payara.deployment.transformer.version>
+        <payara.transformer.version>0.2.13</payara.transformer.version>
 
         <awaitility.version>4.2.0</awaitility.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <!-- Some of these are duplicated from core-bom because it isn't deployed to Maven Central so we need to tell
@@ -113,6 +123,16 @@
             </releases>
             <snapshots>
                 <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
## Description
Built on top of https://github.com/payara/Payara/pull/6564
Testing expanding the deployment-transformer version range from [6.0.0,7.0.0) to [6.0.0,7.0.0] since at the moment there aren't any breaking changes in the internal APIs.

## Important Info
### Blockers
https://github.com/payara/transformer/pull/40

## Testing
### New tests
None

### Testing Performed
Built locally and started admin console - it's alive.

### Testing Environment
Windows 11, Zulu 21.0.2

## Documentation
N/A

## Notes for Reviewers
None
