### PR TITLE
FISH-10086 FISH-10087 FISH-10088 Upgrade Docker JDKs

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,7 +57,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk11.tag>11.0.24-jdk</docker.jdk11.tag>
+        <docker.jdk11.tag>11.0.25-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.13-jdk</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.5-jdk</docker.jdk21.tag>
 

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -59,7 +59,7 @@
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.24-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.12-jdk</docker.jdk17.tag>
-        <docker.jdk21.tag>21.0.4-jdk</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.5-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,7 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.24-jdk</docker.jdk11.tag>
-        <docker.jdk17.tag>17.0.12-jdk</docker.jdk17.tag>
+        <docker.jdk17.tag>17.0.13-jdk</docker.jdk17.tag>
         <docker.jdk21.tag>21.0.5-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -


### PR DESCRIPTION
## Description
Upgrades the Docker JDKs to 21.0.5, 17.0.13, and 11.0.25.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Build Docker images locally

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
