### PR TITLE
FISH-8987 Upgrade EL API to 6.0.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,7 +68,7 @@
         <cdi-api.version>4.1.0</cdi-api.version>
         <grizzly.version>4.0.0.payara-p1</grizzly.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <jakarta.el-api.version>6.0.0</jakarta.el-api.version>
+        <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0-M1</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
         <parsson.version>1.1.5.payara-p1</parsson.version>


### PR DESCRIPTION
## Description
Upgrades the EL API to 6.0.1 to allow passing the TCK.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the EL TCK.
Started the admin console and clicked around - no explosions

### Testing Environment
Windows 11, Java 21.0.3

## Documentation
N/A

## Notes for Reviewers
None
