### PR TITLE
FISH-9802 Fix EJB Failures in Authorization 3.0 TCK

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/AbstractAuthAnnotationHandler.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/AbstractAuthAnnotationHandler.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.deployment.annotation.handlers;
 
@@ -167,9 +168,7 @@ abstract class AbstractAuthAnnotationHandler extends AbstractCommonAttributeHand
         EjbDescriptor ejbDesc = ejbContext.getDescriptor();
         Annotation authAnnotation = ainfo.getAnnotation();
 
-        if (!ejbContext.isInherited() &&
-                (ejbDesc.getMethodPermissionsFromDD() == null ||
-                ejbDesc.getMethodPermissionsFromDD().size() == 0)) {
+        if (!ejbContext.isInherited() && ejbDesc.getMethodPermissionsFromDD().size() == 0) {
             for (MethodDescriptor md : getMethodAllDescriptors(ejbDesc)) {
                 processEjbMethodSecurity(authAnnotation, md, ejbDesc);
             }
@@ -256,18 +255,16 @@ abstract class AbstractAuthAnnotationHandler extends AbstractCommonAttributeHand
     private boolean hasMethodPermissionsFromDD(MethodDescriptor methodDesc,
             EjbDescriptor ejbDesc) {
         Map methodPermissionsFromDD = ejbDesc.getMethodPermissionsFromDD();
-        if (methodPermissionsFromDD != null) {
-            Set allMethods = ejbDesc.getMethodDescriptors();
-            for (Object mdObjsObj : methodPermissionsFromDD.values()) {
-                List mdObjs = (List)mdObjsObj;
-                for (Object mdObj : mdObjs) {
-                    MethodDescriptor md = (MethodDescriptor)mdObj;
-                    for (Object style3MdObj :
-                            md.doStyleConversion(ejbDesc, allMethods)) {
-                        MethodDescriptor style3Md = (MethodDescriptor)style3MdObj;
-                        if (methodDesc.equals(style3Md)) {
-                            return true;
-                        }
+        Set allMethods = ejbDesc.getMethodDescriptors();
+        for (Object mdObjsObj : methodPermissionsFromDD.values()) {
+            List mdObjs = (List) mdObjsObj;
+            for (Object mdObj : mdObjs) {
+                MethodDescriptor md = (MethodDescriptor) mdObj;
+                for (Object style3MdObj :
+                        md.doStyleConversion(ejbDesc, allMethods)) {
+                    MethodDescriptor style3Md = (MethodDescriptor) style3MdObj;
+                    if (methodDesc.equals(style3Md)) {
+                        return true;
                     }
                 }
             }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/AbstractAuthAnnotationHandler.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/AbstractAuthAnnotationHandler.java
@@ -260,8 +260,7 @@ abstract class AbstractAuthAnnotationHandler extends AbstractCommonAttributeHand
             List mdObjs = (List) mdObjsObj;
             for (Object mdObj : mdObjs) {
                 MethodDescriptor md = (MethodDescriptor) mdObj;
-                for (Object style3MdObj :
-                        md.doStyleConversion(ejbDesc, allMethods)) {
+                for (Object style3MdObj : md.doStyleConversion(ejbDesc, allMethods)) {
                     MethodDescriptor style3Md = (MethodDescriptor) style3MdObj;
                     if (methodDesc.equals(style3Md)) {
                         return true;

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbDescriptor.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/descriptor/EjbDescriptor.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2024] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2019-2024 Payara Foundation and/or its affiliates
 
 package org.glassfish.ejb.deployment.descriptor;
 
@@ -108,7 +108,7 @@ public abstract class EjbDescriptor extends CommonResourceDescriptor implements 
     protected boolean usesDefaultTransaction;
     private Hashtable<MethodDescriptor, ContainerTransaction> methodContainerTransactions;
     private Hashtable<MethodPermission, Set<MethodDescriptor>> permissionedMethodsByPermission;
-    private Map<MethodPermission, List<MethodDescriptor>> methodPermissionsFromDD;
+    private Map<MethodPermission, List<MethodDescriptor>> methodPermissionsFromDD = new HashMap<>();
     private Set<EnvironmentProperty> environmentProperties = new HashSet<>();
     private Set<EjbReference> ejbReferences = new HashSet<>();
     private Set<ResourceEnvReferenceDescriptor> resourceEnvReferences = new HashSet<>();
@@ -1423,17 +1423,11 @@ public abstract class EjbDescriptor extends CommonResourceDescriptor implements 
      * Keep a record of all the Method Permissions exactly as they were in the DD
      */
     private void saveMethodPermissionFromDD(MethodPermission methodPermission, MethodDescriptor methodDescriptor) {
-        if (methodPermissionsFromDD == null) {
-            methodPermissionsFromDD = new HashMap<>();
-        }
-
         // We organize by permission, makes it easier...
         // Use Array List as opposed to HashMap or Table because MethodDescriptor
         // Equality once did not take into account differences in
         // method interface, and will process sequentially.
-
-        methodPermissionsFromDD.computeIfAbsent(methodPermission, e -> new ArrayList<>())
-        .add(methodDescriptor);
+        methodPermissionsFromDD.computeIfAbsent(methodPermission, e -> new ArrayList<>()).add(methodDescriptor);
     }
 
     /**

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/EJBSecurityManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/EJBSecurityManager.java
@@ -227,7 +227,7 @@ public final class EJBSecurityManager implements SecurityManager {
                 () -> new GlassFishPrincipalMapper(contextId));
 
         authorizationService.addPermissionsToPolicy(
-                PayaraToExousiaConverter.convertEJBMethodPermissions(ejbDescriptor, contextId));
+                PayaraToExousiaConverter.convertEJBMethodPermissions(ejbDescriptor));
 
         authorizationService.addPermissionsToPolicy(RolesToPermissionsTransformer.createEnterpriseBeansRoleRefPermission(
                 ejbDescriptor.getEjbBundleDescriptor()

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/EJBSecurityManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/EJBSecurityManager.java
@@ -38,6 +38,8 @@
  * holder.
  */
 // Portions Copyright 2016-2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license.
+
 package org.glassfish.ejb.security.application;
 
 import com.sun.ejb.EjbInvocation;

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/PayaraToExousiaConverter.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/PayaraToExousiaConverter.java
@@ -63,16 +63,14 @@ public class PayaraToExousiaConverter {
      * EJBMethodPermission to be added to the returned JakartaPermissions instance.
      *
      * @param ejbDescriptor the ejb descriptor for this EJB.
-     * @param contextId the policy context identifier.
      */
-    public static JakartaPermissions convertEJBMethodPermissions(EjbDescriptor ejbDescriptor, String contextId) throws PolicyContextException {
+    public static JakartaPermissions convertEJBMethodPermissions(EjbDescriptor ejbDescriptor) throws PolicyContextException {
         JakartaPermissions jakartaPermissions = new JakartaPermissions();
 
         String ejbName = ejbDescriptor.getName();
 
         // phase 1
-        Map<MethodPermission, List<MethodDescriptor>> methodPermissionsFromDD = ejbDescriptor
-                .getMethodPermissionsFromDD();
+        Map<MethodPermission, List<MethodDescriptor>> methodPermissionsFromDD = ejbDescriptor.getMethodPermissionsFromDD();
 
         for (var methodPermissionFromDD : methodPermissionsFromDD.entrySet()) {
             MethodPermission methodPermission = methodPermissionFromDD.getKey();

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/PayaraToExousiaConverter.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/PayaraToExousiaConverter.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.ejb.security.application;
+
+import com.sun.enterprise.deployment.MethodDescriptor;
+import com.sun.enterprise.deployment.MethodPermission;
+import com.sun.enterprise.deployment.RoleReference;
+import com.sun.logging.LogDomains;
+
+import jakarta.security.jacc.EJBMethodPermission;
+import jakarta.security.jacc.PolicyContextException;
+
+import java.lang.reflect.Method;
+import java.security.Permission;
+import java.security.Permissions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
+import org.glassfish.exousia.mapping.SecurityRoleRef;
+import org.glassfish.exousia.permissions.JakartaPermissions;
+
+import static java.util.Collections.list;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.SEVERE;
+
+public class PayaraToExousiaConverter {
+
+    private static final Logger _logger = LogDomains.getLogger(EJBSecurityManager.class, LogDomains.EJB_LOGGER);
+
+    /**
+     * This method converts the deployment descriptor in two phases.
+     *
+     * <p>
+     * Phase 1: gets a map representing the methodPermission elements exactly as they
+     * occured for the ejb in the dd. The map is keyed by method-permission element and each method-permission is mapped to a list of
+     * method elements representing the method elements of the method permision element. Each method element is converted to a
+     * corresponding EJBMethodPermission and added, based on its associated method-permission, to the returned JakartaPermissions instance.
+     *
+     * <p>
+     * phase 2: configures additional EJBMethodPermission policy statements for the purpose of optimizing Permissions.implies
+     * matching by the policy provider. This phase also configures unchecked policy statements for any uncovered methods. This method
+     * gets the list of method descriptors for the ejb from the EjbDescriptor object. For each method descriptor, it will get a list
+     * of MethodPermission objects that signify the method permissions for the Method and convert each to a corresponding
+     * EJBMethodPermission to be added to the returned JakartaPermissions instance.
+     *
+     * @param ejbDescriptor the ejb descriptor for this EJB.
+     * @param contextId the policy context identifier.
+     */
+    public static JakartaPermissions convertEJBMethodPermissions(EjbDescriptor ejbDescriptor, String contextId) throws PolicyContextException {
+        JakartaPermissions jakartaPermissions = new JakartaPermissions();
+
+        String ejbName = ejbDescriptor.getName();
+
+        // phase 1
+        Map<MethodPermission, List<MethodDescriptor>> methodPermissionsFromDD = ejbDescriptor
+                .getMethodPermissionsFromDD();
+
+        for (var methodPermissionFromDD : methodPermissionsFromDD.entrySet()) {
+            MethodPermission methodPermission = methodPermissionFromDD.getKey();
+            for (MethodDescriptor methodDescriptor : methodPermissionFromDD.getValue()) {
+                String methodName = methodDescriptor.getName();
+                String methodInterface = methodDescriptor.getEjbClassSymbol();
+                String methodParameters[] = methodDescriptor.getStyle() == 3
+                        ? methodDescriptor.getParameterClassNames()
+                        : null;
+
+                EJBMethodPermission ejbMethodPermission = new EJBMethodPermission(ejbName,
+                        methodName.equals("*") ? null : methodName, methodInterface, methodParameters);
+
+                if (methodPermission.isExcluded()) {
+                    jakartaPermissions.getExcluded().add(ejbMethodPermission);
+                } else if (methodPermission.isUnchecked()) {
+                    jakartaPermissions.getUnchecked().add(ejbMethodPermission);
+                } else if (methodPermission.isRoleBased()) {
+                    jakartaPermissions.getPerRole()
+                            .computeIfAbsent(methodPermission.getRole().getName(), e -> new Permissions())
+                            .add(ejbMethodPermission);
+                }
+            }
+        }
+
+        // phase 2 - configures additional perms:
+        //      . to optimize performance of Permissions.implies
+        //      . to cause any uncovered methods to be unchecked
+
+        for (MethodDescriptor methodDescriptor : ejbDescriptor.getMethodDescriptors()) {
+
+            Method methodName = methodDescriptor.getMethod(ejbDescriptor);
+            String methodInterface = methodDescriptor.getEjbClassSymbol();
+
+            if (methodName == null) {
+                continue;
+            }
+
+            if (methodInterface == null || methodInterface.isEmpty()) {
+                _logger.log(SEVERE, "method_descriptor_not_defined",
+                        new Object[] { ejbName, methodDescriptor.getName(), methodDescriptor.getParameterClassNames() });
+
+                continue;
+            }
+
+            EJBMethodPermission ejbMethodPermission = new EJBMethodPermission(ejbName, methodInterface, methodName);
+
+            Set<MethodPermission> methodPermissions = ejbDescriptor.getMethodPermissionsFor(methodDescriptor);
+            _logger.log(Level.FINEST, "Descriptor: {0}, permissions: {1}",
+                    new Object[] {methodDescriptor, methodPermissions});
+            for (MethodPermission methodPermission : methodPermissions) {
+                if (methodPermission.isExcluded()) {
+                    jakartaPermissions.getExcluded().add(ejbMethodPermission);
+                } else if (methodPermission.isUnchecked()) {
+                    jakartaPermissions.getUnchecked().add(ejbMethodPermission);
+                } else if (methodPermission.isRoleBased()) {
+                    jakartaPermissions.getPerRole()
+                            .computeIfAbsent(methodPermission.getRole().getName(), e -> new Permissions())
+                            .add(ejbMethodPermission);
+                }
+            }
+        }
+
+        return jakartaPermissions;
+    }
+
+    /**
+     * Get the security role refs from the EjbDescriptor.
+     *
+     * @param ejbDescriptor the EjbDescriptor.
+     * @return the security role refs.
+     */
+    public static Map<String, List<SecurityRoleRef>> getSecurityRoleRefsFromBundle(EjbDescriptor ejbDescriptor) {
+        Map<String, List<SecurityRoleRef>> exousiaRoleRefsPerEnterpriseBean = new HashMap<>();
+
+        List<SecurityRoleRef> exousiaSecurityRoleRefs = new ArrayList<>();
+
+        for (RoleReference glassFishSecurityRoleRef : ejbDescriptor.getRoleReferences()) {
+            exousiaSecurityRoleRefs.add(new SecurityRoleRef(
+                    glassFishSecurityRoleRef.getRoleName(),
+                    glassFishSecurityRoleRef.getSecurityRoleLink().getName()));
+        }
+
+        exousiaRoleRefsPerEnterpriseBean.put(ejbDescriptor.getName(), exousiaSecurityRoleRefs);
+
+        return exousiaRoleRefsPerEnterpriseBean;
+    }
+
+    private static void log(JakartaPermissions jakartaPermissions) {
+        for (Permission ejbMethodPermission : list(jakartaPermissions.getExcluded().elements())) {
+            _logger.log(FINE, () ->
+                    "Jakarta Authorization DD conversion: EJBMethodPermission ->(" +
+                            ejbMethodPermission.getName() + " " + ejbMethodPermission.getActions() +
+                            ") is (excluded)");
+        }
+
+        for (Permission ejbMethodPermission : list(jakartaPermissions.getUnchecked().elements())) {
+            _logger.log(FINE, () ->
+                    "Jakarta Authorization conversion: EJBMethodPermission ->(" +
+                            ejbMethodPermission.getName() + " " + ejbMethodPermission.getActions() +
+                            ") is (unchecked)");
+        }
+
+        for (var perMissionsPerRole : jakartaPermissions.getPerRole().entrySet()) {
+            String role = perMissionsPerRole.getKey();
+            for (Permission ejbMethodPermission : list(perMissionsPerRole.getValue().elements())) {
+                _logger.log(FINE, () ->
+                        "Jakarta Authorization conversion: EJBMethodPermission ->(" +
+                                ejbMethodPermission.getName() + " " + ejbMethodPermission.getActions() +
+                                ")protected by role -> " + role);
+            }
+
+        }
+
+    }
+
+}

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccEJBConstraintsTranslator.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/jacc/JaccEJBConstraintsTranslator.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2019-2024 Payara Foundation and/or its affiliates
 package com.sun.enterprise.security.jacc;
 
 import static com.sun.logging.LogDomains.SECURITY_LOGGER;
@@ -123,23 +123,20 @@ public class JaccEJBConstraintsTranslator {
         // Phase 1
         
         Map<MethodPermission, List<MethodDescriptor>> methodPermissions = ejbDescriptor.getMethodPermissionsFromDD();
-        if (methodPermissions != null) {
-            
-            for (Entry<MethodPermission, List<MethodDescriptor>> permissionEntry : methodPermissions.entrySet()) {
 
-                MethodPermission methodPermission = permissionEntry.getKey();
-                
-                for (MethodDescriptor methodDescriptor : permissionEntry.getValue()) {
-                    String methodName = methodDescriptor.getName().equals("*") ? null : methodDescriptor.getName();
-                    String methodInterface = methodDescriptor.getEjbClassSymbol();
-                    String methodParams[] = methodDescriptor.getStyle() == 3 ? methodDescriptor.getParameterClassNames() : null;
+        for (Entry<MethodPermission, List<MethodDescriptor>> permissionEntry : methodPermissions.entrySet()) {
+            MethodPermission methodPermission = permissionEntry.getKey();
 
-                    EJBMethodPermission ejbMethodPermission = new EJBMethodPermission(ejbName, methodName, methodInterface, methodParams);
-                    
-                    perRolePermissions = addToRolePermissions(perRolePermissions, methodPermission, ejbMethodPermission);
-                    uncheckedPermissions = addToUncheckedPermissions(uncheckedPermissions, methodPermission, ejbMethodPermission);
-                    excludedPermissions = addToExcludedPermissions(excludedPermissions, methodPermission, ejbMethodPermission);
-                }
+            for (MethodDescriptor methodDescriptor : permissionEntry.getValue()) {
+                String methodName = methodDescriptor.getName().equals("*") ? null : methodDescriptor.getName();
+                String methodInterface = methodDescriptor.getEjbClassSymbol();
+                String methodParams[] = methodDescriptor.getStyle() == 3 ? methodDescriptor.getParameterClassNames() : null;
+
+                EJBMethodPermission ejbMethodPermission = new EJBMethodPermission(ejbName, methodName, methodInterface, methodParams);
+
+                perRolePermissions = addToRolePermissions(perRolePermissions, methodPermission, ejbMethodPermission);
+                uncheckedPermissions = addToUncheckedPermissions(uncheckedPermissions, methodPermission, ejbMethodPermission);
+                excludedPermissions = addToExcludedPermissions(excludedPermissions, methodPermission, ejbMethodPermission);
             }
         }
 


### PR DESCRIPTION
## Description
Fixes the EJB authorization tests in the Authorization TCK.
This is intended as a stop-gap solution for now, as I believe this class (and all surrounding JACC code) needs some heavy rewrites - we're only "half" using Exousia in the current state, duplicating a lot of code and so not always using Exousia itself for authorization.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the Authorization TCK, didn't spot any new failures (_app-custom-policy2_ tests fails regardless)
Ran all currently passing TCKs, no new failures (jsp runner is currently broken - ignore. #WorksOnMyMachine): https://jenkins.payara.fish/view/Build/job/JakartaEE-11-TCK/48/

### Testing Environment
OpenSUSE WSL, Maven 3.9.9, Zulu JDK 21.0.4

## Documentation
N/A

## Notes for Reviewers
None
