### PR TITLE
Revert "FISH-8557 Bump jline.version from 3.21.0 to 3.26.1"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,7 +130,7 @@
         <junit.version>4.13.2</junit.version>
         <mockito.version>2.28.2</mockito.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
-        <jline.version>3.26.1</jline.version>
+        <jline.version>3.21.0</jline.version>
         <grizzly.npn.api.version>2.0.0.payara-p1</grizzly.npn.api.version>
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
         <mimepull.version>1.10.0</mimepull.version>


### PR DESCRIPTION
Reverts payara/Payara#6649


Executing any asadmin command prints out:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jline.terminal.impl.exec.ExecTerminalProvider$ReflectionRedirectPipeCreator (file:/D:/Git/Payara2/appserver/distributions/payara/target/stage/payara6/glassfish/modules/jline.jar) to constructor java.lang.ProcessBuilder$RedirectPipeImpl()
WARNING: Please consider reporting this to the maintainers of org.jline.terminal.impl.exec.ExecTerminalProvider$ReflectionRedirectPipeCreator
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```