### PR TITLE
FISH-9771 FISH-9688 spot bugs random only used once

### DIFF
--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -77,6 +77,7 @@ import java.io.File;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -612,9 +613,9 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
          */
         @Override
         public void decorate(AdminCommandContext context, final Cluster instance) throws TransactionFailure, PropertyVetoException {
-            SecureRandom random = new SecureRandom();
             Logger logger = ConfigApiLoggerInfo.getLogger();
             LocalStringManagerImpl localStrings = new LocalStringManagerImpl(Cluster.class);
+            Random random = new SecureRandom();
             Transaction t = Transaction.getTransaction(instance);
             //check if cluster software is installed else fail , see issue 12023
             final CopyConfig command = (CopyConfig) runner

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -615,7 +615,6 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
         public void decorate(AdminCommandContext context, final Cluster instance) throws TransactionFailure, PropertyVetoException {
             Logger logger = ConfigApiLoggerInfo.getLogger();
             LocalStringManagerImpl localStrings = new LocalStringManagerImpl(Cluster.class);
-            Random random = new SecureRandom();
             Transaction t = Transaction.getTransaction(instance);
             //check if cluster software is installed else fail , see issue 12023
             final CopyConfig command = (CopyConfig) runner
@@ -725,7 +724,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
 
                         // generate a random port since user did not provide one.
                         // better fix in future would be to walk existing clusters and pick an unused port.
-                        TCPPORT = Integer.toString(random.nextInt(9200 - 9090) + 9090);
+                        TCPPORT = Integer.toString(SecurityUtils.nextInt(9200 - 9090) + 9090);
 
                         // hardcode all instances to use same default port.
                         // generate mode does not support multiple instances on one machine.
@@ -746,7 +745,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
                             gmsListenerPortSysProp.setName(propName);
                             if (TCPPORT == null || TCPPORT.trim().charAt(0) == '$') {
                                 String generateGmsListenerPort = Integer.toString(
-                                        random.nextInt(9200 - 9090) + 9090);
+                                        SecurityUtils.nextInt(9200 - 9090) + 9090);
                                 gmsListenerPortSysProp.setValue(generateGmsListenerPort);
                             } else {
                                 gmsListenerPortSysProp.setValue(TCPPORT);

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -43,7 +43,6 @@ package com.sun.enterprise.config.serverbeans;
 
 import com.sun.enterprise.config.serverbeans.customvalidators.*;
 import com.sun.enterprise.config.util.ConfigApiLoggerInfo;
-import com.sun.enterprise.universal.security.SecurityUtils;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import org.glassfish.api.ActionReport;
@@ -57,6 +56,7 @@ import org.glassfish.api.admin.config.Named;
 import org.glassfish.api.admin.config.PropertiesDesc;
 import org.glassfish.api.admin.config.PropertyDesc;
 import org.glassfish.api.admin.config.ReferenceContainer;
+import org.glassfish.common.util.RandomUtils;
 import org.glassfish.config.support.CreationDecorator;
 import org.glassfish.config.support.DeletionDecorator;
 import org.glassfish.hk2.api.PerLookup;
@@ -723,7 +723,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
 
                         // generate a random port since user did not provide one.
                         // better fix in future would be to walk existing clusters and pick an unused port.
-                        TCPPORT = Integer.toString(SecurityUtils.nextInt(9200 - 9090) + 9090);
+                        TCPPORT = Integer.toString(RandomUtils.nextInt(9200 - 9090) + 9090);
 
                         // hardcode all instances to use same default port.
                         // generate mode does not support multiple instances on one machine.
@@ -744,7 +744,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
                             gmsListenerPortSysProp.setName(propName);
                             if (TCPPORT == null || TCPPORT.trim().charAt(0) == '$') {
                                 String generateGmsListenerPort = Integer.toString(
-                                        SecurityUtils.nextInt(9200 - 9090) + 9090);
+                                        RandomUtils.nextInt(9200 - 9090) + 9090);
                                 gmsListenerPortSysProp.setValue(generateGmsListenerPort);
                             } else {
                                 gmsListenerPortSysProp.setValue(TCPPORT);

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -92,6 +92,8 @@ import static org.glassfish.config.support.Constants.NAME_SERVER_REGEX;
 @NotDuplicateTargetName(message="{cluster.duplicate.name}", payload=Cluster.class)
 @ReferenceConstraint(skipDuringCreation=true, payload=Cluster.class)
 public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemPropertyBag, ReferenceContainer, RefContainer, Payload {
+
+    SecureRandom R = new SecureRandom();
 
     /**
      * Sets the cluster name
@@ -723,7 +725,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
 
                         // generate a random port since user did not provide one.
                         // better fix in future would be to walk existing clusters and pick an unused port.
-                        TCPPORT = Integer.toString(new SecureRandom().nextInt(9200 - 9090) + 9090);
+                        TCPPORT = Integer.toString(R.nextInt(9200 - 9090) + 9090);
 
                         // hardcode all instances to use same default port.
                         // generate mode does not support multiple instances on one machine.
@@ -744,7 +746,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
                             gmsListenerPortSysProp.setName(propName);
                             if (TCPPORT == null || TCPPORT.trim().charAt(0) == '$') {
                                 String generateGmsListenerPort = Integer.toString(
-                                        new SecureRandom().nextInt(9200 - 9090) + 9090);
+                                        R.nextInt(9200 - 9090) + 9090);
                                 gmsListenerPortSysProp.setValue(generateGmsListenerPort);
                             } else {
                                 gmsListenerPortSysProp.setValue(TCPPORT);

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -93,8 +93,6 @@ import static org.glassfish.config.support.Constants.NAME_SERVER_REGEX;
 @ReferenceConstraint(skipDuringCreation=true, payload=Cluster.class)
 public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemPropertyBag, ReferenceContainer, RefContainer, Payload {
 
-    SecureRandom R = new SecureRandom();
-
     /**
      * Sets the cluster name
      * @param value cluster name
@@ -614,6 +612,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
          */
         @Override
         public void decorate(AdminCommandContext context, final Cluster instance) throws TransactionFailure, PropertyVetoException {
+            SecureRandom random = new SecureRandom();
             Logger logger = ConfigApiLoggerInfo.getLogger();
             LocalStringManagerImpl localStrings = new LocalStringManagerImpl(Cluster.class);
             Transaction t = Transaction.getTransaction(instance);
@@ -725,7 +724,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
 
                         // generate a random port since user did not provide one.
                         // better fix in future would be to walk existing clusters and pick an unused port.
-                        TCPPORT = Integer.toString(R.nextInt(9200 - 9090) + 9090);
+                        TCPPORT = Integer.toString(random.nextInt(9200 - 9090) + 9090);
 
                         // hardcode all instances to use same default port.
                         // generate mode does not support multiple instances on one machine.
@@ -746,7 +745,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
                             gmsListenerPortSysProp.setName(propName);
                             if (TCPPORT == null || TCPPORT.trim().charAt(0) == '$') {
                                 String generateGmsListenerPort = Integer.toString(
-                                        R.nextInt(9200 - 9090) + 9090);
+                                        random.nextInt(9200 - 9090) + 9090);
                                 gmsListenerPortSysProp.setValue(generateGmsListenerPort);
                             } else {
                                 gmsListenerPortSysProp.setValue(TCPPORT);

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -43,6 +43,7 @@ package com.sun.enterprise.config.serverbeans;
 
 import com.sun.enterprise.config.serverbeans.customvalidators.*;
 import com.sun.enterprise.config.util.ConfigApiLoggerInfo;
+import com.sun.enterprise.universal.security.SecurityUtils;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import org.glassfish.api.ActionReport;
@@ -74,10 +75,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.beans.PropertyVetoException;
 import java.io.File;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
@@ -132,7 +132,7 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private File backupDir;
 
     private static final String RENDEZVOUS_PROPERTY_NAME = "rendezvousOccurred";
-    private static final SecureRandom r = new SecureRandom();
+    private static final Random random = new SecureRandom();
     private String instanceDottedName;
     private String rendevousDottedName;
 
@@ -335,7 +335,7 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private void backupInstanceDir() {
         File f = getServerDirs().getServerDir();
         if (f != null && f.isDirectory()) {
-            setBackupDir(r.nextInt());
+            setBackupDir(random.nextInt());
             File backup = getBackupDir();
             if (!f.renameTo(backup)) {
                 logger.warning(Strings.get("import.sync.bundle.backupInstanceDirFailed", f.getAbsolutePath(), backup.getAbsolutePath()));

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
@@ -132,7 +132,6 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private File backupDir;
 
     private static final String RENDEZVOUS_PROPERTY_NAME = "rendezvousOccurred";
-    private static final Random random = new SecureRandom();
     private String instanceDottedName;
     private String rendevousDottedName;
 
@@ -335,7 +334,7 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private void backupInstanceDir() {
         File f = getServerDirs().getServerDir();
         if (f != null && f.isDirectory()) {
-            setBackupDir(random.nextInt());
+            setBackupDir(SecurityUtils.nextInt());
             File backup = getBackupDir();
             if (!f.renameTo(backup)) {
                 logger.warning(Strings.get("import.sync.bundle.backupInstanceDirFailed", f.getAbsolutePath(), backup.getAbsolutePath()));

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
@@ -55,14 +55,13 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-
+import com.sun.enterprise.universal.security.SecurityUtils;
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.*;
 import static com.sun.enterprise.admin.cli.CLIConstants.*;
 import com.sun.enterprise.util.io.FileUtils;
 import java.io.FileInputStream;
-import java.security.SecureRandom;
 import org.glassfish.admin.payload.PayloadImpl;
 import org.glassfish.admin.payload.PayloadFilesManager.Perm;
 import org.glassfish.hk2.api.PerLookup;

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
@@ -55,7 +55,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import com.sun.enterprise.universal.security.SecurityUtils;
+import org.glassfish.common.util.RandomUtils;
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.*;
@@ -333,7 +333,7 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private void backupInstanceDir() {
         File f = getServerDirs().getServerDir();
         if (f != null && f.isDirectory()) {
-            setBackupDir(SecurityUtils.nextInt());
+            setBackupDir(RandomUtils.nextInt());
             File backup = getBackupDir();
             if (!f.renameTo(backup)) {
                 logger.warning(Strings.get("import.sync.bundle.backupInstanceDirFailed", f.getAbsolutePath(), backup.getAbsolutePath()));

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/ImportSyncBundleCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2024] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.cli.cluster;
 
@@ -132,6 +132,7 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private File backupDir;
 
     private static final String RENDEZVOUS_PROPERTY_NAME = "rendezvousOccurred";
+    private static final SecureRandom r = new SecureRandom();
     private String instanceDottedName;
     private String rendevousDottedName;
 
@@ -334,7 +335,6 @@ public class ImportSyncBundleCommand extends LocalInstanceCommand {
     private void backupInstanceDir() {
         File f = getServerDirs().getServerDir();
         if (f != null && f.isDirectory()) {
-            SecureRandom r = new SecureRandom();
             setBackupDir(r.nextInt());
             File backup = getBackupDir();
             if (!f.renameTo(backup)) {

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/security/SecurityUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/security/SecurityUtils.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2024] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.universal.security;
 
@@ -51,11 +51,11 @@ public final class SecurityUtils {
 
     private static SecureRandom random = new SecureRandom();
 
-    private static int nextInt() {
+    public static int nextInt() {
         return random.nextInt();
     }
 
-    private static int nextInt(int bound) {
+    public static int nextInt(int bound) {
         return random.nextInt(bound);
     }
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/security/SecurityUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/security/SecurityUtils.java
@@ -49,8 +49,17 @@ import java.security.SecureRandom;
  */
 public final class SecurityUtils {
 
+    private static SecureRandom random = new SecureRandom();
+
+    private static int nextInt() {
+        return random.nextInt();
+    }
+
+    private static int nextInt(int bound) {
+        return random.nextInt(bound);
+    }
+
     public static String getSecureRandomHexString(int numBytes) {
-        SecureRandom random = new SecureRandom();
         byte[] bb = new byte[numBytes];
         random.nextBytes(bb);
         return toHexString(bb);

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/RandomUtils.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/RandomUtils.java
@@ -47,7 +47,7 @@ import java.security.SecureRandom;
  * @author: Petr Aubrecht
  */
 public class RandomUtils {
-    private static SecureRandom random = new SecureRandom();
+    private static final SecureRandom random = new SecureRandom();
 
     public static int nextInt() {
         return random.nextInt();

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/RandomUtils.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/RandomUtils.java
@@ -1,23 +1,23 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
  * and Distribution License("CDDL") (collectively, the "License").  You
  * may not use this file except in compliance with the License.  You can
  * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
  * language governing permissions and limitations under the License.
  *
  * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
+ * file and include the License file at glassfish/legal/LICENSE.txt.
  *
  * GPL Classpath Exception:
- * Oracle designates this particular file as subject to the "Classpath"
- * exception as provided by Oracle in the GPL Version 2 section of the License
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  * file that accompanied this code.
  *
  * Modifications:
@@ -37,48 +37,23 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
-
-package com.sun.enterprise.universal.security;
+package org.glassfish.common.util;
 
 import java.security.SecureRandom;
 
 /**
- * Created October 28, 2010
- * @author Byron Nevins
+ * Centralize usage of random number generator.
+ *
+ * @author: Petr Aubrecht
  */
-public final class SecurityUtils {
+public class RandomUtils {
     private static SecureRandom random = new SecureRandom();
 
-    public static String getSecureRandomHexString(int numBytes) {
-        byte[] bb = new byte[numBytes];
-        random.nextBytes(bb);
-        return toHexString(bb);
+    public static int nextInt() {
+        return random.nextInt();
     }
 
-    /**
-     * No instances allowed.
-     */
-    private SecurityUtils() {
-    }
-
-    private static String toHexString(byte b) {
-        String s = Integer.toHexString((int) b + 128);
-
-        if (s.length() == 1) {
-            s = "0" + s;
-        }
-
-        return s;
-    }
-
-    private static String toHexString(byte[] bb) {
-        StringBuilder sb = new StringBuilder();
-
-        for (byte b : bb) {
-            sb.append(toHexString(b));
-        }
-
-        return sb.toString();
+    public static int nextInt(int bound) {
+        return random.nextInt(bound);
     }
 }


### PR DESCRIPTION

Used `SecurityUtils` to generate a random and use it within the respective classes. Spot bugs issue. (check description)
## Description
Spotbugs warning:
```
Random object created and used only once in com.sun.enterprise.admin.cli.cluster.ImportSyncBundleCommand.backupInstanceDir()

This code creates a java.util.Random object, uses it to generate one random number, and then discards the Random object. This produces mediocre quality random numbers and is inefficient. If possible, rewrite the code so that the Random object is created once and saved, and each time a new random number is required invoke a method on the existing Random object to obtain it.

If it is important that the generated Random numbers not be guessable, you must not create a new Random for each random number; the values are too easily guessable. You should strongly consider using a java.security.SecureRandom instead (and avoid allocating a new SecureRandom for each random number needed).random objects.
```
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
built payara and ran spotbugs against the changes made.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
