### PR TITLE
FISH-8672 FISH-8857 Keep Semantic Versioning Happy

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
@@ -220,7 +220,7 @@ public abstract class ContainerBase
     /**
      * The processor delay for this component.
      */
-    protected AtomicInteger backgroundProcessorDelayAtomic = new AtomicInteger(-1);
+    private AtomicInteger backgroundProcessorDelayAtomic = new AtomicInteger(-1);
 
 
     /**

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
@@ -407,6 +407,7 @@ public abstract class ContainerBase
     @Override
     public void setBackgroundProcessorDelay(int delay) {
         backgroundProcessorDelayAtomic.set(delay);
+        backgroundProcessorDelay = delay;
     }
 
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
@@ -327,31 +327,14 @@ public abstract class ContainerBase
 
 
     /**
-     * The deprecated background thread completion semaphore.
-     *
-     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBase#threadDoneAtomic}.
-     */
-    @Deprecated(forRemoval = true, since = "6.17.0")
-    private volatile boolean threadDone = false;
-
-    /**
      * The background thread completion semaphore.
      */
-    private AtomicBoolean threadDoneAtomic = new AtomicBoolean();
-
-
-    /**
-     * The deprecated session background thread completion semaphore.
-     *
-     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBase#threadSessionDoneAtomic}.
-     */
-    @Deprecated(forRemoval = true, since = "6.17.0")
-    private volatile boolean threadSessionDone = false;
+    private AtomicBoolean threadDone = new AtomicBoolean();
 
     /**
      * The session background thread completion semaphore.
      */
-    private AtomicBoolean threadSessionDoneAtomic = new AtomicBoolean();
+    private AtomicBoolean threadSessionDone = new AtomicBoolean();
 
 
     /**
@@ -1765,9 +1748,9 @@ public abstract class ContainerBase
         if (backgroundProcessorDelayAtomic.get() <= 0)
             return;
 
-        threadDoneAtomic.set(false);
+        threadDone.set(false);
         String threadName = "ContainerBackgroundProcessor[" + toString() + "]";
-        thread = new Thread(new ContainerBackgroundProcessorAtomic(getMappingObject(), threadDoneAtomic,
+        thread = new Thread(new ContainerBackgroundProcessorAtomic(getMappingObject(), threadDone,
                 backgroundProcessorDelayAtomic), threadName);
         thread.setDaemon(true);
         thread.start();
@@ -1781,10 +1764,10 @@ public abstract class ContainerBase
     protected void threadSessionStart() {
         if (sessionThread != null || manager == null)
             return;
-        threadSessionDoneAtomic.set(false);
+        threadSessionDone.set(false);
         String threadName = "ContainerBackgroundSessionProcessor[" + toString() + "]";
         sessionThread = new Thread(new ContainerBackgroundSessionProcessorAtomic(getMappingObject(), manager,
-                threadSessionDoneAtomic), threadName);
+                threadSessionDone), threadName);
         sessionThread.setDaemon(true);
         sessionThread.start();
         
@@ -1800,7 +1783,7 @@ public abstract class ContainerBase
         if (thread == null)
             return;
 
-        threadDoneAtomic.set(true);
+        threadDone.set(true);
         thread.interrupt();
         try {
             thread.join();
@@ -1821,7 +1804,7 @@ public abstract class ContainerBase
             return;
         }
 
-        this.threadSessionDoneAtomic.set(true);
+        this.threadSessionDone.set(true);
         sessionThread.interrupt();
         try {
             sessionThread.join();
@@ -1969,7 +1952,7 @@ public abstract class ContainerBase
 
         public ContainerBackgroundProcessor() {
             containerBackgroundProcessorAtomic = new ContainerBackgroundProcessorAtomic(getMappingObject(),
-                    threadDoneAtomic, backgroundProcessorDelayAtomic);
+                    threadDone, backgroundProcessorDelayAtomic);
         }
 
         public ContainerBackgroundProcessor(ContainerBackgroundProcessorAtomic containerBackgroundProcessorAtomic) {
@@ -1999,7 +1982,7 @@ public abstract class ContainerBase
 
         public ContainerBackgroundSessionProcessor() {
             containerBackgroundSessionProcessorAtomic = new ContainerBackgroundSessionProcessorAtomic(
-                    getMappingObject(), manager, threadSessionDoneAtomic);
+                    getMappingObject(), manager, threadSessionDone);
         }
 
         public ContainerBackgroundSessionProcessor(ContainerBackgroundSessionProcessorAtomic containerBackgroundSessionProcessorAtomic) {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ContainerBase.java
@@ -209,9 +209,18 @@ public abstract class ContainerBase
 
 
     /**
+     * The deprecated processor delay for this component.
+     * 
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBase#backgroundProcessorDelayAtomic}.
+     * Use {@link ContainerBase#getBackgroundProcessorDelay()} and {@link ContainerBase#setBackgroundProcessorDelay(int)}
+     */
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    protected int backgroundProcessorDelay = -1;
+
+    /**
      * The processor delay for this component.
      */
