### PR TITLE
FISH-8627 FISH-8628 FISH-8269 Upgrade Docker Image Java Versions

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -59,7 +59,7 @@
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.23-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.11-jdk</docker.jdk17.tag>
-        <docker.jdk21.tag>21.0.2-jdk</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.3-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,7 +57,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.22-jdk</docker.jdk11.tag>
+        <docker.jdk11.tag>11.0.23-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.10-jdk</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.2-jdk</docker.jdk21.tag>
 

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,7 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.23-jdk</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.10-jdk</docker.jdk17.tag>
+        <docker.jdk17.tag>17.0.11-jdk</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.2-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -


### PR DESCRIPTION
## Description
Upgrades the base Docker Java images to 11.0.23, 17.0.11, and 21.0.3

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the images locally, everything seems bon.
I've checked DockerHub and there appears to be AMD and ARM manifests for all images.

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
