### PR TITLE
FISH-9748 bugfix: fix HA session race condition leading to session attribute loss

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Store.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Store.java
@@ -55,6 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Portions Copyright 2016-2024 Payara Foundation and/or its affiliates
 
 package org.apache.catalina;
 
@@ -181,5 +182,7 @@ public interface Store {
      */
     public void save(Session session) throws IOException;
 
-
+    default boolean isHighAvailability() {
+        return false;
+    }
 }

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/HAStoreBase.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/HAStoreBase.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2024] Payara Foundation and/or affiliates
 
 /*
  * HAStoreBase.java
@@ -311,7 +311,8 @@ public abstract class HAStoreBase extends StoreBase {
 
     //possible generic methods end
 
-
-
-
+    @Override
+    public boolean isHighAvailability() {
+        return true;
+    }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Fixed regression introduced in #6637 

## Important Info
- compare update times to stored session in HA scenarios only
- Use `store.load()` instead of `swapIn()` to load sessions during update time comparison, as `swapIn()` has side effects, such as replacing session object in the session map, and calling users' activation handlers every time a session is retrieved, leading to session loss and performance issues

To further explain this, when the session is replaced in the map by `swapIn()`, other copies of the session hang around in other threads.
Sessions get stored in HA store at the end of each request, and only the session currently in the map gets updated.
Those other copies do not get stored in the HA store when request ends, since they are no longer in the session map.
This leads to the data loss.

Performance problem is caused by the session map thrashing, and session creation callbacks being called every time the `swapIn()` method is called.

## Testing
Manual testing done
