### PR TITLE
FISH-10034 Filter Ordering

### DIFF
--- a/appserver/admingui/cdieventbus-notifier-console-plugin/src/main/resources/cdieventbus/cdiEventbusNotifierConfiguration.jsf
+++ b/appserver/admingui/cdieventbus-notifier-console-plugin/src/main/resources/cdieventbus/cdiEventbusNotifierConfiguration.jsf
@@ -110,7 +110,7 @@
             <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nn.notification.configuration.filter}"
                           helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
-                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"SEVERE", "WARNING", "INFO"} />
             </sun:property>
             <sun:property id="loopBackProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           rendered="#{pageSession.hazelcastEnabled == true}"

--- a/appserver/admingui/eventbus-notifier-console-plugin/src/main/resources/eventbus/eventbusNotifierConfiguration.jsf
+++ b/appserver/admingui/eventbus-notifier-console-plugin/src/main/resources/eventbus/eventbusNotifierConfiguration.jsf
@@ -109,7 +109,7 @@ holder.
             <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nn.notification.configuration.filter}"
                           helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
-                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"SEVERE", "WARNING", "INFO"} />
             </sun:property>
             <sun:property id="topicNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nebn.notifier.eventbus.configuration.topicNameLabel}"

--- a/appserver/admingui/jms-notifier-console-plugin/src/main/resources/jms/jmsNotifierConfiguration.jsf
+++ b/appserver/admingui/jms-notifier-console-plugin/src/main/resources/jms/jmsNotifierConfiguration.jsf
@@ -109,7 +109,7 @@ holder.
             <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nn.notification.configuration.filter}"
                           helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
-                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"SEVERE", "WARNING", "INFO"} />
             </sun:property>
             <sun:property id="contextFactoryClassProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
                           label="$resource{i18njn.notifier.jms.configuration.contextFactoryClassLabel}"  

--- a/appserver/admingui/payara-console-extras/src/main/resources/notification/notification.jsf
+++ b/appserver/admingui/payara-console-extras/src/main/resources/notification/notification.jsf
@@ -99,7 +99,7 @@ holder.
         <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                       label="$resource{i18nn.notification.configuration.filter}"
                       helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
-            <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"SEVERE", "WARNING", "INFO"} />
         </sun:property>
        <sun:property id="logNotifierEnabledProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nn.notification.configuration.logNotifierEnabled}" helpText="$resource{i18nn.notification.configuration.logNotifierEnabledHelp}">
             <sun:checkbox id="logNotifierEnabledLabel" selected="#{pageSession.notifierEnabledSelected}" selectedValue="true" />


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10034
  - Admin Console drop-down now uses descending order for severity levels.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Built the server, opened the admin console, examined the drop-down for filters.  
Used the admin console to change the filter levels and verified this worked in the CLI.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