-    protected AtomicInteger backgroundProcessorDelay = new AtomicInteger(-1);
+    protected AtomicInteger backgroundProcessorDelayAtomic = new AtomicInteger(-1);
 
 
     /**
@@ -318,15 +327,31 @@ public abstract class ContainerBase
 
 
     /**
+     * The deprecated background thread completion semaphore.
+     *
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBase#threadDoneAtomic}.
+     */
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    private volatile boolean threadDone = false;
+
+    /**
      * The background thread completion semaphore.
      */
-    private AtomicBoolean threadDone = new AtomicBoolean();
+    private AtomicBoolean threadDoneAtomic = new AtomicBoolean();
 
+
+    /**
+     * The deprecated session background thread completion semaphore.
+     *
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBase#threadSessionDoneAtomic}.
+     */
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    private volatile boolean threadSessionDone = false;
 
     /**
      * The session background thread completion semaphore.
      */
-    private AtomicBoolean threadSessionDone = new AtomicBoolean();
+    private AtomicBoolean threadSessionDoneAtomic = new AtomicBoolean();
 
 
     /**
@@ -385,7 +410,7 @@ public abstract class ContainerBase
      */
     @Override
     public int getBackgroundProcessorDelay() {
-        return backgroundProcessorDelay.get();
+        return backgroundProcessorDelayAtomic.get();
     }
 
 
@@ -398,7 +423,7 @@ public abstract class ContainerBase
      */
     @Override
     public void setBackgroundProcessorDelay(int delay) {
-        backgroundProcessorDelay.set(delay);
+        backgroundProcessorDelayAtomic.set(delay);
     }
 
 
@@ -1737,13 +1762,13 @@ public abstract class ContainerBase
 
         if (thread != null)
             return;
-        if (backgroundProcessorDelay.get() <= 0)
+        if (backgroundProcessorDelayAtomic.get() <= 0)
             return;
 
-        threadDone.set(false);
+        threadDoneAtomic.set(false);
         String threadName = "ContainerBackgroundProcessor[" + toString() + "]";
-        thread = new Thread(new ContainerBackgroundProcessor(getMappingObject(), threadDone,
-                backgroundProcessorDelay), threadName);
+        thread = new Thread(new ContainerBackgroundProcessorAtomic(getMappingObject(), threadDoneAtomic,
+                backgroundProcessorDelayAtomic), threadName);
         thread.setDaemon(true);
         thread.start();
 
