### PR TITLE
FISH-8760 Update Security Connectors to 3.1.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,7 +57,7 @@
         <payara.core.version>6.16.0-SNAPSHOT</payara.core.version>
         <payara.core.compare-version>6.14.0</payara.core.compare-version>
         <!-- BOM dependencies versions -->
-        <payara.security-connectors.version>3.1</payara.security-connectors.version>
+        <payara.security-connectors.version>3.1.1</payara.security-connectors.version>
         <hk2.version>3.0.1.payara-p4</hk2.version>
         <osgi.version>8.0.0</osgi.version>
         <osgi.annotation.version>8.1.0</osgi.annotation.version>


### PR DESCRIPTION
## Description
Updates the Payara Security Connectors to 3.1.1.

## Important Info
### Blockers
Release and publication of said security connectors.

## Testing
### New tests
N/A

### Testing Performed
None - security connectors not released yet

### Testing Environment
Windows 11, Zulu 11.0.23

## Documentation
N/A

## Notes for Reviewers
None
