### PR TITLE
FISH-6579 Hide ssl tab when security is disabled

### DIFF
--- a/appserver/admingui/web/src/main/resources/configuration/httpListenerTabs.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/httpListenerTabs.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2024] [Payara Foundation and/or its affiliates] -->
 
 <sun:tabSet id="listenerTabs" immediate="$boolean{true}" selected="#{sessionScope.httpListenerTabs}">
     <sun:tab id="generalTab" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.networkListener.listenerTab}" toolTip="$resource{i18n_web.grizzly.networkListener.listenerTab} Tab" >
@@ -47,7 +48,10 @@
         gf.redirect(page="#{request.contextPath}/web/configuration/httpListenerEdit.jsf?configName=#{configName}&name=#{pageSession.encodedListenerName}&cancelTo=#{pageSession.cancelTo}");
         />
     </sun:tab>
-    <sun:tab id="sslTab" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.sslTab}" toolTip="$resource{i18n_web.grizzly.sslTab} Tab" >
+    <sun:tab id="sslTab" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.sslTab}" toolTip="$resource{i18n_web.grizzly.sslTab} Tab" rendered="#{pageSession.protocolMap['securityEnabled']}">
+        <!beforeCreate
+            gf.getEntityAttrs(endpoint="#{sessionScope.REST_URL}/configs/config/#{configName}/network-config/protocols/protocol/#{pageSession.encodedProtocolName}" valueMap="#{pageSession.protocolMap}");
+        />
         <!command
         setSessionAttribute(key="httpListenerTabs" value="sslTab");
         gf.redirect(page="#{request.contextPath}/web/configuration/httpListenerSSL.jsf?configName=#{configName}&name=#{pageSession.encodedProtocolName}&listenerName=#{pageSession.encodedListenerName}&cancelTo=#{pageSession.cancelTo}");

--- a/appserver/admingui/web/src/main/resources/grizzly/listenerTabs.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/listenerTabs.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2024] [Payara Foundation and/or its affiliates] -->
 
 <!-- grizzly/listenerTabs.inc -->
 
@@ -49,7 +50,10 @@
         gf.redirect(page="#{request.contextPath}/web/grizzly/networkListenerEdit.jsf?configName=#{configName}&name=#{pageSession.encodedListenerName}&cancelTo=#{pageSession.cancelTo}");
         />
     </sun:tab>
-    <sun:tab id="sslTab" rendered="#{showSSLTab}" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.sslTab}" toolTip="$resource{i18n_web.grizzly.sslTab} Tab" >
+    <sun:tab id="sslTab" rendered="#{showSSLTab and empty pageSession.protocolMap['securityEnabled'] ? true : pageSession.protocolMap['securityEnabled']}" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.sslTab}" toolTip="$resource{i18n_web.grizzly.sslTab} Tab" >
+        <!beforeCreate
+            gf.getEntityAttrs(endpoint="#{sessionScope.REST_URL}/configs/config/#{configName}/network-config/protocols/protocol/#{pageSession.encodedName}" valueMap="#{pageSession.protocolMap}");
+        />
         <!command
         setSessionAttribute(key="listenerTabs" value="sslTab");
         gf.redirect(page="#{request.contextPath}/web/grizzly/listenerSSLEdit.jsf?configName=#{configName}&name=#{pageSession.encodedProtocolName}&listenerName=#{pageSession.encodedListenerName}&cancelTo=#{pageSession.cancelTo}");

--- a/appserver/admingui/web/src/main/resources/grizzly/protocolTabs.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/protocolTabs.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright [2024] [Payara Foundation and/or its affiliates] -->
 
 <!-- grizzly/protocolTabs.jsf -->
 
@@ -49,7 +50,10 @@
         gf.redirect(page="#{request.contextPath}/web/grizzly/protocolEdit.jsf?configName=#{configName}&name=#{pageSession.encodedName}&cancelTo=#{pageSession.cancelTo}");
         />
     </sun:tab>
-    <sun:tab id="sslTab" rendered="#{showSSLTab}" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.sslTab}" toolTip="$resource{i18n_web.grizzly.sslTab} Tab" >
+    <sun:tab id="sslTab" rendered="#{showSSLTab and empty pageSession.protocolMap['securityEnabled'] ? true : pageSession.protocolMap['securityEnabled']}" immediate="$boolean{true}" text="$resource{i18n_web.grizzly.sslTab}" toolTip="$resource{i18n_web.grizzly.sslTab} Tab" >
+        <!beforeCreate
+            gf.getEntityAttrs(endpoint="#{sessionScope.REST_URL}/configs/config/#{configName}/network-config/protocols/protocol/#{pageSession.encodedName}" valueMap="#{pageSession.protocolMap}");
+        />
         <!command
         setSessionAttribute(key="protocolTabs" value="sslTab");
         gf.redirect(page="#{request.contextPath}/web/grizzly/protocolSSLEdit.jsf?configName=#{configName}&name=#{pageSession.encodedName}&cancelTo=#{pageSession.cancelTo}");


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
In the admin console, the SSL settings tab should be hidden when security is disabled.

This PR gets the securityEnabled attribute and renders the tab if security is enabled.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing, started admin console, visited server-config -> http listeners, network listeners and protocols. 

Verified that the ssl tab was rendered correctly based on Security being enabled.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 11.0.23, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/11.0.23-zulu/zulu-11.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "14.6.1", arch: "aarch64", family: "mac"

## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a