### PR TITLE
FISH-9853 Improve Handling for Accessing Secure Variant of URL

### DIFF
--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccWebAuthorizationManager.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccWebAuthorizationManager.java
@@ -667,16 +667,6 @@ public class JaccWebAuthorizationManager {
         return policyConfigurationFactory;
     }
 
-    private ProtectionDomain getProtectionDomain(Set<Principal> principalSet) {
-        return protectionDomainCache.computeIfAbsent(principalSet, e -> {
-            Principal[] principals = (principalSet == null ? null : (Principal[]) principalSet.toArray(new Principal[0]));
-
-            logProtectionDomainCreated(principals);
-
-            return new ProtectionDomain(codesource, null, null, principals);
-        });
-    }
-
     private static String setPolicyContext(String newContextID) throws Throwable {
         String oldContextID = PolicyContext.getContextID();
 

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccWebAuthorizationManager.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccWebAuthorizationManager.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license.
 
 package com.sun.enterprise.security.jacc;
 
@@ -309,6 +310,7 @@ public class JaccWebAuthorizationManager {
         if (!isGranted && !servletRequest.isSecure()) {
 
             if (uri == null) {
+                uri = getUriMinusContextPath(servletRequest);
                 httpMethod = servletRequest.getMethod();
             }
 
@@ -349,7 +351,7 @@ public class JaccWebAuthorizationManager {
 
         if (logger.isLoggable(FINE)) {
             logger.log(Level.FINE, "[Web-Security] hasResource isGranted: {0}", isGranted);
-            logger.log(Level.FINE, "[Web-Security] hasResource perm: {0}", servletRequest.getRequestURI());
+            logger.log(Level.FINE, "[Web-Security] hasResource perm: {0}", getUriMinusContextPath(servletRequest));
         }
 
         recordWebInvocation(servletRequest, RESOURCE, isGranted);
@@ -675,36 +677,6 @@ public class JaccWebAuthorizationManager {
         });
     }
 
-    private WebResourcePermission createWebResourcePermission(HttpServletRequest servletRequest) {
-        String uri = (String) servletRequest.getAttribute(CONSTRAINT_URI);
-
-        if (uri == null) {
-            uri = servletRequest.getRequestURI();
-            if (uri != null) {
-                // FIX TO BE CONFIRMED (after ~12 years): subtract the context path
-                String contextPath = servletRequest.getContextPath();
-                int contextLength = contextPath == null ? 0 : contextPath.length();
-                if (contextLength > 0) {
-                    uri = uri.substring(contextLength);
-                }
-            }
-        }
-
-        if (uri == null) {
-            logger.fine("[Web-Security] mappedUri is null");
-            throw new RuntimeException("Fatal Error in creating WebResourcePermission");
-        }
-
-        if (uri.equals("/")) {
-            uri = EMPTY_STRING;
-        } else {
-            // FIX TO BE CONFIRMED: encode all colons
-            uri = uri.replaceAll(":", "%3A");
-        }
-
-        return new WebResourcePermission(uri, servletRequest.getMethod());
-    }
-
     private static String setPolicyContext(String newContextID) throws Throwable {
         String oldContextID = PolicyContext.getContextID();
 
@@ -849,6 +821,28 @@ public class JaccWebAuthorizationManager {
                 logger.log(FINE, "[Web-Security] Checking with Principals: null");
             }
         }
+    }
+
+    private static String getUriMinusContextPath(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+
+        if (uri == null) {
+            return EMPTY_STRING;
+        }
+
+        String contextPath = request.getContextPath();
+        int contextLength = contextPath == null ? 0 : contextPath.length();
+
+        if (contextLength > 0) {
+            uri = uri.substring(contextLength);
+        }
+
+        if (uri.equals("/")) {
+            return EMPTY_STRING;
+        }
+
+        // Encode all colons
+        return uri.replaceAll(":", "%3A");
     }
 
 }


### PR DESCRIPTION
## Description
Resync with an update from Eclipse GlassFish, updating a very old (and unused) method to have batter handling for accessing secure variants of URLs.

I also removed another unused method while I was at it.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the Jakarta Servlet TCK locally - all but the client cert tests passed (improvement from before)

### Testing Environment
Windows 11, Zulu JDK 21.0.4, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
