### PR TITLE
FISH-8227 Add Heap Dump command

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/GenerateHeapDumpCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/GenerateHeapDumpCommand.java
@@ -41,7 +41,6 @@
 
 package com.sun.enterprise.v3.admin.commands;
 
-import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.universal.glassfish.TokenResolver;
 import com.sun.enterprise.universal.process.ProcessUtils;
 import com.sun.enterprise.util.StringUtils;
@@ -49,7 +48,14 @@ import org.glassfish.api.ActionReport;
 import org.glassfish.api.ActionReport.ExitCode;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
-import org.glassfish.api.admin.*;
+import org.glassfish.api.admin.AccessRequired;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.FailurePolicy;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.config.support.CommandTarget;
 import org.glassfish.config.support.TargetType;
 import org.glassfish.hk2.api.PerLookup;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/GenerateHeapDumpCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/GenerateHeapDumpCommand.java
@@ -61,7 +61,7 @@ import org.glassfish.config.support.TargetType;
 import org.glassfish.hk2.api.PerLookup;
 import org.jvnet.hk2.annotations.Service;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/GenerateHeapDumpCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/GenerateHeapDumpCommand.java
@@ -1,0 +1,209 @@
+/*
+ *   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *   Copyright (c) [2024] Payara Foundation and/or its affiliates.
+ *   All rights reserved.
+ *
+ *   The contents of this file are subject to the terms of either the GNU
+ *   General Public License Version 2 only ("GPL") or the Common Development
+ *   and Distribution License("CDDL") (collectively, the "License").  You
+ *   may not use this file except in compliance with the License.  You can
+ *   obtain a copy of the License at
+ *   https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *   See the License for the specific
+ *   language governing permissions and limitations under the License.
+ *
+ *   When distributing the software, include this License Header Notice in each
+ *   file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *   GPL Classpath Exception:
+ *   The Payara Foundation designates this particular file as subject to the
+ *   "Classpath" exception as provided by the Payara Foundation in the GPL
+ *   Version 2 section of the License file that accompanied this code.
+ *
+ *   Modifications:
+ *   If applicable, add the following below the License Header, with the fields
+ *   enclosed by brackets [] replaced by your own identifying information:
+ *   "Portions Copyright [year] [name of copyright owner]"
+ *
+ *   Contributor(s):
+ *   If you wish your version of this file to be governed by only the CDDL or
+ *   only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *   elects to include this software in this distribution under the [CDDL or GPL
+ *   Version 2] license."  If you don't indicate a single choice of license, a
+ *   recipient has the option to distribute your version of this file under
+ *   either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *   its licensees as provided above.  However, if you add GPL Version 2 code
+ *   and therefore, elected the GPL Version 2 license, then the option applies
+ *   only if the new code is made subject to such option by the copyright
+ *   holder.
+ */
+
+package com.sun.enterprise.v3.admin.commands;
+
+import com.sun.enterprise.config.serverbeans.Cluster;
+import com.sun.enterprise.config.serverbeans.JavaConfig;
+import com.sun.enterprise.config.serverbeans.Server;
+import com.sun.enterprise.universal.glassfish.TokenResolver;
+import com.sun.enterprise.universal.process.ProcessUtils;
+import com.sun.enterprise.util.StringUtils;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.ActionReport.ExitCode;
+import org.glassfish.api.I18n;
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.*;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Service(name = "generate-heap-dump")
+@PerLookup
+@CommandLock(CommandLock.LockType.NONE)
+@I18n("generate.heap.dump")
+@TargetType({CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTERED_INSTANCE, CommandTarget.DEPLOYMENT_GROUP})
+@ExecuteOn(value = {RuntimeType.INSTANCE}, ifNeverStarted = FailurePolicy.Error)
+@RestEndpoints({
+        @RestEndpoint(configBean = Cluster.class,
+                opType = RestEndpoint.OpType.GET,
+                path = "generate-heap-dump",
+                description = "Generate Heap Dump",
+                params = {
+                        @RestParam(name = "target", value = "$parent")
+                }),
+        @RestEndpoint(configBean = Server.class,
+                opType = RestEndpoint.OpType.GET,
+                path = "generate-heap-dump",
+                description = "Generate Heap Dump",
+                params = {
+                        @RestParam(name = "target", value = "$parent")
+                }),
+        @RestEndpoint(configBean = DeploymentGroup.class,
+                opType = RestEndpoint.OpType.GET,
+                path = "generate-heap-dump",
+                description = "Generate Heap Dump",
+                params = {
+                        @RestParam(name = "target", value = "$parent")
+                }),
+        @RestEndpoint(configBean = JavaConfig.class,
+                opType = RestEndpoint.OpType.GET,
+                path = "generate-heap-dump",
+                description = "Generate Heap Dump",
+                params = {
+                        @RestParam(name = "target", value = "$grandparent")
+                })
+})
+@AccessRequired(resource = "domain/jvm", action = "read")
+public class GenerateHeapDumpCommand implements AdminCommand {
+
+    Logger LOGGER = Logger.getLogger(GenerateHeapDumpCommand.class.getName());
+
+    @Param(name = "target", optional = true)
+    String target;
+
+    @Param(name = "outputDir")
+    String outputDir;
+
+    @Param(name = "outputFileName", optional = true)
+    String outputFileName;
+
+    public void execute(AdminCommandContext ctx) {
+        ActionReport report = ctx.getActionReport();
+
+        if (!StringUtils.ok(outputDir)) {
+            report.setMessage("Invalid Output Directory");
+            report.setActionExitCode(ExitCode.FAILURE);
+            return;
+        }
+
+        StringBuilderNewLineAppender stringBuilderNewLineAppender = new StringBuilderNewLineAppender(new StringBuilder());
+        if (!StringUtils.ok(outputFileName)) {
+            String prefix = StringUtils.ok(target) ? target : "server";
+            outputFileName = prefix + "-heap-dump-" + DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ssX").withZone(ZoneOffset.UTC).format(Instant.now());
+        }
+        try {
+
+            Map<String, String> systemPropsMap = new HashMap<String, String>((Map) (System.getProperties()));
+            TokenResolver resolver = new TokenResolver(systemPropsMap);
+            String resolvedOutput = resolver.resolve(outputDir);
+            if (!resolvedOutput.endsWith("/")) {
+                resolvedOutput = resolvedOutput + "/";
+            }
+            stringBuilderNewLineAppender.append("Resolved the following output directory: " + resolvedOutput);
+
+            Path outputDirPath = Paths.get(resolvedOutput);
+            if (!Files.exists(outputDirPath)) {
+                report.setMessage("Output directory does not exist!");
+                report.setActionExitCode(ExitCode.FAILURE);
+                return;
+            }
+
+
+            int pid = ProcessUtils.getPid();
+            LOGGER.log(Level.FINE, "Process ID is " + pid);
+
+            Runtime runtime = Runtime.getRuntime();
+            boolean error = false;
+            int suffix = 0;
+            while (true) {
+                String finalFileName = outputFileName + (suffix == 0 ? "" : ("(" + suffix + ")"));
+                String command = String.format("jcmd %s GC.heap_dump %s%s.hprof", pid, resolvedOutput, finalFileName);
+                LOGGER.log(Level.FINE, "Executing the following command: " + command);
+                Process process = runtime.exec(command);
+                stringBuilderNewLineAppender.append("Generating Heap Dump");
+                BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                String line;
+                process.waitFor();
+                boolean success = true;
+                while ((line = input.readLine()) != null) {
+                    if (line.contains("File exists")) {
+                        suffix++;
+                        stringBuilderNewLineAppender.append("File already exists, incrementing file name");
+                        success = false;
+                    }
+
+                    if (line.contains("No such file or directory")) {
+                        error = true;
+                        stringBuilderNewLineAppender.append("Directory does not exist! " + resolvedOutput);
+                        break;
+                    }
+                    LOGGER.log(Level.FINE, line);
+                }
+
+                if (success) {
+                    stringBuilderNewLineAppender.append("File name is " + finalFileName);
+                    break;
+                }
+
+            }
+
+            if (error) {
+                stringBuilderNewLineAppender.append("Heap Dump could not be created!");
+                report.setActionExitCode(ExitCode.FAILURE);
+            } else {
+                stringBuilderNewLineAppender.append("Heap Dump has been created");
+                report.setActionExitCode(ExitCode.SUCCESS);
+            }
+            report.setMessage(stringBuilderNewLineAppender.toString());
+        } catch (IOException | InterruptedException e) {
+            report.setMessage("Could not generate the heap dump");
+            report.setActionExitCode(ExitCode.FAILURE);
+        }
+
+    }
+}


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Added the generate-heap-dump command

| Params    | Description|
| -------- | ------- |
| target | specifies the name of an instance, cluster or deployment group.    |
| outputDir | Where the heap dump file should be stored     |
| outputFileName | File name for the heap dump    |

If no outputFileName is present, a file name will be generated.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built Payara, started domain and ran command, tested with target being an instance and deployment group with two instances.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
openjdk version "1.8.0_372"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_372-b07)
OpenJDK 64-Bit Server VM (Temurin)(build 25.372-b07, mixed mode)
Apache Maven 3.9.0 (9b58d2bad23a66be161c4664ef21ce219c2c8584)
Maven home: C:\Maven\apache-maven-3.9.0
Java version: 1.8.0_372, vendor: Temurin, runtime: C:\Java\jdk8u372-b07\jre
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
## Documentation
<!-- Link documentation if a PR exists -->
none at the moment
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
