### PR TITLE
Fish 7358 automate test payara micro

### DIFF
--- a/appserver/tests/functional/payara-micro/README.md
+++ b/appserver/tests/functional/payara-micro/README.md
@@ -1,0 +1,47 @@
+# Payara Micro Tests
+
+Starts 2 instances of Payara Micro
+
+On each instance is deployed ClusterJsp. This application should cluster the different instances and share the httpsession.
+
+Open the first instance in a browser, add an attribute to the httpsession with a value.
+
+Open the second instance in a browser, add an attribute to the httpsession with a value, and check for the presence of the first attribute.
+
+Open the first instance in a browser, check for the presence of the second attribute.
+
+
+## run the tests:
+
+This test depends on some utilities from payara-samples. So it requires to build payara-samples before running this test.
+
+It needs to be run in managed mode, with the command
+
+    mvn clean verify -Ppayara-micro-managed
+
+This will run the test against the current version of Payara Micro, with Arquillian.
+
+Alternatively, you can start specify the location of a different jar for Payara Micro:
+
+    mvn clean verify -Ppayara-micro-managed -Dpayara.microJar=<path>
+
+## Playwright dependencies
+
+By default, this test will check and install Playwright dependencies before running the test. 
+The user needs to have the permissions to install such dependencies. 
+Alternatively, dependencies can be installed manually. 
+Playwright needs the following libraries to run:
+    libatk1.0-0
+    libatk-bridge2.0-0
+    libcups2
+    libxkbcommon0
+    libatspi2.0-0
+    libxcomposite1
+    libxdamage1
+    libxfixes3
+    libxrandr2
+    libgbm1
+    libpango-1.0-0
+    libcairo2
+and to run the test without installing the dependencies with maven and Playwright CLI command:
+    mvn clean verify -Ppayara-micro-managed -P!install-deps

