### PR TITLE
FISH-9082 Move Enforcer to `core-aggregator`

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -236,31 +236,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[${jdk.version},)</version>
-                                    <message>You need at least JDK11</message>
-                                </requireJavaVersion>
-                                <requireMavenVersion>
-                                    <version>[3.0.3,3.2.1],[3.2.3,)</version>
-                                    <message>You need Maven greater than 3.0.3 (3.2.2 not supported)</message>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
                 <extensions>true</extensions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -545,8 +545,8 @@
                                     <message>You need at least JDK11</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>[3.0.3,3.2.1],[3.2.3,)</version>
-                                    <message>You need Maven greater than 3.0.3 (3.2.2 not supported)</message>
+                                    <version>[3.6.3,)</version>
+                                    <message>You need Maven greater than 3.6.3</message>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -528,6 +528,32 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[${jdk.version},)</version>
+                                    <message>You need at least JDK11</message>
+                                </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>[3.0.3,3.2.1],[3.2.3,)</version>
+                                    <message>You need Maven greater than 3.0.3 (3.2.2 not supported)</message>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <!--


### PR DESCRIPTION
## Description
Moves the enforcer to the core-aggregator.
Being under core-parent meant it wasn't being used by the majority of the codebase.

Also updates the minimum Maven version to 3.6.3.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the server.
Ran `mvn versions:display-plugin-updates -pl .` and it didn't scream about the minimum Maven version not being defined.

### Testing Environment
Windows 11, Zulu 11.0.23, Maven 3.9.8

## Documentation
N/A

## Notes for Reviewers
None
