### PR TITLE
FISH-9502: adding validation to skip deploy on target

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -623,8 +623,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         // now were falling back into the mainstream loading/starting sequence, at this
         // time the containers are set up, all the modules have been prepared in their
         // associated engines and the application info is created and registered
-        boolean isAppAvailable = isAppAvailableOnTarget(appInfo.getName(), server.getName());
-        if (loadOnCurrentInstance(context) && isAppAvailable) {
+        if (loadOnCurrentInstance(context) && isAppAvailableOnTarget(appInfo.getName(), server.getName())) {
             try (SpanSequence span = tracing.startSequence(DeploymentTracing.AppStage.INITIALIZE)){
                 notifyLifecycleInterceptorsBefore(ExtendedDeploymentContext.Phase.START, context);
                 appInfo.initialize();

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -659,6 +659,9 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
      */
     private boolean isAppAvailableOnTarget(final String appName, final String targetName) {
         List<String> targets = domain.getAllReferencedTargetsForApplication(appName);
+        if (targets.isEmpty()) {
+            return true;
+        }
         return targets.stream().anyMatch(t -> t.equals(targetName));
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright 2016-2024 Payara Foundation and/or its affiliates.
+// Portions Copyright 2016-2023 Payara Foundation and/or its affiliates.
 
 package com.sun.enterprise.v3.server;
 
@@ -623,7 +623,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         // now were falling back into the mainstream loading/starting sequence, at this
         // time the containers are set up, all the modules have been prepared in their
         // associated engines and the application info is created and registered
-        if (loadOnCurrentInstance(context) && isAppAvailableOnTarget(appInfo.getName(), server.getName())) {
+        if (loadOnCurrentInstance(context)) {
             try (SpanSequence span = tracing.startSequence(DeploymentTracing.AppStage.INITIALIZE)){
                 notifyLifecycleInterceptorsBefore(ExtendedDeploymentContext.Phase.START, context);
                 appInfo.initialize();
@@ -649,21 +649,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             currentDeploymentContext.get().pop();
         }
     }
-
-    /**
-     * This is a method to validate if the app should need to be deployed on the target server
-     * @param appName application Name
-     * @param targetName Target server name
-     * @return boolean
-     */
-    private boolean isAppAvailableOnTarget(final String appName, final String targetName) {
-        List<String> targets = domain.getAllReferencedTargetsForApplication(appName);
-        if (targets.isEmpty()) {
-            return true;
-        }
-        return targets.stream().anyMatch(t -> t.equals(targetName));
-    }
-
+    
     @Override
     public ApplicationInfo deploy(final ExtendedDeploymentContext context) {
         return deploy(null, context);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -456,9 +456,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
             }
 
         } else {
-            if (isAppAvailable) {
-                logger.log(Level.SEVERE, KernelLoggerInfo.notFoundInOriginalLocation, source);
-            }
+            logger.log(Level.SEVERE, KernelLoggerInfo.notFoundInOriginalLocation, source);
         }
         appDeployments.removeIf(t -> t == null);
         return appDeployments;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -397,8 +397,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         }
         List<Deployment.ApplicationDeployment> appDeployments = new ArrayList<>();
         File sourceFile = new File(uri);
-        boolean isAppAvailable = isAppAvailableOnTarget(appName, server.getName());
-        if (sourceFile.exists() && isAppAvailable) {
+        if (sourceFile.exists()) {
             try {
                 ReadableArchive archive = null;
                 try {
@@ -638,16 +637,5 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
             }
         }
         return false;
-    }
-
-    /**
-     * This is a method to validate if the app should need to be deployed on the target server
-     * @param appName application Name
-     * @param targetName Target server name
-     * @return boolean
-     */
-    private boolean isAppAvailableOnTarget(final String appName, final String targetName) {
-        List<String> targets = domain.getAllReferencedTargetsForApplication(appName);
-        return targets.stream().anyMatch(t -> t.equals(targetName));
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLoaderService.java
@@ -397,8 +397,8 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
         }
         List<Deployment.ApplicationDeployment> appDeployments = new ArrayList<>();
         File sourceFile = new File(uri);
-        boolean isAppAvailableOnServer = isAvailableOnTargetServer(appName, server.getName());
-        if (sourceFile.exists() && isAppAvailableOnServer) {
+        boolean isAppAvailable = isAppAvailableOnTarget(appName, server.getName());
+        if (sourceFile.exists() && isAppAvailable) {
             try {
                 ReadableArchive archive = null;
                 try {
@@ -457,7 +457,7 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
             }
 
         } else {
-            if(isAppAvailableOnServer) {
+            if (isAppAvailable) {
                 logger.log(Level.SEVERE, KernelLoggerInfo.notFoundInOriginalLocation, source);
             }
         }
@@ -646,13 +646,8 @@ public class ApplicationLoaderService implements org.glassfish.hk2.api.PreDestro
      * @param targetName Target server name
      * @return boolean
      */
-    private boolean isAvailableOnTargetServer(String appName, String targetName) {
+    private boolean isAppAvailableOnTarget(final String appName, final String targetName) {
         List<String> targets = domain.getAllReferencedTargetsForApplication(appName);
-        for(String t : targets) {
-            if(t.equals(targetName)) {
-                return true;
-            }
-        }
-        return false;
+        return targets.stream().anyMatch(t -> t.equals(targetName));
     }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

Adding validation to skip deploy on target, when not needed

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is to fix a reported issue where an application is deployed on the server instead of only deploy on the instance that was defined from the beginning
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing by deploying multiple applications on different instances and then stop and restart to validate if only the applications are deployed on the instances and not the server:

Follow the steps described on the ticket, here details: https://payara.atlassian.net/browse/FISH-9502
applications attached here:
[Reproducers.zip](https://github.com/user-attachments/files/16681343/Reproducers.zip)
for the steps described on the ticket use the following file: clusterjsp.war

then create other two instances and deploy the following applications:

1. simpleRest.war
2. Jakarta10Refresher-1.0-SNAPSHOT.war

At the end you will have the following deployments:

- instance1 -> clusterjsp.war
- instance2 -> simpleRest.war
- instance3 -> Jakarta10Refresher-1.0-SNAPSHOT.war

![image](https://github.com/user-attachments/assets/d23a4e01-ef3f-4aa6-957f-bc7a318e5fcc)

then stop the server:  asadmin stop-domain

check each application on the specific instances:

instance1: http://localhost:28080/clusterjsp/
![image](https://github.com/user-attachments/assets/490e01a6-76b6-4cd7-af69-67a7c45e2902)

instance2: http://localhost:28081/simpleRest/test/rest
![image](https://github.com/user-attachments/assets/3e962dc7-e5e5-4412-9aad-591e7233dcfa)

instance3:  http://localhost:28082/Jakarta10Refresher-1.0-SNAPSHOT/faces/index.xhtml
![image](https://github.com/user-attachments/assets/339da64b-b5b3-4dc0-bed3-2026ddead04d)

then restart  server and try to call each application using port 8080, you will see error page, that means applications weren't deployed on the server instance:

![image](https://github.com/user-attachments/assets/a5eb9966-a827-4836-a85b-c2e825cda34e)

![image](https://github.com/user-attachments/assets/a4d2d92a-9f51-4426-a69a-6b5c8c3bccd6)

![image](https://github.com/user-attachments/assets/f2ad9425-cb9e-4f21-b3c8-4d618360b93e)

and from logs you will see just the loading application message but for the server now those are not initialized

`
[#|2024-08-21T21:33:21.578-0600|INFO|Payara 6.2024.9|javax.enterprise.system.core|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297601578;_LevelValue=800;_MessageID=NCLS-CORE-00022;|
  Loading application clusterjsp done in 2,168 ms|#]

[#|2024-08-21T21:33:21.930-0600|INFO|Payara 6.2024.9|javax.enterprise.system.core|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297601930;_LevelValue=800;|
  No deployment transformer implementation found.|#]

[#|2024-08-21T21:33:22.017-0600|INFO|Payara 6.2024.9|javax.enterprise.system.core|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297602017;_LevelValue=800;_MessageID=NCLS-CORE-00022;|
  Loading application simpleRest done in 437 ms|#]

[#|2024-08-21T21:33:22.213-0600|INFO|Payara 6.2024.9|javax.enterprise.system.core|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297602213;_LevelValue=800;|
  No deployment transformer implementation found.|#]

[#|2024-08-21T21:33:22.317-0600|INFO|Payara 6.2024.9|org.jboss.weld.Version|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297602317;_LevelValue=800;|
  WELD-000900: 5.0.1 (Final)|#]

[#|2024-08-21T21:33:24.129-0600|INFO|Payara 6.2024.9|fish.payara.micro.cdi.extension.ClusteredCDIEventBusImpl|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297604129;_LevelValue=800;|
  Clustered CDI Event bus initialized|#]

[#|2024-08-21T21:33:24.141-0600|INFO|Payara 6.2024.9|javax.enterprise.system.core|_ThreadID=45;_ThreadName=RunLevelControllerThread-1724297596011;_TimeMillis=1724297604141;_LevelValue=800;_MessageID=NCLS-CORE-00022;|
  Loading application Jakarta10Refresher-1.0-SNAPSHOT done in 2,121 ms|#]

[#|2024-08-21T21:33:24.200-0600|INFO|Payara 6.2024.9|javax.enterprise.system.core|_ThreadID=46;_ThreadName=RunLevelControllerThread-1724297596017;_TimeMillis=1724297604200;_LevelValue=800;_MessageID=NCLS-CORE-00101;|
  Network Listener JMS_PROXY_default_JMS_host started in: 2ms - bound to [/0.0.0.0:7676]|#]
`

for testing also review section for modules and components:

![image](https://github.com/user-attachments/assets/e8afaa67-28a2-40f3-8849-823456e05bc4)

![image](https://github.com/user-attachments/assets/cc4e513d-a102-4483-998d-2ad68d1b2497)

![image](https://github.com/user-attachments/assets/861ed0c7-c125-4619-91ce-6e6b4061aff1)

include for testing deployment on deployment groups and cluster:

for deployment groups create a new group, add an instance and start, then deploy the application: clusterjsp.war
![image](https://github.com/user-attachments/assets/9b11252a-8038-4999-a683-8580df512036)
![image](https://github.com/user-attachments/assets/9029266d-a107-4d65-bcc6-b7703e649025)
test the application on port: 28080 and 8080
![image](https://github.com/user-attachments/assets/3b4e5483-ac63-4b38-be79-8f55ba40144e)
8080 is not working this is expected behavior:
![image](https://github.com/user-attachments/assets/d4dfe623-7e5e-4fd9-9e52-019dba3fff6f)

stop deployment group and restart server. Again test application o both ports and both will show error:
![image](https://github.com/user-attachments/assets/dca00fb5-573b-41e0-8623-ea795488c829)
![image](https://github.com/user-attachments/assets/fece2bb9-0108-4cc1-b8bd-f01eb23397cc)


start again the deployment group, test application on port 28080,  you will see the application up and running only on port 28080
![image](https://github.com/user-attachments/assets/1cf02c11-ffcc-46d5-93da-d8ed7ea69063)

Make the same test for cluster,

create a cluster with one instance and deploy the application: simpleRest.war

![image](https://github.com/user-attachments/assets/229323d8-a270-44fd-861e-a39a10d9b9e5)

test application on ports: 28081 and 8080:
![image](https://github.com/user-attachments/assets/cd734b83-5450-4de6-9c85-e62e14fde106)

![image](https://github.com/user-attachments/assets/b697d2c1-27a3-4e16-81bc-9eeb0ddd7692)
8080 is not working this is expected behavior:
![image](https://github.com/user-attachments/assets/656b0172-f19c-4995-972b-6455713dae2c)

stop cluster and restart server. Again test application o both ports and both will show error:
![image](https://github.com/user-attachments/assets/a33e8cde-1cfb-45d9-95d9-d33acf9b740a)

![image](https://github.com/user-attachments/assets/92c0adfd-0316-4776-a93f-92a4adf2c71b)

start again the cluster, test application on port 28081,  you will see the application up and running only on port 28081

![image](https://github.com/user-attachments/assets/e41bb019-2ea8-4f4c-895f-536484193144)


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
ubuntu 20.04, azul jdk 11, maven 3.8.6
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
