### PR TITLE
FISH-9690: adding validation to prevent invalid characters on header values

### DIFF
--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -2,7 +2,7 @@
 <!--
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-     Copyright (c) 2021-2023 Payara Foundation and/or its affiliates. All rights reserved.
+     Copyright (c) 2021-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
      The contents of this file are subject to the terms of either the GNU
      General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -90,6 +90,7 @@
         <module>reproducers</module>
         <module>opentelemetry</module>
         <module>use-bundled-jsf-primefaces</module>
+        <module>rfc-9110</module>
     </modules>
 
     <dependencyManagement>

--- a/appserver/tests/payara-samples/samples/rfc-9110/pom.xml
+++ b/appserver/tests/payara-samples/samples/rfc-9110/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) [2024] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/main/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <groupId>fish.payara.samples</groupId>
+        <version>6.2024.11-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rfc-9110</artifactId>
+    <name>Payara Samples - Payara - rfc-9110</name>
+    <packaging>war</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <arquillian-bom.version>1.9.1.Final</arquillian-bom.version>
+        <junit-jupiter.version>5.11.1</junit-jupiter.version>
+        <arquillian-payara.version>3.0.alpha4</arquillian-payara.version>
+        <shrinkwrap.version>3.3.1</shrinkwrap.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${shrinkwrap.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <version>${shrinkwrap.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/appserver/tests/payara-samples/samples/rfc-9110/src/main/java/fish/payara/samples/headers/SimpleServlet.java
+++ b/appserver/tests/payara-samples/samples/rfc-9110/src/main/java/fish/payara/samples/headers/SimpleServlet.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.samples.headers;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Alfonso Valdez
+ */
+
+@WebServlet(value = "/test")
+public class SimpleServlet extends HttpServlet {
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getOutputStream().print("Hello Servlet");
+    }
+}

--- a/appserver/tests/payara-samples/samples/rfc-9110/src/test/java/fish/payara/samples/headers/PayaraValidationRFCHeadersIT.java
+++ b/appserver/tests/payara-samples/samples/rfc-9110/src/test/java/fish/payara/samples/headers/PayaraValidationRFCHeadersIT.java
@@ -1,0 +1,175 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.samples.headers;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.jboss.arquillian.junit.InSequence;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.net.URL;
+
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.client.ClientBuilder.newClient;
+import org.junit.Assert;
+
+/**
+ * @author Alfonso Valdez <alfonso.altamirano@payara.fish>
+ */
+
+@ExtendWith(ArquillianExtension.class)
+public class PayaraValidationRFCHeadersIT {
+
+    private static final Logger logger = Logger.getLogger(PayaraValidationRFCHeadersIT.class.getName());
+    
+    @ArquillianResource
+    private URL base;
+
+    private Client client;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "headers.war")
+                .addPackage(SimpleServlet.class.getPackage());
+    }
+
+    @BeforeEach
+    public void setup() {
+        logger.info("setting client");
+        this.client = newClient();
+    }
+
+    @Test
+    @RunAsClient
+    public void testInvalidLFHeader() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("InvalidValue", "\\n hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(400, headerResponse.getStatus());
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void testInvalidLFHeaderASCII() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("InvalidValue", "\\x0A hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(400, headerResponse.getStatus());
+        }
+    }
+    
+    @Test
+    @RunAsClient
+    public void testInvalidNULHeader() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("InvalidValue", "\\0 hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(400, headerResponse.getStatus());
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void testInvalidNULHeaderASCII() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("InvalidValue", "\\x00 hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(400, headerResponse.getStatus());
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void testInvalidCRHeader() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("InvalidValue", "\\r hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(400, headerResponse.getStatus());
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void testInvalidCRHeaderASCII() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("InvalidValue", "\\x0D hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(400, headerResponse.getStatus());
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void testValidHeader() throws Exception {
+        logger.log(Level.INFO, " client: {0}, baseURL: {1}", new Object[]{client, base});
+        final var headersTarget = this.client.target(new URL(this.base, "test").toExternalForm());
+        try (final Response headerResponse = headersTarget.request()
+                .accept(TEXT_PLAIN).header("ValidValue", "hello").get()) {
+            logger.log(Level.INFO, " response: {0}", new Object[]{headerResponse});
+            Assert.assertEquals(200, headerResponse.getStatus());
+        }
+    }
+}

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/LogFacade.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/LogFacade.java
@@ -56,6 +56,8 @@
  * limitations under the License.
  */
 
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
+
 package org.apache.catalina;
 
 import org.glassfish.logging.annotation.LogMessageInfo;
@@ -3635,5 +3637,11 @@ public class LogFacade {
             level = "WARNING"
     )
     public static final String NONCACHEABLE_UNSAFE_PUSH_METHOD_EXCEPTION = prefix + "00548";
+    
+    @LogMessageInfo(
+            message = "Invalid Header value, you cannot include CR, LF or NUL characters, please refer to RFC-9110",
+            level = "WARNING"
+    )
+    public static final String INVALID_HEADER_VALUE_RFC_9110 = prefix + "00549";
 
 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -1051,10 +1051,10 @@ public class CoyoteAdapter extends HttpHandler {
      */
     private boolean validateHeaderValues(final org.glassfish.grizzly.http.server.Request req) {
         Iterable<String> headers = req.getHeaderNames();
+        Pattern p = Pattern.compile(INVALID_PATTERNS_RFC_9110);
         if (headers != null) {
             for (String nameHeader : headers) {
                 String headerValue = req.getHeader(nameHeader);
-                Pattern p = Pattern.compile(INVALID_PATTERNS_RFC_9110);
                 Matcher matcher = p.matcher(headerValue);
                 if (matcher.find()) {
                     return false;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -308,12 +308,11 @@ public class CoyoteAdapter extends HttpHandler {
 //        }
         //adding validation to reject request if invalid characters available RFC-9110
         if (!validateHeaderValues(req)) {
-            String msg = LogFacade.INVALID_HEADER_VALUE_RFC_9110;
             
             if (log.isLoggable(Level.INFO)) {
-                log.log(Level.INFO, msg);
+                log.log(Level.INFO, LogFacade.INVALID_HEADER_VALUE_RFC_9110);
             }
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, msg);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, LogFacade.INVALID_HEADER_VALUE_RFC_9110);
             return;
         }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fix for RFC-9110 regarding invalid characters on header values
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix for a bug reported from the service team regarding to prevent any issue when invalid characters are set on header values based on the [RFC-9110](https://www.rfc-editor.org/rfc/rfc9110.html)
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
Arquillian test added on the Payara Samples:  appserver/tests/payara-samples/samples/rfc-9110/src/test/java/fish/payara/samples/headers/PayaraValidationRFCHeadersIT.java
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing:
Deploy the following application in Payara 6:
[ReproducerJDK11.zip](https://github.com/user-attachments/files/17485085/ReproducerJDK11.zip)
when the application is deployed open a git bash terminal from windows or use postman to execute a get call for the following URL:  http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
for curl use the following command including an invalid header including the following list of invalid characters: 

-  \x00  \0   : any of those represent NUL
- \x0A \n  : any of those represent LF
- \x0D \r : any of those represent CR

example of commands using git bash:
`
curl -i -v -H "X-MyHeader: \nhello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`
`
curl -i -v -H "X-MyHeader: \rhello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`
`
curl -i -v -H "X-MyHeader: \0hello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`
`
curl -i -v -H "X-MyHeader: \x00hello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`
`
curl -i -v -H "X-MyHeader: \x0Ahello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`
`
curl -i -v -H "X-MyHeader: \x0Dhello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`

with invalid characters now the response should be a 400 error with specific error code on the server:

![image](https://github.com/user-attachments/assets/db96392e-8b21-4814-b2a4-db02184bf1fd)

server log:

![image](https://github.com/user-attachments/assets/90d4a3ee-dcf5-4f88-947c-6094180c8f2e)


with valid characters the call should return 200
`
curl -i -v -H "X-MyHeader: hello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
`

![image](https://github.com/user-attachments/assets/6bdde1a0-5a44-4cad-875b-fde86dc07f6f)

from postman:
![image](https://github.com/user-attachments/assets/0698a080-a9eb-4383-8ec0-57c6292cb76f)


Arquillian test execution passing with success:
![image](https://github.com/user-attachments/assets/a70d6d7b-d910-4a10-8f28-bcaa38ecf95f)

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, azul JDK 11,  maven 3.9.5
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
