### PR TITLE
FISH-9604 Upgrade Ant to 1.10.15

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -136,8 +136,7 @@
         <!-- Build -->
 
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
-        <ant.version>1.10.14</ant.version>
-        <ant-launcher.version>1.10.14</ant-launcher.version>
+        <ant.version>1.10.15</ant.version>
         <javadoc.options>-Xdoclint:none</javadoc.options>
 
         <!-- Debug / analysis -->
@@ -806,7 +805,7 @@ Parent is ${project.parent}</echo>
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-launcher</artifactId>
-                <version>${ant-launcher.version}</version>
+                <version>${ant.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun</groupId>


### PR DESCRIPTION
## Description
Upgrades Apache Ant to 1.10.15, and aligns the ant-launcher dependency to the same version and property.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Jenkins test please

### Testing Environment
Jenkins

## Documentation
N/A

## Notes for Reviewers
None
