### PR TITLE
FISH-8174: adding fix to guarantee each thread updates lastaccesstime…

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -2910,7 +2910,7 @@ public class Request implements HttpRequest, HttpServletRequest {
 
     // ------------------------------------------------------ Protected Methods
 
-    protected synchronized Session doGetSession(boolean create) {
+    protected Session doGetSession(boolean create) {
         // There cannot be a session if no context has been assigned yet
         if (context == null) {
             return null;
@@ -2953,8 +2953,11 @@ public class Request implements HttpRequest, HttpServletRequest {
             if (session != null && !session.isValid()) {
                 session = null;
             }
+            
             if (session != null) {
-                session.access();
+                synchronized (this) {
+                    session.access();
+                }
                 return session;
             }
         }
@@ -3036,7 +3039,9 @@ public class Request implements HttpRequest, HttpServletRequest {
         }
 
         if (session != null) {
-            session.access();
+            synchronized (this) {
+                session.access();
+            }
             return session;
         } else {
             return null;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//Portions Copyright [2016-2022] [Payara Foundation]
+//Portions Copyright [2016-2024] [Payara Foundation]
 
 package org.apache.catalina.connector;
 
@@ -2910,8 +2910,7 @@ public class Request implements HttpRequest, HttpServletRequest {
 
     // ------------------------------------------------------ Protected Methods
 
-    protected Session doGetSession(boolean create) {
-
+    protected synchronized Session doGetSession(boolean create) {
         // There cannot be a session if no context has been assigned yet
         if (context == null) {
             return null;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -2955,9 +2955,7 @@ public class Request implements HttpRequest, HttpServletRequest {
             }
             
             if (session != null) {
-                synchronized (this) {
-                    session.access();
-                }
+                session.access();
                 return session;
             }
         }
@@ -3039,9 +3037,7 @@ public class Request implements HttpRequest, HttpServletRequest {
         }
 
         if (session != null) {
-            synchronized (this) {
-                session.access();
-            }
+            session.access();
             return session;
         } else {
             return null;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -751,9 +751,10 @@ public class StandardSession implements HttpSession, Session, Serializable {
      */
     @Override
     public void access() {
-        this.lastAccessedTime = this.thisAccessedTime;
-        this.thisAccessedTime = System.currentTimeMillis();
-
+        synchronized (this) {
+            this.lastAccessedTime = this.thisAccessedTime;
+            this.thisAccessedTime = System.currentTimeMillis();
+        }
         evaluateIfValid();
     }
 


### PR DESCRIPTION
Adding fix to guarantee each thread update lastaccesstime and thisAccessedTime after validating if session hasExpired

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for a reported bug regarding http session management when using cluster configuration with lite and normal Payara micro instances
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing with reproducers included on the ticket:
https://payara.atlassian.net/browse/FISH-8174
not only can be tested with docker configuration but also with local environment with stand alone Payara Micro. Here the steps:
Use following war file, and configuration files on the following zip:
[Reproducer.zip](https://github.com/payara/Payara/files/14609980/Reproducer.zip)

unzip on the place where the payara micro jar is installed:
![image](https://github.com/payara/Payara/assets/279375/8b258eae-8ee3-4f3e-b051-3f50fa32b44d)

the application on the war file set the session timeout limit to 1 minute, if you need to configure more time use the following zip file with the code and customize the time as you need: 
[Shared-Session-Code.zip](https://github.com/payara/Payara/files/14610013/Shared-Session-Code.zip)


then create two instances of Payara Micro with the following commands:
instance1:
java -jar payara-micro.jar --clustermode multicast --clusterName myService-cluster --deploy Shared-Session-1.0.war --nohostaware --logProperties logging.properties --hzConfigFile payara-hazelcast.xml

instance2:
java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9002 -jar payara-micro.jar --lite --clustermode multicast --clusterName myService-cluster --deploy Shared-Session-1.0.war --nohostaware --logProperties logging.properties --hzConfigFile payara-hazelcast.xml --port 8081

![image](https://github.com/payara/Payara/assets/279375/28c8c38d-7785-4415-a42d-1122825cfafd)

open browser with two tabs for the following URLs: 
open first and with a chronometer, from the mobile calculate 1 minute 
http://localhost:8080/Shared-Session-1.0/safe
this is going to create the session

then open second with the other url:
before to achieve the timeout (60 seconds), for example second 57 or 58 
http://localhost:8081/Shared-Session-1.0/safe

then you will see that the session is not recreated, just the values for the lastaccesstime and the thisAccessedTime are updated this will fix the problem of the gap for the session. From the reported issue the session is expired and created a new one 2 or 3 seconds before the timeout

![image](https://github.com/payara/Payara/assets/279375/8a46644e-15e1-42b5-a785-65007a58f078)

![image](https://github.com/payara/Payara/assets/279375/3b643f05-0476-4eea-b262-1ea64a60f72f)

I tested the following configuration of timeouts:

- 1 minute
- 2 minutes
- 30 minutes
- 60 minutes
-  120 minutes
from all of them now the session is not expired prematurely

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11,  Azul JDK 11, Maven 3.9.5
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
