### PR TITLE
FISH-8497 update dependabot conditions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,147 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
     target-branch: "master"
+    ignore:
+      # Ignore major and minor version updates for dependencies with group IDs starting with jakarta
+      - dependency-name: "jakarta.*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+      # Ignore major and minor version updates for dependencies with group IDs starting with org.eclipse.microprofile
+      - dependency-name: org.eclipse.microprofile*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+      # Ignore major version updates for individual dependencies within the org.eclipse.persistence group
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa.spql"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.moxy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.sdo"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.dbws"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.oracle"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.antlr"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.asm"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor"
+        update-types: ["version-update:semver-major"]
+
+      # Ignore major version updates for org.glassfish and related dependencies
+      - dependency-name: "org.glassfish:jakarta.enterprise.concurrent"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.mq:mq"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish:jakarta.faces"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.soteria:jakarta.security.enterprise"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.soteria:soteria.spi.bean.decorator.weld"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.metro:webservices-osgi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.metro:webservices-extra-jdk-packages"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.metro:webservices-api-osgi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.web:jakarta.servlet.jsp.jstl"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.expressly:expressly"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.wasp:wasp"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.hk2:hk2-bom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.grizzly:grizzly-bom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.jersey:jersey-bom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.tyrus:tyrus-bom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.exousia:exousia"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.woodstock:woodstock-webui-jsf"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.woodstock:woodstock-webui-jsf-suntheme"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.jsftemplating:jsftemplating"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.annotations:logging-annotation-processor"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.pfl:pfl-tf-tools"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.pfl:pfl-basic-tools"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.pfl:pfl-dynamic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.pfl:pfl-basic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.corba:glassfish-corba-omgapi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.corba:glassfish-corba-internal-api"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.corba:rmic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.corba:glassfish-corba-orb"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.corba:glassfish-corba-csiv2-idl"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.glassfish.ha:ha-api"
+        update-types: ["version-update:semver-major"]
+      
+      # Ignore major version updates for org.eclipse and related dependencies
+      - dependency-name: "org.eclipse:yasson"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.parsson:jakarta.json"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.parsson:parsson-media"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.angus:angus-activation"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.eclipse.angus:angus-mail"
+        update-types: ["version-update:semver-major"]
+      
+      # Ignore major version updates for com.ibm.jbatch and related dependencies
+      - dependency-name: "com.ibm.jbatch:com.ibm.jbatch.container"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.ibm.jbatch:com.ibm.jbatch.spi"
+        update-types: ["version-update:semver-major"]
+      
+      # Ignore major version updates for com.sun.xml.bind
+      - dependency-name: "com.sun.xml.bind:jaxb-osgi"
+        update-types: ["version-update:semver-major"]
+      
+      # Ignore major version updates for org.hibernate.validator and related dependencies
+      - dependency-name: "org.hibernate.validator:hibernate-validator"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.hibernate.validator:hibernate-validator-cdi"
+        update-types: ["version-update:semver-major"]
+      
+      # Ignore major version updates for org.jboss.weld and related dependencies
+      - dependency-name: "org.jboss.weld:weld-osgi-bundle"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jboss.weld:weld-api"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jboss.weld:weld-lite-extension-translator"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jboss.weld:weld-core-impl"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jboss.weld:weld-spi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jboss.weld.se:weld-se-shaded"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jboss.weld.environment:weld-environment-common"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+    - dependency-name: "*"
+    target-branch: "master"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
       - dependency-name: org.eclipse.microprofile*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
+      # Ignore major version updates for dependencies with group ID starting with fish.payara
+      - dependency-name: "fish.payara.*"
+        update-types: ["version-update:semver-major"]
+        
       # Ignore major version updates for individual dependencies within the org.eclipse.persistence group
       - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.core"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       # Ignore major version updates for dependencies with group ID starting with fish.payara
       - dependency-name: "fish.payara.*"
         update-types: ["version-update:semver-major"]
-        
+
       # Ignore major version updates for individual dependencies within the org.eclipse.persistence group
       - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.core"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
•	Jakarta EE APIs - Ignore major and minor version increases (patch updates only) on "jakarta*"

•	Jakarta EE Implementations - ignore major version increases (minor and patch updates only)

•	MicroProfile APIs - Ignore major and minor version increases (patch updates only). Can probably wildcard on "org.eclipse.microprofile.*"

•	Ignore all submodules
