### PR TITLE
FISH-8953 Fix Incorrect Unprocessed Change Showing for Hazelcast Encryption Settings

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -683,7 +683,8 @@ public class HazelcastCore implements EventListener, ConfigListener {
     public UnprocessedChangeEvents changed(PropertyChangeEvent[] pces) {
         List<UnprocessedChangeEvent> unprocessedChanges = new ArrayList<>();
         for (PropertyChangeEvent pce : pces) {
-            if (pce.getPropertyName().equalsIgnoreCase("datagrid-encryption-enabled")) {
+            if (pce.getPropertyName().equalsIgnoreCase("datagrid-encryption-enabled")
+                    && Boolean.parseBoolean(pce.getOldValue().toString()) != Boolean.parseBoolean(pce.getNewValue().toString())) {
                 unprocessedChanges.add(new UnprocessedChangeEvent(pce, "Hazelcast encryption settings changed"));
             }
         }


### PR DESCRIPTION
## Description
Check that the Hazelcast encryption settings have actually changed before displaying "Restart Required".

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the admin console and went to the datagrid config page (Domain > Data Grid).
Set 'Restart Data Grid' to true (and change nothing else) and click 'Save' - "Restart Domain" should not be shown.
Enable 'Encrypt Data Grid' and click 'Save' again - "Restart Domain" should be shown (as well as some warnings saying you haven't configured it properly).

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
