### PR TITLE
FISH-8630 - run functional test with payara micro in Jenkins pipeline

### DIFF
--- a/appserver/tests/functional/embeddedtest/README.md
+++ b/appserver/tests/functional/embeddedtest/README.md
@@ -6,6 +6,16 @@ It compiles the test with the required jar, starts payara embedded, deploy clust
 
 ## Usage
 
+### To run the current version of Payara Embedded:
+
+From the location ${PAYARA_HOME}/appserver/tests/functional/embeddedtest, run the command:
+
+> mvn clean test -P{FullProfile/WebProfile} 
+
+the test is designed to adapt to jdk 8, 11 and higher. 
+
+### To run a specific version of Payara Embedded:
+
 have the desired payara-embedded jar placed in ${PAYARA_HOME}/appserver/tests/functional/embeddedtest/lib
 
 The jar should have a name following this format: payara-embedded-{web/all}-{payara-version}.jar
@@ -14,8 +24,15 @@ example: payara-embedded-all-6.2023.8.RC1.jar
 
 From the location ${PAYARA_HOME}/appserver/tests/functional/embeddedtest, run the command:
 
-> mvn clean -P {FullProfile/WebProfile} -Dpayara.version="6.2023.8.RC1" compile test 
+> mvn validate -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" 
 
-the test is designed to adapt to jdk 8, 11, or 17. 
+This first command installs the local jar before the compilation
 
-If needed, the version of jdk used to compile and run can be modified with the properties maven.compiler.source, maven.compiler.target
+> mvn clean verify -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" 
+
+It is also possible to specify a different location for the embedded jar:
+
+> mvn validate -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" -Djarlocation="/tmp/payara-embedded-all-6.2023.8.RC1.jar"
+
+> mvn clean verify -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" -Djarlocation="/tmp/payara-embedded-all-6.2023.8.RC1.jar"
+

--- a/appserver/tests/functional/embeddedtest/README.md
+++ b/appserver/tests/functional/embeddedtest/README.md
@@ -24,15 +24,15 @@ example: payara-embedded-all-6.2023.8.RC1.jar
 
 From the location ${PAYARA_HOME}/appserver/tests/functional/embeddedtest, run the command:
 
-> mvn validate -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" 
+> mvn validate -P{FullProfile/WebProfile},specificJar -Dpayara.version="6.2023.8.RC1" 
 
 This first command installs the local jar before the compilation
 
-> mvn clean verify -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" 
+> mvn clean verify -P{FullProfile/WebProfile},specificJar -Dpayara.version="6.2023.8.RC1" 
 
 It is also possible to specify a different location for the embedded jar:
 
-> mvn validate -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" -Djarlocation="/tmp/payara-embedded-all-6.2023.8.RC1.jar"
+> mvn validate -P{FullProfile/WebProfile},specificJar -Dpayara.version="6.2023.8.RC1" -Djarlocation="/tmp/payara-embedded-all-6.2023.8.RC1.jar"
 
-> mvn clean verify -P{FullProfile/WebProfile},specificJar -Dversion="6.2023.8.RC1" -Djarlocation="/tmp/payara-embedded-all-6.2023.8.RC1.jar"
+> mvn clean verify -P{FullProfile/WebProfile},specificJar -Dpayara.version="6.2023.8.RC1" -Djarlocation="/tmp/payara-embedded-all-6.2023.8.RC1.jar"
 

--- a/appserver/tests/functional/embeddedtest/pom.xml
+++ b/appserver/tests/functional/embeddedtest/pom.xml
@@ -2,7 +2,7 @@
 <!--
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2023-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/functional/embeddedtest/pom.xml
+++ b/appserver/tests/functional/embeddedtest/pom.xml
@@ -6,17 +6,17 @@
 
     <groupId>fish.payara.extras</groupId>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>maven-unit-test</artifactId>
+    <artifactId>payara-embedded-test</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>6.2024.6-SNAPSHOT</version>
 
     <properties>
         <!-- https://maven.apache.org/general.html#encoding-warning -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <payara.version>6.5.0.RC1</payara.version>
         <payara.profile>all</payara.profile>
+        <jarlocation>${project.basedir}/lib/payara-embedded-${payara.profile}-${version}.jar</jarlocation>
     </properties>
 
     
@@ -26,48 +26,35 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.8.1</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>fish.payara.extras</groupId>
             <artifactId>payara-embedded-${payara.profile}</artifactId>
-            <version>${payara.version}</version>
+            <version>${version}</version>
             <type>jar</type>
         </dependency>
 
     </dependencies>
-
+    
     <build>
-        <finalName>maven-embedded-deployment-test</finalName>
         <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>install-external-non-maven-jar-Embedded-${payara.profile}-into-local-maven-repo</id>
-                        <phase>clean</phase>
-                        <configuration>
-                            <repositoryLayout>default</repositoryLayout>
-                            <groupId>fish.payara.extras</groupId>
-                            <artifactId>payara-embedded-${payara.profile}</artifactId>
-                            <version>${payara.version}</version>
-                            <file>${project.basedir}/lib/payara-embedded-${payara.profile}-${payara.version}.jar</file>
-                            <packaging>jar</packaging>
-                            <generatePom>true</generatePom>
-                        </configuration>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
-        
     </build>
