### PR TITLE
Fish 8722 upgrade expression language api to 6

### DIFF
--- a/appserver/packager/external/jakarta-ee11-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee11-shim/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- jakarta.el-->
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Downgrade shim for HK2 3.0 (now 4.0) as Jersey not yet upgraded to 4.0 and InSight not upgraded for EE11.
         Remove once Jersey upgraded to 4.0 and InSight upgraded to a version aligned with Payara 7 (presumably 3.0), or
@@ -114,7 +120,9 @@
                                     comment with which other component still requires the downgrade shim. -->
                                     org.glassfish.hk2.api,
                                     org.glassfish.hk2.locator,
-                                    org.glassfish.hk2.utils
+                                    org.glassfish.hk2.utils,
+                                    <!-- jakarta.el-->
+                                    jakarta.el-api
                                 </Require-Bundle>
                                 <!-- Manually specify the shim versions of packages to be exported via this bundle -->
                                 <!-- Note the "shortened" syntax here: For every API the packages are delimited with
@@ -128,7 +136,8 @@
                                     jakarta.annotation;
                                     jakarta.annotation.security;
                                     jakarta.annotation.sql;version="3.0.99";shim=true,
-
+                                    <!-- el previous version-->
+                                    jakarta.el;version="5.0.99";shim=true,
                                     <!-- Downgrade shim for HK2 3.0 (now 4.0) as Jersey not yet upgraded to 4.0 and
                                     InSight not upgraded for EE11. Remove once Jersey upgraded to 4.0 and InSight
                                     upgraded to a version aligned with Payara 7 (presumably 3.0), or update this

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,7 +68,7 @@
         <cdi-api.version>4.1.0-M1</cdi-api.version>
         <grizzly.version>4.0.0.payara-p1</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
+        <jakarta.el-api.version>6.0.0</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
         <parsson.version>1.1.5.payara-p1</parsson.version>


### PR DESCRIPTION
## Description
Upgrade Expression Language API to 6.0

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Payara Samples, Quicklook etc

### Testing Environment
Zulu JDK 21 on WSL Ubuntu 22.04 with Maven 3.8.4

