### PR TITLE
FISH-10049 bugfix: Split CDI bean deployment when multiple WARs exist in an EAR

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.concurrent.runtime;
 
@@ -378,9 +378,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
             restorer.endContext();
         }
 
-        if (handle.getContextClassLoader() != null) {
-            Utility.setContextClassLoader(handle.getContextClassLoader());
-        }
+        Utility.setContextClassLoader(handle.getContextClassLoader());
         if (handle.getSecurityContext() != null) {
             SecurityContext.setCurrent(handle.getSecurityContext());
         }

--- a/appserver/deployment/javaee-full/src/main/java/org/glassfish/javaee/full/deployment/EarDeployer.java
+++ b/appserver/deployment/javaee-full/src/main/java/org/glassfish/javaee/full/deployment/EarDeployer.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.javaee.full.deployment;
 
@@ -101,7 +102,7 @@ import org.glassfish.logging.annotation.LogMessagesResourceBundle;
 @Service
 @PerLookup
 public class EarDeployer implements Deployer {
-
+    public static final String PER_BDA_METADATA_KEY = "[PerBDA]";
     //    private static final Class GLASSFISH_APPCLIENT_GROUP_FACADE_CLASS =
 //            org.glassfish.appclient.client.AppClientGroupFacade.class;
 // Currently using a string instead of a Class constant to avoid a circular
@@ -457,15 +458,21 @@ public class EarDeployer implements Deployer {
         @Override
         public void addTransientAppMetaData(String metaDataKey,
                                             Object metaData) {
-            context.addTransientAppMetaData(metaDataKey,
-                metaData);
+            if (metaDataKey.startsWith(PER_BDA_METADATA_KEY)) {
+                super.addTransientAppMetaData(metaDataKey, metaData);
+            } else {
+                context.addTransientAppMetaData(metaDataKey, metaData);
+            }
         }
 
         @Override
         public <T> T getTransientAppMetaData(String metaDataKey,
                                              Class<T> metadataType) {
-            return context.getTransientAppMetaData(metaDataKey,
-                metadataType);
+            if (metaDataKey.startsWith(PER_BDA_METADATA_KEY)) {
+                return super.getTransientAppMetaData(metaDataKey, metadataType);
+            } else {
+                return context.getTransientAppMetaData(metaDataKey, metadataType);
+            }
         }
 
         @Override

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -65,6 +65,7 @@ import com.sun.appserv.server.util.PreprocessorUtil;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.glassfish.bootstrap.MainHelper.HotSwapHelper;
+import com.sun.enterprise.loader.CacheCleaner;
 import com.sun.enterprise.security.integration.DDPermissionsLoader;
 import com.sun.enterprise.security.integration.PermsHolder;
 import com.sun.enterprise.util.io.FileUtils;
@@ -2051,7 +2052,7 @@ public class WebappClassLoader
         // START SJSAS 6258619
         ClassLoaderUtil.releaseLoader(this);
         // END SJSAS 6258619
-        clearJaxRSCache();
+        CacheCleaner.clearCaches(this);
 
         synchronized(jarFilesLock) {
             started = false;
@@ -2655,23 +2656,6 @@ public class WebappClassLoader
                         getString(LogFacade.CLEAR_RMI_FAIL,
                         contextName), e);
             }
-        }
-    }
-
-    private void clearJaxRSCache() {
-        try {
-            Class<?> cdiComponentProvider = CachingReflectionUtil
-                    .getClassFromCache("org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider", this);
-            if (cdiComponentProvider != null) {
-                Field runtimeSpecificsField = CachingReflectionUtil.getFieldFromCache(cdiComponentProvider,
-                        "runtimeSpecifics", true);
-                Object runtimeSpecifics = runtimeSpecificsField.get(null);
-                CachingReflectionUtil.getMethodFromCache(runtimeSpecifics.getClass(),
-                                "clearJaxRsResource", true, ClassLoader.class)
-                        .invoke(runtimeSpecifics, this);
-            }
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Error clearing Jax-Rs cache", e);
         }
     }
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/ACLSingletonProvider.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/ACLSingletonProvider.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2019] Payara Foundation and/or affiliates
+ * Portions Copyright [2017-2024] Payara Foundation and/or affiliates
  */
 
 package org.glassfish.weld;
@@ -108,11 +108,11 @@ public class ACLSingletonProvider extends SingletonProvider
       @Override
       public T get( String id )
       {
-        ClassLoader acl = getClassLoader();
-        T instance = store.get(acl);
+        T instance = storeById.get(id);
         if (instance == null)
         {
-            instance = storeById.get(id);
+            ClassLoader acl = getClassLoader();
+            instance = store.get(acl);
             if (instance == null) {
                 throw new IllegalStateException("Singleton not set for " + acl);
             }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -62,9 +62,12 @@ import jakarta.enterprise.inject.spi.InjectionTarget;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
@@ -79,37 +82,37 @@ import static org.glassfish.web.loader.NonCachedJarStreamHandler.forceNonCachedJ
 import static org.glassfish.weld.WeldDeployer.WELD_BOOTSTRAP;
 import static org.glassfish.weld.connector.WeldUtils.*;
 
-
-
 /*
  * The means by which Weld Beans are discovered on the classpath.
  */
-public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
+public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive, Serializable {
+    private static final long serialVersionUID = 1L;
 
     private static final Logger logger = Logger.getLogger(BeanDeploymentArchiveImpl.class.getName());
 
-    private ReadableArchive archive;
-    private String id;
-    private List<String> moduleClassNames = null; // Names of classes in the module
-    private List<String> beanClassNames = null; // Names of bean classes in the module
-    private List<Class<?>> moduleClasses = null; // Classes in the module
-    private List<Class<?>> beanClasses = null; // Classes identified as Beans through Weld SPI
-    private List<URL> beansXmlURLs = null;
-    private final Collection<EjbDescriptor<?>> ejbDescImpls;
-    private List<BeanDeploymentArchive> beanDeploymentArchives;
+    private transient ReadableArchive archive;
+    private final String id;
+    private final List<String> moduleClassNames; // Names of classes in the module
+    private final List<String> beanClassNames; // Names of bean classes in the module
+    private transient List<Class<?>> moduleClasses; // Classes in the module
+    private transient List<Class<?>> beanClasses; // Classes identified as Beans through Weld SPI
+    private final List<URL> beansXmlURLs;
+    private transient Collection<EjbDescriptor<?>> ejbDescImpls;
+    private transient Set<BeanDeploymentArchive> beanDeploymentArchives;
+    private transient List<BeanDeploymentArchive> deserializedBDAs;
 
-    private SimpleServiceRegistry simpleServiceRegistry = null;
+    private transient SimpleServiceRegistry simpleServiceRegistry = null;
+    private int originalIdentity;
 
     private BDAType bdaType = BDAType.UNKNOWN;
 
-    private DeploymentContext context;
+    transient DeploymentContext context;
+    transient WeldBootstrap weldBootstrap;
 
-    private WeldBootstrap weldBootstrap;
-
-    private final Map<AnnotatedType<?>, InjectionTarget<?>> itMap = new HashMap<>();
+    private transient Map<AnnotatedType<?>, InjectionTarget<?>> itMap = new HashMap<>();
 
     //workaround: WELD-781
-    private ClassLoader moduleClassLoaderForBDA = null;
+    private transient ClassLoader moduleClassLoaderForBDA;
 
     private String friendlyId = "";
 
@@ -147,8 +150,8 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         }
 
         this.friendlyId = this.id;
-        this.ejbDescImpls = new HashSet<>();
-        this.beanDeploymentArchives = new ArrayList<>();
+        this.ejbDescImpls = new LinkedHashSet<>();
+        this.beanDeploymentArchives = new LinkedHashSet<>();
         this.context = ctx;
         this.weldBootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
 
@@ -184,8 +187,8 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         }
 
         this.beansXmlURLs = beansXmlUrls;
-        this.ejbDescImpls = new HashSet<>();
-        this.beanDeploymentArchives = new ArrayList<>();
+        this.ejbDescImpls = new LinkedHashSet<>();
+        this.beanDeploymentArchives = new LinkedHashSet<>();
         this.context = ctx;
         this.weldBootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
         populateEJBsForThisBDA(ejbs);
@@ -194,6 +197,39 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         getClassLoader();
     }
 
+    public BeanDeploymentArchiveImpl(BeanDeploymentArchiveImpl beanDeploymentArchive) {
+        this.id = beanDeploymentArchive.id;
+        this.originalIdentity = beanDeploymentArchive.originalIdentity;
+        this.moduleClassNames = new ArrayList<>(beanDeploymentArchive.moduleClassNames);
+        this.beanClassNames = new ArrayList<>(beanDeploymentArchive.beanClassNames);
+        this.beansXmlURLs = new CopyOnWriteArrayList<>(beanDeploymentArchive.beansXmlURLs);
+        this.deserializedBDAs = beanDeploymentArchive.deserializedBDAs;
+        this.friendlyId = beanDeploymentArchive.friendlyId;
+        this.bdaType = beanDeploymentArchive.bdaType;
+        this.deploymentComplete = beanDeploymentArchive.deploymentComplete;
+
+        initializeFromOriginal();
+    }
+
+    void initializeFromOriginal() {
+        if (context == null) {
+            this.context = DeploymentImpl.currentDeploymentContext.get();
+            this.weldBootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
+            this.moduleClasses = getOriginal().moduleClasses;
+            this.beanClasses = getOriginal().beanClasses;
+            getServices().addAll(getOriginal().getServices().entrySet());
+            this.moduleClassLoaderForBDA = getOriginal().moduleClassLoaderForBDA;
+            this.ejbDescImpls = new LinkedHashSet<>(getOriginal().ejbDescImpls);
+            if (this.itMap == null) {
+                this.itMap = new HashMap<>();
+            }
+            this.itMap.putAll(getOriginal().itMap);
+        }
+    }
+
+    BeanDeploymentArchiveImpl getOriginal() {
+        return DeploymentImpl.currentBDAs.get().get(originalIdentity);
+    }
 
     private void populateEJBsForThisBDA(Collection<com.sun.enterprise.deployment.EjbDescriptor> ejbs) {
         for (com.sun.enterprise.deployment.EjbDescriptor next : ejbs) {
@@ -208,11 +244,15 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
 
     @Override
     public Collection<BeanDeploymentArchive> getBeanDeploymentArchives() {
+        if (beanDeploymentArchives == null && deserializedBDAs != null) {
+            beanDeploymentArchives = new LinkedHashSet<>(deserializedBDAs);
+        }
         return beanDeploymentArchives;
     }
 
     @Override
     public Collection<String> getBeanClasses() {
+        initializeFromOriginal();
         //This method is called during BeanDeployment.deployBeans, so this would
         //be the right time to place the module classloader for the BDA as the TCL
         if (logger.isLoggable(FINER)) {
@@ -230,6 +270,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     }
 
     public Collection<Class<?>> getBeanClassObjects() {
+        initializeFromOriginal();
         return beanClasses;
     }
 
@@ -238,6 +279,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     }
 
     public Collection<Class<?>> getModuleBeanClassObjects() {
+        initializeFromOriginal();
         return moduleClasses;
     }
 
@@ -272,7 +314,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         if (beansXmlURLs.size() == 1) {
             result = weldBootstrap.parse(beansXmlURLs.get(0));
         } else {
-            // This method attempts to performs a merge, but loses some
+            // This method attempts to perform a merge, but loses some
             // information (e.g., version, bean-discovery-mode)
             result = weldBootstrap.parse(beansXmlURLs);
         }
@@ -287,11 +329,12 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
      */
     @Override
     public Collection<EjbDescriptor<?>> getEjbs() {
-
+        initializeFromOriginal();
         return ejbDescImpls;
     }
 
     public EjbDescriptor getEjbDescriptor(String ejbName) {
+        initializeFromOriginal();
         EjbDescriptor match = null;
 
         for (EjbDescriptor next : ejbDescImpls) {
@@ -306,6 +349,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
 
     @Override
     public ServiceRegistry getServices() {
+        initializeFromOriginal();
         if (simpleServiceRegistry == null) {
             simpleServiceRegistry = new SimpleServiceRegistry();
         }
@@ -328,10 +372,36 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
 
     @Override
     public Collection<Class<?>> getLoadedBeanClasses() {
+        initializeFromOriginal();
         return beanClasses;
     }
 
+    Object readResolve() throws ObjectStreamException {
+        return new BeanDeploymentArchiveImpl(this);
+    }
 
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        originalIdentity = System.identityHashCode(this);
+        if (DeploymentImpl.currentBDAs.get().put(originalIdentity, this) != null) {
+            throw new IllegalStateException("Duplicate BDA detected: " + this);
+        }
+        out.writeInt(originalIdentity);
+        out.writeInt(beanDeploymentArchives.size());
+        for (BeanDeploymentArchive bda : beanDeploymentArchives) {
+            out.writeObject(bda);
+        }
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        originalIdentity = in.readInt();
+        int size = in.readInt();
+        deserializedBDAs = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            deserializedBDAs.add((BeanDeploymentArchive) in.readObject());
+        }
+    }
 
     //A graphical representation of the BDA hierarchy to aid in debugging
     //and to provide a better representation of how Weld treats the deployed
@@ -601,14 +671,13 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
             }
             //update modified BDA
             if (modified) {
-                int idx = this.beanDeploymentArchives.indexOf(firstBDA);
                 if (logger.isLoggable(FINE)) {
                     logger.log(FINE,
                                CDILoggerInfo.ENSURE_WEB_LIB_JAR_VISIBILITY_ASSOCIATION_UPDATING,
                                new Object[]{firstBDA.getFriendlyId()});
                 }
-                if (idx >= 0) {
-                    this.beanDeploymentArchives.set(idx, firstBDA);
+                if (this.beanDeploymentArchives.remove(firstBDA)) {
+                    this.beanDeploymentArchives.add(firstBDA);
                 }
             }
         }
@@ -622,9 +691,8 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                            CDILoggerInfo.ENSURE_WEB_LIB_JAR_VISIBILITY_ASSOCIATION_INCLUDING,
                            new Object[]{subBDA.getId(), this.getId()});
             }
