### PR TITLE
FISH-8334 Fix Incorrect Hazelcast Config for Instances in Deployment Groups

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -76,6 +76,7 @@ import com.sun.enterprise.util.Utility;
 import fish.payara.nucleus.events.HazelcastEvents;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.admin.ServerEnvironment.Status;
@@ -169,6 +170,7 @@ public class HazelcastCore implements EventListener, ConfigListener {
     HazelcastRuntimeConfiguration configuration;
 
     @Inject
+    @Named(ServerEnvironment.DEFAULT_INSTANCE_NAME)
     HazelcastConfigSpecificConfiguration nodeConfig;
 
     @Inject


### PR DESCRIPTION
## Description
Fixes instances in a deployment group getting the incorrect configuration getting injected.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Disable auto increment port: Admin Console > Domain > Data Grid > Auto Increment Port > Disable
* Create an instance: instance1
* Create a second instance: instance2
* Set Hazelcast port for instance1 to 12000
* Set Hazelcast port for instance2 to 13000
* Restart DAS
* Create a deployment group and add instance1 & instance2 to it: group1
* Start deployment group: both instances should start successfully, with instance1 binding Hazelcast to 12000 and instance2 to 13000 (should be no port conflicts, as this would imply both instances are using the same Hazelcast config and trying to bind to the same port)

### Testing Environment
Windows 11, Zulu 11.0.23

## Documentation
N/A

## Notes for Reviewers
None
