### PR TITLE
FISH-8855-Added Auto name for deployment group

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/dg/dgNew.jsf
+++ b/appserver/admingui/cluster/src/main/resources/dg/dgNew.jsf
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2018-2024] [Payara Foundation and/or its affiliates]
 
 -->
 
@@ -69,6 +69,7 @@
         }
         
           gf.getChildrenNamesList(endpoint="#{sessionScope.REST_URL}/nodes/node", result="#{pageSession.nodesList}");
+        setPageSessionAttribute(key="autoNameSelected" value="#{false}");
     />
     </event>
     <sun:form id="propertyForm" autoComplete="off">
@@ -80,8 +81,12 @@
             <sun:button id="newButton" text="$resource{i18n.button.OK}"
                 onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) {submitAndDisable(this, '$resource{i18n.button.Processing}');}; return false;" >
             <!command
-                setAttribute(key="nameToCheck" value="#{pageSession.name}");
-                gfj.checkNameExist();
+                py.generateInstanceNameIfRequired(name="#{pageSession.name}", autoname="#{pageSession.autoNameSelected}", instanceName="#{pageSession.name}");
+                if (!#{pageSession.autoNameSelected}) {
+                    setAttribute(key="nameToCheck" value="#{pageSession.name}");
+                    gfj.checkNameExist();
+                }
+
                 createMap(result="#{requestScope.ct}");
                 mapPut(map="#{requestScope.ct}" key="id" value="#{pageSession.name}" );
                 gf.createEntity( endpoint="#{sessionScope.REST_URL}/deployment-groups/deployment-group"   attrs="#{requestScope.ct}")
@@ -98,6 +103,7 @@
                 
                 py.createDeploymentGroupInstances(deploymentGroupName="#{pageSession.name}", instanceRow="#{instances}");            
                 gf.redirect(page="#{request.contextPath}/cluster/dg/dgs.jsf?alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}");
+                setPageSessionAttribute(key="autoNameSelected" value="#{false}");
              />
             </sun:button>
             <sun:button id="cancelButton" immediate="#{true}" text="$resource{i18n.button.Cancel}" primary="#{false}" >
@@ -114,9 +120,11 @@
     <sun:propertySheet id="propertySheet">
         <sun:propertySheetSection id="propertySectionTextField">
             <sun:property id="NameTextProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.dg.dgName}" >
-                <sun:textField id="NameText" text="#{pageSession.name}" styleClass="required" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.dg.dgName']}" required="#{true}" />
+                <sun:textField id="NameText" text="#{pageSession.name}" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.dg.dgName']}" required="#{false}" />
             </sun:property>
-            
+            <sun:property id="AutoNameProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.autoName}" helpText="$resource{i18ncs.autoName.help}" >
+                <sun:checkbox id="AutoName" selected="#{pageSession.autoNameSelected}" selectedValue="#{true}" />
+            </sun:property> 
               <sun:property id="avaliableInstances" visible="#{pageSession.showInstancesSection}" labelAlign="left" noWrap="#{true}" overlapLabel="#{true}">
                 <sun:addRemove id="deploymentGroupAddRemove"
                                selectAll="$boolean{true}"

--- a/appserver/admingui/cluster/src/main/resources/dg/dgNew.jsf
+++ b/appserver/admingui/cluster/src/main/resources/dg/dgNew.jsf
@@ -122,7 +122,7 @@
             <sun:property id="NameTextProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.dg.dgName}" >
                 <sun:textField id="NameText" text="#{pageSession.name}" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.dg.dgName']}" required="#{false}" />
             </sun:property>
-            <sun:property id="AutoNameProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.autoName}" helpText="$resource{i18ncs.autoName.help}" >
+            <sun:property id="AutoNameProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.autoName}" helpText="$resource{i18ncs.autoName.helpDg}" >
                 <sun:checkbox id="AutoName" selected="#{pageSession.autoNameSelected}" selectedValue="#{true}" />
             </sun:property> 
               <sun:property id="avaliableInstances" visible="#{pageSession.showInstancesSection}" labelAlign="left" noWrap="#{true}" overlapLabel="#{true}">

--- a/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
+++ b/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
@@ -448,4 +448,4 @@ clusters.ejbTimers.TimerCountCol=Timer Count
 general.serverNameCol=Server Name
 
 autoName=Auto Name
-autoName.help=When enabled, will generate a name for your instance if none is provided, or will otherwise resolve any name conflicts. 
+autoName.help=When enabled, will generate a name for your instance/deployment group if none is provided, or will otherwise resolve any name conflicts. 

--- a/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
+++ b/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
@@ -448,4 +448,5 @@ clusters.ejbTimers.TimerCountCol=Timer Count
 general.serverNameCol=Server Name
 
 autoName=Auto Name
-autoName.help=When enabled, will generate a name for your instance/deployment group if none is provided, or will otherwise resolve any name conflicts. 
+autoName.helpDg=When enabled, will generate a name for your deployment group if none is provided, or will otherwise resolve any name conflicts. 
+autoName.help=When enabled, will generate a name for your instance if none is provided, or will otherwise resolve any name conflicts. 

--- a/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
+++ b/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 tree.clusters=Clusters (Deprecated)
 tree.dgs=Deployment Groups


### PR DESCRIPTION
FISH-8855 added auto name for deployment group
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
I have made changes to the strings.properties file so that instead of saying autoname instance, it says autoname instance/deployment group so it saves creating another autoname.help text.

Changed dgNew.jsf to include the checkbox button and changed the commands block for the new button so that the Deployment group label does not show as required (as autoname is an option) and if autoname is selected, it will use the same code as the instance autoname.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built and ran the server, made sure it was working. Tested auto naming multiple deployment groups and instances to make sure both worked correctly. Tested leaving everything blank to display error messages and tested setting own name + ticking the box to make sure that if the label is populated, it will default the name to that even if the box is checked.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
I could of made the same exact functions that the instance auto name uses and changed to deployment group but I felt it would be unnecessary code.