### PR TITLE
FISH-9961 Revert #7015

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,7 +173,7 @@
         <maven.dependency.plugin.version>3.8.0</maven.dependency.plugin.version>
         <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <maven.deploy.plugin.version>3.1.3</maven.deploy.plugin.version>
-        <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.10.1</maven.javadoc.plugin.version>
         <maven.install.plugin.version>3.1.3</maven.install.plugin.version>
         <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>


### PR DESCRIPTION
## Description
This reverts commit 25f915e9cdf419b2eaa709771fb686862626e786, reversing changes made to c358409cddf764b9ebf416e981c38acd4d5c979b in #7015

It breaks the generation of sources and needs addressing separately
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.1:jar-no-fork (attach-sources) on project opentelemetry-repackaged: Presumably you have configured maven-source-plugin to execute twice in your build. You have to configure a classifier for at least one of them. -> [Help 1]`

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the server and let sources get generated

### Testing Environment
Windows 11, Zulu JDK 11.0.24, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
