### PR TITLE
FISH-9171 bugfix: prevent deployment failures from causing an undeployment failure and leaks

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -5956,7 +5956,7 @@ public class StandardContext
                     try {
                         ((StandardManager)manager).stop(isShutdown);
                     } catch (LifecycleException e) {
-                        log.log(Level.INFO, LogFacade.MANAGER_NOT_STARTED_INFO, e);
+                        log.log(Level.INFO, e.getMessage());
                     }
                 } else {
                     ((Lifecycle)manager).stop();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -2303,9 +2303,9 @@ public class StandardContext
         Wrapper oldJspServlet = null;
 
         // Allow webapp to override JspServlet inherited from global web.xml.
-        boolean isJspServlet = "jsp".equals(wrapperName);
+        boolean isJspServlet = Constants.JSP_SERVLET_NAME.equals(wrapperName);
         if (isJspServlet) {
-            oldJspServlet = (Wrapper) findChild("jsp");
+            oldJspServlet = (Wrapper) findChild(Constants.JSP_SERVLET_NAME);
             if (oldJspServlet != null) {
                 removeChild(oldJspServlet);
             }
@@ -3238,7 +3238,7 @@ public class StandardContext
     public void addJspMapping(String pattern) {
         String servletName = findServletMapping("*.jsp");
         if (servletName == null) {
-            servletName = "jsp";
+            servletName = Constants.JSP_SERVLET_NAME;
         }
 
         if( findChild(servletName) != null) {
@@ -5766,6 +5766,8 @@ public class StandardContext
         } catch (Throwable t) {
             log.log(Level.SEVERE, LogFacade.STARTUP_CONTEXT_FAILED_EXCEPTION, getName());
             try {
+                // ensure that all JSP resources are released in stop() method below
+                forceLoadJspServlet();
                 stop();
             } catch (Throwable tt) {
                 log.log(Level.SEVERE, LogFacade.CLEANUP_FAILED_EXCEPTION, tt);
@@ -5951,7 +5953,11 @@ public class StandardContext
 
             if ((manager != null) && (manager instanceof Lifecycle)) {
                 if(manager instanceof StandardManager) {
-                    ((StandardManager)manager).stop(isShutdown);
+                    try {
+                        ((StandardManager)manager).stop(isShutdown);
+                    } catch (LifecycleException e) {
+                        log.log(Level.INFO, LogFacade.MANAGER_NOT_STARTED_INFO, e);
+                    }
                 } else {
                     ((Lifecycle)manager).stop();
                 }
@@ -8131,5 +8137,21 @@ public class StandardContext
             return ((WebappClassLoader)cl).getExtractedResourcePath(path);
         }
         return null;
+    }
+
+
+    /**
+     * Force loading of the JSP servlet. This is needed in case of
+     * initialization failure, so the JSP servlet would be unloaded properly
+     * and release all of its resources
+     *
+     * @throws ServletException
+     */
+    private void forceLoadJspServlet() throws ServletException {
+        Container jspServlet = findChild(Constants.JSP_SERVLET_NAME);
+        if (jspServlet instanceof Wrapper) {
+            Wrapper jspServletWrapper = (Wrapper) jspServlet;
+            jspServletWrapper.load();
+        }
     }
 }

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -231,6 +231,9 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
 
     @Inject
     private LoggingRuntime loggingRuntime;
+
+    @Inject
+    private Deployment deployment;
 
     private final Map<String, WebConnector> connectorMap = new HashMap<>();
 
@@ -2058,7 +2061,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
             }
         }
 
-        if (!hasBeenUndeployed) {
+        if (!hasBeenUndeployed && deployment.getCurrentDeploymentContext() == null) {
             logger.log(Level.SEVERE, LogFacade.UNDEPLOY_ERROR, contextRoot);
         }
     }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Bugfix. Application Deployment failure results Class Loader leak and extra error messages.
The root cause is the message stops undeployment process from proceeding further.
This is now fixed and leaks are removed.

```
[#|2024-07-28T04:01:23.573-0500|SEVERE|Payara 6.2024.7|jakarta.enterprise.web.core|_ThreadID=97;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1722157283573;_LevelValue=1000;_MessageID=AS-WEB-CORE-00175;|
  Exception during cleanup after start failed
org.apache.catalina.LifecycleException: Manager has not yet been started
	at org.apache.catalina.session.StandardManager.stop(StandardManager.java:872)
	at org.apache.catalina.core.StandardContext.stop(StandardContext.java:5954)
	at com.sun.enterprise.web.WebModule.stop(WebModule.java:648)
	at org.apache.catalina.core.StandardContext.start(StandardContext.java:5769)
	at com.sun.enterprise.web.WebModule.start(WebModule.java:619)
	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:982)
	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:965)
	at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:694)
	at com.sun.enterprise.web.WebContainer.loadWebModule(WebContainer.java:1813)
	at com.sun.enterprise.web.WebContainer.loadWebModule(WebContainer.java:1565)
	at com.sun.enterprise.web.WebApplication.start(WebApplication.java:107)
	at org.glassfish.internal.data.EngineRef.start(EngineRef.java:123)
	at org.glassfish.internal.data.ModuleInfo.start(ModuleInfo.java:292)
	at org.glassfish.internal.data.ApplicationInfo.start(ApplicationInfo.java:361)
	at com.sun.enterprise.v3.server.ApplicationLifecycle.initialize(ApplicationLifecycle.java:633)
	at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:574)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:556)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:552)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:453)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:551)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:582)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:574)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:453)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:573)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1497)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1879)
	at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1755)
	at org.glassfish.admin.rest.resources.admin.CommandResource.executeCommand(CommandResource.java:409)
	at org.glassfish.admin.rest.resources.admin.CommandResource.execCommandSimpInMultOut(CommandResource.java:236)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:261)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:240)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:697)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:367)
	at org.glassfish.admin.rest.adapter.JerseyContainerCommandService$3.service(JerseyContainerCommandService.java:179)
	at org.glassfish.admin.rest.adapter.RestAdapter.service(RestAdapter.java:189)
	at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
	at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
	at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:174)
	at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:153)
	at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:196)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:88)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:246)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:178)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:118)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:96)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:51)
	at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:510)
	at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:82)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:83)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:101)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515)
	at java.base/java.lang.Thread.run(Thread.java:1570)
|#]
```

## Important Info
## Testing
### Testing Performed
Using ClassloaderDataAPI to test for leaks