--- a/appserver/tests/functional/payara-micro/pom.xml
+++ b/appserver/tests/functional/payara-micro/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>6.2024.3-SNAPSHOT</version>
+        <relativePath>../payara-samples/samples</relativePath>
+    </parent>
+
+    <artifactId>payara-micro</artifactId>
+    <name>Payara Samples - Payara Micro</name>
+
+    <properties>
+      <playwright.version>1.40.0</playwright.version>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+          <groupId>com.microsoft.playwright</groupId>
+          <artifactId>playwright</artifactId>
+          <version>${playwright.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-micro</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.extras</groupId>
+            <artifactId>payara-micro-boot</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>payara-micro-managed</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation> 
+        </profile>
+        <profile>
+            <id>payara-server-remote</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>payara-server-managed</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        
+        <profile>
+            <id>install-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>  
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                          <execution>
+                            <id>install-playwright-dependencies</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                              <goal>exec</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                        <configuration>
+                            <executable>java</executable>
+                            <mainClass>com.microsoft.playwright.CLI</mainClass>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>com.microsoft.playwright.CLI</argument>
+                                <argument>install-deps</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>         
+        </profile>
+    </profiles>
+</project>

--- a/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/ClusterHAJSPPage.java
+++ b/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/ClusterHAJSPPage.java
@@ -1,0 +1,57 @@
+package fish.payara.functional.micro;
+
+import com.microsoft.playwright.*;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+public class ClusterHAJSPPage {
+
+    static public Page openNewPage(String url) {
+        Playwright playwright = Playwright.create();
+        // to disable the headless mode, use playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(false))
+        Browser browser = playwright.chromium().launch();
+        BrowserContext context = browser.newContext();
+        Page page = context.newPage();
+        page.navigate(url);
+        page.waitForLoadState();
+        assertThat(page).hasTitle("Cluster - Ha JSP Sample ");
+        return page;
+    }
+
+    static public void openNewUrl(Page page, String url) {
+        page.navigate(url);
+        page.waitForLoadState();
+        assertThat(page).hasTitle("Cluster - Ha JSP Sample ");
+    }
+
+    static public void enterNameAttribute(Page page, String value) {
+        Locator textInputDataName = page.locator("input[name='dataName']");
+        textInputDataName.fill(value);
+    }
+
+    static public void enterValueAttribute(Page page, String value) {
+        Locator textInputDataValue = page.locator("input[name='dataValue']");
+        textInputDataValue.fill(value);
+    }
+
+    static public void addSessionData(Page page) {
+        Locator buttonAddSessionData = page.locator("input[value='ADD SESSION DATA']");
+        buttonAddSessionData.click();
+    }
+
+    static public void reloadPage(Page page) {
+        Locator buttonAddSessionData = page.locator("input[value='RELOAD PAGE']");
+        buttonAddSessionData.click();
+        page.waitForLoadState();
+    }
+
+    static public void clearSession(Page page) {
+        Locator buttonAddSessionData = page.locator("input[value='CLEAR SESSION']");
+        buttonAddSessionData.click();
+    }
+
+    static public String readDataHttpSession(Page page) {
+        Locator dataHttpSession = page.locator("body > ul:nth-child(12)");
+        dataHttpSession.allInnerTexts();
+        return dataHttpSession.allInnerTexts().toString();
+    }
+}

--- a/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/DualSessionsIT.java
+++ b/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/DualSessionsIT.java
@@ -1,0 +1,88 @@
+package fish.payara.functional.micro;
+
+import com.microsoft.playwright.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import org.jboss.arquillian.container.test.api.Deployment;
+
+import fish.payara.samples.PayaraArquillianTestRunner;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(PayaraArquillianTestRunner.class)
+public class DualSessionsIT {
+
+    public static WebArchive createClusterJsp() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "clusterjsp.war")
+                .addAsWebInfResource(new File("src/test/resources/clusterjsp/clusterjsp-war/web/WEB-INF/sun-web.xml"))
+                .addAsWebInfResource(new File("src/test/resources/clusterjsp/clusterjsp-war/web/WEB-INF/web.xml"))
+                .addAsWebResource(new File("src/test/resources/clusterjsp/clusterjsp-war/web/HaJsp.jsp"))
+                .addAsWebResource(new File("src/test/resources/clusterjsp/clusterjsp-war/web/ClearSession.jsp"))
+                .addAsManifestResource(new File("src/test/resources/clusterjsp/clusterjsp-war/web/MANIFEST.MF"));
+        return archive;
+    }
+
+    // Deployment with testable = false as otherwise, Arquillian would add its own libraries to the war
+    // including the library arquillian-jakarta-servlet-protocol.jar, preventing clusterjsp to work as intended
+    @Deployment(name = "microInstance1", order = 1, testable = false)
+    @TargetsContainer("micro1")
+    public static WebArchive microInstance1() {
+        return createClusterJsp();
+    }
+
+    @ArquillianResource
+    @OperateOnDeployment("microInstance1")
+    private URL deployment1URL;
+
+    @Deployment(name = "microInstance2", order = 2, testable = false)
+    @TargetsContainer("micro2")
+    public static WebArchive microInstance2() {
+        return createClusterJsp();
+    }
+
+    @ArquillianResource
+    @OperateOnDeployment("microInstance2")
+    private URL deployment2URL;
+
+
+    @Test
+    @RunAsClient
+    public void addAndReadAttributes() throws MalformedURLException, InterruptedException {
+        try (Page page = ClusterHAJSPPage.openNewPage(deployment1URL.toString())) {
+            ClusterHAJSPPage.enterNameAttribute(page, "attribute1");
+            ClusterHAJSPPage.enterValueAttribute(page, "value1");
+            ClusterHAJSPPage.addSessionData(page);
+            String results = ClusterHAJSPPage.readDataHttpSession(page);
+            assertThat(results, containsString("attribute1 = value1"));
+            System.out.println("attribute1 found in instance1");
+
+            ClusterHAJSPPage.openNewUrl(page, deployment2URL.toString());
+            ClusterHAJSPPage.enterNameAttribute(page, "attribute2");
+            ClusterHAJSPPage.enterValueAttribute(page, "value2");
+            ClusterHAJSPPage.addSessionData(page);
+            String results2 = ClusterHAJSPPage.readDataHttpSession(page);
+            assertThat(results2, containsString("attribute1 = value1"));
+            System.out.println("attribute1 found in instance2");
+
+            ClusterHAJSPPage.openNewUrl(page, deployment1URL.toString());
+            ClusterHAJSPPage.reloadPage(page);
+            String results3 = ClusterHAJSPPage.readDataHttpSession(page);
+            assertThat(results3, containsString("attribute1 = value1"));
+            System.out.println("attribute1 found in instance1");
+            assertThat(results3, containsString("attribute2 = value2"));
+            System.out.println("attribute2 found in instance1");
+        }
+    }
+
+}

