### PR TITLE
Don't use SNAPSHOT release of Concurro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <microprofile-release.version>6.1</microprofile-release.version>
         <payara-arquillian-container.version>4.0.alpha1</payara-arquillian-container.version>
         <h2db.version>2.2.224</h2db.version>
-        <concurro.version>3.1.0-SNAPSHOT</concurro.version>
+        <concurro.version>3.1.0-M4</concurro.version>
 
         <monitoring-console-process.version>3.0.0-SNAPSHOT</monitoring-console-process.version>
         <monitoring-console-webapp.version>3.0.0-SNAPSHOT</monitoring-console-webapp.version>


### PR DESCRIPTION
## Description
We shouldn't be using a snapshot release of concurro.

## Important Info
### Blockers
Concurro doesn't seem to be constructed correctly - misunderstanding of multirelease jars?
CNFEs caused by the java 21 classes not being present.

## Testing
### New tests
None

### Testing Performed
Built the server

### Testing Environment
Windows 11, Zulu JDK 21.0.5, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
