### PR TITLE
FISH-9579 FISH-9580 FISH-9582 Upgrade Docker JDKs

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,7 +57,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.23-jdk</docker.jdk11.tag>
+        <docker.jdk11.tag>11.0.24-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.11-jdk</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.3-jdk</docker.jdk21.tag>
 

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,7 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.24-jdk</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.11-jdk</docker.jdk17.tag>
+        <docker.jdk17.tag>17.0.12-jdk</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.3-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -59,7 +59,7 @@
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.24-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.12-jdk</docker.jdk17.tag>
-        <docker.jdk21.tag>21.0.3-jdk</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.4-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.


### PR DESCRIPTION
## Description
Upgrades the Docker JDKs to 11.0.24, 17.0.12, and 21.0.4.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the Docker images and let the integration test run.

### Testing Environment
Windows 11, Zulu JDK 11.0.24, Maven 3.9.8, Docker Desktop 4.33.1

## Documentation
N/A

## Notes for Reviewers
None
