### PR TITLE
FISH-9618 Fix Incorrect `payara-micro-remote` Dependency Name

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -193,7 +193,7 @@
 
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-micro-remote</artifactId>
+                <artifactId>arquillian-payara-micro-remote</artifactId>
                 <version>${payara-arquillian-container.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -254,7 +254,7 @@
             <dependencies>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>payara-micro-remote</artifactId>
+                    <artifactId>arquillian-payara-micro-remote</artifactId>
                     <scope>test</scope>
                     <optional>true</optional>
                 </dependency>


### PR DESCRIPTION
## Description
This dependency was renamed a while ago.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Checked in IDE that dependency version of `arquillian-payara-micro-remote` is inherited from bom.

### Testing Environment
IntelliJ IDE

## Documentation
N/A (apparently - no mention of it in https://github.com/payara/Payara-Documentation)

## Notes for Reviewers
None
