### PR TITLE
FISH-8634 Add Jakarta Staging Repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
         stage('Build') {
             steps {
                 echo '*#*#*#*#*#*#*#*#*#*#*#*#  Building SRC  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
-                sh """mvn -B -V -ff -e clean install --strict-checksums -PQuickBuild \
+                sh """mvn -B -V -ff -e clean install --strict-checksums -PQuickBuild,jakarta-staging \
                     -Djavax.net.ssl.trustStore=${env.JAVA_HOME}/lib/security/cacerts \
                     -Djavax.xml.accessExternalSchema=all -Dbuild.number=${payaraBuildNumber}"""
                 echo '*#*#*#*#*#*#*#*#*#*#*#*#    Built SRC   *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'

--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -658,6 +658,21 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jakarta-staging</id>
+            <repositories>
+                <repository>
+                    <id>jakarta-releases</id>
+                    <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <deploy.skip>true</deploy.skip>
         <javadoc.skip>true</javadoc.skip>
         <source.skip>true</source.skip>
-        <license-maven-plugin.version>2.3.0</license-maven-plugin.version>
+        <license-maven-plugin.version>2.4.0</license-maven-plugin.version>
     </properties>
 
     <profiles>
@@ -371,22 +371,16 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license-maven-plugin.version}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
                         <id>download-and-aggregate-licenses</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>aggregate-add-third-party</goal>
                         </goals>
-                        <configuration>
-                            <executable>mvn</executable>
-                            <arguments>
-                                <argument>license:aggregate-add-third-party</argument>
-                            </arguments>
-                        </configuration>
                     </execution>
                 </executions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,21 @@
             </modules>
         </profile>
 
+        <profile>
+            <id>jakarta-staging</id>
+            <repositories>
+                <repository>
+                    <id>jakarta-releases</id>
+                    <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,27 @@
                 </repository>
             </repositories>
         </profile>
+
+        <profile>
+            <id>GenerateThirdPartyLicenseFile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>download-and-aggregate-licenses</id>
+                                <goals>
+                                    <goal>aggregate-add-third-party</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -368,22 +389,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>${license-maven-plugin.version}</version>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>download-and-aggregate-licenses</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>aggregate-add-third-party</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
         </plugins>
 


### PR DESCRIPTION
## Description
Adds the Jakarta staging repo as a Maven repository (under a profile)
Also cherry-picks https://github.com/payara/Payara/pull/6541 because otherwise the exec ignores the command line defined profile (since it spins up a new maven command).

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Cleaned maven repo, built server with `jakarta.security.enterprise.version` set to 4.0.0-M3

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
