### PR TITLE
FISH-9690: adding new version of grizzly to validate headers RFC-9110

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -617,7 +617,6 @@
                                     <exclude>io.opentelemetry.extension</exclude>
                                     <exclude>io.opentelemetry.instrumentation</exclude>
                                     <exclude>fish.payara.shaded</exclude>
-                                    <exclude>org.glassfish.grizzly.http</exclude>
                                 </excludes>
                             </parameter>
                         </configuration>

--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -617,6 +617,7 @@
                                     <exclude>io.opentelemetry.extension</exclude>
                                     <exclude>io.opentelemetry.instrumentation</exclude>
                                     <exclude>fish.payara.shaded</exclude>
+                                    <exclude>org.glassfish.grizzly.http</exclude>
                                 </excludes>
                             </parameter>
                         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
         <cdi-api.version>4.0.1</cdi-api.version>
-        <grizzly.version>4.0.0.payara-p2</grizzly.version>
+        <grizzly.version>4.0.0.payara-p2-SNAPSHOT</grizzly.version> <!-- Set to snapshot for testing purposes -->
         <servlet-api.version>6.0.0</servlet-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
         <cdi-api.version>4.0.1</cdi-api.version>
-        <grizzly.version>4.0.0.payara-p2</grizzly.version> <!-- Set to snapshot for testing purposes -->
+        <grizzly.version>4.0.0.payara-p2</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
         <cdi-api.version>4.0.1</cdi-api.version>
-        <grizzly.version>4.0.0.payara-p1</grizzly.version>
+        <grizzly.version>4.0.2.payara-p2</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
         <cdi-api.version>4.0.1</cdi-api.version>
-        <grizzly.version>4.0.2.payara-p2</grizzly.version>
+        <grizzly.version>4.0.0.payara-p2</grizzly.version>
         <servlet-api.version>6.0.0</servlet-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <jakarta.security.enterprise.version>3.0.3.payara-p1</jakarta.security.enterprise.version>
         <cdi-api.version>4.0.1</cdi-api.version>
-        <grizzly.version>4.0.0.payara-p2-SNAPSHOT</grizzly.version> <!-- Set to snapshot for testing purposes -->
+        <grizzly.version>4.0.0.payara-p2</grizzly.version> <!-- Set to snapshot for testing purposes -->
         <servlet-api.version>6.0.0</servlet-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0</expressly.version>

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/HttpRedirectTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/HttpRedirectTest.java
@@ -159,9 +159,9 @@ public class HttpRedirectTest extends BaseTestGrizzlyConfig {
         try {
             Socket s = socketFactory.createSocket("localhost", 48480);
             OutputStream out = s.getOutputStream();
-            out.write(("GET " + resourceURL + " HTTP/1.1\n").getBytes());
-            out.write(("Host: " + host + ':' + Integer.toString(port) + '\n').getBytes());
-            out.write("\n".getBytes());
+            out.write(("GET " + resourceURL + " HTTP/1.1\r\n").getBytes());
+            out.write(("Host: " + host + ':' + Integer.toString(port) + "\r\n").getBytes());
+            out.write("\r\n".getBytes());
             out.flush();
             InputStream in = s.getInputStream();
             BufferedReader br = new BufferedReader(new InputStreamReader(in));


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Adding Header validation for RFC-9110
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a security fix to prevent issues based on CVE reported here:  `[CVE-2024-45687](https://www.cve.org/CVERecord?id=CVE-2024-45687)` and here [glassfish issue](https://github.com/eclipse-ee4j/glassfish/issues/25128)
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
Manual testing:

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
To test this set the dependency version on the payara server: 4.0.0.payara-p2 build and run
deploy the following reproducer: 
[ReproducerJDK11.zip](https://github.com/user-attachments/files/17711134/ReproducerJDK11.zip)

By default grizzly is setting two new properties that enable the validation of the headers by default. You can customize this behavior by seeting the following properties from UI or by cli command o directly on the domain.xml file 

- -Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110=true
- -Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110=true

![image](https://github.com/user-attachments/assets/814d709c-2668-4f31-b17c-aae104bdd409)

![image](https://github.com/user-attachments/assets/4ba7231a-2e2a-4ab2-9c60-95ebd4eb1bfc)

`
asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110\=true"
`

`
asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110\=true"
`

after adding the properties you need to restart the server

by default on the grizzly side those properties are set as true

deploy the reproducer and make curl calls

Header Name Validation tests:

-  curl -i -v -H $"X-MyHeader\n: hello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
- curl -i -v -H $"X-MyHeader\r: hello" http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject

the result of any of those test should be error 400:
![image](https://github.com/user-attachments/assets/40e914e7-ee01-4bff-8cee-20ad936f3217)

this will return status 200  but the header will be discarted because of the \0 character
- curl -i -v -H $'X-MyHeader\0: hello' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject

![image](https://github.com/user-attachments/assets/cc66442e-8dd7-45ce-9351-0c1ca299ff00)

Header Value Validations tests:
- curl -i -v -H $'X-MyHeader: he\nllo' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
![image](https://github.com/user-attachments/assets/6e7ffde3-3336-450f-902a-77141c398df5)
- curl -i -v -H $'X-MyHeader: he\rllo' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject 
![image](https://github.com/user-attachments/assets/104f6bdc-7db5-433b-b47e-21bf14eaa8e5)
- curl -i -v -H $'X-MyHeader: he\0llo' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
![image](https://github.com/user-attachments/assets/b057dcbc-d96f-48a4-933c-3177e4ab3352)


The \0 is immediately not processed from curl because by default we can't consider that character on the request headers and the the \r and \n characters are not permitted alone on the header value content


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, Azul jdk 11, maven 3.9.5
## Documentation
<!-- Link documentation if a PR exists -->
working on documentation
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