--- a/appserver/tests/functional/payara-micro/src/test/resources/arquillian.xml
+++ b/appserver/tests/functional/payara-micro/src/test/resources/arquillian.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns="http://jboss.org/schema/arquillian"
+   xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+      <group qualifier="managed" default="true">
+          <container qualifier="micro1" default="true"/>
+          <container qualifier="micro2"/>
+      </group>
+ </arquillian>

--- a/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/ClearSession.jsp
+++ b/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/ClearSession.jsp
@@ -1,0 +1,40 @@
+<%--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<HTML>
+<HEAD><TITLE>Cluster - Ha JSP Sample </TITLE></HEAD>
+<BODY>
+
+<% String action = request.getParameter("action");
+   System.out.println("ClearSession.jsp: invalidating session");
+   if (action != null && action.equals("CLEAR SESSION")) {
+        session.invalidate();
+   }
+%>
+<BR><BR><BR>
+Served From Server: <b><%= request.getServerName() %></b>
+
+<BR><BR>
+<B>Instruction</B>
+<UL>
+<LI>Click on START NEW SESSION to start a new session</LI>
+</UL>
+<BR>
+<A HREF="HaJsp.jsp" NAME="Link3">START NEW SESSION</A>
+</BODY>
+</HTML>

--- a/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/HaJsp.jsp
+++ b/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/HaJsp.jsp
@@ -1,0 +1,86 @@
+<%--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@page contentType="text/html"%>
+
+<HTML>
+<HEAD><TITLE>Cluster - Ha JSP Sample </TITLE></HEAD>
+<BODY BGCOLOR="white">
+<H1>Cluster - HA JSP Sample </H1>
+<B>HttpSession Information:</B>
+<UL>
+<LI>Served From Server:   <b><%= request.getServerName() %></b></LI>
+<LI>Server Port Number:   <b><%= request.getServerPort() %></b></LI>
+<LI>Executed From Server: <b><%= java.net.InetAddress.getLocalHost().getHostName() %></b></LI>
+<LI>Executed Server IP Address: <b><%= java.net.InetAddress.getLocalHost().getHostAddress() %></b></LI>
+<LI>Session ID:    <b><%= session.getId() %></b></LI>
+<LI>Session Created:  <%= new java.util.Date(session.getCreationTime())%></LI>
+<LI>Last Accessed:    <%= new java.util.Date(session.getLastAccessedTime())%></LI>
+<LI>Session will go inactive in  <b><%= session.getMaxInactiveInterval() %> seconds</b></LI>
+</UL>
+<BR>
+<B> Enter session attribute data: </B><BR>
+<FORM ACTION="HaJsp.jsp" METHOD="POST" NAME="Form1">
+    Name of Session Attribute: 
+    <INPUT TYPE="text" SIZE="20" NAME="dataName" test-id="dataName">
+    <BR>
+    Value of Session Attribute: 
+    <INPUT TYPE="text" SIZE="20" NAME="dataValue" test-id="dataValue">
+    <BR>
+    <INPUT TYPE="submit" NAME="action" VALUE="ADD SESSION DATA" test-id="buttonAddData">
+    <INPUT TYPE="submit" NAME="action" VALUE="RELOAD PAGE" test-id="buttonReload">
+</FORM>
+<FORM ACTION="ClearSession.jsp" method="POST" name="Form2" >
+    <INPUT TYPE="submit" NAME="action" VALUE="CLEAR SESSION" test-id="buttonClear">
+</FORM>
+
+<%
+    String dataname = request.getParameter("dataName");
+    String datavalue = request.getParameter("dataValue");
+    if (dataname != null && datavalue != null && !dataname.equals("")) {
+        System.out.println("Add to session: " + dataname + " = " + datavalue);
+        session.setAttribute(dataname,datavalue);
+    }
+%>
+<HR><BR>
+<B>Data retrieved from the HttpSession: </B>
+<% 
+    java.util.Enumeration valueNames = session.getAttributeNames();
+    if (!valueNames.hasMoreElements()) {
+        System.out.println("No parameter entered for this request");
+    } else {
+        out.println("<UL test-id='results'>");
+        while (valueNames.hasMoreElements()) {
+            String param = (String) valueNames.nextElement();
+            String value = session.getAttribute(param).toString();
+            out.println("<LI>" + param + " = " + value + "</LI>");
+        }
+        out.println("</UL>");
+    }
+%>
+<BR><BR>
+<HR>
+<B>INSTRUCTIONS</B>
+<UL>
+<LI>Add session data using the form. Upon pressing ADD SESSION DATA, the current session data will be listed.</LI>
+<LI>Click on RELOAD PAGE to display the current session data without adding new data.</LI>
+<LI>Click on CLEAR SESSION to invalidate the current session.</LI>
+</UL>
+
+</BODY>
+</HTML>

