### PR TITLE
FISH-8556 Bump org.virtualbox:vboxjws from 4.1.4 to 4.2.8

### DIFF
--- a/nucleus/packager/external/vboxjws/pom.xml
+++ b/nucleus/packager/external/vboxjws/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.virtualbox</groupId>
             <artifactId>vboxjws</artifactId>
-            <version>4.1.4</version>
+            <version>4.2.8</version>
             <!-- By indicating the scope as provided, GF distribution mechanism 
                  excludes this -->
             <optional>true</optional>


### PR DESCRIPTION
Port of https://github.com/payara/Payara-Enterprise/pull/1231

Bumps org.virtualbox:vboxjws from 4.1.4 to 4.2.8.

---
updated-dependencies:
- dependency-name: org.virtualbox:vboxjws dependency-type: direct:production update-type: version-update:semver-minor ...