### PR TITLE
FISH-8342 : hazelcast yaml files allowed

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/SetHazelcastConfiguration.java
@@ -40,6 +40,7 @@
 package fish.payara.nucleus.hazelcast.admin;
 
 import com.hazelcast.config.FileSystemXmlConfig;
+import com.hazelcast.config.FileSystemYamlConfig;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Server;
@@ -229,16 +230,27 @@ public class SetHazelcastConfiguration implements AdminCommand, DeploymentTarget
             return;
         }
         if (configFile != null && !"hazelcast-config.xml".equals(configFile)) {
-            File xmlConfigFile = new File(configFile);
-            if (!xmlConfigFile.exists()) {
-                String message = "Hazelcast config file not found: " + configFile;
+            File configFile = new File(this.configFile);
+            if (!configFile.exists()) {
+                String message = "Hazelcast config file not found: " + this.configFile;
                 logger.log(Level.INFO, message);
                 actionReport.setMessage(message);
                 actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
                 return;
             }
             try {
-                new FileSystemXmlConfig(xmlConfigFile);
+                final String fileName = configFile.getName();
+                if (fileName.endsWith(".xml")) {
+                    new FileSystemXmlConfig(configFile);
+                } else if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) {
+                    new FileSystemYamlConfig((configFile));
+                } else {
+                    String message = "Hazelcast config file type not allowed. Should be a XML or YAML file.";
+                    logger.log(Level.INFO, message);
+                    actionReport.setMessage(message);
+                    actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
+                    return;
+                }
             } catch (Exception ex) {
                 String message = "Hazelcast config file parsing exception: " + ex.toString();
                 logger.log(Level.INFO, message);


### PR DESCRIPTION
## Description
Support YAML format for Hazelcast Configuration file

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Build Server
2. Run Server
3. Download yaml example at https://payara.atlassian.net/browse/FISH-8342
4. Run: asadmin set-hazelcast-configuration --hazelcastconfigurationfile PATH\to\hazelcast-config.yaml

### Testing Environment
Zulu JDK 11.0.11 on Windows 11 with Maven 3.8.4