--- a/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/MANIFEST.MF
+++ b/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Created-By: 1.6.0_24 (Sun Microsystems Inc.)
+

--- a/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/WEB-INF/sun-web.xml
+++ b/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/WEB-INF/sun-web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+	
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License v. 2.0, which is available at
+	http://www.eclipse.org/legal/epl-2.0.
+	
+	This Source Code may also be made available under the following Secondary
+	Licenses when the conditions for such availability set forth in the
+	Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+	version 2 with the GNU Classpath Exception, which is available at
+	https://www.gnu.org/software/classpath/license.html.
+	
+	SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 8.1 Servlet 2.4//EN" "http://www.sun.com/software/appserver/dtds/sun-web-app_2_4-1.dtd">
+<sun-web-app>
+  <session-config>
+    <session-properties/>
+    <cookie-properties/>
+  </session-config>
+  <cache max-entries="4096" timeout-in-seconds="30" enabled="false">
+    <default-helper/>
+  </cache>
+  <jsp-config>
+    <property value="true" name="classdebuginfo">
+      <description>Enable debug info compilation in the generated servlet class</description>
+    </property>
+    <property value="true" name="mappedfile">
+      <description>Maintain a one-to-one correspondence between static content and the generated servlet class' java code</description>
+    </property>
+    <property name="fork" value="false" />
+  </jsp-config>
+</sun-web-app>

--- a/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/WEB-INF/web.xml
+++ b/appserver/tests/functional/payara-micro/src/test/resources/clusterjsp/clusterjsp-war/web/WEB-INF/web.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ 	Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+	
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License v. 2.0, which is available at
+	http://www.eclipse.org/legal/epl-2.0.
+	
+	This Source Code may also be made available under the following Secondary
+	Licenses when the conditions for such availability set forth in the
+	Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+	version 2 with the GNU Classpath Exception, which is available at
+	https://www.gnu.org/software/classpath/license.html.
+	
+	SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">  
+  <display-name>clusterjsp</display-name>
+  <distributable/>
+  <servlet>
+    <display-name>HaJsp</display-name>
+    <servlet-name>HaJsp</servlet-name>    
+    <jsp-file>/HaJsp.jsp</jsp-file>
+  </servlet>
+  <servlet>
+    <display-name>ClearSession</display-name>
+    <servlet-name>ClearSession</servlet-name>    
+    <jsp-file>/ClearSession.jsp</jsp-file>
+  </servlet>
+  <session-config>
+    <session-timeout>30</session-timeout>
+  </session-config>
+  <welcome-file-list>
+    <welcome-file>HaJsp.jsp</welcome-file>
+  </welcome-file-list>
+</web-app>


### PR DESCRIPTION
Adds a functional test with Payara Micro.
It starts 2 instances, deploys ClusterJsp in both and expect them to cluster. Using Playwright, in a browser, the test adds an attribute in the first instance. Then opens the second instance, checks for attribute 1, and adds attribute 2. Then navigates to Instance1, and checks for attribute1 and attribute2.

The test depends on some utilities from payara-samples, and requires to build payara-samples before running the test. Because of that, it requires to specify the profile `payara-micro-managed` when executing the test with maven.

The test uses Playwright. By default, it will use Playwright CLI command to install the dependencies. In Linux, this will use sudo to install the dependencies. To disable that installation, disable the profile `install-deps`
(see the readme for the relevant commands)