+    
     <profiles>
         <profile>
             <id>Jdk8</id>
@@ -82,16 +69,16 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.2.5</version>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
-            <id>Jdk11</id>
+            <id>Jdk11+</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
                 <maven.compiler.source>11</maven.compiler.source>
@@ -101,30 +88,8 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
-                        <configuration>
-                            <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>Jdk17</id>
-            <activation>
-                <jdk>17</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.source>17</maven.compiler.source>
-                <maven.compiler.target>17</maven.compiler.target>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.2.5</version>
                         <configuration>
                             <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
                         </configuration>
@@ -143,6 +108,42 @@
             <properties>
                 <payara.profile>web</payara.profile> 
             </properties>
+        </profile>
+        <profile>
+            <id>specificJar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>install-jar-Embedded-${payara.profile}-into-local-maven-repo</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <repositoryLayout>default</repositoryLayout>
+                                    <groupId>fish.payara.extras</groupId>
+                                    <artifactId>payara-embedded-${payara.profile}</artifactId>
+                                    <version>${version}</version>
+                                    <file>${jarlocation}</file>
+                                    <generatePom>true</generatePom>
+                                </configuration>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-install</id>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
     </profiles>

--- a/appserver/tests/functional/embeddedtest/pom.xml
+++ b/appserver/tests/functional/embeddedtest/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2023-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
@@ -16,7 +55,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <payara.profile>all</payara.profile>
-        <jarlocation>${project.basedir}/lib/payara-embedded-${payara.profile}-${version}.jar</jarlocation>
+        <payara.version>${project.version}</payara.version>
+        <jarlocation>${project.basedir}/lib/payara-embedded-${payara.profile}-${payara.version}.jar</jarlocation>
     </properties>
 
     
@@ -31,7 +71,7 @@
         <dependency>
             <groupId>fish.payara.extras</groupId>
             <artifactId>payara-embedded-${payara.profile}</artifactId>
-            <version>${version}</version>
+            <version>${payara.version}</version>
             <type>jar</type>
         </dependency>
 
@@ -125,7 +165,7 @@
                                     <repositoryLayout>default</repositoryLayout>
                                     <groupId>fish.payara.extras</groupId>
                                     <artifactId>payara-embedded-${payara.profile}</artifactId>
-                                    <version>${version}</version>
+                                    <version>${payara.version}</version>
                                     <file>${jarlocation}</file>
                                     <generatePom>true</generatePom>
                                 </configuration>

--- a/appserver/tests/functional/embeddedtest/src/test/java/fish/payara/embedded/EmbeddedDeploymentIT.java
+++ b/appserver/tests/functional/embeddedtest/src/test/java/fish/payara/embedded/EmbeddedDeploymentIT.java
@@ -1,3 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
 package fish.payara.embedded;
  
 import java.io.File;

--- a/appserver/tests/functional/embeddedtest/src/test/java/fish/payara/embedded/EmbeddedDeploymentIT.java
+++ b/appserver/tests/functional/embeddedtest/src/test/java/fish/payara/embedded/EmbeddedDeploymentIT.java
@@ -21,10 +21,10 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-public class EmbeddedDeploymentTest {
+public class EmbeddedDeploymentIT {
  
     @Test
-    public void testDeployCluster() throws IOException {
+    public void DeployCluster() throws IOException {
         String filename = "testEmbeddedDeploymentLog.xml";
         String currentPath = new java.io.File(".").getCanonicalPath();
         try {
@@ -59,7 +59,6 @@ public class EmbeddedDeploymentTest {
             new File(filename).delete();
 
         } catch (GlassFishException ex) {
-            ex.printStackTrace();
         }
     }
 
@@ -91,7 +90,6 @@ public class EmbeddedDeploymentTest {
                 }
             }
         } catch (IOException | ParserConfigurationException | DOMException | SAXException e) {
-            e.printStackTrace();
         }
         return testSuccess;
     }

--- a/appserver/tests/functional/payara-micro/pom.xml
+++ b/appserver/tests/functional/payara-micro/pom.xml
@@ -2,7 +2,7 @@
 <!--
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2024-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/functional/payara-micro/pom.xml
+++ b/appserver/tests/functional/payara-micro/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2024-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/ClusterHAJSPPage.java
+++ b/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/ClusterHAJSPPage.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2024-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.functional.micro;
 
 import com.microsoft.playwright.*;

--- a/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/ClusterHAJSPPage.java
+++ b/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/ClusterHAJSPPage.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2024-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/DualSessionsIT.java
+++ b/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/DualSessionsIT.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2024-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.functional.micro;
 
 import com.microsoft.playwright.*;

--- a/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/DualSessionsIT.java
+++ b/appserver/tests/functional/payara-micro/src/test/java/fish/payara/functional/micro/DualSessionsIT.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2024-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
Add a new stage in the Jenkins pipeline to run the functional test for payara micro and payara embedded.

Note: when running the test for Payara Micro, one step installs the dependencies for Playwright. This may throw an error 
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 3598 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?

This has to do with different installations colliding. As of now, I haven't found a simple way to avoid that issue from happening.

