### PR TITLE
FISH-5740: changed URL direction and updated copyright date.

### DIFF
--- a/appserver/admingui/common/src/main/resources/pluginTreeNodeSecurity.jsf
+++ b/appserver/admingui/common/src/main/resources/pluginTreeNodeSecurity.jsf
@@ -39,7 +39,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2019] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright [2019-2024] Payara Foundation and/or affiliates -->
 
 <!-- pluginTreeNodeJVM.jsf -->
 
@@ -53,7 +53,7 @@
     </facet>
     
     <!facet image>
-	<sun:imageHyperlink imageURL="/resource/common/security/images/security.gif" url="#{request.contextPath}/common/adminAudit/adminaudit.jsf?configName=${configName}" 
+	<sun:imageHyperlink imageURL="/resource/common/security/images/security.gif" url="#{request.contextPath}/common/security/security.jsf?configName=${configName}"
 	    alt="$resource{i18n.tree.adminAudit}" border="0" immediate="true" />
     </facet>
     


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
FISH-5740 URL redirects to audit instead of security jsf
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built the server and tested it points to the right direction
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
