### PR TITLE
FISH-8557 Upgrade JLine to 3.26.3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,7 +130,7 @@
         <junit.version>4.13.2</junit.version>
         <mockito.version>2.28.2</mockito.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
-        <jline.version>3.26.1</jline.version>
+        <jline.version>3.26.3</jline.version>
         <grizzly.npn.api.version>2.0.0.payara-p1</grizzly.npn.api.version>
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
         <mimepull.version>1.10.0</mimepull.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,7 +130,7 @@
         <junit.version>4.13.2</junit.version>
         <mockito.version>2.28.2</mockito.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
-        <jline.version>3.21.0</jline.version>
+        <jline.version>3.26.1</jline.version>
         <grizzly.npn.api.version>2.0.0.payara-p1</grizzly.npn.api.version>
         <tiger.types.version>1.4.payara-p1</tiger.types.version>
         <mimepull.version>1.10.0</mimepull.version>

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1429,7 +1429,7 @@ public abstract class CLICommand implements PostConstruct {
     protected void buildTerminal() {
         try {
             if (terminal == null) {
-                System.setProperty("org.jline.terminal.exec.redirectPipeCreationMode", "native");
+                System.setProperty(TerminalBuilder.PROP_REDIRECT_PIPE_CREATION_MODE, TerminalBuilder.PROP_REDIRECT_PIPE_CREATION_MODE_NATIVE);
                 terminal = TerminalBuilder.builder()
                     .system(true)
                     .build();

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1429,7 +1429,8 @@ public abstract class CLICommand implements PostConstruct {
     protected void buildTerminal() {
         try {
             if (terminal == null) {
-            terminal = TerminalBuilder.builder()
+                System.setProperty("org.jline.terminal.exec.redirectPipeCreationMode", "native");
+                terminal = TerminalBuilder.builder()
                     .system(true)
                     .build();
             }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2024] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.cli;
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
-  Resolves FISH-8557
- Prevents the illegal reflection warning message from appearing on JDK 11.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built the server and deployed a simple application.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
