### PR TITLE
FISH-10136 Fix NPE in Payara Micro and Embedded

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -2673,8 +2673,16 @@ public class WebappClassLoader
     private void clearBeanResolver(Class<?> elUtilsClass) throws Exception {
         Optional<Class<?>> elResolverClass = Optional.ofNullable(CachingReflectionUtil
                 .getClassFromCache("jakarta.el.BeanELResolver", this));
-        Object resolver = CachingReflectionUtil.getFieldFromCache(elUtilsClass, "BEAN_RESOLVER",
-                false).get(null);
+
+        Field field = CachingReflectionUtil.getFieldFromCache(elUtilsClass, "BEAN_RESOLVER", false);
+        if (field == null) {
+            logger.log(Level.FINE, "Could not find BEAN_RESOLVER field on {0}", elUtilsClass.getName());
+            return;
+        }
+
+        // TODO: Review whether this is still required; Mojarra may have fixed this themselves in PR#5479?
+        // Is there solution enough? Do we need to retain this for cases where another Faces implementation is being provided?
+        Object resolver = field.get(null);
         if (resolver != null && elResolverClass.isPresent()) {
             logger.fine(String.format("Fields: %s", Arrays.stream(elResolverClass.get().getDeclaredFields())
                     .map(Field::toString).collect(Collectors.toList())));

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -2051,7 +2051,6 @@ public class WebappClassLoader
         // START SJSAS 6258619
         ClassLoaderUtil.releaseLoader(this);
         // END SJSAS 6258619
-        clearBeanELResolverCache();
         clearJaxRSCache();
 
         synchronized(jarFilesLock) {
@@ -2657,69 +2656,6 @@ public class WebappClassLoader
                         contextName), e);
             }
         }
-    }
-
-    private void clearBeanELResolverCache() {
-        try {
-            Class<?> elUtilsClass = CachingReflectionUtil.getClassFromCache("com.sun.faces.el.ELUtils", this);
-            if (elUtilsClass != null) {
-                clearBeanResolver(elUtilsClass);
-            }
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Error clearing BeanELResolver cache", e);
-        }
-    }
-
-    private void clearBeanResolver(Class<?> elUtilsClass) throws Exception {
-        Optional<Class<?>> elResolverClass = Optional.ofNullable(CachingReflectionUtil
-                .getClassFromCache("jakarta.el.BeanELResolver", this));
-
-        Field field = CachingReflectionUtil.getFieldFromCache(elUtilsClass, "BEAN_RESOLVER", false);
-        if (field == null) {
-            logger.log(Level.FINE, "Could not find BEAN_RESOLVER field on {0}", elUtilsClass.getName());
-            return;
-        }
-
-        // TODO: Review whether this is still required; Mojarra may have fixed this themselves in PR#5479?
-        // Is there solution enough? Do we need to retain this for cases where another Faces implementation is being provided?
-        Object resolver = field.get(null);
-        if (resolver != null && elResolverClass.isPresent()) {
-            logger.fine(String.format("Fields: %s", Arrays.stream(elResolverClass.get().getDeclaredFields())
-                    .map(Field::toString).collect(Collectors.toList())));
-            Method clearPropertiesMethod = CachingReflectionUtil.getMethodFromCache(elResolverClass.get(),
-                    "clearProperties", false, ClassLoader.class);
-            if (clearPropertiesMethod != null) {
-                clearPropertiesMethod.invoke(resolver, this);
-            } else {
-                clearBeanELResolverPropertiesCache(resolver, elResolverClass.get());
-            }
-        } else {
-            logger.warning("BeanELResolver not found");
-        }
-    }
-
-    /**
-     * Workaround until clearProperties() is available in Jakarta EL
-     * @see <a href="https://github.com/jakartaee/expression-language/pull/215">Jakarta EL Pull Request</a>
-     */
-    private void clearBeanELResolverPropertiesCache(Object resolver, Class<?> elResolverClass) throws Exception {
-        Optional<Class<?>> elResolverCacheClass = Optional.ofNullable(CachingReflectionUtil
-                .getClassFromCache("jakarta.el.BeanELResolver$SoftConcurrentHashMap", this));
-        var propertiesField = Optional.ofNullable(CachingReflectionUtil
-                .getFieldFromCache(elResolverClass, "properties", true));
-        @SuppressWarnings("unchecked")
-        ConcurrentHashMap<Class<?>, Object> properties =
-                (ConcurrentHashMap<Class<?>, Object>) propertiesField.get().get(resolver);
-        properties.entrySet().removeIf(entry -> entry.getKey().getClassLoader() == this);
-        var mapField = Optional.ofNullable(CachingReflectionUtil
-                .getFieldFromCache(elResolverCacheClass.get(), "map", true));
-        @SuppressWarnings("unchecked")
-        ConcurrentHashMap<Class<?>, Object> map =
-                (ConcurrentHashMap<Class<?>, Object>) mapField.get().get(propertiesField.get().get(resolver));
-        map.entrySet().removeIf(entry -> entry.getKey().getClassLoader() == this);
-        var cleanupMethod = Optional.ofNullable(CachingReflectionUtil
-                .getMethodFromCache(elResolverCacheClass.get(), "cleanup", true));
-        cleanupMethod.get().invoke(propertiesField.get().get(resolver));
     }
 
     private void clearJaxRSCache() {


### PR DESCRIPTION
## Description
Adds a fallout clause for if field doesn't exist. The field in question belonged in Mojarra, who have since potentially fixed the issue themselves in https://github.com/eclipse-ee4j/mojarra/pull/5479?

Without this change, the following error is thrown on application deployment/undeployment (most prominently in Micro and Embedded)
```
[2024-11-13T08:49:24.762+0200] [] [WARNING] [] [jakarta.enterprise.web.util] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1731480564762] [levelValue: 900] [[
  Error clearing BeanELResolver cache
java.lang.NullPointerException
	at org.glassfish.web.loader.WebappClassLoader.clearBeanResolver(WebappClassLoader.java:2677)
	at org.glassfish.web.loader.WebappClassLoader.clearBeanELResolverCache(WebappClassLoader.java:2666)
	at org.glassfish.web.loader.WebappClassLoader.stop(WebappClassLoader.java:2054)
	at org.glassfish.web.loader.WebappClassLoader.preDestroy(WebappClassLoader.java:2017)
```

Need to look into if this entire block of code is still required any more; it seems quite closely tied to Mojarra who have potentially resolved it themselves? Would need to follow it through carefully across redeployments to see if we're still holding on to anything on our side.

Originally introduced here: https://github.com/payara/Payara/pull/6677

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started Payara Micro and deployed clusterjsp - no explosions.

Started Payara Server and redeployed classloader-data-api several times - the number of class loaders didn't continually increase.

### Testing Environment
Windows 11, Zulu JDK 11.0.25

## Documentation
N/A

## Notes for Reviewers
None
