### PR TITLE
Properly cleaning up ContainerBackgroundSessionProcessor threads after application is undeployed

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
@@ -1750,7 +1750,7 @@ public abstract class ContainerBase
      * to update lastaccesstime and accessedTime.
      */
     protected void threadSessionStart() {
-        if (sessionThread != null)
+        if (sessionThread != null || manager == null)
             return;
         threadSessionDone = false;
         String threadName = "ContainerBackgroundSessionProcessor[" + toString() + "]";

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -5946,6 +5946,8 @@ public class StandardContext
 
             // Stop ContainerBackgroundProcessor thread
             super.threadStop();
+            // Stop ContainerBackgroundSessionProcessor thread
+            super.threadSessionStop();
 
             if ((manager != null) && (manager instanceof Lifecycle)) {
                 if(manager instanceof StandardManager) {


### PR DESCRIPTION
fixes #6747 
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Bugfix. #6637 caused a regression that left dangling threads around

## Important Info
## Testing
Manual testing for memory leaks
