### PR TITLE
FISH-6456: checking if http2 is enabled

### DIFF
--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -487,9 +487,9 @@ public class GenericGrizzlyListener implements GrizzlyListener {
                         ProtocolFinder.class, finderClassname, finderClassname);
                     configureElement(habitat, networkListener, finderConfig, protocolFinder);
                     final Protocol subProtocol = finderConfig.findProtocol();
-                    
+
                     if (subProtocol.getHttp() != null) {
-                        if (LOGGER.isLoggable(WARNING)) {
+                        if (LOGGER.isLoggable(WARNING) && isHttp2Enabled()) {
                             LOGGER.log(WARNING, 
                                 "HTTP/2 (enabled by default) is unsupported with port " + 
                                 "unification and will be disabled for network listener {0}.", networkListener.getName());

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/GenericGrizzlyListener.java
@@ -38,7 +38,7 @@
  * holder.
  * 
  * 
- * Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates] 
+ * Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
  */
 package org.glassfish.grizzly.config;
 


### PR DESCRIPTION
## Description
This warning is displayed in the log files even though the http2 is disabled:
```
[2022-06-27T17:32:17.140+0100] [Payara 5.37.0] [WARNING] [] [org.glassfish.grizzly.config.GenericGrizzlyListener] [tid: _ThreadID=45 _ThreadName=RunLevelControllerThread-1656347531709] [timeMillis: 1656347537140] [levelValue: 900] [[
HTTP/2 (enabled by default) is unsupported with port unification and will be disabled for network listener admin-listener.]]
```

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed

1. Start a Payara server domain
2. Create a local instance.
3. Disable HTTP 2 support:
4. set configs.config.server-config.network-config.protocols.protocol.admin-listener.http.http2-enabled=false
5. Check for the warning in the log files of the local instance.

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.6

## Documentation
None
