### PR TITLE
FISH-8888 clear-cache command endpoint incorrect

### DIFF
--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ClearCache.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/admin/ClearCache.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2016-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -76,8 +76,8 @@ import org.jvnet.hk2.annotations.Service;
 @TargetType(value = {CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CLUSTERED_INSTANCE, CommandTarget.CONFIG, CommandTarget.DEPLOYMENT_GROUP})
 @RestEndpoints({
     @RestEndpoint(configBean = Domain.class,
-            opType = RestEndpoint.OpType.GET,
-            path = "lclear-cache",
+            opType = RestEndpoint.OpType.POST,
+            path = "clear-cache",
             description = "Clears a JCache or Hazalcast IMap")
 })
 public class ClearCache implements AdminCommand {
@@ -91,7 +91,7 @@ public class ClearCache implements AdminCommand {
     @Param(name = "target", optional = true, defaultValue = "server")
     protected String target;
 
-    @Param(name = "name", defaultValue = "")
+    @Param(name = "cache-name")
     protected String cacheName;
     
     @Param(name = "key", optional = true)


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
FISH-8888 clear-cache command endpoint incorrect.
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
I changed the parameter name to cache-name as the previous key was already being used which resulted in an error.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested using ./asadmin start-domain --debug domain1. Got the name of a cache from - localhost:4848/management/domain/list-caches and cleared successfully.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
