### PR TITLE
FISH-8728 Refine RE to allow host in jdwp agent address

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.launcher;
 
@@ -382,15 +382,17 @@ public abstract class GFLauncher {
         return option.startsWith("-Xrunjdwp:") || option.startsWith("-agentlib:jdwp");
     }
 
+    private static final String DEBUG_ADDRESS_PORT_GROUP = "port";
+    private static final Pattern DEBUG_ADDRESS_PATTERN = Pattern.compile(".*address=(?<hostWithColon>(?<host>[^:]*):)?(?<port>\\d*).*");
+
     static int extractDebugPort(String option) {
-        Pattern portRegex = Pattern.compile(".*address=(?<port>\\d*).*");
-        Matcher m = portRegex.matcher(option);
+        Matcher m = DEBUG_ADDRESS_PATTERN.matcher(option);
         if (!m.matches()) {
             return -1;
         }
         try {
-            String addressGroup = m.group("port");
-            return Integer.parseInt(addressGroup);
+            String portGroup = m.group(DEBUG_ADDRESS_PORT_GROUP);
+            return Integer.parseInt(portGroup);
         } catch (NumberFormatException nfex) {
             return -1;
         }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -383,7 +383,7 @@ public abstract class GFLauncher {
     }
 
     private static final String DEBUG_ADDRESS_PORT_GROUP = "port";
-    private static final Pattern DEBUG_ADDRESS_PATTERN = Pattern.compile(".*address=(?<hostWithColon>(?<host>[^:]*):)?(?<port>\\d*).*");
+    private static final Pattern DEBUG_ADDRESS_PATTERN = Pattern.compile(".*address=(?<hostWithColon>(?<host>.+):)?(?<port>\\d*).*");
 
     static int extractDebugPort(String option) {
         Matcher m = DEBUG_ADDRESS_PATTERN.matcher(option);

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractPortTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractPortTest.java
@@ -59,6 +59,27 @@ public class GFLauncherExtractPortTest {
     }
 
     @Test
+    public void shouldExtractPortNumberFromDebugOptionWithHostName() {
+      int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,address=localhost:9876,suspend=n");
+
+      assertEquals(9876, port);
+    }
+
+    @Test
+    public void shouldExtractPortNumberFromDebugOptionWithIPv4Host() {
+      int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,address=127.0.0.1:9876,suspend=n");
+
+      assertEquals(9876, port);
+    }
+
+    @Test
+    public void shouldExtractPortNumberFromDebugOptionWithIPv6Host() {
+      int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,address=[fd27:2024:0518::1]:9876,suspend=n");
+
+      assertEquals(9876, port);
+    }
+
+    @Test
     public void shouldNotFindPortNumberInOption() {
       int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
 

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractPortTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherExtractPortTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -47,6 +47,13 @@ public class GFLauncherExtractPortTest {
     @Test
     public void shouldExtractPortNumberFromDebugOption() {
       int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9876");
+
+      assertEquals(9876, port);
+    }
+
+    @Test
+    public void shouldExtractPortNumberFromDebugOptionWithHost() {
+      int port = GFLauncher.extractDebugPort("-agentlib:jdwp=transport=dt_socket,server=y,address=*:9876,suspend=n");
 
       assertEquals(9876, port);
     }


### PR DESCRIPTION
## Description
This is a fix.

Related:
- https://github.com/payara/Payara/issues/4386
- https://github.com/payara/Payara/pull/4387 - but it didn't consider alteration made in `JavaConfig.java` (https://github.com/payara/Payara/pull/3905) https://github.com/payara/Payara/blob/26c504bb440432cfaa40e425730650945a23c823/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JavaConfig.java#L165


## Testing
### New tests

New UT added for host part in address.

### Testing Performed
```
$ uzip -q -d /tmp/payara appserver/distributions/payara/target/payara.zip
$ /tmp/payara/payara6/glassfish/bin/asadmin start-domain --debug=true
Waiting for domain1 to start .............
Successfully started the domain : domain1
domain  Location: /tmp/payara/payara6/glassfish/domains/domain1
Log File: /tmp/payara/payara6/glassfish/domains/domain1/logs/server.log
Admin Port: 4848
Debugging is enabled.  The debugging port is: 9009
Command start-domain executed successfully.
```

### Testing Environment
- GNU/Linux
- openjdk version "11.0.23" 2024-04-16 + Apache Maven 3.9.6 (build)
- openjdk version "17.0.11" 2024-04-16 (test)

## Documentation
https://github.com/payara/Payara/blob/26c504bb440432cfaa40e425730650945a23c823/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1#L68-L70

## Notes for Reviewers