@@ -1756,10 +1781,10 @@ public abstract class ContainerBase
     protected void threadSessionStart() {
         if (sessionThread != null || manager == null)
             return;
-        threadSessionDone.set(false);
+        threadSessionDoneAtomic.set(false);
         String threadName = "ContainerBackgroundSessionProcessor[" + toString() + "]";
-        sessionThread = new Thread(new ContainerBackgroundSessionProcessor(getMappingObject(), manager,
-                threadSessionDone), threadName);
+        sessionThread = new Thread(new ContainerBackgroundSessionProcessorAtomic(getMappingObject(), manager,
+                threadSessionDoneAtomic), threadName);
         sessionThread.setDaemon(true);
         sessionThread.start();
         
@@ -1775,7 +1800,7 @@ public abstract class ContainerBase
         if (thread == null)
             return;
 
-        threadDone.set(true);
+        threadDoneAtomic.set(true);
         thread.interrupt();
         try {
             thread.join();
@@ -1796,7 +1821,7 @@ public abstract class ContainerBase
             return;
         }
 
-        this.threadSessionDone.set(true);
+        this.threadSessionDoneAtomic.set(true);
         sessionThread.interrupt();
         try {
             sessionThread.join();
@@ -1808,17 +1833,18 @@ public abstract class ContainerBase
 
     // -------------------------------------- ContainerExecuteDelay Inner Class
 
-
     /**
      * Private thread class to invoke the backgroundProcess method 
      * of this container and its children after a fixed delay.
+     *
+     * Replaces {@link ContainerBackgroundProcessor}
      */
-    protected static class ContainerBackgroundProcessor implements Runnable {
+    protected static class ContainerBackgroundProcessorAtomic implements Runnable {
         private final WeakReference<?> base;
         private final AtomicBoolean threadDone;
         private final AtomicInteger backgroundProcessorDelay;
 
-        public ContainerBackgroundProcessor(Object base,
+        public ContainerBackgroundProcessorAtomic(Object base,
                                             AtomicBoolean threadDone, AtomicInteger backgroundProcessorDelay) {
             this.base = new WeakReference<>(base);
             this.threadDone = threadDone;
@@ -1870,13 +1896,15 @@ public abstract class ContainerBase
     /**
      * Thread class to invoke the backgroundSessionUpdate method 
      * of this container and its children after 500 milliseconds.
+     *
+     * Replaces {@link ContainerBackgroundSessionProcessor}
      */
-    protected static class ContainerBackgroundSessionProcessor implements Runnable {
+    protected static class ContainerBackgroundSessionProcessorAtomic implements Runnable {
         private final WeakReference<?> base;
         private final WeakReference<Manager> manager;
         private final AtomicBoolean threadSessionDone;
 
-        public ContainerBackgroundSessionProcessor(Object base, Manager manager, AtomicBoolean threadSessionDone) {
+        public ContainerBackgroundSessionProcessorAtomic(Object base, Manager manager, AtomicBoolean threadSessionDone) {
             this.base = new WeakReference<>(base);
             this.manager = new WeakReference<>(manager);
             this.threadSessionDone = threadSessionDone;
@@ -1923,6 +1951,68 @@ public abstract class ContainerBase
                     processChildren(child, cl);
                 }
             }
+        }
+
+    }
+
+    // -------------------------------------- DEPRECATED!
+    /**
+     * Deprecated private thread class to invoke the backgroundProcess method
+     * of this container and its children after a fixed delay.
+     *
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBackgroundProcessorAtomic}.
+     */
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    protected class ContainerBackgroundProcessor implements Runnable {
+
+        private final ContainerBackgroundProcessorAtomic containerBackgroundProcessorAtomic;
+
+        public ContainerBackgroundProcessor() {
+            containerBackgroundProcessorAtomic = new ContainerBackgroundProcessorAtomic(getMappingObject(),
+                    threadDoneAtomic, backgroundProcessorDelayAtomic);
+        }
+
+        public ContainerBackgroundProcessor(ContainerBackgroundProcessorAtomic containerBackgroundProcessorAtomic) {
+            this.containerBackgroundProcessorAtomic = containerBackgroundProcessorAtomic;
+        }
+
+        @Override
+        public void run() {
+            containerBackgroundProcessorAtomic.run();
+        }
+
+        protected void processChildren(Container container, ClassLoader cl) {
+            containerBackgroundProcessorAtomic.processChildren(container, cl);
+        }
+    }
+
+    /**
+     * Deprecated thread class to invoke the backgroundSessionUpdate method
+     * of this container and its children after 500 milliseconds.
+     *
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ContainerBackgroundSessionProcessorAtomic}.
+     */
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    protected class ContainerBackgroundSessionProcessor implements Runnable {
+
+        private final ContainerBackgroundSessionProcessorAtomic containerBackgroundSessionProcessorAtomic;
+
+        public ContainerBackgroundSessionProcessor() {
+            containerBackgroundSessionProcessorAtomic = new ContainerBackgroundSessionProcessorAtomic(
+                    getMappingObject(), manager, threadSessionDoneAtomic);
+        }
+
+        public ContainerBackgroundSessionProcessor(ContainerBackgroundSessionProcessorAtomic containerBackgroundSessionProcessorAtomic) {
+            this.containerBackgroundSessionProcessorAtomic = containerBackgroundSessionProcessorAtomic;
+        }
+
+        @Override
+        public void run() {
+            containerBackgroundSessionProcessorAtomic.run();
+        }
+
+        protected void processChildren(Container container, ClassLoader cl) {
+            containerBackgroundSessionProcessorAtomic.processChildren(container, cl);
         }
 
     }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardEngine.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardEngine.java
@@ -97,7 +97,7 @@ public class StandardEngine
         } catch(Exception ex) {
         }
         // By default, the engine will hold the reloading thread
-        backgroundProcessorDelay.set(10);
+        backgroundProcessorDelayAtomic.set(10);
 
     }
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardEngine.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardEngine.java
@@ -97,7 +97,7 @@ public class StandardEngine
         } catch(Exception ex) {
         }
         // By default, the engine will hold the reloading thread
-        backgroundProcessorDelayAtomic.set(10);
+        setBackgroundProcessorDelay(10);
 
     }
 

--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -642,8 +642,6 @@
                                     <exclude>io.opentelemetry.extension</exclude>
                                     <exclude>io.opentelemetry.instrumentation</exclude>
                                     <exclude>fish.payara.shaded</exclude>
-                                    <exclude>org.glassfish.api.invocation</exclude>
-                                    <exclude>org.apache.catalina.core</exclude>
                                 </excludes>
                             </parameter>
                         </configuration>

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocation.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocation.java
@@ -86,7 +86,7 @@ public class ComponentInvocation implements Cloneable {
      *
      */
     @Deprecated(forRemoval = true, since = "6.17.0")
-    public Object container; //
+    public Object container;
 
     /**
      * DO NOT USE! Retained for semantic versioning. Replaced by {@link ComponentInvocation#jndiEnvironmentReference}.

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocation.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/ComponentInvocation.java
@@ -79,11 +79,25 @@ public class ComponentInvocation implements Cloneable {
     private String instanceName;
 
     /**
-     * ServletContext for servlet, Container for EJB
+     * The deprecated ServletContext for servlet, Container for EJB
+     *
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ComponentInvocation#containerReference}.
+     * Use {@link ComponentInvocation#getContainer()} and {@link ComponentInvocation#setContainer(Object)} instead.
+     *
      */
-    private WeakReference<Object> container;
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    public Object container; //
 
-    private WeakReference<Object> jndiEnvironment;
+    /**
+     * DO NOT USE! Retained for semantic versioning. Replaced by {@link ComponentInvocation#jndiEnvironmentReference}.
+     * Use {@link ComponentInvocation#getJNDIEnvironment()} and {@link ComponentInvocation#setJNDIEnvironment(Object)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "6.17.0")
+    public Object jndiEnvironment;
+
+    private WeakReference<Object> containerReference;
+
+    private WeakReference<Object> jndiEnvironmentReference;
 
     public String componentId;
 
@@ -118,13 +132,13 @@ public class ComponentInvocation implements Cloneable {
     protected String registrationName;
 
     public ComponentInvocation() {
-        container = new WeakReference<>(null);
+        containerReference = new WeakReference<>(null);
     }
 
     public ComponentInvocation(String componentId, ComponentInvocationType invocationType, Object container, String appName, String moduleName, String registrationName) {
         this.componentId = componentId;
         this.invocationType = invocationType;
-        this.container = new WeakReference<>(container);
+        this.containerReference = new WeakReference<>(container);
         this.appName = appName;
         this.moduleName = moduleName;
         this.registrationName = registrationName;
@@ -134,7 +148,7 @@ public class ComponentInvocation implements Cloneable {
         this.componentId = componentId;
         this.invocationType = invocationType;
         this.instance = instance;
-        this.container = new WeakReference<>(container);
+        this.containerReference = new WeakReference<>(container);
         this.transaction = transaction;
     }
 
@@ -211,22 +225,22 @@ public class ComponentInvocation implements Cloneable {
     }
 
     public void setJNDIEnvironment(Object val) {
-        jndiEnvironment = new WeakReference<>(val);
+        jndiEnvironmentReference = new WeakReference<>(val);
     }
 
     public Object getJNDIEnvironment() {
-        if (jndiEnvironment == null) {
+        if (jndiEnvironmentReference == null) {
             return null;
         }
-        return jndiEnvironment.get();
+        return jndiEnvironmentReference.get();
     }
 
     public Object getContainer() {
-        return container.get();
+        return containerReference.get();
     }
 
     public void setContainer(Object container) {
-        this.container = new WeakReference<>(container);
+        this.containerReference = new WeakReference<>(container);
     }
 
     public Object getContainerContext() {


### PR DESCRIPTION
## Description
https://github.com/payara/Payara/pull/6677 introduced breaking changes to Core classes, which in turn broke Enterprise.
This reinstates semantic versioning and "unbreaks" the changes.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built this branch and started the domain - everything bon.
Built Payara Enterprise - compiles correctly.

I haven't tested for leaks (yet™), but I don't believe I've reintroduced usage of the non-WeakReference or Atomic variables anywhere.

### Testing Environment
Windows 11, Zulu 11.0.23

## Documentation
N/A

## Notes for Reviewers
I am aware these changes are ugly and fragile. It is however the state we end up in when we have a split codebase and enforce semantic versioning. We're in a bit of a pickle because the Core major versions are somewhat tied to Jakarta APIs - 7.0.0.Alpha1 has already been released for usage with Payara 7. 

Naming is also hard - if you can think of better names for the "new" variables & classes please suggest them!
