### PR TITLE
FISH-9186 : Use the LinkOption.NOFOLLOW_LINKS option

### DIFF
--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
@@ -59,6 +59,7 @@
 
 package org.apache.naming.resources;
 
+import java.nio.file.LinkOption;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Logger;
@@ -927,7 +928,7 @@ public class FileDirContext extends BaseDirContext {
             // Check that this file belongs to our root path
             String canPath = null;
             try {
-                canPath = normalize(file.toPath().toRealPath().toString());
+                canPath = normalize(file.toPath().toRealPath(LinkOption.NOFOLLOW_LINKS).toString());
             } catch (IOException e) {
             }
             if (canPath == null || (!canPath.startsWith(canonicalBase) && !allowLinking)) {


### PR DESCRIPTION
## Description
A customer has reported that their document root bases that point to directories that live on a DFSN server do not work correctly on Payara Server when the server runs on a Windows Server 2019.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Quicklook, Samples etc

### Testing Environment
Zulu JDK 11 on Ubuntu 22 with Maven 3.8.4

## Documentation
None
