### PR TITLE
FISH-9112 : setting local Name and Port for /managment/domain URI

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestAdapter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestAdapter.java
@@ -151,7 +151,7 @@ public abstract class RestAdapter extends HttpHandler implements ProxiedRestAdap
     @Override
     public void service(Request req, Response res) {
         RestLogging.restLogger.log(Level.FINER, "Received resource request: {0}", req.getRequestURI());
-
+        
         try {
             res.setCharacterEncoding(Constants.ENCODING);
             if (latch.await(20L, TimeUnit.SECONDS)) {


### PR DESCRIPTION
## Description
It is possible to trick the Payara Server’s management REST interface by “injecting” a malicious URL via the Host header of a sample request to let the HTML page that is generated by the REST interface when the /management/domain endpoint is targeted.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps:
1. run Payara Server
2. on Powershell run: 
>   Invoke-RestMethod -Method Get `
>   -Uri http://local:4848/management/domain `
>   -Headers @{
>       'Accept' = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
>       'Accept-Encoding' = 'gzip, deflate, br'
>       'Accept-Language' = 'en-US,en;q=0.5'
>       'Host' = 'google.com'
>   } > result.html
3. Open file result.html
4. Check that google.com is not in the URLs

### Testing Environment
Zulu JDK 11.0.11 Windows 11 with Maven 3.8.4

## Documentation
None

## Notes for Reviewers
