### PR TITLE
CUSTCOM-75 FISH-8273 Allow Deleting System Properties via Admin Console

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterSystemPropertiesButtons.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterSystemPropertiesButtons.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2024 Payara Foundation and/or its affiliates -->
 <sun:button id="saveButton" text="$resource{i18n.button.Save}" onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) {submitAndDisable(this, '$resource{i18n.button.Processing}');}; return false;" >
     <!command
         gf.isClusterName(clusterName="#{pageSession.clusterName}" );
@@ -46,7 +47,7 @@
         foreach (var="row" list="#{pageSession.tableList}") {
             mapPut(map="#{requestScope.data}", key="#{row.name}", value="#{row.overrideValue}");
         }
-        gf.restRequest(endpoint="#{pageSession.selfUrl}", method="POST", attrs="#{requestScope.data}", contentType="application/x-www-form-urlencoded", result="#{requestScope.restResponse}");
+        gf.restRequest(endpoint="#{pageSession.selfUrl}", method="PUT", attrs="#{requestScope.data}", contentType="application/x-www-form-urlencoded", result="#{requestScope.restResponse}");
         prepareSuccessfulMsg();
         gf.redirect(page="#{pageSession.selfPage}&alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}");
         />

--- a/appserver/admingui/common/src/main/resources/configuration/configSystemPropertiesButtons.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/configSystemPropertiesButtons.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2024 Payara Foundation and/or its affiliates -->
 
 
 <sun:button id="saveButton" text="$resource{i18n.button.Save}" >
@@ -51,7 +52,7 @@
         foreach (var="row" list="#{pageSession.tableList}") {
             mapPut(map="#{requestScope.data}", key="#{row.name}", value="#{row.value}");
         }
-        gf.restRequest(endpoint="#{pageSession.selfUrl}", method="POST", attrs="#{requestScope.data}", contentType="application/x-www-form-urlencoded", result="#{requestScope.restResponse}");
+        gf.restRequest(endpoint="#{pageSession.selfUrl}", method="PUT", attrs="#{requestScope.data}", contentType="application/x-www-form-urlencoded", result="#{requestScope.restResponse}");
         prepareSuccessfulMsg();
         gf.redirect(page="#{pageSession.selfPage}&alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}");
 		gf.isConfigName(configName="#{pageSession.configName}" );


### PR DESCRIPTION
## Description
Applies the fix from https://github.com/payara/Payara/pull/4497 to allow deleting system properties via the admin console.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Added a system proeprty via the admin console.
Deleted system property via the admin console.
Clicked off the page each time to ensure it was reloaded.

### Testing Environment
Windows 11, Zulu 11

## Documentation
N/A

## Notes for Reviewers
None