-            int idx = this.beanDeploymentArchives.indexOf(subBDA);
-            if (idx >= 0) {
-                this.beanDeploymentArchives.set(idx, subBDA);
+            if (this.beanDeploymentArchives.remove(subBDA)) {
+                this.beanDeploymentArchives.add(subBDA);
             }
         }
     }
@@ -741,14 +809,17 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     }
 
     public InjectionTarget<?> getInjectionTarget(AnnotatedType<?> annotatedType) {
+        initializeFromOriginal();
         return itMap.get(annotatedType);
     }
 
     void putInjectionTarget(AnnotatedType<?> annotatedType, InjectionTarget<?> it) {
+        initializeFromOriginal();
         itMap.put(annotatedType, it);
     }
 
     public ClassLoader getModuleClassLoaderForBDA() {
+        initializeFromOriginal();
         return moduleClassLoaderForBDA;
     }
 
@@ -852,5 +923,18 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
             }
         }
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BeanDeploymentArchiveImpl)) return false;
+        BeanDeploymentArchiveImpl that = (BeanDeploymentArchiveImpl) o;
+        return Objects.equals(id, that.id) && Objects.equals(beanClasses, that.beanClasses);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, beanClasses);
     }
 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanManagerNamingProxy.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanManagerNamingProxy.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -93,7 +94,9 @@ public class BeanManagerNamingProxy implements NamedNamingObjectProxy {
 
                 if( inv != null ) {
 
-                    JndiNameEnvironment componentEnv = compEnvManager.getJndiNameEnvironment(inv.getComponentId());
+                    JndiNameEnvironment componentEnv = inv.getComponentId() != null
+                            ? compEnvManager.getJndiNameEnvironment(inv.getComponentId())
+                            : null;
 
                     if( componentEnv != null ) {
 
@@ -112,7 +115,7 @@ public class BeanManagerNamingProxy implements NamedNamingObjectProxy {
                         if( bundle != null ) {
                             BeanDeploymentArchive bda = weldDeployer.getBeanDeploymentArchiveForBundle(bundle);
                             if( bda != null ) {
-                                WeldBootstrap bootstrap = weldDeployer.getBootstrapForApp(bundle.getApplication());
+                                WeldBootstrap bootstrap = weldDeployer.getBootstrapForArchive(bda);
                                 //System.out.println("BeanManagerNamingProxy:: getting BeanManagerImpl for" + bda);
                                 beanManager = bootstrap.getManager(bda);
                             }
@@ -121,7 +124,6 @@ public class BeanManagerNamingProxy implements NamedNamingObjectProxy {
                         if( beanManager == null) {
                             throw new IllegalStateException("Cannot resolve bean manager");
                         }
-
 
                     } else {
                         throw new IllegalStateException("No invocation context found");
@@ -137,6 +139,4 @@ public class BeanManagerNamingProxy implements NamedNamingObjectProxy {
 
         return beanManager;
     }
-
-
 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -45,9 +45,15 @@ import com.sun.enterprise.container.common.spi.util.InjectionManager;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.glassfish.weld.connector.WeldUtils.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -62,9 +68,11 @@ import com.sun.enterprise.deploy.shared.ArchiveFactory;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.cdi.CDILoggerInfo;
+import org.glassfish.common.util.ObjectInputStreamWithLoader;
 import org.glassfish.deployment.common.DeploymentContextImpl;
 import org.glassfish.deployment.common.InstalledLibrariesResolver;
 import org.glassfish.hk2.classmodel.reflect.Types;
+import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.javaee.core.deployment.ApplicationHolder;
 import org.glassfish.weld.connector.WeldUtils;
 import org.glassfish.weld.connector.WeldUtils.BDAType;
@@ -85,47 +93,51 @@ import org.jboss.weld.injection.spi.InjectionServices;
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
 import java.security.PrivilegedAction;
+import java.util.stream.Stream;
 import static java.lang.System.getSecurityManager;
 import static java.security.AccessController.doPrivileged;
 
 import jakarta.enterprise.inject.build.compatible.spi.SkipIfPortableExtensionPresent;
 
-
 /*
  * Represents a deployment of a CDI (Weld) application.
  */
-public class DeploymentImpl implements CDI11Deployment {
+public class DeploymentImpl implements CDI11Deployment, Serializable {
+    private static final long serialVersionUID = 1L;
+    static final ThreadLocal<DeploymentImpl> currentDeployment = new ThreadLocal<>();
+    static final ThreadLocal<Map<Integer, BeanDeploymentArchiveImpl>> currentBDAs = new ThreadLocal<>();
+    static final ThreadLocal<DeploymentContext> currentDeploymentContext = new ThreadLocal<>();
 
     // Keep track of our BDAs for this deployment
-    private List<RootBeanDeploymentArchive> rarRootBdas;
-    private List<RootBeanDeploymentArchive> ejbRootBdas;
-    private List<RootBeanDeploymentArchive> warRootBdas;
-    private List<RootBeanDeploymentArchive> libJarRootBdas = null;
+    private final Set<RootBeanDeploymentArchive> rarRootBdas = new LinkedHashSet<>();
+    final Set<RootBeanDeploymentArchive> ejbRootBdas = new LinkedHashSet<>();
+    private final Set<RootBeanDeploymentArchive> warRootBdas = new LinkedHashSet<>();
+    private final Set<RootBeanDeploymentArchive> libJarRootBdas = new LinkedHashSet<>();
 
-    private List<BeanDeploymentArchive> beanDeploymentArchives = new ArrayList<>();
-    private DeploymentContext context;
+    private final Set<BeanDeploymentArchive> beanDeploymentArchives = new LinkedHashSet<>();
+    final transient DeploymentContext context;
 
     // A convenience Map to get BDA for a given BDA ID
-    private Map<String, BeanDeploymentArchive> idToBeanDeploymentArchive = new HashMap<>();
-    private SimpleServiceRegistry simpleServiceRegistry = null;
+    final Map<String, BeanDeploymentArchive> idToBeanDeploymentArchive = new HashMap<>();
+    private transient SimpleServiceRegistry simpleServiceRegistry = null;
 
-    private Logger logger = CDILoggerInfo.getLogger();
+    private final transient Logger logger;
 
     // holds BDA's created for extensions
-    private Map<ClassLoader, BeanDeploymentArchive> extensionBDAMap = new HashMap<>();
+    private final Map<ClassLoader, BeanDeploymentArchive> extensionBDAMap = new HashMap<>();
 
-    private Iterable<Metadata<Extension>> extensions;
+    private final List<Metadata<Extension>> extensions = new ArrayList<>();
 
-    private List<Metadata<Extension>> dynamicExtensions = new ArrayList<>();
+    private final List<Metadata<Extension>> dynamicExtensions = new ArrayList<>();
 
-    private Collection<EjbDescriptor> deployedEjbs = new LinkedList<>();
-    private ArchiveFactory archiveFactory;
+    private final transient Collection<EjbDescriptor> deployedEjbs;
+    private final transient ArchiveFactory archiveFactory;
 
     private boolean earContextAppLibBdasProcessed = false;
 
     private String appName;
     private String contextId;
-    final InjectionManager injectionManager;
+    final transient InjectionManager injectionManager;
 
     /**
      * Produce <code>BeanDeploymentArchive</code>s for this <code>Deployment</code>
@@ -137,6 +149,8 @@ public class DeploymentImpl implements CDI11Deployment {
                           ArchiveFactory archiveFactory,
                           String moduleName,
                           InjectionManager injectionManager) {
+        logger = CDILoggerInfo.getLogger();
+        deployedEjbs = new LinkedList<>();
         if ( logger.isLoggable( FINE ) ) {
             logger.log(FINE, CDILoggerInfo.CREATING_DEPLOYMENT_ARCHIVE, new Object[]{ archive.getName()});
         }
@@ -147,8 +161,8 @@ public class DeploymentImpl implements CDI11Deployment {
         // Collect /lib Jar BDAs (if any) from the parent module.
         // If we've produced BDA(s) from any /lib jars, <code>return</code> as
         // additional BDA(s) will be produced for any subarchives (war/jar).
-        libJarRootBdas = scanForLibJars(archive, ejbs, context);
-        if ((libJarRootBdas != null) && !libJarRootBdas.isEmpty()) {
+        libJarRootBdas.addAll(scanForLibJars(archive, ejbs, context));
+        if (!libJarRootBdas.isEmpty()) {
             return;
         }
 
@@ -165,24 +179,112 @@ public class DeploymentImpl implements CDI11Deployment {
         createModuleBda(archive, ejbs, context, contextId);
     }
 
+    DeploymentImpl(DeploymentImpl deployment) {
+        this.rarRootBdas.addAll(deployment.rarRootBdas);
+        this.ejbRootBdas.addAll(deployment.ejbRootBdas);
+        this.warRootBdas.addAll(deployment.warRootBdas);
+        this.libJarRootBdas.addAll(deployment.libJarRootBdas);
+        this.beanDeploymentArchives.addAll(deployment.beanDeploymentArchives);
+        this.appName = deployment.appName;
+        this.contextId = deployment.contextId;
+        this.earContextAppLibBdasProcessed = deployment.earContextAppLibBdasProcessed;
+
+        this.context = currentDeploymentContext.get();
+        this.archiveFactory = currentDeployment.get().archiveFactory;
+        getServices().addAll(currentDeployment.get().getServices().entrySet());
+        this.injectionManager = currentDeployment.get().injectionManager;
+        this.logger = currentDeployment.get().logger;
+        this.deployedEjbs = currentDeployment.get().deployedEjbs;
+    }
+
+    DeploymentImpl filter(RootBeanDeploymentArchive rootBDA, ApplicationInfo applicationInfo) {
+        DeploymentImpl filteredDeployment;
+        try {
+            filteredDeployment = serializeAndDeserialize(this, applicationInfo.getAppClassLoader());
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+
+        List<String> nonRooIDs = List.of(rootBDA.getId(), rootBDA.getModuleBda().getId());
+        filteredDeployment.clearAndAddAll(filteredDeployment.warRootBdas, filterBDAs(filteredDeployment.warRootBdas, nonRooIDs));
+        filteredDeployment.clearAndAddAll(filteredDeployment.beanDeploymentArchives,
+                filterBDAs(filteredDeployment.beanDeploymentArchives, nonRooIDs, filteredDeployment.rarRootBdas,
+                        filteredDeployment.ejbRootBdas, filteredDeployment.libJarRootBdas));
+        filteredDeployment.contextId = rootBDA.getId() + ".bda";
+        return filteredDeployment;
+    }
+
+    private <TT extends BeanDeploymentArchive> void clearAndAddAll(Set<TT> originalBdas, Set<TT> bdas) {
+        originalBdas.clear();
+        originalBdas.addAll(bdas);
+    }
+
+    Set<RootBeanDeploymentArchive> getRootBDAs() {
+        if (!warRootBdas.isEmpty()) {
+            return warRootBdas;
+        } else if (!ejbRootBdas.isEmpty()) {
+            return ejbRootBdas;
+        } else if (!rarRootBdas.isEmpty()) {
+            return rarRootBdas;
+        } else if (!libJarRootBdas.isEmpty()) {
+            return libJarRootBdas;
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <TT> TT serializeAndDeserialize(TT original, ClassLoader classLoader)
+            throws IOException, ClassNotFoundException {
+        // serialize
+        var byteArrayOutputStream = new ByteArrayOutputStream();
+        try (var outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            outputStream.writeObject(original);
+        }
+
+        // deserialize
+        try (var inputStream = new ObjectInputStreamWithLoader(
+                new ByteArrayInputStream(byteArrayOutputStream.toByteArray()), classLoader)) {
+            return (TT) inputStream.readObject();
+        }
+    }
+
+    Object readResolve() throws ObjectStreamException {
+        return new DeploymentImpl(this);
+    }
+
+    @SafeVarargs
+    private <TT extends BeanDeploymentArchive> Set<TT> filterBDAs(Set<TT> bdas, List<String> bda,
+                                                                   Set<RootBeanDeploymentArchive>... include) {
+        if (bdas == null) {
+            return null;
+        }
+        List<RootBeanDeploymentArchive> includeRootList = Arrays.stream(include)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(toList());
+        List<BeanDeploymentArchive> includeList = includeRootList.stream()
+                .flatMap(list -> Stream.of(list, list.getModuleBda()))
+                .collect(toList());
+        return bdas.stream()
+                .filter(b -> bda.stream().anyMatch(b.getId()::startsWith) || includeList.contains(b))
+                .collect(toSet());
+    }
+
     private void addBeanDeploymentArchives(RootBeanDeploymentArchive bda) {
+        rootBDAs(bda).add(bda);
+    }
+
+    private Set<RootBeanDeploymentArchive> rootBDAs(RootBeanDeploymentArchive bda) {
         BDAType moduleBDAType = bda.getModuleBDAType();
         if (moduleBDAType.equals(BDAType.WAR)) {
-            if (warRootBdas == null) {
-                warRootBdas = new ArrayList<>();
-            }
-            warRootBdas.add(bda);
+            return warRootBdas;
         } else if (moduleBDAType.equals(BDAType.JAR)) {
-            if (ejbRootBdas == null) {
-                ejbRootBdas = new ArrayList<>();
-            }
-            ejbRootBdas.add(bda);
+            return ejbRootBdas;
         } else if (moduleBDAType.equals(BDAType.RAR)) {
-            if (rarRootBdas == null) {
-                rarRootBdas = new ArrayList<>();
-            }
-            rarRootBdas.add(bda);
+            return rarRootBdas;
         }
+        throw new IllegalArgumentException("Unknown BDAType: " + moduleBDAType);
     }
 
     /**
@@ -192,14 +294,13 @@ public class DeploymentImpl implements CDI11Deployment {
      * been created.
      */
     public void scanArchive(ReadableArchive archive, Collection<EjbDescriptor> ejbs, DeploymentContext context, String moduleName) {
-        if (libJarRootBdas == null) {
-            libJarRootBdas = scanForLibJars(archive, ejbs, context);
-            if ((libJarRootBdas != null) && !libJarRootBdas.isEmpty()) {
+        if (libJarRootBdas.isEmpty()) {
+            libJarRootBdas.addAll(scanForLibJars(archive, ejbs, context));
+            if (!libJarRootBdas.isEmpty()) {
                 return;
             }
         }
 
-        this.context = context;
         createModuleBda(archive, ejbs, context, moduleName);
     }
 
@@ -214,52 +315,44 @@ public class DeploymentImpl implements CDI11Deployment {
         //    /ejb1.jar <----> /ejb2.jar
         // If there are any application (/lib) jars, make them accessible
 
-        if (ejbRootBdas != null) {
-            for (RootBeanDeploymentArchive ejbRootBda : ejbRootBdas) {
-                BeanDeploymentArchive ejbModuleBda = ejbRootBda.getModuleBda();
+        for (RootBeanDeploymentArchive ejbRootBda : ejbRootBdas) {
+            BeanDeploymentArchive ejbModuleBda = ejbRootBda.getModuleBda();
 
-                boolean modifiedArchive = false;
-                for (RootBeanDeploymentArchive otherEjbRootBda : ejbRootBdas) {
-                    BeanDeploymentArchive otherEjbModuleBda = otherEjbRootBda.getModuleBda();
-                    if (otherEjbModuleBda.getId().equals(ejbModuleBda.getId())) {
-                        continue;
-                    }
-                    ejbRootBda.getBeanDeploymentArchives().add(otherEjbRootBda);
-                    ejbRootBda.getBeanDeploymentArchives().add(otherEjbModuleBda);
-                    ejbModuleBda.getBeanDeploymentArchives().add(otherEjbModuleBda);
-                    modifiedArchive = true;
+            boolean modifiedArchive = false;
+            for (RootBeanDeploymentArchive otherEjbRootBda : ejbRootBdas) {
+                BeanDeploymentArchive otherEjbModuleBda = otherEjbRootBda.getModuleBda();
+                if (otherEjbModuleBda.getId().equals(ejbModuleBda.getId())) {
+                    continue;
                 }
+                ejbRootBda.getBeanDeploymentArchives().add(otherEjbRootBda);
+                ejbRootBda.getBeanDeploymentArchives().add(otherEjbModuleBda);
+                ejbModuleBda.getBeanDeploymentArchives().add(otherEjbModuleBda);
+                modifiedArchive = true;
+            }
 
-                // Make /lib jars accessible to the ejbs.
-                if (libJarRootBdas != null) {
-                    for (RootBeanDeploymentArchive libJarRootBda : libJarRootBdas) {
-                        BeanDeploymentArchive libJarModuleBda = libJarRootBda.getModuleBda();
-                        ejbRootBda.getBeanDeploymentArchives().add(libJarRootBda);
-                        ejbRootBda.getBeanDeploymentArchives().add(libJarModuleBda);
-                        ejbModuleBda.getBeanDeploymentArchives().add(libJarRootBda);
-                        ejbModuleBda.getBeanDeploymentArchives().add(libJarModuleBda);
-                        modifiedArchive = true;
-                    }
-                }
+            // Make /lib jars accessible to the ejbs.
+            for (RootBeanDeploymentArchive libJarRootBda : libJarRootBdas) {
+                BeanDeploymentArchive libJarModuleBda = libJarRootBda.getModuleBda();
+                ejbRootBda.getBeanDeploymentArchives().add(libJarRootBda);
+                ejbRootBda.getBeanDeploymentArchives().add(libJarModuleBda);
+                ejbModuleBda.getBeanDeploymentArchives().add(libJarRootBda);
+                ejbModuleBda.getBeanDeploymentArchives().add(libJarModuleBda);
+                modifiedArchive = true;
+            }
 
-                // Make rars accessible to ejbs
-                if (rarRootBdas != null) {
-                    for (RootBeanDeploymentArchive rarRootBda : rarRootBdas) {
-                        BeanDeploymentArchive rarModuleBda = rarRootBda.getModuleBda();
-                        ejbRootBda.getBeanDeploymentArchives().add(rarRootBda);
-                        ejbRootBda.getBeanDeploymentArchives().add(rarModuleBda);
-                        ejbModuleBda.getBeanDeploymentArchives().add(rarRootBda);
-                        ejbModuleBda.getBeanDeploymentArchives().add(rarModuleBda);
-                        modifiedArchive = true;
-                    }
-                }
+            // Make rars accessible to ejbs
+            for (RootBeanDeploymentArchive rarRootBda : rarRootBdas) {
+                BeanDeploymentArchive rarModuleBda = rarRootBda.getModuleBda();
+                ejbRootBda.getBeanDeploymentArchives().add(rarRootBda);
+                ejbRootBda.getBeanDeploymentArchives().add(rarModuleBda);
+                ejbModuleBda.getBeanDeploymentArchives().add(rarRootBda);
+                ejbModuleBda.getBeanDeploymentArchives().add(rarModuleBda);
+                modifiedArchive = true;
+            }
 
-                if (modifiedArchive) {
-                    int idx = getBeanDeploymentArchives().indexOf(ejbModuleBda);
-                    if (idx >= 0) {
-                        getBeanDeploymentArchives().remove(idx);
-                        getBeanDeploymentArchives().add(ejbModuleBda);
-                    }
+            if (modifiedArchive) {
+                if (getBeanDeploymentArchives().remove(ejbModuleBda)) {
+                    getBeanDeploymentArchives().add(ejbModuleBda);
                 }
             }
         }
@@ -268,73 +361,75 @@ public class DeploymentImpl implements CDI11Deployment {
         //    /web.war ----> /ejb.jar
         // If there are any application (/lib) jars, make them accessible
 
-        if (warRootBdas != null) {
-            ListIterator<RootBeanDeploymentArchive> warIter = warRootBdas.listIterator();
-            boolean modifiedArchive = false;
-            while (warIter.hasNext()) {
-                RootBeanDeploymentArchive warRootBda = warIter.next();
-                BeanDeploymentArchive warModuleBda = warRootBda.getModuleBda();
-                if (ejbRootBdas != null) {
-                    for (RootBeanDeploymentArchive ejbRootBda : ejbRootBdas) {
-                        BeanDeploymentArchive ejbModuleBda = ejbRootBda.getModuleBda();
-                        warRootBda.getBeanDeploymentArchives().add(ejbRootBda);
-                        warRootBda.getBeanDeploymentArchives().add(ejbModuleBda);
-                        warModuleBda.getBeanDeploymentArchives().add(ejbRootBda);
-                        warModuleBda.getBeanDeploymentArchives().add(ejbModuleBda);
+        Iterator<RootBeanDeploymentArchive> warIter = warRootBdas.iterator();
+        boolean modifiedArchive = false;
+        while (warIter.hasNext()) {
+            RootBeanDeploymentArchive warRootBda = warIter.next();
+            BeanDeploymentArchive warModuleBda = warRootBda.getModuleBda();
+            for (RootBeanDeploymentArchive ejbRootBda : ejbRootBdas) {
+                BeanDeploymentArchive ejbModuleBda = ejbRootBda.getModuleBda();
+                warRootBda.getBeanDeploymentArchives().add(ejbRootBda);
+                warRootBda.getBeanDeploymentArchives().add(ejbModuleBda);
+                warModuleBda.getBeanDeploymentArchives().add(ejbRootBda);
+                warModuleBda.getBeanDeploymentArchives().add(ejbModuleBda);
 
-                       for ( BeanDeploymentArchive oneBda : warModuleBda.getBeanDeploymentArchives() ) {
-                         oneBda.getBeanDeploymentArchives().add( ejbRootBda );
-                         oneBda.getBeanDeploymentArchives().add( ejbModuleBda );
-                       }
-
-                      modifiedArchive = true;
-                    }
+                for ( BeanDeploymentArchive oneBda : warModuleBda.getBeanDeploymentArchives() ) {
+                    oneBda.getBeanDeploymentArchives().add( ejbRootBda );
+                    oneBda.getBeanDeploymentArchives().add( ejbModuleBda );
                 }
 
-                // Make /lib jars accessible to the war and it's sub bdas
-                if (libJarRootBdas != null) {
-                    for (RootBeanDeploymentArchive libJarRootBda : libJarRootBdas) {
-                        BeanDeploymentArchive libJarModuleBda = libJarRootBda.getModuleBda();
-                        warRootBda.getBeanDeploymentArchives().add(libJarRootBda);
-                        warRootBda.getBeanDeploymentArchives().add(libJarModuleBda);
-                        warModuleBda.getBeanDeploymentArchives().add(libJarRootBda);
-                        warModuleBda.getBeanDeploymentArchives().add(libJarModuleBda);
+                modifiedArchive = true;
+            }
 
-                        for ( BeanDeploymentArchive oneBda : warModuleBda.getBeanDeploymentArchives() ) {
-                          oneBda.getBeanDeploymentArchives().add( libJarRootBda );
-                          oneBda.getBeanDeploymentArchives().add( libJarModuleBda );
-                        }
+            // Make /lib jars accessible to the war and it's sub bdas
+            for (RootBeanDeploymentArchive libJarRootBda : libJarRootBdas) {
+                BeanDeploymentArchive libJarModuleBda = libJarRootBda.getModuleBda();
+                warRootBda.getBeanDeploymentArchives().add(libJarRootBda);
+                warRootBda.getBeanDeploymentArchives().add(libJarModuleBda);
+                warModuleBda.getBeanDeploymentArchives().add(libJarRootBda);
+                warModuleBda.getBeanDeploymentArchives().add(libJarModuleBda);
 
-                        modifiedArchive = true;
-                    }
+                // make WAR's BDAs accessible to libJar BDAs
+                Set<BeanDeploymentArchive> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+                beanDeploymentArchives.stream()
+                        .filter(RootBeanDeploymentArchive.class::isInstance)
+                        .map(RootBeanDeploymentArchive.class::cast)
+                        .forEach(bda -> recursivelyAdd(bda.getBeanDeploymentArchives(), warModuleBda, seen));
+                recursivelyAdd(beanDeploymentArchives, warModuleBda, seen);
+                libJarRootBda.getBeanDeploymentArchives().add(warRootBda);
+                libJarModuleBda.getBeanDeploymentArchives().add(warRootBda);
+                libJarRootBda.getBeanDeploymentArchives().add(warModuleBda);
+                libJarModuleBda.getBeanDeploymentArchives().add(warModuleBda);
+
+                for ( BeanDeploymentArchive oneBda : warModuleBda.getBeanDeploymentArchives() ) {
+                    oneBda.getBeanDeploymentArchives().add( libJarRootBda );
+                    oneBda.getBeanDeploymentArchives().add( libJarModuleBda );
                 }
 
-                // Make rars accessible to wars and it's sub bdas
-                if (rarRootBdas != null) {
-                    for (RootBeanDeploymentArchive rarRootBda : rarRootBdas) {
-                        BeanDeploymentArchive rarModuleBda = rarRootBda.getModuleBda();
-                        warRootBda.getBeanDeploymentArchives().add(rarRootBda);
-                        warRootBda.getBeanDeploymentArchives().add(rarModuleBda);
-                        warModuleBda.getBeanDeploymentArchives().add(rarRootBda);
-                        warModuleBda.getBeanDeploymentArchives().add(rarModuleBda);
+                modifiedArchive = true;
+            }
 
-                      for ( BeanDeploymentArchive oneBda : warModuleBda.getBeanDeploymentArchives() ) {
-                        oneBda.getBeanDeploymentArchives().add( rarRootBda );
-                        oneBda.getBeanDeploymentArchives().add( rarModuleBda );
-                      }
+            // Make rars accessible to wars and it's sub bdas
+            for (RootBeanDeploymentArchive rarRootBda : rarRootBdas) {
+                BeanDeploymentArchive rarModuleBda = rarRootBda.getModuleBda();
+                warRootBda.getBeanDeploymentArchives().add(rarRootBda);
+                warRootBda.getBeanDeploymentArchives().add(rarModuleBda);
+                warModuleBda.getBeanDeploymentArchives().add(rarRootBda);
+                warModuleBda.getBeanDeploymentArchives().add(rarModuleBda);
 
-                      modifiedArchive = true;
-                    }
+                for ( BeanDeploymentArchive oneBda : warModuleBda.getBeanDeploymentArchives() ) {
+                    oneBda.getBeanDeploymentArchives().add( rarRootBda );
+                    oneBda.getBeanDeploymentArchives().add( rarModuleBda );
                 }
 
-                if (modifiedArchive) {
-                    int idx = getBeanDeploymentArchives().indexOf(warModuleBda);
-                    if (idx >= 0) {
-                        getBeanDeploymentArchives().remove(idx);
-                        getBeanDeploymentArchives().add(warModuleBda);
-                    }
-                    modifiedArchive = false;
+                modifiedArchive = true;
+            }
+
+            if (modifiedArchive) {
+                if (getBeanDeploymentArchives().remove(warModuleBda)) {
+                    getBeanDeploymentArchives().add(warModuleBda);
                 }
+                modifiedArchive = false;
             }
         }
 
@@ -361,8 +456,17 @@ public class DeploymentImpl implements CDI11Deployment {
         }
     }
 
+    private void recursivelyAdd(Collection<BeanDeploymentArchive> bdas, BeanDeploymentArchive bda, Set<BeanDeploymentArchive> seen) {
+        for (BeanDeploymentArchive subBda : new LinkedHashSet<>(bdas)) {
+            if (seen.add(subBda)) {
+                subBda.getBeanDeploymentArchives().add(bda);
+                recursivelyAdd(subBda.getBeanDeploymentArchives(), bda, seen);
+            }
+        }
+    }
+
     @Override
-    public List<BeanDeploymentArchive> getBeanDeploymentArchives() {
+    public Set<BeanDeploymentArchive> getBeanDeploymentArchives() {
         if ( logger.isLoggable( FINE ) ) {
             logger.log(FINE, CDILoggerInfo.GET_BEAN_DEPLOYMENT_ARCHIVES, new Object[] {beanDeploymentArchives});
         }
@@ -374,9 +478,9 @@ public class DeploymentImpl implements CDI11Deployment {
         if ( logger.isLoggable( FINE ) ) {
             logger.log(FINE, CDILoggerInfo.LOAD_BEAN_DEPLOYMENT_ARCHIVE, new Object[] { beanClass });
         }
-        List<BeanDeploymentArchive> beanDeploymentArchives = getBeanDeploymentArchives();
+        Set<BeanDeploymentArchive> beanDeploymentArchives = getBeanDeploymentArchives();
 
-        ListIterator<BeanDeploymentArchive> lIter = beanDeploymentArchives.listIterator();
+        Iterator<BeanDeploymentArchive> lIter = beanDeploymentArchives.iterator();
         while (lIter.hasNext()) {
             BeanDeploymentArchive bda = lIter.next();
             if ( logger.isLoggable( FINE ) ) {
@@ -446,7 +550,7 @@ public class DeploymentImpl implements CDI11Deployment {
                            CDILoggerInfo.LOAD_BEAN_DEPLOYMENT_ARCHIVE_ADD_NEW_BDA_TO_ROOTS,
                            new Object[] {} );
             }
-            lIter = beanDeploymentArchives.listIterator();
+            lIter = beanDeploymentArchives.iterator();
             while (lIter.hasNext()) {
                 BeanDeploymentArchive bda = lIter.next();
                 bda.getBeanDeploymentArchives().add(newBda);
@@ -479,11 +583,11 @@ public class DeploymentImpl implements CDI11Deployment {
 
     @Override
     public Iterable<Metadata<Extension>> getExtensions() {
-        if (extensions != null) {
+        if (!extensions.isEmpty()) {
             return extensions;
         }
 
-        List<BeanDeploymentArchive> bdas = getBeanDeploymentArchives();
+        Set<BeanDeploymentArchive> bdas = getBeanDeploymentArchives();
         ArrayList<Metadata<Extension>> extnList = new ArrayList<>();
 
         //registering the org.jboss.weld.lite.extension.translator.LiteExtensionTranslator
@@ -516,14 +620,12 @@ public class DeploymentImpl implements CDI11Deployment {
                 ClassLoader moduleClassLoader = ((BeanDeploymentArchiveImpl)bda).getModuleClassLoaderForBDA();
                 if (!scannedClassLoaders.contains(moduleClassLoader)) {
                     scannedClassLoaders.add(moduleClassLoader);
-                    extensions = context.getTransientAppMetaData(WeldDeployer.WELD_BOOTSTRAP,
-                                                                 WeldBootstrap.class).loadExtensions(moduleClassLoader);
-                    if (extensions != null) {
-                        for (Metadata<Extension> bdaExtn : extensions) {
-                            if (loadedExtensions.get(bdaExtn.getValue().getClass()) == null) {
-                                extnList.add(bdaExtn);
-                                loadedExtensions.put(bdaExtn.getValue().getClass(), bdaExtn);
-                            }
+                    var extensions = context.getTransientAppMetaData(WeldDeployer.WELD_BOOTSTRAP,
+                            WeldBootstrap.class).loadExtensions(moduleClassLoader);
+                    for (Metadata<Extension> bdaExtn : extensions) {
+                        if (loadedExtensions.get(bdaExtn.getValue().getClass()) == null) {
+                            extnList.add(bdaExtn);
+                            loadedExtensions.put(bdaExtn.getValue().getClass(), bdaExtn);
                         }
                     }
                 }
@@ -543,7 +645,7 @@ public class DeploymentImpl implements CDI11Deployment {
         }
 
         extnList.addAll(dynamicExtensions);
-        extensions = extnList;
+        extensions.addAll(extnList);
         return extnList;
     }
 
@@ -562,10 +664,8 @@ public class DeploymentImpl implements CDI11Deployment {
     @Override
     public String toString() {
         StringBuilder valBuff = new StringBuilder();
-        List<BeanDeploymentArchive> beanDeploymentArchives = getBeanDeploymentArchives();
-        ListIterator<BeanDeploymentArchive> lIter = beanDeploymentArchives.listIterator();
-        while (lIter.hasNext()) {
-            BeanDeploymentArchive bda = lIter.next();
+        Set<BeanDeploymentArchive> beanDeploymentArchives = getBeanDeploymentArchives();
+        for(BeanDeploymentArchive bda : beanDeploymentArchives) {
             valBuff.append(bda.toString());
         }
         return valBuff.toString();
@@ -576,23 +676,11 @@ public class DeploymentImpl implements CDI11Deployment {
     }
 
     public void cleanup() {
-        if (ejbRootBdas != null) {
-            ejbRootBdas.clear();
-        }
-        if (warRootBdas != null) {
-            warRootBdas.clear();
-        }
-        if (libJarRootBdas != null) {
-            libJarRootBdas.clear();
-        }
-
-        if ( rarRootBdas != null ) {
-            rarRootBdas.clear();
-        }
-
-        if (idToBeanDeploymentArchive != null) {
-            idToBeanDeploymentArchive.clear();
-        }
+        ejbRootBdas.clear();
+        warRootBdas.clear();
+        libJarRootBdas.clear();
+        rarRootBdas.clear();
+        idToBeanDeploymentArchive.clear();
     }
 
     private List<Class<? extends BuildCompatibleExtension>> getBuildCompatibleExtensions() {
@@ -600,14 +688,14 @@ public class DeploymentImpl implements CDI11Deployment {
                 ServiceLoader.load(BuildCompatibleExtension.class, Thread.currentThread().getContextClassLoader())
                         .stream()
                         .map(java.util.ServiceLoader.Provider::get)
-                        .map(e -> e.getClass())
+                        .map(BuildCompatibleExtension::getClass)
                         .filter(e -> !e.isAnnotationPresent(SkipIfPortableExtensionPresent.class))
                         .collect(toList());
     }
 
     // This method creates and returns a List of BeanDeploymentArchives for each
     // Weld enabled jar under /lib of an existing Archive.
-    private List<RootBeanDeploymentArchive> scanForLibJars( ReadableArchive archive,
+    private Set<RootBeanDeploymentArchive> scanForLibJars( ReadableArchive archive,
                                                             Collection<EjbDescriptor> ejbs,
                                                             DeploymentContext context) {
         List<ReadableArchive> libJars = null;
@@ -663,9 +751,6 @@ public class DeploymentImpl implements CDI11Deployment {
         if (moduleBeansXml == null || !moduleBeansXml.getBeanDiscoveryMode().equals(BeanDiscoveryMode.NONE)) {
             addBdaToDeploymentBdas(rootLibBda);
             addBdaToDeploymentBdas(libModuleBda);
-            if (libJarRootBdas == null) {
-                libJarRootBdas = new ArrayList<>();
-            }
 
             for ( RootBeanDeploymentArchive existingLibJarRootBda : libJarRootBdas) {
                 rootLibBda.getBeanDeploymentArchives().add( existingLibJarRootBda );
@@ -766,9 +851,9 @@ public class DeploymentImpl implements CDI11Deployment {
             return null;
         }
 
-        for ( BeanDeploymentArchive oneBda : beanDeploymentArchives ) {
+        for (BeanDeploymentArchive oneBda : beanDeploymentArchives) {
             BeanDeploymentArchiveImpl beanDeploymentArchiveImpl = (BeanDeploymentArchiveImpl) oneBda;
-            if ( beanDeploymentArchiveImpl.getKnownClasses().contains(beanClass.getName()) ) {
+            if (beanDeploymentArchiveImpl.getKnownClasses().contains(beanClass.getName())) {
                 return oneBda;
             }
         }
@@ -790,7 +875,7 @@ public class DeploymentImpl implements CDI11Deployment {
         return rootBda;
     }
 
-    private RootBeanDeploymentArchive findRootBda( ClassLoader classLoader, List<RootBeanDeploymentArchive> rootBdas ) {
+    private RootBeanDeploymentArchive findRootBda( ClassLoader classLoader, Set<RootBeanDeploymentArchive> rootBdas ) {
         if ( rootBdas == null || classLoader == null ) {
             return null;
         }
@@ -837,16 +922,10 @@ public class DeploymentImpl implements CDI11Deployment {
 
 
     public Iterator<RootBeanDeploymentArchive> getLibJarRootBdas() {
-        if ( libJarRootBdas == null ) {
-            return null;
-        }
         return libJarRootBdas.iterator();
     }
 
     public Iterator<RootBeanDeploymentArchive> getRarRootBdas() {
-        if ( rarRootBdas == null ) {
-            return null;
-        }
         return rarRootBdas.iterator();
     }
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/GlassFishWeldProvider.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/GlassFishWeldProvider.java
@@ -37,9 +37,15 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
+import com.sun.enterprise.deployment.BundleDescriptor;
+import com.sun.enterprise.deployment.EjbDescriptor;
+import com.sun.enterprise.deployment.WebBundleDescriptor;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.internal.api.Globals;
 import org.jboss.weld.Container;
 import org.jboss.weld.SimpleCDI;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
@@ -54,7 +60,16 @@ import java.util.Set;
  * @author <a href="mailto:j.j.snyder@oracle.com">JJ Snyder</a>
  */
 public class GlassFishWeldProvider implements CDIProvider {
+    private static final WeldDeployer weldDeployer = Globals.get(WeldDeployer.class);
+    private static final InvocationManager invocationManager = Globals.get(InvocationManager.class);
+
     private static class GlassFishEnhancedWeld extends SimpleCDI {
+        GlassFishEnhancedWeld() {
+        }
+
+        GlassFishEnhancedWeld(String contextId) {
+            super(contextId == null ? Container.instance() : Container.instance(contextId));
+        }
 
         @Override
         protected BeanManagerImpl unsatisfiedBeanManager(String callerClassName) {
@@ -92,15 +107,30 @@ public class GlassFishWeldProvider implements CDIProvider {
 
     @Override
     public CDI<Object> getCDI() {
-      try {
-        return new GlassFishEnhancedWeld();
-      } catch ( Throwable throwable ) {
-        Throwable cause = throwable.getCause();
-        if ( cause instanceof IllegalStateException ) {
-          return null;
-        }
-        throw throwable;
-      }
-    }
+        try {
+            BundleDescriptor bundle = null;
+            Object componentEnv = invocationManager.getCurrentInvocation().getJNDIEnvironment();
+            if( componentEnv instanceof EjbDescriptor) {
+                bundle = (BundleDescriptor)
+                        ((EjbDescriptor) componentEnv).getEjbBundleDescriptor().
+                                getModuleDescriptor().getDescriptor();
 
+            } else if( componentEnv instanceof WebBundleDescriptor) {
+                bundle = (BundleDescriptor) componentEnv;
+            }
+
+            BeanDeploymentArchive bda = weldDeployer.getBeanDeploymentArchiveForBundle(bundle);
+            if (bda == null) {
+                return new GlassFishEnhancedWeld();
+            } else {
+                return new GlassFishEnhancedWeld(weldDeployer.getContextIdForArchive(bda));
+            }
+        } catch ( Throwable throwable ) {
+            Throwable cause = throwable.getCause();
+            if ( cause instanceof IllegalStateException ) {
+                return null;
+            }
+            throw throwable;
+        }
+    }
 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/RootBeanDeploymentArchive.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/RootBeanDeploymentArchive.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -49,10 +49,12 @@ import org.glassfish.weld.connector.WeldUtils;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 
+import java.io.ObjectStreamException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * A root BDA represents the root of a module where a module is a war, ejb, rar, ear lib
@@ -70,7 +72,7 @@ import java.util.Collections;
  * @author <a href="mailto:j.j.snyder@oracle.com">JJ Snyder</a>
  */
 public class RootBeanDeploymentArchive extends BeanDeploymentArchiveImpl {
-    private BeanDeploymentArchiveImpl moduleBda;
+    BeanDeploymentArchiveImpl moduleBda;
 
     public RootBeanDeploymentArchive(ReadableArchive archive,
                                      Collection<EjbDescriptor> ejbs,
@@ -88,6 +90,11 @@ public class RootBeanDeploymentArchive extends BeanDeploymentArchiveImpl {
               new ArrayList<EjbDescriptor>(),
               deploymentContext);
         createModuleBda(archive, ejbs, deploymentContext, moduleBdaID);
+    }
+
+    public RootBeanDeploymentArchive(RootBeanDeploymentArchive rootBeanDeploymentArchive) {
+        super(rootBeanDeploymentArchive);
+        moduleBda = rootBeanDeploymentArchive.moduleBda;
     }
 
     private void createModuleBda(ReadableArchive archive,
@@ -149,5 +156,22 @@ public class RootBeanDeploymentArchive extends BeanDeploymentArchiveImpl {
 
     public WeldUtils.BDAType getModuleBDAType() {
         return moduleBda.getBDAType();
+    }
+
+    Object readResolve() throws ObjectStreamException {
+        return new RootBeanDeploymentArchive(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RootBeanDeploymentArchive)) return false;
+        RootBeanDeploymentArchive that = (RootBeanDeploymentArchive) o;
+        return Objects.equals(moduleBda, that.moduleBda);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(moduleBda);
     }
 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/ValidationNamingProxy.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/ValidationNamingProxy.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld;
 
@@ -48,7 +49,6 @@ import com.sun.enterprise.deployment.WebBundleDescriptor;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.api.naming.NamedNamingObjectProxy;
-import org.glassfish.api.naming.NamespacePrefixes;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jboss.weld.bootstrap.WeldBootstrap;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
@@ -59,9 +59,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import javax.naming.NamingException;
-import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import jakarta.validation.ValidatorContext;
 import jakarta.validation.ValidatorFactory;
 import java.util.Set;
 
@@ -189,7 +187,7 @@ public class ValidationNamingProxy implements NamedNamingObjectProxy {
                 if( bundle != null ) {
                     BeanDeploymentArchive bda = weldDeployer.getBeanDeploymentArchiveForBundle(bundle);
                     if( bda != null ) {
-                        WeldBootstrap bootstrap = weldDeployer.getBootstrapForApp(bundle.getApplication());
+                        WeldBootstrap bootstrap = weldDeployer.getBootstrapForArchive(bda);
 
                         beanManager = bootstrap.getManager(bda);
                     }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -67,6 +67,7 @@ import static org.jboss.weld.bootstrap.spi.BeanDiscoveryMode.NONE;
 import static org.jboss.weld.manager.BeanManagerLookupService.lookupBeanManager;
 
 import java.security.AccessController;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -155,7 +156,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
     public static final String WELD_EXTENSION = "org.glassfish.weld";
     public static final String WELD_DEPLOYMENT = "org.glassfish.weld.WeldDeployment";
-    /* package */ static final String WELD_BOOTSTRAP = "org.glassfish.weld.WeldBootstrap";
+    /* package */ static final String WELD_BOOTSTRAP = "[PerBDA]org.glassfish.weld.WeldBootstrap";
     public static final String SNIFFER_EXTENSIONS = "org.glassfish.weld.sniffers";
     private static final String WELD_CONTEXT_LISTENER = "org.glassfish.weld.WeldContextListener";
 
@@ -207,8 +208,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
     @Inject
     private Deployment deployment;
-
-    private Map<Application, WeldBootstrap> appToBootstrap = new HashMap<>();
 
     private Map<BundleDescriptor, BeanDeploymentArchive> bundleToBeanDeploymentArchive = new HashMap<>();
 
@@ -276,11 +275,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
         ReadableArchive archive = context.getSource();
 
-        boolean[] setTransientAppMetaData = {false};
-
-        // See if a WeldBootsrap has already been created - only want one per app.
-        WeldBootstrap bootstrap = getWeldBootstrap(context, applicationInfo, setTransientAppMetaData);
-
+        ensureWeldBootstrapCreated(context, applicationInfo);
         EjbBundleDescriptor ejbBundle = getEjbBundleFromContext(context);
 
         EjbServices ejbServices = null;
@@ -295,7 +290,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         // If the archive is a composite, or has version numbers per maven conventions, strip them out
         String archiveName = getArchiveName(context, applicationInfo, archive);
 
-        DeploymentImpl deploymentImpl = context.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);
+        DeploymentImpl deploymentImpl = applicationInfo.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);
         if (deploymentImpl == null) {
             deploymentImpl = new DeploymentImpl(archive, ejbs, context, archiveFactory, archiveName, services.getService(InjectionManager.class));
 
@@ -336,14 +331,8 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         deploymentImpl.getServices().add(ExternalConfiguration.class, externalConfiguration);
 
         BeanDeploymentArchive beanDeploymentArchive = deploymentImpl.getBeanDeploymentArchiveForArchive(archiveName);
-        if (beanDeploymentArchive != null
-                && (!beanDeploymentArchive.getBeansXml().getBeanDiscoveryMode().equals(NONE) || forceInitialisation(context))) {
-            if (setTransientAppMetaData[0]) {
-                // Do this only if we have a root BDA
-                appToBootstrap.put(context.getModuleMetaData(Application.class), bootstrap);
-                applicationInfo.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
-            }
-
+        if (beanDeploymentArchive != null && !beanDeploymentArchive.getBeansXml().getBeanDiscoveryMode().equals(NONE)
+                || forceInitialisation(context)) {
             WebBundleDescriptor webBundleDescriptor = context.getModuleMetaData(WebBundleDescriptor.class);
             boolean developmentMode = isDevelopmentMode(context);
             if (webBundleDescriptor != null) {
@@ -379,8 +368,8 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             }
 
             BundleDescriptor bundle = (webBundleDescriptor != null) ? webBundleDescriptor : ejbBundle;
-            if (bundle != null
-                    && (!beanDeploymentArchive.getBeansXml().getBeanDiscoveryMode().equals(NONE) || forceInitialisation(context))) {
+            if (bundle != null && (!beanDeploymentArchive.getBeansXml().getBeanDiscoveryMode().equals(NONE)
+                    || forceInitialisation(context))) {
                 // Register EE injection manager at the bean deployment archive level.
                 // We use the generic InjectionService service to handle all EE-style
                 // injection instead of the per-dependency-type InjectionPoint approach.
@@ -414,7 +403,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             bundleToBeanDeploymentArchive.put(bundle, beanDeploymentArchive);
         }
 
-        context.addTransientAppMetaData(WELD_DEPLOYMENT, deploymentImpl);
         applicationInfo.addTransientAppMetaData(WELD_DEPLOYMENT, deploymentImpl);
 
         return new WeldApplicationContainer();
@@ -464,139 +452,192 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         return bundleToBeanDeploymentArchive.containsKey(bundle);
     }
 
-    public WeldBootstrap getBootstrapForApp(Application app) {
-        return appToBootstrap.get(app);
+    public WeldBootstrap getBootstrapForArchive(BeanDeploymentArchive archive) {
+        return ((BeanDeploymentArchiveImpl) archive).weldBootstrap;
     }
 
-
+    public String getContextIdForArchive(BeanDeploymentArchive archive) {
+        var impl = (BeanDeploymentArchiveImpl) archive;
+        String rootContextId = impl.getBeanDeploymentArchives().stream()
+                .filter(RootBeanDeploymentArchive.class::isInstance)
+                .map(RootBeanDeploymentArchive.class::cast)
+                .filter(bda -> bda.moduleBda.getBDAType() != WeldUtils.BDAType.UNKNOWN)
+                .findFirst().map(BeanDeploymentArchive::getId).orElse(null);
+        return rootContextId == null ? null : rootContextId + ".bda";
+    }
 
     // ### Private methods
 
-
-    private WeldBootstrap getWeldBootstrap(DeploymentContext context, ApplicationInfo appInfo, boolean[] setTransientAppMetaData) {
-        // See if a WeldBootsrap has already been created - only want one per app.
-        WeldBootstrap bootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
-
-        if (bootstrap != null && appInfo.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class) == null) {
-            // No bootstrap if no CDI BDAs exist yet
-            bootstrap = null;
+    private WeldBootstrap ensureWeldBootstrapCreated(DeploymentContext context, ApplicationInfo applicationInfo) {
+        @SuppressWarnings("unchecked")
+        List<WeldBootstrap> toShutdown = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP, List.class);
+        if (toShutdown == null) {
+            toShutdown = new ArrayList<>();
+            applicationInfo.addTransientAppMetaData(WELD_BOOTSTRAP, toShutdown);
         }
+
+        // See if a WeldBootstrap has already been created - only want one per context.
+        WeldBootstrap bootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
 
         if (bootstrap == null) {
             bootstrap = new WeldBootstrap();
-            setTransientAppMetaData[0] = true;
 
-            // Stash the WeldBootstrap instance, so we may access the WeldManager later..
+            // Stash the WeldBootstrap instance, so we may access the WeldManager later...
             context.addTransientAppMetaData(WELD_BOOTSTRAP, bootstrap);
+            toShutdown.add(bootstrap);
 
             // Making sure that if WeldBootstrap is added, shutdown is set to false, as it is/would not have
             // been called.
-            appInfo.addTransientAppMetaData(WELD_BOOTSTRAP_SHUTDOWN, "false");
+            applicationInfo.addTransientAppMetaData(WELD_BOOTSTRAP_SHUTDOWN, "false");
         }
-
         return bootstrap;
     }
 
     private void processApplicationLoaded(ApplicationInfo applicationInfo) {
-        WeldBootstrap bootstrap = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
+        DeploymentImpl deploymentImpl = applicationInfo.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);
+        if (deploymentImpl == null) {
+            return;
+        }
 
-        if (bootstrap != null) {
-            DeploymentImpl deploymentImpl = applicationInfo.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);
-            deploymentImpl.buildDeploymentGraph();
+        // Get current TCL
+        ClassLoader oldTCL = Thread.currentThread().getContextClassLoader();
 
-            List<BeanDeploymentArchive> archives = deploymentImpl.getBeanDeploymentArchives();
+        invocationManager.pushAppEnvironment(applicationInfo::getName);
 
-            addResourceLoaders(archives);
-            addCdiServicesToNonModuleBdas(deploymentImpl.getLibJarRootBdas(), services.getService(InjectionManager.class));
-            addCdiServicesToNonModuleBdas(deploymentImpl.getRarRootBdas(), services.getService(InjectionManager.class));
+        ComponentInvocation componentInvocation = createComponentInvocation(applicationInfo);
 
-            // Get current TCL
-            ClassLoader oldTCL = Thread.currentThread().getContextClassLoader();
-
-            invocationManager.pushAppEnvironment(applicationInfo::getName);
-
-            ComponentInvocation componentInvocation = createComponentInvocation(applicationInfo);
-
-            try {
-                invocationManager.preInvoke(componentInvocation);
-                bootstrap.startExtensions(postProcessExtensions(deploymentImpl.getExtensions(), archives));
-                bootstrap.startContainer(deploymentImpl.getContextId() + ".bda", SERVLET, deploymentImpl);
-
-                //This changes added to pass the following test
-                // CreateBeanAttributesTest#testBeanAttributesForSessionBean
-                if(!deploymentImpl.getBeanDeploymentArchives().isEmpty()) {
-                    BeanDeploymentArchive rootArchive = deploymentImpl.getBeanDeploymentArchives().get(0);
-                    ServiceRegistry rootServices = bootstrap.getManager(rootArchive).getServices();
-                    EjbSupport originalEjbSupport = rootServices.get(EjbSupport.class);
-                    if (originalEjbSupport != null) {
-                        // We need to create a proxy instead of a simple wrapper
-                        EjbSupport proxyEjbSupport = (EjbSupport) java.lang.reflect.Proxy.newProxyInstance(EjbSupport.class.getClassLoader(),
-                                new Class[]{EjbSupport.class}, new java.lang.reflect.InvocationHandler() {
-                                    @Override
-                                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws Throwable {
-                                        if (method.getName().equals("isEjb")) {
-
-                                            EjbSupport targetEjbSupport = getTargetEjbSupport((Class<?>) args[0]);
-
-                                            if (targetEjbSupport != null) {
-                                                return method.invoke(targetEjbSupport, args);
-                                            }
-
-                                        } else if (method.getName().equals("createSessionBeanAttributes")) {
-                                            Object enhancedAnnotated = args[0];
-
-                                            Class<?> beanClass = (Class<?>)
-                                                    enhancedAnnotated.getClass()
-                                                            .getMethod("getJavaClass")
-                                                            .invoke(enhancedAnnotated);
-
-                                            EjbSupport targetEjbSupport = getTargetEjbSupport(beanClass);
-                                            if (targetEjbSupport != null) {
-                                                return method.invoke(targetEjbSupport, args);
-                                            }
-                                        }
-
-                                        return method.invoke(originalEjbSupport, args);
-                                    }
-
-                                    private EjbSupport getTargetEjbSupport(Class<?> beanClass) {
-                                        BeanDeploymentArchive ejbArchive = deploymentImpl.getBeanDeploymentArchive(beanClass);
-                                        if (ejbArchive == null) {
-                                            return null;
-                                        }
-
-                                        BeanManagerImpl ejbBeanManager = lookupBeanManager(beanClass, bootstrap.getManager(ejbArchive));
-
-                                        return ejbBeanManager.getServices().get(EjbSupport.class);
-                                    }
-                                });
-                        rootServices.add(EjbSupport.class, proxyEjbSupport);
+        try {
+            invocationManager.preInvoke(componentInvocation);
+            // Modern, multiple WARs in an EAR scenario
+            if (deploymentImpl.ejbRootBdas.isEmpty()) {
+                for (RootBeanDeploymentArchive rootBDA : deploymentImpl.getRootBDAs()) {
+                    DeploymentImpl.currentDeployment.set(deploymentImpl);
+                    DeploymentImpl.currentBDAs.set(new HashMap<>());
+                    DeploymentImpl.currentDeploymentContext.set(rootBDA.context);
+                    try {
+                        DeploymentImpl filtered = deploymentImpl.filter(rootBDA, applicationInfo);
+                        completeDeployment(filtered);
+                        WeldBootstrap bootstrap = filtered.context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
+                        startWeldBootstrap(applicationInfo, rootBDA, bootstrap, filtered, componentInvocation);
+                    } finally {
+                        DeploymentImpl.currentDeployment.remove();
+                        DeploymentImpl.currentBDAs.remove();
+                        DeploymentImpl.currentDeploymentContext.remove();
                     }
                 }
-                bootstrap.startInitialization();
-                fireProcessInjectionTargetEvents(bootstrap, applicationInfo, deploymentImpl);
-                bootstrap.deployBeans();
-                bootstrap.validateBeans();
-                bootstrap.endInitialization();
-            } catch (Throwable t) {
-                doBootstrapShutdown(applicationInfo);
-
-                throw new DeploymentException(getDeploymentErrorMsgPrefix(t) + t.getMessage(), t);
-            } finally {
-                try {
-                    invocationManager.postInvoke(componentInvocation);
-                    invocationManager.popAppEnvironment();
-                    deploymentComplete(deploymentImpl);
-                } catch (Throwable t) {
-                    logger.log(SEVERE, "Exception dispatching post deploy event", t);
-                }
-
-                // The TCL is originally the EAR classloader and is reset during Bean deployment to the
-                // corresponding module classloader in BeanDeploymentArchiveImpl.getBeans
-                // for Bean classloading to succeed.
-                // The TCL is reset to its old value here.
-                Thread.currentThread().setContextClassLoader(oldTCL);
+            } else if (!deploymentImpl.getRootBDAs().isEmpty()) {
+                completeDeployment(deploymentImpl);
+                // Legacy EJB-Jar scenario, one Weld instance per EAR
+                RootBeanDeploymentArchive bda = deploymentImpl.getRootBDAs().iterator().next();
+                WeldBootstrap bootstrap = unifyBootstrap(bda, applicationInfo);
+                startWeldBootstrap(applicationInfo, bda, bootstrap, deploymentImpl, componentInvocation);
             }
+        } catch (Throwable t) {
+            doBootstrapShutdown(applicationInfo);
+
+            throw new DeploymentException(getDeploymentErrorMsgPrefix(t) + t.getMessage(), t);
+        } finally {
+            try {
+                invocationManager.postInvoke(componentInvocation);
+                invocationManager.popAppEnvironment();
+                deploymentComplete(deploymentImpl);
+            } catch (Throwable t) {
+                logger.log(SEVERE, "Exception dispatching post deploy event", t);
+            }
+
+            // The TCL is originally the EAR classloader and is reset during Bean deployment to the
+            // corresponding module classloader in BeanDeploymentArchiveImpl.getBeans
+            // for Bean classloading to succeed.
+            // The TCL is reset to its old value here.
+            Thread.currentThread().setContextClassLoader(oldTCL);
+        }
+    }
+
+    private void completeDeployment(DeploymentImpl deploymentImpl) {
+        deploymentImpl.buildDeploymentGraph();
+
+        Set<BeanDeploymentArchive> archives = deploymentImpl.getBeanDeploymentArchives();
+
+        addResourceLoaders(archives);
+        addCdiServicesToNonModuleBdas(deploymentImpl.getLibJarRootBdas(), services.getService(InjectionManager.class));
+        addCdiServicesToNonModuleBdas(deploymentImpl.getRarRootBdas(), services.getService(InjectionManager.class));
+    }
+
+    private WeldBootstrap unifyBootstrap(BeanDeploymentArchiveImpl rootArchive, ApplicationInfo applicationInfo) {
+        WeldBootstrap bootstrap = ensureWeldBootstrapCreated(rootArchive.context, applicationInfo);
+        rootArchive.getBeanDeploymentArchives().stream().map(BeanDeploymentArchiveImpl.class::cast)
+                .forEach(bda -> bda.weldBootstrap = bootstrap);
+        return bootstrap;
+    }
+
+    private void startWeldBootstrap(ApplicationInfo applicationInfo, RootBeanDeploymentArchive rootBDA,
+                                    WeldBootstrap bootstrap, DeploymentImpl deploymentImpl,
+                                    ComponentInvocation componentInvocation) {
+        bootstrap.startExtensions(postProcessExtensions(deploymentImpl.getExtensions(),
+                deploymentImpl.getBeanDeploymentArchives()));
+        bootstrap.startContainer(deploymentImpl.getContextId(), SERVLET, deploymentImpl);
+
+        //This changes added to pass the following test
+        // CreateBeanAttributesTest#testBeanAttributesForSessionBean
+        if (!rootBDA.getBeanDeploymentArchives().isEmpty()) {
+            createProxyEJBs(rootBDA, bootstrap, componentInvocation, deploymentImpl);
+        }
+        bootstrap.startInitialization();
+        fireProcessInjectionTargetEvents(bootstrap, applicationInfo, deploymentImpl);
+        bootstrap.deployBeans();
+        bootstrap.validateBeans();
+        bootstrap.endInitialization();
+    }
+
+    private static void createProxyEJBs(RootBeanDeploymentArchive warRootBDA, WeldBootstrap bootstrap,
+                                        ComponentInvocation componentInvocation, DeploymentImpl deploymentImpl) {
+        BeanManagerImpl beanManager = bootstrap.getManager(warRootBDA);
+        componentInvocation.setInstance(beanManager);
+        ServiceRegistry rootServices = beanManager.getServices();
+        EjbSupport originalEjbSupport = rootServices.get(EjbSupport.class);
+        if (originalEjbSupport != null) {
+            // We need to create a proxy instead of a simple wrapper
+            EjbSupport proxyEjbSupport = (EjbSupport) java.lang.reflect.Proxy.newProxyInstance(EjbSupport.class.getClassLoader(),
+                    new Class[]{EjbSupport.class}, new java.lang.reflect.InvocationHandler() {
+                        @Override
+                        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws Throwable {
+                            if (method.getName().equals("isEjb")) {
+
+                                EjbSupport targetEjbSupport = getTargetEjbSupport((Class<?>) args[0]);
+
+                                if (targetEjbSupport != null) {
+                                    return method.invoke(targetEjbSupport, args);
+                                }
+
+                            } else if (method.getName().equals("createSessionBeanAttributes")) {
+                                Object enhancedAnnotated = args[0];
+
+                                Class<?> beanClass = (Class<?>)
+                                        enhancedAnnotated.getClass()
+                                                .getMethod("getJavaClass")
+                                                .invoke(enhancedAnnotated);
+
+                                EjbSupport targetEjbSupport = getTargetEjbSupport(beanClass);
+                                if (targetEjbSupport != null) {
+                                    return method.invoke(targetEjbSupport, args);
+                                }
+                            }
+
+                            return method.invoke(originalEjbSupport, args);
+                        }
+
+                        private EjbSupport getTargetEjbSupport(Class<?> beanClass) {
+                            BeanDeploymentArchive ejbArchive = deploymentImpl.getBeanDeploymentArchive(beanClass);
+                            if (ejbArchive == null) {
+                                return null;
+                            }
+
+                            BeanManagerImpl ejbBeanManager = lookupBeanManager(beanClass, bootstrap.getManager(ejbArchive));
+
+                            return ejbBeanManager.getServices().get(EjbSupport.class);
+                        }
+                    });
+            rootServices.add(EjbSupport.class, proxyEjbSupport);
         }
     }
 
@@ -605,7 +646,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         Application application = applicationInfo.getMetaData(Application.class);
         if (application != null) {
             removeBundleDescriptors(application);
-            appToBootstrap.remove(application);
         }
 
         String shutdown = applicationInfo.getTransientAppMetaData(WELD_SHUTDOWN, String.class);
@@ -617,8 +657,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         Thread.currentThread().setContextClassLoader(applicationInfo.getAppClassLoader());
 
         try {
-            WeldBootstrap bootstrap = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
-            if (bootstrap != null) {
                 invocationManager.pushAppEnvironment(applicationInfo::getName);
 
                 try {
@@ -630,7 +668,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
                 }
 
                 applicationInfo.addTransientAppMetaData(WELD_SHUTDOWN, "true");
-            }
         } finally {
             Thread.currentThread().setContextClassLoader(currentContextClassLoader);
         }
@@ -642,7 +679,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
     }
 
-    private void addResourceLoaders(List<BeanDeploymentArchive> archives) {
+    private void addResourceLoaders(Set<BeanDeploymentArchive> archives) {
         for (BeanDeploymentArchive archive : archives) {
             archive.getServices().add(
                 ResourceLoader.class,
@@ -667,7 +704,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         return componentInvocation;
     }
 
-    private Iterable<Metadata<Extension>> postProcessExtensions(Iterable<Metadata<Extension>> extensions, List<BeanDeploymentArchive> archives) {
+    private Iterable<Metadata<Extension>> postProcessExtensions(Iterable<Metadata<Extension>> extensions, Set<BeanDeploymentArchive> archives) {
 
         // See if the Jersey extension that scans all classes in the bean archives is present.
         // Normally this should always be the case as this extension is statically included with Jersey,
@@ -710,7 +747,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
                 .filter(e -> e.getValue().getClass().getName().equals(JERSEY_PROCESS_ALL_CLASS_NAME)).findAny();
     }
 
-    private boolean hasJerseyHk2Provider(List<BeanDeploymentArchive> archives, ClassLoader jaxRsClassLoader)
+    private boolean hasJerseyHk2Provider(Set<BeanDeploymentArchive> archives, ClassLoader jaxRsClassLoader)
             throws ClassNotFoundException {
         Class<?> hk2Provider = Class.forName(JERSEY_HK2_CLASS_NAME, false, jaxRsClassLoader);
 
@@ -756,11 +793,13 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
     }
 
     private void doBootstrapShutdown(ApplicationInfo applicationInfo) {
-        WeldBootstrap bootstrap = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
+        List<WeldBootstrap> bootstrap = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP, List.class);
         String bootstrapShutdown = applicationInfo.getTransientAppMetaData(WELD_BOOTSTRAP_SHUTDOWN, String.class);
 
         if (bootstrapShutdown == null || Boolean.valueOf(bootstrapShutdown).equals(FALSE)) {
-            bootstrap.shutdown();
+            if (bootstrap != null) {
+                bootstrap.forEach(WeldBootstrap::shutdown);
+            }
             applicationInfo.addTransientAppMetaData(WELD_BOOTSTRAP_SHUTDOWN, "true");
         }
     }
@@ -807,7 +846,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
      */
     private void fireProcessInjectionTargetEvents(WeldBootstrap bootstrap, ApplicationInfo applicationInfo,
             DeploymentImpl deploymentImpl) {
-        List<BeanDeploymentArchive> beanDeploymentArchives = deploymentImpl.getBeanDeploymentArchives();
+        Set<BeanDeploymentArchive> beanDeploymentArchives = deploymentImpl.getBeanDeploymentArchives();
 
         Class<?> messageListenerClass = getMessageListenerClass();
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/JCDIServiceImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/JCDIServiceImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.weld.services;
 
@@ -213,7 +213,7 @@ public class JCDIServiceImpl implements JCDIService {
         // First get BeanDeploymentArchive for this ejb
         BeanDeploymentArchive bda = getBDAForBeanClass(topLevelBundleDesc, ejb.getEjbClassName());
 
-        WeldBootstrap bootstrap = weldDeployer.getBootstrapForApp(ejb.getEjbBundleDescriptor().getApplication());
+        WeldBootstrap bootstrap = weldDeployer.getBootstrapForArchive(bda);
         WeldManager weldManager = bootstrap.getManager(bda);
         //sanitizing the null reference of weldManager and returning null
         //when calling _createJCDIInjectionContext
@@ -350,9 +350,8 @@ public class JCDIServiceImpl implements JCDIService {
         BundleDescriptor topLevelBundleDesc = (BundleDescriptor) bundle.getModuleDescriptor().getDescriptor();
 
         // First get BeanDeploymentArchive for this ejb
-        BeanDeploymentArchive bda = weldDeployer.getBeanDeploymentArchiveForBundle(topLevelBundleDesc);
-        //BeanDeploymentArchive bda = getBDAForBeanClass(topLevelBundleDesc, managedObject.getClass().getName());
-        WeldBootstrap bootstrap = weldDeployer.getBootstrapForApp(bundle.getApplication());
+        BeanDeploymentArchive bda = getBDAForBeanClass(topLevelBundleDesc, managedObject.getClass().getName());
+        WeldBootstrap bootstrap = weldDeployer.getBootstrapForArchive(bda);
         BeanManager beanManager = bootstrap.getManager(bda);
         @SuppressWarnings("unchecked")
         AnnotatedType<T> annotatedType = beanManager.createAnnotatedType((Class<T>) managedObject.getClass());
@@ -400,7 +399,7 @@ public class JCDIServiceImpl implements JCDIService {
         // First get BeanDeploymentArchive for this ejb
         BeanDeploymentArchive bda = getBDAForBeanClass(topLevelBundleDesc, ejb.getEjbClassName());
 
-        WeldBootstrap bootstrap = weldDeployer.getBootstrapForApp(ejb.getEjbBundleDescriptor().getApplication());
+        WeldBootstrap bootstrap = weldDeployer.getBootstrapForArchive(bda);
         BeanManagerImpl beanManager = bootstrap.getManager(bda);
 
         org.jboss.weld.ejb.spi.EjbDescriptor<T> ejbDesc = beanManager.getEjbDescriptor( ejb.getName());
@@ -481,7 +480,7 @@ public class JCDIServiceImpl implements JCDIService {
         // First get BeanDeploymentArchive for this ejb
         BeanDeploymentArchive bda = weldDeployer.getBeanDeploymentArchiveForBundle(topLevelBundleDesc);
 
-        WeldBootstrap bootstrap = weldDeployer.getBootstrapForApp(bundle.getApplication());
+        WeldBootstrap bootstrap = weldDeployer.getBootstrapForArchive(bda);
 
         BeanManager beanManager = bootstrap.getManager(bda);
 

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/weld/services/JCDIServiceImplTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/weld/services/JCDIServiceImplTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2021-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -96,26 +96,24 @@ public class JCDIServiceImplTest extends TestCase {
         Collection<String> emptyListNames = Collections.emptyList();
         Collection<BeanDeploymentArchive> emptyListOfArchives = Collections.emptyList();
         when(ejbDescriptor.getEjbBundleDescriptor()).thenReturn(ejbBundleDescriptor);
-        when(ejbBundleDescriptor.getApplication()).thenReturn(application);
         when(ejbBundleDescriptor.getModuleDescriptor()).thenReturn(moduleDescriptor);
         when(moduleDescriptor.getDescriptor()).thenReturn(bundleDescriptor);
         when(ejbDescriptor.getEjbClassName()).thenReturn("EjbName");
         when(weldDeployer.getBeanDeploymentArchiveForBundle(bundleDescriptor)).thenReturn(beanDeploymentArchive);
-        when(weldDeployer.getBootstrapForApp(application)).thenReturn(bootstrap);
+        when(weldDeployer.getBootstrapForArchive(beanDeploymentArchive)).thenReturn(bootstrap);
         when(beanDeploymentArchive.getBeanClasses()).thenReturn(emptyListNames);
         when(beanDeploymentArchive.getBeanDeploymentArchives()).thenReturn(emptyListOfArchives);
 
         Object obj = jcdiServiceImpl.createJCDIInjectionContext(ejbDescriptor, ejbInfo);
 
         assertNull(obj);
-        verify(ejbDescriptor, times(2)).getEjbBundleDescriptor();
+        verify(ejbDescriptor, times(1)).getEjbBundleDescriptor();
         verify(ejbBundleDescriptor, times(1)).getModuleDescriptor();
         verify(moduleDescriptor, times(1)).getDescriptor();
         verify(weldDeployer, times(1)).getBeanDeploymentArchiveForBundle(bundleDescriptor);
         verify(beanDeploymentArchive, times(1)).getBeanClasses();
         verify(beanDeploymentArchive, times(1)).getBeanDeploymentArchives();
-        verify(ejbBundleDescriptor, times(1)).getApplication();
-        verify(weldDeployer, times(1)).getBootstrapForApp(application);
+        verify(weldDeployer, times(1)).getBootstrapForArchive(beanDeploymentArchive);
         verify(bootstrap, times(1)).getManager(beanDeploymentArchive);
     }
 }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/CacheCleaner.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/CacheCleaner.java
@@ -1,0 +1,103 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.enterprise.loader;
+
+import com.sun.enterprise.util.CULoggerInfo;
+import java.lang.reflect.Field;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CacheCleaner {
+    private static final Logger logger = CULoggerInfo.getLogger();
+
+    public static void clearCaches(ClassLoader classLoader) {
+        clearOmniFacesCache(classLoader);
+        clearJNACache(classLoader);
+        while (classLoader != null) {
+            clearJaxRSCache(classLoader);
+            classLoader = classLoader.getParent();
+        }
+    }
+
+    private static void clearJaxRSCache(ClassLoader classLoader) {
+        try {
+            Class<?> cdiComponentProvider = CachingReflectionUtil
+                    .getClassFromCache("org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider", classLoader);
+            if (cdiComponentProvider != null) {
+                Field runtimeSpecificsField = CachingReflectionUtil.getFieldFromCache(cdiComponentProvider,
+                        "runtimeSpecifics", true);
+                Object runtimeSpecifics = runtimeSpecificsField.get(null);
+                CachingReflectionUtil.getMethodFromCache(runtimeSpecifics.getClass(),
+                                "clearJaxRsResource", true, ClassLoader.class)
+                        .invoke(runtimeSpecifics, classLoader);
+            }
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Error clearing Jax-Rs cache", e);
+        }
+    }
+
+    private static void clearOmniFacesCache(ClassLoader classLoader) {
+        try {
+            Class<?> eagerBeans = CachingReflectionUtil
+                    .getClassFromCache("org.omnifaces.cdi.eager.EagerBeansRepository", classLoader);
+            if (eagerBeans != null && eagerBeans.getClassLoader() instanceof CurrentBeforeParentClassLoader) {
+                Field instance = CachingReflectionUtil.getFieldFromCache(eagerBeans, "instance", true);
+                instance.set(null, null);
+            }
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Error clearing OmniFaces cache", e);
+        }
+    }
+
+    private static void clearJNACache(ClassLoader classLoader) {
+        try {
+            Class<?> cleanerClass = CachingReflectionUtil
+                    .getClassFromCache("com.sun.jna.internal.Cleaner", classLoader);
+            if (cleanerClass != null && cleanerClass.getClassLoader() instanceof CurrentBeforeParentClassLoader) {
+                Field instanceField = CachingReflectionUtil.getFieldFromCache(cleanerClass, "INSTANCE", true);
+                Object instance = instanceField.get(null);
+                CachingReflectionUtil.getFieldFromCache(instance.getClass(), "cleanerThread", true)
+                        .set(instance, null);
+            }
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Error clearing JNA cache", e);
+        }
+    }
+}

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/CachingReflectionUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/CachingReflectionUtil.java
@@ -37,54 +37,70 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.web.loader;
+package com.sun.enterprise.loader;
 
 
+import com.sun.enterprise.util.CULoggerInfo;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-/**
- * @deprecated This class is not used and will be removed in a future release.
- * Functionality has been moved to {@link com.sun.enterprise.loader.CachingReflectionUtil}.
- */
-@Deprecated(forRemoval = true)
 public class CachingReflectionUtil {
-    /**
-     * @deprecated This method is not used and will be removed in a future release.
-     * Functionality has been moved to {@link com.sun.enterprise.loader.CachingReflectionUtil}.
-     * @param className
-     * @param classLoader
-     * @return
-     */
-    @Deprecated(forRemoval = true)
+    private static final Logger logger = CULoggerInfo.getLogger();
+
+    private static final Map<String, Class<?>> classCache = new ConcurrentHashMap<>();
+    private static final Map<String, Method> methodCache = new ConcurrentHashMap<>();
+    private static final Map<String, Field> fieldCache = new ConcurrentHashMap<>();
+
     public static Class<?> getClassFromCache(String className, ClassLoader classLoader) {
-        return com.sun.enterprise.loader.CachingReflectionUtil.getClassFromCache(className, classLoader);
+        var cls = classCache.computeIfAbsent(className, k -> {
+            try {
+                return classLoader.loadClass(className);
+            } catch (ClassNotFoundException e) {
+                logger.log(Level.FINE, "Class not found: " + className, e);
+                return null;
+            }
+        });
+        if (cls != null && cls.getClassLoader() == classLoader) {
+            classCache.remove(cls.getName());
+        }
+        return cls;
     }
 
-    /**
-     * @deprecated This method is not used and will be removed in a future release.
-     * Functionality has been moved to {@link com.sun.enterprise.loader.CachingReflectionUtil}.
-     * @param cls
-     * @param methodName
-     * @param isPrivate
-     * @param parameterTypes
-     * @return
-     */
-    @Deprecated(forRemoval = true)
     public static Method getMethodFromCache(Class<?> cls, String methodName, boolean isPrivate, Class<?>... parameterTypes) {
-        return com.sun.enterprise.loader.CachingReflectionUtil.getMethodFromCache(cls, methodName, isPrivate, parameterTypes);
+        return methodCache.computeIfAbsent(methodName, k -> {
+            try {
+                if (isPrivate) {
+                    Method method = cls.getDeclaredMethod(methodName, parameterTypes);
+                    method.setAccessible(true);
+                    return method;
+                } else {
+                    return cls.getMethod(methodName, parameterTypes);
+                }
+            } catch (NoSuchMethodException e) {
+                logger.log(Level.FINE, "Method not found: " + methodName, e);
+                return null;
+            }
+        });
     }
 
-    /**
-     * @deprecated This method is not used and will be removed in a future release.
-     * Functionality has been moved to {@link com.sun.enterprise.loader.CachingReflectionUtil}.
-     * @param cls
-     * @param fieldName
-     * @param isPrivate
-     * @return
-     */
-    @Deprecated(forRemoval = true)
     public static Field getFieldFromCache(Class<?> cls, String fieldName, boolean isPrivate) {
-        return com.sun.enterprise.loader.CachingReflectionUtil.getFieldFromCache(cls, fieldName, isPrivate);
+        return fieldCache.computeIfAbsent(fieldName, k -> {
+            try {
+                if (isPrivate) {
+                    Field field = cls.getDeclaredField(fieldName);
+                    field.setAccessible(true);
+                    return field;
+                } else {
+                    return cls.getField(fieldName);
+                }
+            } catch (NoSuchFieldException e) {
+                logger.log(Level.FINE, "Field not found: " + fieldName, e);
+                return null;
+            }
+        });
     }
 }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/DirWatcher.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/DirWatcher.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) [2019-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development
@@ -208,7 +208,7 @@ class DirWatcher {
             try (Stream<Path> stream = Files.list(root)){
                 stream.forEach(this::registerSubProcessor);
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Error when listing directory",e);
+                LOGGER.log(Level.FINE, "Error when listing directory",e);
             }
         }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -604,6 +604,7 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
             if (report.getActionExitCode() != ActionReport.ExitCode.SUCCESS) {
                 context.postDeployClean(false /* not final clean-up yet */);
                 events.send(new Event<>(Deployment.DEPLOYMENT_FAILURE, context));
+                currentDeploymentContext.get().pop();
             }
         }
         ApplicationDeployment depl = new ApplicationDeployment(appInfo, context);
@@ -646,8 +647,8 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                     events.send(new Event<>(Deployment.DEPLOYMENT_SUCCESS, appInfo));
                 }
             }
-            currentDeploymentContext.get().pop();
         }
+        currentDeploymentContext.get().pop();
     }
     
     @Override

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2022] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.deployment.common;
 
@@ -55,6 +55,7 @@ import org.glassfish.internal.api.ClassLoaderHierarchy;
 import org.glassfish.internal.deployment.*;
 import org.glassfish.loader.util.ASClassLoaderUtil;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.logging.Logger;
 import java.io.File;
@@ -117,7 +118,7 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
     Map<String, Object> modulesMetaData = new HashMap<String, Object>();
     List<ClassFileTransformer> transformers = new ArrayList<ClassFileTransformer>();
     Phase phase = Phase.UNKNOWN;
-    ClassLoader sharableTemp = null;
+    WeakReference<ClassLoader> sharableTemp = null;
     Map<String, Properties> modulePropsMap = new HashMap<String, Properties>();
     Map<String, Object> transientAppMetaData = new HashMap<String, Object>();
     Map<String, ArchiveHandler> moduleArchiveHandlers = new HashMap<String, ArchiveHandler>();
@@ -184,7 +185,7 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
         boolean hotDeploy = getCommandParameters(DeployCommandParameters.class).hotDeploy;
         if (!hotDeploy) {
             try {
-                PreDestroy.class.cast(sharableTemp).preDestroy();
+                PreDestroy.class.cast(sharableTemp.get()).preDestroy();
             } catch (Exception e) {
                 // ignore, the classloader does not need to be destroyed
             }
@@ -249,9 +250,9 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
         this.addTransientAppMetaData(ExtendedDeploymentContext.IS_TEMP_CLASSLOADER, Boolean.TRUE);
         boolean hotDeploy = getCommandParameters(DeployCommandParameters.class).hotDeploy;
         if (hotDeploy && this.cloader != null) {
-            this.sharableTemp = this.cloader;
+            this.sharableTemp = new WeakReference<>(this.cloader);
         } else {
-            this.sharableTemp = createClassLoader(clh, handler, null);
+            this.sharableTemp = new WeakReference<>(createClassLoader(clh, handler, null));
         }
     }
 
@@ -280,7 +281,7 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
         // otherwise, we return the final one.
         if (phase == Phase.PREPARE) {
             if (sharable) {
-                return sharableTemp;
+                return sharableTemp.get();
             } else {
                 InstrumentableClassLoader cl = InstrumentableClassLoader.class.cast(sharableTemp);
                 return cl.copy();
@@ -288,7 +289,7 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
         } else {
             // we are out of the prepare phase, destroy the shareableTemp and 
             // return the final classloader
-            if (sharableTemp != null && sharableTemp != cloader) {
+            if (sharableTemp != null && sharableTemp.get() != cloader) {
                 try {
                     PreDestroy.class.cast(sharableTemp).preDestroy();
                 } catch (Exception e) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Bugfix. BeanManager isn't properly constructed when multiple CDI WARs exist in an EAR.
Also allows EAR-libraries to be scanned for CDI annotations

fixes #7031 
also fixes #7078 
Appears specifically when multiple WARs use OmniFaces

## Important Info
This is the *head* PR in the CDI-performance and modernization sequence.
PRs #7165 and #7097 depend on this PR

## Testing
Tested with the failing reproducer
** Needs TCK run
