### PR TITLE
FISH-7757 FISH-8344 Upgrade to Parsson 1.1.5 with JSONP-API Deprecated to 2.1.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
-        <parsson.version>1.1.5</parsson.version>
+        <parsson.version>1.1.5.payara-p1</parsson.version>
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.1.payara-p1</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
-        <jsonp-api.version>2.1.0</jsonp-api.version>
+        <jsonp-api.version>2.1.3</jsonp-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
-        <parsson.version>1.1.1.payara-p1</parsson.version>
+        <parsson.version>1.1.5</parsson.version>
         <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
         <jaxb-api.version>4.0.1.payara-p1</jaxb-api.version>
         <jackson.version>2.15.0</jackson.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <hibernate.validator-cdi.version>8.0.0.Final</hibernate.validator-cdi.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
-        <jsonp-api.version>2.1.3</jsonp-api.version>
+        <jsonp-api.version>2.1.0</jsonp-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
         <jakarta.security.jacc-api.version>2.1.0</jakarta.security.jacc-api.version>
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>


### PR DESCRIPTION
## Description
Upgrades us to Parsson 1.1.5 with the JSONP-API deprecated to 2.1.0 to grab the fixes for CVE-2023-4043.
Parsson 1.1.5 includes the same upgrades that caught us out when we tried to upgrade to 1.1.4 - JSONP-API has been updated from 2.1.0.

Changes introduced in JSONP-API to the `JsonProvider.provider()` method appear to break our TCK runner.
They reworked how system properties are loaded by this SPI class, and it now (correctly) finds the system property. This however breaks us because this SPI class doesn't fall back to the other methods available for loading the factory class (service loader, OSGi, default) - it simply fails with a (wrapped) ClassNotFoundException.
In our case, we previously passed this TCK test because our Service Loader would end up returning the expected dummy TCK factory class, and now it doesn't reach this point. Payara is attempting to load the dummy factory class using the class loader available to the jakarta.json.jar module - the OSGi bundle class loader. This fails as the jakarta.json.jar module doesn't have the dummy TCK factory class as an OSGi import, and it's not otherwise available on this class loader.

This PR is a temporary measure just so we have the CVE fix - the intent is that we will continue to investigate and address this class loader issue for a future release.

## Important Info
### Blockers
https://github.com/payara/patched-src-parsson/pull/2

## Testing
### New tests
None

### Testing Performed
Built the blocking PR, built Payara, and ran the JSONP TCK.

### Testing Environment
Windows 11, Zulu 11.0.22

## Documentation
https://github.com/payara/Payara-Documentation/pull/423

## Notes for Reviewers
See description.
