### PR TITLE
FISH-9806 FISH-8522: Prevent duplicate HELP metadata in OpenMetrics endpoint

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/OpenMetricsExporter.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/OpenMetricsExporter.java
@@ -285,16 +285,17 @@ public class OpenMetricsExporter implements MetricExporter {
     }
 
     protected void appendTYPE(String globalName, OpenMetricsType type) {
-        if (typeWrittenByGlobalName.contains(globalName)) {
+        if (!typeWrittenByGlobalName.add(globalName)) {
+            // write metadata only once per metric
             return;
         }
-        typeWrittenByGlobalName.add(globalName);
         out.append("# TYPE ").append(globalName).append(' ').append(type.name()).append('\n');
     }
 
     protected void appendHELP(String globalName, Metadata metadata) {
-        if(!helpWrittenByGlobalName.contains(globalName)) {
-            helpWrittenByGlobalName.add(globalName);
+        if (!helpWrittenByGlobalName.add(globalName)) {
+            // write metadata only once per metric
+           return;
         }
         Optional<String> description = metadata.description();
         out.append("# HELP ").append(globalName).append(' ').append(description.isPresent() ? description.get(): "").append('\n');

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/writer/OpenMetricsExporterTest.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/java/fish/payara/microprofile/metrics/writer/OpenMetricsExporterTest.java
@@ -210,7 +210,6 @@ public class OpenMetricsExporterTest {
         assertEquals("# TYPE common gauge\n" +
                 "# HELP common description\n" +
                 "common{a=\"b\"} 1\n" +
-                "# HELP common description\n"+
                 "common{some=\"other\"} 2\n", actual.getBuffer().toString());
     }
 

--- a/appserver/payara-appserver-modules/microprofile/metrics/src/test/resources/examples/GaugeTags.txt
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/test/resources/examples/GaugeTags.txt
@@ -4,5 +4,4 @@ fooVal_seconds{store="webshop"} 12.345
 # TYPE barVal_bytes gauge
 # HELP barVal_bytes 
 barVal_bytes{component="backend",store="webshop"} 42000.0
-# HELP barVal_bytes 
 barVal_bytes{component="frontend",store="webshop"} 63000.0


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Fixes #6596. Duplicate HELP line for a metric was tracked, but not prevented.

## Important Info

## Testing
### New tests

Updated unit tests to reflect new behavior

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Checked metric endpoint output.

### Testing Environment
Zulu 11.0.18, Linux, Maven 3.9.5
