### PR TITLE
Fish 8453 Fix apicmp Dependency on Previous Version

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -616,19 +616,6 @@
             </activation>
             <build>
                 <plugins>
-                    <!-- plugin to parse version number without "-SNAPSHOT" -->
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>released-version</id>
-                                <goals>
-                                    <goal>released-version</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>com.github.siom79.japicmp</groupId>
                         <artifactId>japicmp-maven-plugin</artifactId>
@@ -638,7 +625,7 @@
                                 <dependency>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>${project.artifactId}</artifactId>
-                                    <version>${releasedVersion.majorVersion}.${releasedVersion.minorVersion}.${releasedVersion.incrementalVersion}</version>
+                                    <version>${payara.core.compare-version}</version>
                                     <type>jar</type>
                                 </dependency>
                             </oldVersion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,6 +55,7 @@
 
     <properties>
         <payara.core.version>7.0.0-SNAPSHOT</payara.core.version>
+        <payara.core.compare-version>6.13.0</payara.core.compare-version>
         <!-- BOM dependencies versions -->
         <payara.security-connectors.version>3.1</payara.security-connectors.version>
         <hk2.version>3.0.1.payara-p4</hk2.version>


### PR DESCRIPTION
## Description
We relied on finding latest version of previously published API, but this fails for a deployment of branch 6.x.y, while there is already published branch 7.

It will be necessary to update value `payara.core.compare-version` every release. Therefor it is next to the version number.

For the Payara 7, first build, we have to use `6.13.0` as the previous version, because `7.0.0-SNAPSHOT` is not in nexus. Japicmp then fails to find it there with this error:
```
[ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.17.2:cmp (default) on project j-interop-repackaged: Error while checking for incompatible changes: Cannot compare versions because the number of old versions is different than the number of new versions.
```

## Testing
### Testing Performed
Local build.

### Testing Environment
Linux, OpenJDK 21
