### PR TITLE
FISH-8736 Fix for Web Services Engine Inconsistently Starting

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
@@ -156,26 +156,25 @@ public class SnifferManagerImpl implements SnifferManager {
     private <T extends Sniffer> List<T> getApplicableSniffers(DeploymentContext context, List<URI> uris, Types types, Collection<T> sniffers, boolean checkPath) {
         ArchiveType archiveType = habitat.getService(ArchiveType.class, context.getArchiveHandler().getArchiveType());
 
-        if (sniffers==null || sniffers.isEmpty()) {
+        if (sniffers == null || sniffers.isEmpty()) {
             return Collections.emptyList();
         }
 
         List<T> result = new ArrayList<T>();
         for (T sniffer : sniffers) {
-            if (archiveType != null && 
-                !sniffer.supportsArchiveType(archiveType)) {
+            if (archiveType != null && !sniffer.supportsArchiveType(archiveType)) {
                 continue;
             }
             String[] annotationNames = sniffer.getAnnotationNames(context);
-            if (annotationNames==null) continue;
-            for (String annotationName : annotationNames)  {
-              if (types != null) {
-                  Type type = types.getAllTypes().stream()
-                          .filter(t -> t instanceof AnnotationType && t.getName().equals(annotationName))
-                          .findFirst().orElse(null);
-                  if (type == null) {
-                      continue;
-                  }
+            if (annotationNames == null) continue;
+            for (String annotationName : annotationNames) {
+                if (types != null) {
+                    Type type = types.getAllTypes().stream()
+                            .filter(t -> t instanceof AnnotationType && t.getName().equals(annotationName))
+                            .findFirst().orElse(null);
+                    if (type == null) {
+                        continue;
+                    }
                     Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
                     for (AnnotatedElement element : elements) {
                         if (checkPath) {
@@ -199,7 +198,7 @@ public class SnifferManagerImpl implements SnifferManager {
                             break;
                         }
                     }
-              }
+                }
             }
         }
         return result;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
@@ -166,37 +166,37 @@ public class SnifferManagerImpl implements SnifferManager {
                 continue;
             }
             String[] annotationNames = sniffer.getAnnotationNames(context);
-            if (annotationNames == null) continue;
+            if (annotationNames == null || types == null) {
+                continue;
+            }
             for (String annotationName : annotationNames) {
-                if (types != null) {
-                    types.getAllTypes().stream()
-                            .filter(type -> type instanceof AnnotationType && type.getName().equals(annotationName))
-                            .findFirst().ifPresent(type -> {
-                                Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
-                                for (AnnotatedElement element : elements) {
-                                    if (checkPath) {
-                                        Type t;
-                                        if (element instanceof Member) {
-                                            t = ((Member) element).getDeclaringType();
-                                        } else if (element instanceof Type) {
-                                            t = (Type) element;
-                                        } else if (element instanceof ParameterizedType) {
-                                            t = ((ParameterizedType) element).getType();
-                                        } else {
-                                            LOGGER.log(Level.WARNING, "Unrecognised type: {0}.", element);
-                                            continue;
-                                        }
-                                        if (t.wasDefinedIn(uris)) {
-                                            result.add(sniffer);
-                                            break;
-                                        }
+                types.getAllTypes().stream()
+                        .filter(type -> type instanceof AnnotationType && type.getName().equals(annotationName))
+                        .findFirst().ifPresent(type -> {
+                            Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
+                            for (AnnotatedElement element : elements) {
+                                if (checkPath) {
+                                    Type t;
+                                    if (element instanceof Member) {
+                                        t = ((Member) element).getDeclaringType();
+                                    } else if (element instanceof Type) {
+                                        t = (Type) element;
+                                    } else if (element instanceof ParameterizedType) {
+                                        t = ((ParameterizedType) element).getType();
                                     } else {
+                                        LOGGER.log(Level.WARNING, "Unrecognised type: {0}.", element);
+                                        continue;
+                                    }
+                                    if (t.wasDefinedIn(uris)) {
                                         result.add(sniffer);
                                         break;
                                     }
+                                } else {
+                                    result.add(sniffer);
+                                    break;
                                 }
-                            });
-                }
+                            }
+                        });
             }
         }
         return result;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2020-2021] Payara Foundation and/or affiliates
+// Portions Copyright 2020-2024 Payara Foundation and/or affiliates
 
 package com.sun.enterprise.v3.server;
 
@@ -170,8 +170,12 @@ public class SnifferManagerImpl implements SnifferManager {
             if (annotationNames==null) continue;
             for (String annotationName : annotationNames)  {
               if (types != null) {
-                Type type = types.getBy(annotationName);
-                if (type instanceof AnnotationType) {
+                  Type type = types.getAllTypes().stream()
+                          .filter(t -> t instanceof AnnotationType && t.getName().equals(annotationName))
+                          .findFirst().orElse(null);
+                  if (type == null) {
+                      continue;
+                  }
                     Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
                     for (AnnotatedElement element : elements) {
                         if (checkPath) {
@@ -195,7 +199,6 @@ public class SnifferManagerImpl implements SnifferManager {
                             break;
                         }
                     }
-                }
               }
             }
         }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
@@ -169,35 +169,33 @@ public class SnifferManagerImpl implements SnifferManager {
             if (annotationNames == null) continue;
             for (String annotationName : annotationNames) {
                 if (types != null) {
-                    Type type = types.getAllTypes().stream()
-                            .filter(t -> t instanceof AnnotationType && t.getName().equals(annotationName))
-                            .findFirst().orElse(null);
-                    if (type == null) {
-                        continue;
-                    }
-                    Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
-                    for (AnnotatedElement element : elements) {
-                        if (checkPath) {
-                            Type t;
-                            if (element instanceof Member) {
-                                t = ((Member) element).getDeclaringType();
-                            } else if (element instanceof Type) {
-                                t = (Type) element;
-                            } else if (element instanceof ParameterizedType) {
-                                t = ((ParameterizedType) element).getType();
-                            } else {
-                                LOGGER.log(Level.WARNING, "Unrecognised type: {0}.", element);
-                                continue;
-                            }
-                            if (t.wasDefinedIn(uris)) {
-                                result.add(sniffer);
-                                break;
-                            }
-                        } else {
-                            result.add(sniffer);
-                            break;
-                        }
-                    }
+                    types.getAllTypes().stream()
+                            .filter(type -> type instanceof AnnotationType && type.getName().equals(annotationName))
+                            .findFirst().ifPresent(type -> {
+                                Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
+                                for (AnnotatedElement element : elements) {
+                                    if (checkPath) {
+                                        Type t;
+                                        if (element instanceof Member) {
+                                            t = ((Member) element).getDeclaringType();
+                                        } else if (element instanceof Type) {
+                                            t = (Type) element;
+                                        } else if (element instanceof ParameterizedType) {
+                                            t = ((ParameterizedType) element).getType();
+                                        } else {
+                                            LOGGER.log(Level.WARNING, "Unrecognised type: {0}.", element);
+                                            continue;
+                                        }
+                                        if (t.wasDefinedIn(uris)) {
+                                            result.add(sniffer);
+                                            break;
+                                        }
+                                    } else {
+                                        result.add(sniffer);
+                                        break;
+                                    }
+                                }
+                            });
                 }
             }
         }


### PR DESCRIPTION
## Description
Fixes the XML Web Services engine seemingly only starting inconsistently.

In the case that an application bundles its own version of Metro, the annotations that the Web Service Sniffer looks for will be detected by HK2 twice - once as an `AnnotationType` and once as an `InterfaceModel`.
Within HK2, both of these get stored in a Map of Maps with the same name (but in different maps). It’s a Map essentially indexed by the class name, but separated into separate Maps based on the model type (AnnotationType vs. InterfaceModel vs. EnumType etc.).

```
/**
 * Storage indexed by TYPE : interface | class | annotation and then by name.
 */
private final ConcurrentMap<Class, ConcurrentMap<String, TypeProxy<Type>>> storage=
        new ConcurrentHashMap<Class, ConcurrentMap<String, TypeProxy<Type>>>();
```
The `Types.getType(name)` method which we are invoking will simply return the first match found, and since this isn’t an ordered map it will not necessarily be consistent between runs. If it finds the entry in the `InterfaceModel` map first the application doesn’t get detected as containing a web service, if the entry in the `AnnotationType` map is found first it is.

As the `Types` interface in HK2 doesn't provide a means of only searching through a map of a specific Type, I've reworked our integration to instead use the `Types.getAllTypes` method and filter the results.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Redeployed the customer application attached to the Jira issue 20 times - the web service sniffer correctly identifies as being required for the application.

The customer application requires that at the very least some dummy resources exist: see the Jira ticket for instructions, I've omitted them here for confidentiality (just in case). 

### Testing Environment
Windows 11, Zulu 11.
OpenSUSE Leap 15.6 WSL, Zulu 17.

## Documentation
N/A

## Notes for Reviewers
I haven't done any performance testing to determine if this is the most efficient way to search through the map of types, but I don't believe I've done anything particularly egregious. I don't believe that stream filter will iterate over the entire collection, it Should™ stop iterating once it's found the desired annotation. Without testing I don't know if it's quicker to collect all of the `AnnotationType` entries into a single list, and _then_ iterate over it again searching for each of the desired annotation names - I suspect it depends on the same inconsistency of the collection ordering!
