### PR TITLE
FISH-7670 Integerate Latest Concurro with Virtual Threads

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
-  ~    Copyright (c) 2019-2023 Payara Foundation and/or its affiliates. All rights reserved.
+  ~    Copyright (c) 2019-2024 Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~    The contents of this file are subject to the terms of either the GNU
   ~    General Public License Version 2 only ("GPL") or the Common Development

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -470,9 +470,9 @@
                 <version>${com.ibm.jbatch.spi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.enterprise.concurrent</artifactId>
-                <version>${concurrent.version}</version>
+                <groupId>org.glassfish.concurro</groupId>
+                <artifactId>concurro</artifactId>
+                <version>${concurro.version}</version>
             </dependency>
 
             <dependency>

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
@@ -125,9 +125,6 @@ public interface ManagedExecutorService extends ConfigBeanProxy, Resource,
      */
     void setUseForkJoinPool(String value) throws PropertyVetoException;
 
-    @DuckTyped
-    String getIdentity();
-
     /**
      * Gets the value of the useVirtualThreads property.
      *
@@ -142,6 +139,9 @@ public interface ManagedExecutorService extends ConfigBeanProxy, Resource,
      * @param value allowed object is {@link String }
      */
     void setUseVirtualThreads(String value) throws PropertyVetoException;
+
+    @DuckTyped
+    String getIdentity();
 
     class Duck {
         public static String getIdentity(ManagedExecutorService resource){

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
@@ -128,6 +128,21 @@ public interface ManagedExecutorService extends ConfigBeanProxy, Resource,
     @DuckTyped
     String getIdentity();
 
+    /**
+     * Gets the value of the useVirtualThreads property.
+     *
+     * @return possible object is {@link String }
+     */
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    String getUseVirtualThreads();
+
+    /**
+     * Sets the value of the useVirtualThreads property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    void setUseVirtualThreads(String value) throws PropertyVetoException;
+
     class Duck {
         public static String getIdentity(ManagedExecutorService resource){
             return resource.getJndiName();

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2024] Payara Foundation and/or affiliates
 package org.glassfish.concurrent.config;
 
 import com.sun.enterprise.config.modularity.ConfigBeanInstaller;

--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -108,8 +108,8 @@
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
         </dependency>
        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.enterprise.concurrent</artifactId>
+            <groupId>org.glassfish.concurro</groupId>
+            <artifactId>concurro</artifactId>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>

--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -41,7 +41,7 @@
 
 -->
 
-<!-- Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
@@ -1,7 +1,7 @@
 /**
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright (c) 2016 Payara Foundation and/or its affiliates.
+ * Copyright (c) 2016-2024 Payara Foundation and/or its affiliates.
  * All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
@@ -20,7 +20,7 @@ package fish.payara.concurrent.monitoring;
 import org.glassfish.concurrent.config.ManagedExecutorService;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.concurrent.runtime.deployer.ManagedExecutorServiceConfig;
-import org.glassfish.enterprise.concurrent.ManagedExecutorServiceImpl;
+import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.external.probe.provider.StatsProviderManager;
 import org.glassfish.external.statistics.CountStatistic;
 import org.glassfish.external.statistics.impl.CountStatisticImpl;
@@ -41,7 +41,7 @@ public class ManagedExecutorServiceStatsProvider
 {   
     private final String name;
     private boolean registered = false;
-    private final ManagedExecutorServiceImpl managedExecutorServiceImpl;
+    private final AbstractManagedExecutorService managedExecutorServiceImpl;
     
     private CountStatisticImpl completedTaskCount = new CountStatisticImpl(
             "CompletedTaskCount", "count", 

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedExecutorServiceStatsProvider.java
@@ -20,7 +20,7 @@ package fish.payara.concurrent.monitoring;
 import org.glassfish.concurrent.config.ManagedExecutorService;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.concurrent.runtime.deployer.ManagedExecutorServiceConfig;
-import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
+import org.glassfish.concurro.AbstractManagedExecutorService;
 import org.glassfish.external.probe.provider.StatsProviderManager;
 import org.glassfish.external.statistics.CountStatistic;
 import org.glassfish.external.statistics.impl.CountStatisticImpl;

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
@@ -1,7 +1,7 @@
 /**
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright (c) 2016 Payara Foundation and/or its affiliates.
+ * Copyright (c) 2016-2024 Payara Foundation and/or its affiliates.
  * All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
@@ -20,7 +20,7 @@ package fish.payara.concurrent.monitoring;
 import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.concurrent.runtime.deployer.ManagedScheduledExecutorServiceConfig;
-import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl;
+import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
 import org.glassfish.external.probe.provider.StatsProviderManager;
 import org.glassfish.external.statistics.CountStatistic;
 import org.glassfish.external.statistics.impl.CountStatisticImpl;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -71,15 +71,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.naming.NamingException;
-import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
-import org.glassfish.enterprise.concurrent.AbstractManagedThread;
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ForkJoinManagedExecutorService;
-import org.glassfish.enterprise.concurrent.ManagedExecutorServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
-import org.glassfish.enterprise.concurrent.virtualthreads.VirtualThreadsManagedExecutorService;
-import org.glassfish.enterprise.concurrent.spi.ContextHandle;
+import org.glassfish.concurro.AbstractManagedExecutorService;
+import org.glassfish.concurro.AbstractManagedThread;
+import org.glassfish.concurro.ContextServiceImpl;
+import org.glassfish.concurro.ForkJoinManagedExecutorService;
+import org.glassfish.concurro.ManagedExecutorServiceImpl;
+import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
+import org.glassfish.concurro.ManagedThreadFactoryImpl;
+import org.glassfish.concurro.virtualthreads.VirtualThreadsManagedExecutorService;
+import org.glassfish.concurro.spi.ContextHandle;
 import org.glassfish.resourcebase.resources.naming.ResourceNamingService;
 
 /**

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.concurrent.runtime;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -49,12 +49,11 @@ import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.security.SecurityContext;
 import com.sun.enterprise.transaction.api.JavaEETransactionManager;
 import com.sun.enterprise.util.Utility;
-import fish.payara.opentracing.propagation.MapToTextMap;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.concurrent.LogFacade;
-import org.glassfish.enterprise.concurrent.spi.ContextHandle;
-import org.glassfish.enterprise.concurrent.spi.ContextSetupProvider;
+import org.glassfish.concurro.spi.ContextHandle;
+import org.glassfish.concurro.spi.ContextSetupProvider;
 import org.glassfish.internal.deployment.Deployment;
 
 import jakarta.enterprise.concurrent.ContextService;
@@ -71,12 +70,9 @@ import java.util.logging.Logger;
 
 import fish.payara.nucleus.requesttracing.RequestTracingService;
 import fish.payara.nucleus.healthcheck.stuck.StuckThreadsStore;
-import fish.payara.notification.requesttracing.RequestTraceSpanContext;
 import fish.payara.opentracing.OpenTracingService;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
-import io.opentracing.propagation.Format;
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -317,7 +313,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
         }
 
         if (stuckThreads != null) {
-            stuckThreads.registerThread(Thread.currentThread().getId());
+            stuckThreads.registerThread(Thread.currentThread().threadId());
         }
 
         // execute thread contexts snapshots to begin
@@ -410,7 +406,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
             requestTracing.endTrace();
         }
         if (stuckThreads != null) {
-            stuckThreads.deregisterThread(Thread.currentThread().getId());
+            stuckThreads.deregisterThread(Thread.currentThread().threadId());
         }
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.concurrent.runtime;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/InvocationContext.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/InvocationContext.java
@@ -49,7 +49,7 @@ import io.opentracing.Tracer;
 import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
 import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
 import org.glassfish.api.invocation.ComponentInvocation;
-import org.glassfish.enterprise.concurrent.spi.ContextHandle;
+import org.glassfish.concurro.spi.ContextHandle;
 import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.data.ApplicationRegistry;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/InvocationContext.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/InvocationContext.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2023] [Payara Foundation and/or its affiliates.]
+// Portions Copyright [2018-2024] [Payara Foundation and/or its affiliates.]
 
 package org.glassfish.concurrent.runtime;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionHandleImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionHandleImpl.java
@@ -41,7 +41,7 @@
 package org.glassfish.concurrent.runtime;
 
 
-import org.glassfish.enterprise.concurrent.spi.TransactionHandle;
+import org.glassfish.concurro.spi.TransactionHandle;
 
 import jakarta.transaction.Transaction;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionHandleImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionHandleImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates 
 
 package org.glassfish.concurrent.runtime;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionSetupProviderImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.runtime;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/TransactionSetupProviderImpl.java
@@ -42,8 +42,8 @@
 package org.glassfish.concurrent.runtime;
 
 import com.sun.enterprise.transaction.api.JavaEETransactionManager;
-import org.glassfish.enterprise.concurrent.spi.TransactionHandle;
-import org.glassfish.enterprise.concurrent.spi.TransactionSetupProvider;
+import org.glassfish.concurro.spi.TransactionHandle;
+import org.glassfish.concurro.spi.TransactionSetupProvider;
 
 import jakarta.enterprise.concurrent.ManagedTask;
 import jakarta.transaction.InvalidTransactionException;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2022] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.runtime.deployer;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
@@ -41,6 +41,7 @@
 
 package org.glassfish.concurrent.runtime.deployer;
 
+import jakarta.enterprise.concurrent.ManagedExecutorService;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.enterprise.concurrent.*;
 import org.glassfish.resourcebase.resources.api.ResourceInfo;
@@ -95,8 +96,8 @@ public class ConcurrentObjectFactory implements ObjectFactory {
         return managedThreadFactory;
     }
 
-    private ManagedExecutorServiceAdapter getManagedExecutorService(ManagedExecutorServiceConfig config, ResourceInfo resourceInfo) {
-        ManagedExecutorServiceImpl mes = getRuntime().getManagedExecutorService(resourceInfo, config);
+    private ManagedExecutorService getManagedExecutorService(ManagedExecutorServiceConfig config, ResourceInfo resourceInfo) {
+        AbstractManagedExecutorService mes = getRuntime().getManagedExecutorService(resourceInfo, config);
         return mes.getAdapter();
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
@@ -43,7 +43,11 @@ package org.glassfish.concurrent.runtime.deployer;
 
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
-import org.glassfish.enterprise.concurrent.*;
+import org.glassfish.concurro.AbstractManagedExecutorService;
+import org.glassfish.concurro.ContextServiceImpl;
+import org.glassfish.concurro.ManagedScheduledExecutorServiceAdapter;
+import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
+import org.glassfish.concurro.ManagedThreadFactoryImpl;
 import org.glassfish.resourcebase.resources.api.ResourceInfo;
 
 import javax.naming.Context;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceDefinitionDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceDefinitionDescriptorDeployer.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.concurrent.runtime.ContextSetupProviderImpl;
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.glassfish.concurro.ContextServiceImpl;
 import org.glassfish.resourcebase.resources.api.ResourceConflictException;
 import org.glassfish.resourcebase.resources.api.ResourceDeployer;
 import org.glassfish.resourcebase.resources.api.ResourceDeployerInfo;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceDefinitionDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ContextServiceDefinitionDescriptorDeployer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -47,6 +47,9 @@ import com.sun.enterprise.deployment.ManagedExecutorDefinitionDescriptor;
 import jakarta.inject.Inject;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.concurrent.config.ManagedExecutorService;
+import org.glassfish.concurrent.runtime.ConcurrentRuntime;
+import org.glassfish.concurro.AbstractManagedExecutorService;
+import org.glassfish.concurro.ContextServiceImpl;
 import org.glassfish.resourcebase.resources.api.ResourceConflictException;
 import org.glassfish.resourcebase.resources.api.ResourceDeployer;
 import org.glassfish.resourcebase.resources.api.ResourceDeployerInfo;
@@ -61,9 +64,6 @@ import java.beans.PropertyVetoException;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
-import org.glassfish.concurrent.runtime.ConcurrentRuntime;
-import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 
 @Service
 @ResourceDeployerInfo(ManagedExecutorDefinitionDescriptor.class)

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -62,8 +62,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
+import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedExecutorServiceImpl;
 
 @Service
 @ResourceDeployerInfo(ManagedExecutorDefinitionDescriptor.class)
@@ -101,7 +101,7 @@ public class ManagedExecutorDescriptorDeployer implements ResourceDeployer {
                 managedExecutorDefinitionDescriptor.getResourceId(), managedExecutorDefinitionDescriptor.getName(), managedExecutorDefinitionDescriptor.getResourceType());
         ResourceInfo resourceInfo = new ResourceInfo(customNameOfResource, applicationName, moduleName);
 
-        ManagedExecutorServiceImpl managedExecutorService = concurrentRuntime.createManagedExecutorService(resourceInfo, managedExecutorServiceConfig, contextService);
+        AbstractManagedExecutorService managedExecutorService = concurrentRuntime.createManagedExecutorService(resourceInfo, managedExecutorServiceConfig, contextService);
         resourceNamingService.publishObject(resourceInfo, customNameOfResource, managedExecutorService, true);
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -392,7 +392,8 @@ public class ManagedExecutorDescriptorDeployer implements ResourceDeployer {
 
         @Override
         public String getUseVirtualThreads() {
-            return managedExecutorDefinitionDescriptor.getVirtual().toString();
+            Boolean virtualFromDefinition = managedExecutorDefinitionDescriptor.getVirtual();
+            return (virtualFromDefinition == null ? Boolean.FALSE : virtualFromDefinition).toString();
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -389,5 +389,14 @@ public class ManagedExecutorDescriptorDeployer implements ResourceDeployer {
         @Override
         public void setContext(String value) throws PropertyVetoException {
         }
+
+        @Override
+        public String getUseVirtualThreads() {
+            return managedExecutorDefinitionDescriptor.getVirtual().toString();
+        }
+
+        @Override
+        public void setUseVirtualThreads(String value) throws PropertyVetoException {
+        }
     }
 }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2024] Payara Foundation and/or affiliates
 package org.glassfish.concurrent.runtime.deployer;
 
 import org.glassfish.concurrent.config.ManagedExecutorService;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
@@ -50,6 +50,7 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
     private int hungAfterSeconds;
     private boolean longRunningTasks;
     private boolean useForkJoinPool;
+    private boolean useVirtualThread;
     private int threadPriority;
     private int corePoolSize;
     private long keepAliveSeconds;
@@ -63,6 +64,7 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
         hungAfterSeconds = parseInt(config.getHungAfterSeconds(), 0);
         longRunningTasks = Boolean.valueOf(config.getLongRunningTasks());
         useForkJoinPool = Boolean.valueOf(config.getUseForkJoinPool());
+        useVirtualThread = Boolean.valueOf(config.getUseVirtualThreads());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
         corePoolSize = parseInt(config.getCorePoolSize(), 0);
         keepAliveSeconds = parseLong(config.getKeepAliveSeconds(), 60);
@@ -106,6 +108,10 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
     
     public boolean getUseForkJoinPool() {
         return useForkJoinPool;
+    }
+
+    public boolean getUseVirtualThread() {
+        return useVirtualThread;
     }
 
     public String getContext() {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -62,8 +62,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl;
+import org.glassfish.concurro.ContextServiceImpl;
+import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
 
 @Service
 @ResourceDeployerInfo(ManagedScheduledExecutorDefinitionDescriptor.class)

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -62,8 +62,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.glassfish.concurro.ContextServiceImpl;
+import org.glassfish.concurro.ManagedThreadFactoryImpl;
 
 @Service
 @ResourceDeployerInfo(ManagedThreadFactoryDefinitionDescriptor.class)

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedExecutorDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedExecutorDefinitionHandler.java
@@ -105,6 +105,7 @@ public class ManagedExecutorDefinitionHandler extends AbstractResourceHandler {
             medd.setMaximumPoolSize(managedExecutorDefinition.maxAsync());
         }
 
+        medd.setVirtual(managedExecutorDefinition.virtual());
         medd.setMetadataSource(MetadataSource.ANNOTATION);
         return medd;
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedExecutorDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedExecutorDefinitionHandler.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedScheduledExecutorDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedScheduledExecutorDefinitionHandler.java
@@ -106,6 +106,7 @@ public class ManagedScheduledExecutorDefinitionHandler extends AbstractResourceH
         } else {
             msedd.setMaxAsync(managedScheduledExecutorDefinition.maxAsync());
         }
+        msedd.setVirtual(managedScheduledExecutorDefinition.virtual());
 
         msedd.setMetadataSource(MetadataSource.ANNOTATION);
         return msedd;
@@ -128,6 +129,10 @@ public class ManagedScheduledExecutorDefinitionHandler extends AbstractResourceH
 
                 if (descriptor.getMaxAsync() == -1) {
                     descriptor.setMaxAsync(msed.maxAsync());
+                }
+
+                if (descriptor.getVirtual() == null) {
+                    descriptor.setVirtual(msed.virtual());
                 }
 
                 if (descriptor.getContext() == null && msed.context() != null && !msed.context().isBlank()) {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedScheduledExecutorDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedScheduledExecutorDefinitionHandler.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/runtime/ConcurrentRuntimeTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/runtime/ConcurrentRuntimeTest.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.runtime;
 

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/runtime/ConcurrentRuntimeTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/runtime/ConcurrentRuntimeTest.java
@@ -43,7 +43,7 @@ package org.glassfish.concurrent.runtime;
 
 import org.glassfish.concurrent.config.ContextService;
 import org.glassfish.concurrent.runtime.deployer.ContextServiceConfig;
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.glassfish.concurro.ContextServiceImpl;
 import org.glassfish.resourcebase.resources.api.ResourceInfo;
 import org.junit.Before;
 import org.junit.Test;

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedExecutorDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedExecutorDefinitionDescriptor.java
@@ -51,6 +51,7 @@ public class ManagedExecutorDefinitionDescriptor extends ResourceDescriptor {
     private String name;
     private int maximumPoolSize = Integer.MAX_VALUE;
     private long hungAfterSeconds = 0;
+    private Boolean virtual = null;
     private String context;
     private Properties properties = new Properties();
 
@@ -102,6 +103,14 @@ public class ManagedExecutorDefinitionDescriptor extends ResourceDescriptor {
 
     public Properties getProperties() {
         return properties;
+    }
+
+    public Boolean getVirtual() {
+        return virtual;
+    }
+
+    public void setVirtual(Boolean virtual) {
+        this.virtual = virtual;
     }
 
     @Override

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedExecutorDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedExecutorDefinitionDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedScheduledExecutorDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedScheduledExecutorDefinitionDescriptor.java
@@ -52,6 +52,7 @@ public class ManagedScheduledExecutorDefinitionDescriptor extends ResourceDescri
     private String context;
     private long hungTaskThreshold = 0;
     private int maxAsync = Integer.MAX_VALUE;
+    private Boolean virtual = null;
 
     private Properties properties = new Properties();
 
@@ -106,6 +107,14 @@ public class ManagedScheduledExecutorDefinitionDescriptor extends ResourceDescri
             thisName = JAVA_COMP_URL + thisName;
         }
         return thisName;
+    }
+
+    public Boolean getVirtual() {
+        return virtual;
+    }
+
+    public void setVirtual(Boolean virtual) {
+        this.virtual = virtual;
     }
 
     @Override

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedScheduledExecutorDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedScheduledExecutorDefinitionDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/packager/glassfish-common/pom.xml
+++ b/appserver/packager/glassfish-common/pom.xml
@@ -177,9 +177,9 @@
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
        </dependency>
        <dependency>
-           <groupId>org.glassfish</groupId>
-           <artifactId>jakarta.enterprise.concurrent</artifactId>
-       </dependency> 
+            <groupId>org.glassfish.concurro</groupId>
+            <artifactId>concurro</artifactId>
+        </dependency>
        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>

--- a/appserver/packager/glassfish-common/pom.xml
+++ b/appserver/packager/glassfish-common/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <temp.dir>${project.build.directory}/dependency</temp.dir>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -87,7 +87,7 @@
         <profile>
             <id>ips</id>
             <activation>
-                <activeByDefault>false</activeByDefault>  
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -108,7 +108,7 @@
                                 <id>process-step5</id>
                                 <goals>
                                     <goal>exec</goal>
-                                </goals>                            
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -124,7 +124,7 @@
             </build>
         </profile>
     </profiles>
-    
+
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.packager</groupId>
@@ -132,7 +132,7 @@
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>fish.payara.server.core.common</groupId>
             <artifactId>glassfish-naming</artifactId>
@@ -158,37 +158,35 @@
             <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
-           <groupId>fish.payara.server.internal.admingui</groupId>
-	   <artifactId>console-concurrent-plugin</artifactId>
-           <version>${project.version}</version>
-       </dependency> 
-       <dependency>
-           <groupId>fish.payara.server.internal.concurrent</groupId>
-           <artifactId>concurrent-connector</artifactId>
-           <version>${project.version}</version>
-       </dependency>
-       <dependency>
-           <groupId>fish.payara.server.internal.concurrent</groupId>
-	   <artifactId>concurrent-impl</artifactId>
-           <version>${project.version}</version>
-       </dependency> 
-       <dependency>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>console-concurrent-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.concurrent</groupId>
+            <artifactId>concurrent-connector</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.internal.concurrent</groupId>
+            <artifactId>concurrent-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-       </dependency>
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.concurro</groupId>
             <artifactId>concurro</artifactId>
         </dependency>
-       <dependency>
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-       </dependency>
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
-       </dependency>
-       
-       
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/packager/glassfish-common/pom.xml
+++ b/appserver/packager/glassfish-common/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -150,7 +150,7 @@
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
                     <dir>${stage.dir}/${install.dir.name}/glassfish/modules</dir>
-                    <excludes>jakarta.inject-api.jar,jakarta.servlet.jsp.jstl.jar,wasp.jar,jakarta.persistence.jar</excludes>
+                    <excludes>jakarta.inject-api.jar,jakarta.servlet.jsp.jstl.jar,wasp.jar,concurro.jar,jakarta.persistence.jar</excludes>
 		    <specs>
 			<!-- Activation-API -->
 			<spec>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -150,7 +150,7 @@
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
                     <dir>${stage.dir}/${install.dir.name}/glassfish/modules</dir>
-                    <excludes>jakarta.inject-api.jar,jakarta.servlet.jsp.jstl.jar,wasp.jar,jakarta.enterprise.concurrent.jar, jakarta.persistence.jar</excludes>
+                    <excludes>jakarta.inject-api.jar,jakarta.servlet.jsp.jstl.jar,wasp.jar,jakarta.persistence.jar</excludes>
 		    <specs>
 			<!-- Activation-API -->
 			<spec>

--- a/appserver/tests/payara-samples/samples/concurrency/pom.xml
+++ b/appserver/tests/payara-samples/samples/concurrency/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/concurrency/pom.xml
+++ b/appserver/tests/payara-samples/samples/concurrency/pom.xml
@@ -85,22 +85,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.enterprise.concurrent</groupId>
-            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-            <version>${jakarta-concurrent.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.arquillian.testng</groupId>
-                    <artifactId>arquillian-testng-container</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>

--- a/appserver/tests/payara-samples/samples/concurrency/src/main/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorEJB.java
+++ b/appserver/tests/payara-samples/samples/concurrency/src/main/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorEJB.java
@@ -43,13 +43,12 @@ import jakarta.annotation.Resource;
 import jakarta.ejb.Stateless;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jakarta.enterprise.concurrent.Trigger;
 import jakarta.enterprise.concurrent.CronTrigger;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -68,8 +67,8 @@ public class ManagedScheduledExecutorEJB {
         ZoneId mexico = ZoneId.of("America/Mexico_City");
         Trigger trigger = new CronTrigger("* * * * * *", mexico);
         ScheduledFuture feature = customManagedScheduleExecutorD.schedule(() -> {
-            numberExecution.getAndIncrement();
-            System.out.println("Cron Trigger running");
+            int current = numberExecution.getAndIncrement();
+            System.out.printf("Cron Trigger running, #%d at %s%n", current, LocalTime.now().toString());
         }, trigger);
         Thread.sleep(1500);
         feature.cancel(true);

--- a/appserver/tests/payara-samples/samples/concurrency/src/main/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorEJB.java
+++ b/appserver/tests/payara-samples/samples/concurrency/src/main/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorEJB.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/concurrency/src/test/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorApplicationIT.java
+++ b/appserver/tests/payara-samples/samples/concurrency/src/test/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorApplicationIT.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -122,7 +122,7 @@ public class ManagedScheduledExecutorApplicationIT {
         String[] data = message.split(":");
         if(data[1] != null) {
             int numberOfExecutions = Integer.parseInt(data[1]);
-            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Exptected number of executions for 1.5 second is 1-3, was " + numberOfExecutions);
+            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Expected number of executions for 1.5 second is 1-3, was " + numberOfExecutions);
         }
         assertTrue(message.contains("CronTrigger Submitted"));
     }
@@ -139,7 +139,7 @@ public class ManagedScheduledExecutorApplicationIT {
         String[] data = message.split(":");
         if(data[1] != null) {
             int numberOfExecutions = Integer.parseInt(data[1]);
-            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Exptected number of executions for 1.5 second is 1-3, was " + numberOfExecutions);
+            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Expected number of executions for 1.5 second is 1-3, was " + numberOfExecutions);
         }
         assertTrue(message.contains("CronTrigger Submitted"));
     }

--- a/appserver/tests/payara-samples/samples/concurrency/src/test/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorApplicationIT.java
+++ b/appserver/tests/payara-samples/samples/concurrency/src/test/java/fish/payara/sample/concurrency/annotations/managedscheduledexecutor/ManagedScheduledExecutorApplicationIT.java
@@ -122,7 +122,7 @@ public class ManagedScheduledExecutorApplicationIT {
         String[] data = message.split(":");
         if(data[1] != null) {
             int numberOfExecutions = Integer.parseInt(data[1]);
-            assertTrue( numberOfExecutions > 0 && numberOfExecutions <= 3);
+            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Exptected number of executions for 1.5 second is 1-3, was " + numberOfExecutions);
         }
         assertTrue(message.contains("CronTrigger Submitted"));
     }
@@ -139,7 +139,7 @@ public class ManagedScheduledExecutorApplicationIT {
         String[] data = message.split(":");
         if(data[1] != null) {
             int numberOfExecutions = Integer.parseInt(data[1]);
-            assertTrue( numberOfExecutions > 0 && numberOfExecutions <= 3);
+            assertTrue(numberOfExecutions > 0 && numberOfExecutions <= 3, "Exptected number of executions for 1.5 second is 1-3, was " + numberOfExecutions);
         }
         assertTrue(message.contains("CronTrigger Submitted"));
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,7 +114,7 @@
         <websocket-api.version>2.1.0</websocket-api.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
         <jstl-api.version>3.0.0</jstl-api.version>
-        <concurrent-api.version>3.0.2</concurrent-api.version>
+        <concurrent-api.version>3.1.0-M1</concurrent-api.version>
         <jaxws-api.version>4.0.0</jaxws-api.version>
         <jms-api.version>3.1.0</jms-api.version>
         <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   ~
   ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
-  ~  Copyright (c) 2011-2023 Payara Foundation and/or its affiliates. All rights reserved.
+  ~  Copyright (c) 2011-2024 Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~  The contents of this file are subject to the terms of either the GNU
   ~  General Public License Version 2 only ("GPL") or the Common Development

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,7 +64,7 @@
         <osgi.cmpn.version>7.0.0</osgi.cmpn.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
-        <cdi-api.version>4.0.1</cdi-api.version>
+        <cdi-api.version>4.1.0-M1</cdi-api.version>
         <grizzly.version>4.0.0.payara-p1</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
@@ -85,7 +85,7 @@
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
+        <jakarta.interceptor-api.version>2.2.0-M1</jakarta.interceptor-api.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <json.bind-api.version>3.0.0</json.bind-api.version>
         <jakarta-persistence-api.version>3.1.0</jakarta-persistence-api.version>
@@ -114,7 +114,7 @@
         <websocket-api.version>2.1.0</websocket-api.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
         <jstl-api.version>3.0.0</jstl-api.version>
-        <concurrent-api.version>3.1.0-M1</concurrent-api.version>
+        <concurrent-api.version>3.1.0-SNAPSHOT</concurrent-api.version>
         <jaxws-api.version>4.0.0</jaxws-api.version>
         <jms-api.version>3.1.0</jms-api.version>
         <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,7 +114,7 @@
         <websocket-api.version>2.1.0</websocket-api.version>
         <jax-rs-api.impl.version>3.1.0</jax-rs-api.impl.version>
         <jstl-api.version>3.0.0</jstl-api.version>
-        <concurrent-api.version>3.1.0-SNAPSHOT</concurrent-api.version>
+        <concurrent-api.version>3.1.0-M1</concurrent-api.version>
         <jaxws-api.version>4.0.0</jaxws-api.version>
         <jms-api.version>3.1.0</jms-api.version>
         <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright 2017-2023 Payara Foundation and/or affiliates
+    Portions Copyright 2017-2024 Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <microprofile-release.version>6.1</microprofile-release.version>
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <h2db.version>2.2.224</h2db.version>
-        <concurrent.version>3.0.2.payara-p1</concurrent.version>
+        <concurrent.version>3.1.0-SNAPSHOT</concurrent.version>
         <monitoring-console-process.version>2.0.2</monitoring-console-process.version>
         <monitoring-console-webapp.version>2.0.2</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <microprofile-release.version>6.1</microprofile-release.version>
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <h2db.version>2.2.224</h2db.version>
-        <concurrent.version>3.1.0-SNAPSHOT</concurrent.version>
+        <concurro.version>3.1.0-SNAPSHOT</concurro.version>
         <monitoring-console-process.version>2.0.2</monitoring-console-process.version>
         <monitoring-console-webapp.version>2.0.2</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>


### PR DESCRIPTION
## Description
We donated Fork&Join Pool to Concurro plus one fix, so we can start using the upstream project again

This PR integrates the latest version and also implements usage of virtual threads

## Testing
### Testing Performed
I uploaded a testing application to the Jira ticket. The app defines its own MES:
```
@ManagedExecutorDefinition(name = "java:app/VirtMES", maxAsync = 10, virtual = true)
```

1. Compile Payara 7 and the app, both with Java 21.
2. Deploy the app to Payara
3. Open `http://localhost:8080/ConcurrencyVirtual-1.0-SNAPSHOT/rest/test`
It displays 3 stacktraces of the tasks, all of the ending with
```
java.base/java.lang.VirtualThread.run(VirtualThread.java:309)
```
E.g. the threads are executed in virtual threads!

### Testing Environment
Linux, OpenJDK 21

## Notes for Reviewers
I deployed concurro, version `3.1.0-SNAPSHOT` to our snapshot nexus repository. We will use this until Concurro will not release a new version with all required changes.
The required change:
https://github.com/eclipse-ee4j/glassfish-concurro/pull/82