### PR TITLE
FISH-10107 Test Notifier Severity

### DIFF
--- a/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/admin/TestNotifier.java
+++ b/nucleus/payara-modules/notification-core/src/main/java/fish/payara/nucleus/notification/admin/TestNotifier.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -41,6 +41,7 @@ package fish.payara.nucleus.notification.admin;
 
 import java.util.List;
 
+import fish.payara.internal.notification.EventLevel;
 import jakarta.inject.Inject;
 
 import org.glassfish.api.ActionReport;
@@ -105,7 +106,8 @@ public class TestNotifier implements AdminCommand {
         PayaraNotificationBuilder builder = factory.newBuilder()
                 .eventType(EVENT_TYPE)
                 .subject(SUBJECT)
-                .message(MESSAGE);
+                .message(MESSAGE)
+                .level(EventLevel.SEVERE);
 
         if (all == null || !all) {
             if (notifiers == null || notifiers.isEmpty()) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10107
  - The "test" button in the Admin Console now sends the notification at `SEVERE` level. This ensures the test message is always received, regardless of notifier configuration.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Configured the Teams notifier with a webhook, set the Teams notifier to `SEVERE`, pressed the "test" button in the Admin Console, saw the message appear on Teams.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
