### PR TITLE
FISH-9185 Revert "FISH-8933 Upgrade tyrus to 2.1.5.payara-p1"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,7 +108,7 @@
         <jakartaee.api.version>10.0.0</jakartaee.api.version>
         <weld-api.version>5.0.SP3</weld-api.version>
         <weld.version>5.0.1.Final</weld.version>
-        <tyrus.version>2.1.5.payara-p1</tyrus.version>
+        <tyrus.version>2.1.3.payara-p1</tyrus.version>
         <jsp-impl.version>3.2.2</jsp-impl.version>
         <asm.version>9.7</asm.version>
         <websocket-api.version>2.1.1</websocket-api.version>


### PR DESCRIPTION
## Description
This reverts commit 0514ba3aef666330a145155655aa306a7d1fbd16.
Upgrading Tyrus appears to break the TCK, due to an OSGi error
```
org.osgi.framework.BundleException: Unable to resolve org.glassfish.tyrus.container-grizzly-client [47](R 47.0): missing requirement [org.glassfish.tyrus.container-grizzly-client [47](R 47.0)] osgi.wiring.package; (osgi.wiring.package=org.glassfish.tyrus.client.exception) Unresolved requirements: [[org.glassfish.tyrus.container-grizzly-client [47](R 47.0)] osgi.wiring.package; (osgi.wiring.package=org.glassfish.tyrus.client.exception)]
```

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the Websocket TCK

### Testing Environment
Jenkins and local (WSL)

## Documentation
N/A

## Notes for Reviewers
None
