### PR TITLE
FISH-8664 Payara 7 Monitoring Console

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,6 +249,18 @@
         </repository>
 
         <repository>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
             <id>payara-nexus-artifacts</id>
             <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
             <releases>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -135,7 +135,7 @@
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
         <mimepull.version>1.10.0</mimepull.version>
         <gmbal.version>4.0.3</gmbal.version>
-        <monitoring-console-api.version>2.0.2</monitoring-console-api.version>
+        <monitoring-console-api.version>3.0.0-SNAPSHOT</monitoring-console-api.version>
         <metainf-services.version>1.11</metainf-services.version>
         <ldapbp.version>1.0</ldapbp.version>
         <!-- Javassist (JAVA programming ASSISTant) makes Java bytecode manipulation simple. It is a class library for editing bytecodes in Java. -->

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@
         <payara-arquillian-container.version>3.0.alpha6</payara-arquillian-container.version>
         <h2db.version>2.2.224</h2db.version>
         <concurro.version>3.1.0-SNAPSHOT</concurro.version>
-        <monitoring-console-process.version>2.0.2</monitoring-console-process.version>
-        <monitoring-console-webapp.version>2.0.2</monitoring-console-webapp.version>
+        <monitoring-console-process.version>3.0.0-SNAPSHOT</monitoring-console-process.version>
+        <monitoring-console-webapp.version>3.0.0-SNAPSHOT</monitoring-console-webapp.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
 
         <deploy.skip>true</deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,17 @@
             </snapshots>
         </repository>
         <repository>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>payara-nexus-artifacts</id>
             <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
             <releases>


### PR DESCRIPTION
## Description
Upgrades the monitoring console to one aligned with EE11 and Payara 7.
Version purposefully left as SNAPSHOT for now, as we may want to push additional changes.

## Important Info
### Blockers
https://github.com/payara/monitoring-console/pull/42
https://github.com/payara/patched-src-hk2/pull/34
https://github.com/payara/Payara/pull/6693
https://github.com/payara/Payara/pull/6630

## Testing
### New tests
None

### Testing Performed
Built the server and started the admin console - monitoring console factory resolved and bootstrapped.
Enabled the monitoring console, some metrics, and loaded the console:
* `asadmin set-monitoring-console-configuration --enabled=true`
* Admin Console -> Configurations -> server-config -> Monitoring -> enable everything
* Load localhost:8080/monitoring-console - should load successfully and you should be able to see the graphs collecting data.

### Testing Environment
Windows 11, Zulu 21.0.3

## Documentation
N/A

## Notes for Reviewers
None
