### PR TITLE
FISH-8927 Upgrade Authentication API

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
         <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
         <jsonp-api.version>2.1.3</jsonp-api.version>
-        <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>
+        <jakarta.security.auth.message-api.version>3.1.0</jakarta.security.auth.message-api.version>
         <jakarta.authorization-api.version>3.0.0-M4</jakarta.authorization-api.version>
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
         <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
         <jsonp-api.version>2.1.3</jsonp-api.version>
-        <jakarta.security.auth.message-api.version>3.1.0</jakarta.security.auth.message-api.version>
+        <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
         <jakarta.authorization-api.version>3.0.0-M4</jakarta.authorization-api.version>
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
@@ -911,7 +911,7 @@
             <dependency>
                 <groupId>jakarta.authentication</groupId>
                 <artifactId>jakarta.authentication-api</artifactId>
-                <version>${jakarta.security.auth.message-api.version}</version>
+                <version>${jakarta.authentication-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.persistence</groupId>


### PR DESCRIPTION
## Description
Upgrades the Authentication API to 3.1.1, and removes Security Manager code from the `BaseAuthConfigFactory` as the permissions inherited from the Jakarta API had been removed.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the server and let unit tests run, started the admin console and poked around - no explosions

### Testing Environment
Windows 11, Zulu JDK 21.0.4, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
