### PR TITLE
FISH-9185 Core 6.18.1 - Revert Tyrus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>fish.payara.server.core</groupId>
         <artifactId>core-aggregator</artifactId>
-        <version>6.18.0</version>
+        <version>6.18.1</version>
         <relativePath>core</relativePath>
     </parent>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Description
Updates Core to 6.18.1 - Tyrus reverted.

## Important Info
### Blockers
Staging and release of Core 6.18.1

## Testing
### New tests
None

### Testing Performed
Reverted Tyrus on `main` branch and ran Websocket TCK.

### Testing Environment
None

## Documentation
N/A

## Notes for Reviewers
None